### PR TITLE
fix(hermes): stop the adapter reporting success for writes that never happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,14 +54,30 @@ now an anomaly worth investigating, not the norm.
   / `blueprints` undefined, and now return real (if short) lists. And both
   catch-alls are gone: an unrecognised path under either prefix 404s, so the
   desktop can tell a missing route from a served one.
+- **hermes adapter: serve the two `/api/profiles` reads the route census could
+  not see.** `GET /api/profiles/active` (`store/profile.ts:114`, runs at
+  startup) and `GET /api/profiles/projects/tree` (`store/projects.ts:479`, the
+  all-profiles sidebar) are emitted from the desktop's stores, not from
+  `hermes.ts` — so narrowing the `/api/profiles` branch to an allowlist derived
+  from a `hermes.ts`-only grep 404'd both. Each is now served with its real
+  upstream shape: `{active, current}` and the four-key empty project tree. The
+  project-tree one matters beyond tidiness — the caller's failure path only
+  reacts to JSON-RPC method-missing errors, so an HTTP 404 left
+  `$projectsRpcAvailable` pinned at `null` instead of "the surface exists and
+  is empty". The parity fixture's census is now swept whole-tree (`src/**` +
+  `electron/**`) with its residual scope written down, and a new case asserts
+  every desktop-emitted `/api/profiles` GET is still served, so an allowlist
+  narrowing cannot silently drop one again.
 - **hermes adapter: honour `source` / `exclude_sources` on the session-list
   routes.** They were ignored, so the sidebar's cron slice and its recents
   slice returned the identical unfiltered fleet. Both the batched sidebar route
   and `/api/profiles/sessions` now filter through one shared helper.
 - **hermes adapter: two JSON-RPC results now match upstream.**
   `session.history` carries `count` alongside `messages`, and
-  `session.most_recent` returns `{session_id}` (null when there is none)
-  rather than `{session}` — the key every caller destructures.
+  `session.most_recent` returns the four-key hit shape
+  `{session_id, title, started_at, source}` — falling back to the bare
+  `{session_id: null}` when there is no eligible session — rather than
+  `{session}`, the key no caller was ever finding.
 
 ## v0.21.7 — a Fable-pinned agent boots on Fable, a cron edit stops failing on its first try, and the merge queue stops ejecting innocent PRs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,36 @@ now an anomaly worth investigating, not the norm.
   off — the worst week in the log, scored as healthier than the milder August
   incident it did catch.
 
+### Bug fixes
+
+- **hermes adapter: stop reporting success for writes and reads that never
+  happened.** The REST handler's `/api/cron` and `/api/profiles` prefix
+  branches both ended in a catch-all `return {status: 200, body: {}}`, which
+  answered a fabricated success for every route underneath them that had no
+  handler. Four things that cost, all now fixed: `PUT /api/cron/jobs/:id` (the
+  desktop's `updateCronJob`) fell to that catch-all, so the cron editor told
+  the operator the edit saved while nothing was written — it now returns the
+  same 422 its POST/PATCH/DELETE siblings already return, because switchroom
+  schedules are YAML-owned. `GET /api/profiles/sessions/sidebar` was swallowed
+  by a `pathname.includes('sessions')` test and answered with a
+  `PaginatedSessions` literal; since the desktop's `isEndpointMissingError`
+  only recognises 404-shaped failures, a 200 never tripped its legacy fallback
+  and the sidebar rendered three permanently-empty slices — it now serves the
+  real batched `SidebarSessionsResponse` off the same session list the
+  per-slice route uses. `GET /api/cron/delivery-targets` and
+  `GET /api/cron/blueprints` returned `{}`, leaving the destructured `targets`
+  / `blueprints` undefined, and now return real (if short) lists. And both
+  catch-alls are gone: an unrecognised path under either prefix 404s, so the
+  desktop can tell a missing route from a served one.
+- **hermes adapter: honour `source` / `exclude_sources` on the session-list
+  routes.** They were ignored, so the sidebar's cron slice and its recents
+  slice returned the identical unfiltered fleet. Both the batched sidebar route
+  and `/api/profiles/sessions` now filter through one shared helper.
+- **hermes adapter: two JSON-RPC results now match upstream.**
+  `session.history` carries `count` alongside `messages`, and
+  `session.most_recent` returns `{session_id}` (null when there is none)
+  rather than `{session}` — the key every caller destructures.
+
 ## v0.21.7 — a Fable-pinned agent boots on Fable, a cron edit stops failing on its first try, and the merge queue stops ejecting innocent PRs
 
 ### Dependencies

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -898,15 +898,61 @@ export async function handleHermesRest(
     if (pathname.endsWith("/soul")) {
       return { status: 200, body: { content: "", exists: false } };
     }
-    // /api/profiles/:name/setup-command — { command: string }. Switchroom has
-    // no shell-launchable profiles, so the command is empty; the key must
-    // still be present and a string (upstream returns a bare `string`,
-    // hermes_cli/web_routers/profiles.py:779-781).
+    // /api/profiles/:name/setup-command — upstream returns an OBJECT,
+    // `{"command": _profile_setup_command(name)}`
+    // (hermes_cli/web_routers/profiles.py:779-781), and the desktop
+    // destructures `.command` off it (hermes.ts:1544-1548). Switchroom has no
+    // shell-launchable profiles, so the command is empty — but the key must
+    // still be present and a string, not missing and not null.
     if (pathname.endsWith("/setup-command")) {
       return { status: 200, body: { command: "" } };
     }
-    // Everything else under /api/profiles is unimplemented — 404 rather than a
-    // fabricated 200 the client cannot distinguish from a real answer.
+    // /api/profiles/active — { active, current }
+    // (hermes_cli/web_routers/profiles.py:738-755). NOT emitted from
+    // apps/desktop/src/hermes.ts: `refreshActiveProfile`
+    // (apps/desktop/src/store/profile.ts:105-118) calls it directly, at
+    // startup. Switchroom has exactly one implicit profile and no
+    // `hermes profile use` sticky-default concept, so both keys are the
+    // desktop's own canonical root-profile name — which is also what upstream
+    // falls back to when its profile module raises (profiles.py:747, :753) and
+    // what `$activeProfile` is seeded with (store/profile.ts:31).
+    if (pathname === "/api/profiles/active") {
+      return { status: 200, body: { active: "default", current: "default" } };
+    }
+    // /api/profiles/projects/tree — the all-profiles grouped sidebar's tree
+    // (hermes_cli/web_routers/profiles.py:457-533). Also not emitted from
+    // hermes.ts: `refreshProjectTreeAcrossProfiles`
+    // (apps/desktop/src/store/projects.ts:473-499) calls it directly.
+    //
+    // Switchroom has no project/checkout grouping to report — a session is an
+    // agent, not a repo working tree — so every list is empty. Served rather
+    // than 404'd because the caller's failure path
+    // (`markProjectsRpcFailure`, store/projects.ts:52-56) only reacts to
+    // *JSON-RPC method-missing* errors (`isMissingRpcMethod`,
+    // lib/gateway-rpc.ts:2-6), which an HTTP 404 never matches: a 404 leaves
+    // `$projectsRpcAvailable` stuck at null forever, while the full-shape
+    // empty payload runs `applyProjectTreePayload` + `markProjectsRpcSuccess`
+    // and tells the truth ("the surface exists, it has nothing in it").
+    // All four upstream keys are emitted, not just the one the desktop's
+    // `ProjectTreePayload` (store/projects.ts:389-393) declares.
+    if (pathname === "/api/profiles/projects/tree") {
+      return {
+        status: 200,
+        body: { projects: [], active_id: null, scoped_session_ids: [], errors: [] },
+      };
+    }
+    // Deliberate 404s under this prefix, and why each is safe:
+    //   - POST /api/profiles/sessions/pull-requests (hermes.ts:571-582) —
+    //     switchroom transcripts carry no `gh pr create` tool output to scan.
+    //     `recoverSessionPullRequests` (store/pull-requests.ts:96) awaits it
+    //     inside a try/catch and simply records no PRs.
+    // Every other verb under /api/profiles (create/rename/delete/import/
+    // export/soul-write) is a profile *mutation*; switchroom's fleet is
+    // YAML-owned, and those all fell through to a 404 before this branch too
+    // (the prefix branch has always been GET-gated).
+    //
+    // Anything else 404s rather than returning a fabricated 200 the client
+    // cannot distinguish from a real answer.
     return null;
   }
 
@@ -1075,12 +1121,29 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
     }
 
     case "session.most_recent": {
-      // Upstream returns the bare id — `{"session_id": <id|null>}`, with null
-      // meaning "no eligible session right now"
-      // (tui_gateway/methods_session.py:214-235). Returning `{session}` here
-      // meant no caller ever found the id it destructures.
+      // Upstream has TWO result shapes (tui_gateway/methods_session.py:214-260):
+      // a hit returns four keys — `{session_id, title, started_at, source}`
+      // (:248-256) — and every no-answer path (no db, no eligible row, or an
+      // internal exception) returns the bare `{"session_id": null}`
+      // (:234, :257, :260). Returning `{session}` here meant no caller ever
+      // found the id it destructures; returning only `session_id` on a hit
+      // would still be short three keys the adapter has in hand.
       const sessions = await buildAllSessions(config);
-      sendResponse(ctx, rpcOk(id, { session_id: sessions[0]?.id ?? null }));
+      const mostRecent = sessions[0];
+      sendResponse(
+        ctx,
+        rpcOk(
+          id,
+          mostRecent
+            ? {
+                session_id: mostRecent.id,
+                title: mostRecent.title ?? "",
+                started_at: mostRecent.started_at ?? 0,
+                source: mostRecent.source ?? "",
+              }
+            : { session_id: null },
+        ),
+      );
       break;
     }
 
@@ -1158,7 +1221,17 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
       const agentsDir = resolveAgentsDir(config);
       const histMessages = readHistoryDb(agentsDir, histAgent, limit);
       // `count` is part of the upstream result — `{"count", "messages"}`,
-      // tui_gateway/methods_session.py:2456-2462.
+      // tui_gateway/methods_session.py:2457-2462.
+      //
+      // Not byte-for-byte the upstream contract, deliberately: upstream's
+      // `count` is `len(history)`, the RAW pre-projection row count, while
+      // `messages` is `_history_to_messages(history)` — a lossy display
+      // projection (tui_gateway/server.py:7136+) that drops hidden scaffolding
+      // rows and assistant turns that are only tool calls. So upstream's
+      // `count >= len(messages)`, strictly greater on any tool-using
+      // transcript. The adapter applies no such projection, so the two are
+      // always equal here; `count` is still the honest count of what
+      // `messages` was built from, which is what the key means.
       if (histMessages !== null) {
         sendResponse(
           ctx,

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -184,6 +184,48 @@ async function buildAllSessions(
   return sessions
 }
 
+/**
+ * Source scoping for the session-list endpoints.
+ *
+ * Upstream's `list_sessions_rich` takes `source` (keep only this source) and
+ * `exclude_sources` (drop these), and the desktop leans on both: the sidebar's
+ * cron slice asks for `source=cron`, its recents slice excludes the cron and
+ * messaging taxonomies, and its messaging slice excludes the local ones
+ * (`apps/desktop/src/app/session/hooks/use-session-list-actions.ts:47-50`,
+ * `hermes.ts:436-441` at 9da6d45). Ignoring them makes every slice return the
+ * identical unfiltered fleet — the starvation the upstream comment at
+ * `hermes.ts:418-422` describes.
+ *
+ * Every switchroom session reports `source: "switchroom"` (see
+ * {@link toHermesSession}), which is in none of the desktop's exclude
+ * taxonomies and is not `cron` — so `source=cron` correctly yields nothing.
+ */
+function filterSessionsBySource<T extends { source: string }>(
+  sessions: T[],
+  opts: { source?: string | null; excludeSources?: string[] },
+): T[] {
+  const exclude = new Set(opts.excludeSources ?? []);
+  return sessions.filter(
+    (s) => (!opts.source || s.source === opts.source) && !exclude.has(s.source),
+  );
+}
+
+/** Read a comma-separated query param (`exclude_sources`, `recents_exclude`, …). */
+function csvParam(params: URLSearchParams, key: string): string[] {
+  return (params.get(key) ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** Clamp a numeric query param the way upstream's sidebar route does. */
+function intParam(params: URLSearchParams, key: string, fallback: number): number {
+  const raw = params.get(key);
+  if (raw === null) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? Math.min(Math.max(n, 1), 500) : fallback;
+}
+
 // ─── prompt.submit → inject_inbound ──────────────────────────────────────────
 
 interface InjectResult {
@@ -607,7 +649,11 @@ export async function handleHermesRest(
     method === "GET" &&
     (pathname === "/api/sessions" || pathname === "/api/profiles/sessions")
   ) {
-    const sessions = await buildAllSessions(config);
+    const query = new URLSearchParams(search);
+    const sessions = filterSessionsBySource(await buildAllSessions(config), {
+      source: query.get("source"),
+      excludeSources: csvParam(query, "exclude_sources"),
+    });
     return {
       status: 200,
       body: {
@@ -616,6 +662,58 @@ export async function handleHermesRest(
         limit: sessions.length,
         offset: 0,
         profile_totals: { default: sessions.length },
+      },
+    };
+  }
+
+  // GET /api/profiles/sessions/sidebar — the batched three-slice sidebar payload
+  // (SidebarSessionsResponse, apps/desktop/src/hermes.ts:486-491 at 9da6d45).
+  //
+  // MUST be served or 404'd honestly, never answered with a bare 200: the
+  // desktop's `isEndpointMissingError` (hermes.ts:520-536) only recognises
+  // 404-shaped failures, so a 200 with the wrong body never trips the
+  // `listSidebarSessionsLegacy` fallback — the sidebar just renders three
+  // permanently-empty slices. Serving it for real is strictly better than
+  // 404-ing, because the data is the same `buildAllSessions` list the
+  // per-slice route already answers from.
+  //
+  // Slice semantics mirror hermes_cli/web_routers/profiles.py:232-383: all
+  // three windows are recency-ordered and source-scoped, cron is an implicit
+  // `source=cron`, and recents/messaging honour the caller's CSV exclude lists.
+  //
+  // Consequence worth knowing: `source: "switchroom"` is in neither the
+  // recents nor the messaging exclude list, so a switchroom session appears in
+  // both slices. That is what the taxonomy says — every switchroom session is
+  // a Telegram thread AND a recent chat — and the alternative (retagging
+  // sessions as `source: "telegram"`) would move the whole fleet OUT of
+  // recents, since the desktop excludes every messaging source from it
+  // (use-session-list-actions.ts:47). Deliberate, not an oversight.
+  if (method === "GET" && pathname === "/api/profiles/sessions/sidebar") {
+    const query = new URLSearchParams(search);
+    const all = await buildAllSessions(config);
+    const recentsCap = intParam(query, "recents_limit", 20);
+    const cronCap = intParam(query, "cron_limit", 50);
+    const messagingCap = intParam(query, "messaging_limit", 100);
+    const recents = filterSessionsBySource(all, {
+      excludeSources: csvParam(query, "recents_exclude"),
+    }).slice(0, recentsCap);
+    const cron = filterSessionsBySource(all, { source: "cron" }).slice(0, cronCap);
+    const messaging = filterSessionsBySource(all, {
+      excludeSources: csvParam(query, "messaging_exclude"),
+    }).slice(0, messagingCap);
+    return {
+      status: 200,
+      body: {
+        // `profiles_usage` is deliberately omitted rather than zero-filled:
+        // switchroom does no token/spend metering, and upstream declares the
+        // key optional (hermes.ts:465-467), so absent is the honest answer.
+        recents: {
+          sessions: recents,
+          profiles_truncated: { default: recents.length >= recentsCap },
+        },
+        cron: { sessions: cron },
+        messaging: { sessions: messaging, total: messaging.length },
+        errors: [],
       },
     };
   }
@@ -735,24 +833,63 @@ export async function handleHermesRest(
       return { status: 200, body: job };
     }
 
-    // Create/update/pause/resume/delete: schedules are config-owned, not UI-mutable.
-    if (method === "POST" || method === "PATCH" || method === "DELETE") {
+    // GET /api/cron/delivery-targets — the platforms a cron job may deliver to.
+    // Upstream (hermes_cli/web_routers/cron.py:72-95) always prepends the
+    // implicit `local` option and derives the rest from the configured gateway
+    // platforms. Switchroom's only delivery platform is Telegram, and a cron
+    // fire lands in the agent's own thread — so `home_target_set` is true iff
+    // at least one agent actually resolves a channel target.
+    if (method === "GET" && pathname === "/api/cron/delivery-targets") {
+      const telegramConfigured = Object.keys(config.agents ?? {}).some(
+        (name) =>
+          resolveChannelTarget(config as Parameters<typeof resolveChannelTarget>[0], name) !== null,
+      );
+      return {
+        status: 200,
+        body: {
+          targets: [
+            { id: "local", name: "Local (save only)", home_target_set: true, home_env_var: null },
+            {
+              id: "telegram",
+              name: "Telegram",
+              home_target_set: telegramConfigured,
+              home_env_var: null,
+            },
+          ],
+        },
+      };
+    }
+
+    // GET /api/cron/blueprints — the automation-blueprint gallery
+    // (`{ blueprints }`, read at apps/desktop/src/hermes.ts:1480-1486).
+    // Switchroom has no blueprint catalog, and instantiating one would be a
+    // schedule write, which the 422 below refuses anyway — so the honest
+    // answer is an empty catalog, not a bare 200 that leaves `blueprints`
+    // undefined at the call site.
+    if (method === "GET" && pathname === "/api/cron/blueprints") {
+      return { status: 200, body: { blueprints: [] } };
+    }
+
+    // Create/update/pause/resume/delete: schedules are config-owned, not
+    // UI-mutable. PUT is in this list because `updateCronJob`
+    // (apps/desktop/src/hermes.ts:1428-1434) uses it — without it the edit fell
+    // through to a 200 and the desktop reported a save that never happened.
+    if (method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE") {
       return { status: 422, body: { error: "Schedules are managed via switchroom YAML config — edit the agent config file and apply." } };
     }
 
-    return { status: 200, body: {} };
+    // No blanket 200 for unrecognised /api/cron reads: a fabricated empty
+    // success is indistinguishable from a served route at the call site, so an
+    // unknown path 404s (via the caller's null handling) and the desktop can
+    // tell that the route is missing.
+    return null;
   }
 
-  if (method === "GET" && pathname.startsWith("/api/messaging")) {
-    // GET /api/messaging/platforms → { platforms: [] }
-    if (pathname === "/api/messaging/platforms") return { status: 200, body: { platforms: [] } };
-    return { status: 200, body: {} };
+  if (method === "GET" && pathname === "/api/messaging/platforms") {
+    return { status: 200, body: { platforms: [] } };
   }
 
   if (method === "GET" && pathname.startsWith("/api/profiles")) {
-    if (pathname.includes("sessions")) {
-      return { status: 200, body: { sessions: [], total: 0, limit: 0, offset: 0 } };
-    }
     // /api/profiles — ProfilesResponse: { profiles: ProfileInfo[] }
     if (pathname === "/api/profiles") {
       return { status: 200, body: { profiles: [] } };
@@ -761,11 +898,16 @@ export async function handleHermesRest(
     if (pathname.endsWith("/soul")) {
       return { status: 200, body: { content: "", exists: false } };
     }
-    return { status: 200, body: {} };
-  }
-
-  if (method === "GET" && pathname === "/api/memory/providers") {
-    return { status: 200, body: {} };
+    // /api/profiles/:name/setup-command — { command: string }. Switchroom has
+    // no shell-launchable profiles, so the command is empty; the key must
+    // still be present and a string (upstream returns a bare `string`,
+    // hermes_cli/web_routers/profiles.py:779-781).
+    if (pathname.endsWith("/setup-command")) {
+      return { status: 200, body: { command: "" } };
+    }
+    // Everything else under /api/profiles is unimplemented — 404 rather than a
+    // fabricated 200 the client cannot distinguish from a real answer.
+    return null;
   }
 
   // GET /api/fs/default-cwd — remote mode cwd seeding (caught by caller)
@@ -783,7 +925,14 @@ export async function handleHermesRest(
     return { status: 200, body: { ok: true, model: null } };
   }
 
-  // GET /api/auth/providers — OAuth provider listing (only needed in OAuth mode)
+  // GET /api/auth/providers — the login-bootstrap provider list
+  // (hermes_cli/dashboard_auth/routes.py:152). NOT dead weight: Hermes
+  // Desktop's *main* process probes it — `gatewayAuthProviders`
+  // (apps/desktop/electron/main.ts:4954) and `probeRemoteAuthMode`
+  // (:7590) — to label the sign-in button and to tell a password provider
+  // from an OAuth one. Both read `body.providers` and both treat a failure as
+  // "keep the strict guard", so switchroom's token-auth gateway answering an
+  // empty list is the correct signal.
   if (method === "GET" && pathname === "/api/auth/providers") {
     return { status: 200, body: { providers: [] } };
   }
@@ -926,8 +1075,12 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
     }
 
     case "session.most_recent": {
+      // Upstream returns the bare id — `{"session_id": <id|null>}`, with null
+      // meaning "no eligible session right now"
+      // (tui_gateway/methods_session.py:214-235). Returning `{session}` here
+      // meant no caller ever found the id it destructures.
       const sessions = await buildAllSessions(config);
-      sendResponse(ctx, rpcOk(id, { session: sessions[0] ?? null }));
+      sendResponse(ctx, rpcOk(id, { session_id: sessions[0]?.id ?? null }));
       break;
     }
 
@@ -1004,12 +1157,18 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
       const { agentName: histAgent } = parseHermesSessionId(sessionId);
       const agentsDir = resolveAgentsDir(config);
       const histMessages = readHistoryDb(agentsDir, histAgent, limit);
+      // `count` is part of the upstream result — `{"count", "messages"}`,
+      // tui_gateway/methods_session.py:2456-2462.
       if (histMessages !== null) {
-        sendResponse(ctx, rpcOk(id, { session_id: sessionId, messages: histMessages }));
+        sendResponse(
+          ctx,
+          rpcOk(id, { session_id: sessionId, count: histMessages.length, messages: histMessages }),
+        );
       } else {
         // Fall back to turns preview if history.db is unavailable
         const result = handleGetTurns(config, sessionId, Math.min(limit, 200));
-        sendResponse(ctx, rpcOk(id, { session_id: sessionId, messages: turnsToMessages(result.turns ?? []) }));
+        const messages = turnsToMessages(result.turns ?? []);
+        sendResponse(ctx, rpcOk(id, { session_id: sessionId, count: messages.length, messages }));
       }
       break;
     }

--- a/src/web/hermes-rest-parity.test.ts
+++ b/src/web/hermes-rest-parity.test.ts
@@ -161,9 +161,9 @@ const CENSUS: CensusRow[] = [
     path: "/api/profiles/sessions/sidebar",
     served: true,
     note:
-      "Served, but with the WRONG shape — see the sidebar case in Part 2. " +
-      "`pathname.includes('sessions')` inside the /api/profiles branch " +
-      "(hermes-adapter.ts:753) swallows it.",
+      "Served for real — the batched three-slice SidebarSessionsResponse, off " +
+      "the same buildAllSessions list the per-slice route answers from. See " +
+      "the sidebar case in Part 2.",
   },
   {
     line: 658,
@@ -214,8 +214,13 @@ const CENSUS: CensusRow[] = [
     path: "/api/providers/oauth",
     served: false,
     note:
-      "The adapter serves /api/auth/providers (hermes-adapter.ts:787), which " +
-      "no desktop call site emits — a stub aimed at a route that does not exist.",
+      "The adapter serves /api/auth/providers instead. That is NOT a stub " +
+      "aimed at a dead route: /api/auth/providers is a real upstream route " +
+      "(hermes_cli/dashboard_auth/routes.py:152) called by the desktop's " +
+      "Electron MAIN process — gatewayAuthProviders (electron/main.ts:4954) " +
+      "and probeRemoteAuthMode (:7590). This census only greps " +
+      "apps/desktop/src/hermes.ts, which is the renderer, so main-process " +
+      "call sites are out of its scope by construction.",
   },
   { line: 981, method: "DELETE", path: "/api/providers/oauth/anthropic", served: false },
   { line: 989, method: "POST", path: "/api/providers/oauth/anthropic/start", served: false },
@@ -230,8 +235,10 @@ const CENSUS: CensusRow[] = [
     path: "/api/memory/providers/hindsight/config",
     served: false,
     note:
-      "The adapter serves the bare /api/memory/providers (hermes-adapter.ts:767); " +
-      "no desktop call site emits that path, only this /:provider/config one.",
+      "Still unimplemented. The adapter used to serve the bare " +
+      "/api/memory/providers instead — a path with no upstream route " +
+      "(hermes_cli/memory_oauth.py:18 mounts the prefix but registers no bare " +
+      "handler) and no call site; that dead stub has been deleted.",
   },
   { line: 878, method: "PUT", path: "/api/memory/providers/hindsight/config", served: false },
   { line: 1024, method: "POST", path: "/api/memory/providers/hindsight/oauth/start", served: false },
@@ -519,10 +526,6 @@ const CONTRACT: ContractCase[] = [
     search: "?limit=40&offset=0&min_messages=1&archived=exclude&order=recent&profile=all&source=cron",
     client: "hermes.ts:434-445 — the cron slice passes source='cron'",
     server: "hermes_cli/web_routers/profiles.py:82",
-    gap:
-      "hermes-adapter.ts:601-620 ignores `source`, so the sidebar's cron slice " +
-      "and its recents slice return the identical unfiltered fleet list — the " +
-      "exact starvation the upstream comment at hermes.ts:418-422 describes.",
     assert: (res) => {
       const b = body200(res);
       // No switchroom session has source='cron' (toHermesSession hardcodes
@@ -540,15 +543,6 @@ const CONTRACT: ContractCase[] = [
     search: "?recents_profile=all&recents_limit=40&cron_limit=20&messaging_limit=20",
     client: "hermes.ts:596-628 (listSidebarSessions); shape at hermes.ts:487-492",
     server: "hermes_cli/web_routers/profiles.py:232",
-    gap:
-      "The /api/profiles prefix branch's `pathname.includes('sessions')` test " +
-      "(hermes-adapter.ts:752-755) swallows this path and answers 200 with a " +
-      "PaginatedSessions-shaped literal. That is strictly WORSE than not " +
-      "implementing it: `isEndpointMissingError` (hermes.ts:520-536) only " +
-      "matches 404-ish shapes, so a 200 never trips the legacy fallback at " +
-      "hermes.ts:619-626. The sidebar reads `result.recents?.sessions ?? []` " +
-      "(hermes.ts:629) and renders three permanently-empty slices instead of " +
-      "degrading to listSidebarSessionsLegacy.",
     assert: (res) => {
       const b = body200(res);
       for (const slice of ["recents", "cron", "messaging"]) {
@@ -558,20 +552,37 @@ const CONTRACT: ContractCase[] = [
     },
   },
   {
-    name: "GET /api/profiles/sessions/sidebar 404s if unimplemented, so the legacy fallback fires",
+    // The paired "…or 404 so the legacy fallback fires" case that used to sit
+    // here is gone: the adapter now serves the batched route for real, so the
+    // tolerance-side assertion is unreachable by construction. Kept as a note
+    // because the tolerance still matters — an unrecognised /api/profiles path
+    // must 404, never answer a bare 200 (isEndpointMissingError, hermes.ts:520-536,
+    // only recognises 404-shaped failures).
+    name: "an unrecognised /api/profiles GET 404s rather than faking a 200 (synthetic probe path)",
+    method: "GET",
+    path: "/api/profiles/default/__not_a_route__",
+    client: "hermes.ts:520-536 (isEndpointMissingError)",
+    server: "hermes_cli/web_routers/profiles.py:232",
+    assert: (res) => {
+      expect(res === null || res.status === 404).toBe(true);
+    },
+  },
+  {
+    name: "the sidebar's cron slice is source-scoped, not a copy of recents",
     method: "GET",
     path: "/api/profiles/sessions/sidebar",
     search: "?recents_profile=all&recents_limit=40&cron_limit=20&messaging_limit=20",
-    client: "hermes.ts:520-536 (isEndpointMissingError) + hermes.ts:619-626",
-    server: "hermes_cli/web_routers/profiles.py:232",
-    gap:
-      "Same root cause as the case above, asserted from the tolerance side: " +
-      "if the adapter is not going to serve the batched route it MUST 404 so " +
-      "the desktop falls back. Today it 200s. Either this case or the one " +
-      "above goes green when the gap is fixed — never both; whichever fix " +
-      "lands, delete the other.",
+    client: "hermes.ts:543-552 (listSidebarSessionsLegacy passes source='cron')",
+    server: "hermes_cli/web_routers/profiles.py:347 (_slice(db, source='cron'))",
     assert: (res) => {
-      expect(res === null || res.status === 404).toBe(true);
+      const b = body200(res);
+      const recents = (b.recents as Record<string, unknown>).sessions as unknown[];
+      const cron = (b.cron as Record<string, unknown>).sessions as unknown[];
+      // No switchroom session reports source='cron' (toHermesSession hardcodes
+      // 'switchroom'), so a correctly-scoped cron slice is empty while recents
+      // is not — which is exactly what "not a copy of recents" means here.
+      expect(recents.length).toBeGreaterThan(0);
+      expect(cron).toEqual([]);
     },
   },
 
@@ -896,12 +907,6 @@ const CONTRACT: ContractCase[] = [
     path: `/api/cron/jobs/${AGENT}~0`,
     client: "hermes.ts:1428-1434 (updateCronJob)",
     server: "hermes_cli/web_server.py",
-    gap:
-      "The cron branch refuses POST/PATCH/DELETE with 422 " +
-      "(hermes-adapter.ts:739-741) but not PUT, so an edit falls to the " +
-      "catch-all `return {status:200, body:{}}` at :743. The desktop reads a " +
-      "200 and reports the edit saved; nothing was written. Schedules are " +
-      "YAML-owned, so PUT belongs in the same 422 list as the other verbs.",
     assert: (res) => {
       expect(res).not.toBeNull();
       expect(res!.status).toBe(422);
@@ -945,15 +950,19 @@ const CONTRACT: ContractCase[] = [
     method: "GET",
     path: "/api/cron/delivery-targets",
     client: "hermes.ts:1410-1416 (getCronDeliveryTargets) — destructures { targets }",
-    server: "hermes_cli/web_server.py",
-    gap:
-      "The /api/cron prefix branch's catch-all (hermes-adapter.ts:743) answers " +
-      "200 {} for this, so `const { targets } = ...` is undefined. The caller " +
-      "coalesces (`targets ?? []`), so this degrades rather than throwing — " +
-      "but the cron editor then offers zero delivery targets.",
+    server: "hermes_cli/web_routers/cron.py:72 (always prepends the implicit `local`)",
     assert: (res) => {
       const b = body200(res);
-      expect(Array.isArray(b.targets)).toBe(true);
+      const targets = b.targets as Record<string, unknown>[];
+      expect(Array.isArray(targets)).toBe(true);
+      // Upstream's contract: `local` is always offered, and every entry carries
+      // the four CronDeliveryTarget fields (types/hermes.ts:836-841).
+      expect(targets.map((t) => t.id)).toContain("local");
+      for (const t of targets) {
+        for (const field of ["id", "name", "home_target_set", "home_env_var"]) {
+          expect(t, `CronDeliveryTarget.${field} missing`).toHaveProperty(field);
+        }
+      }
     },
   },
 
@@ -1051,13 +1060,12 @@ const CONTRACT: ContractCase[] = [
     path: "/api/profiles/default/setup-command",
     client: "hermes.ts:1544-1548 (getProfileSetupCommand)",
     server: "hermes_cli/web_routers/profiles.py:779",
-    gap:
-      "The /api/profiles catch-all (hermes-adapter.ts:764) answers 200 {}. " +
-      "Degrades rather than throwing, but the profile pane shows no setup " +
-      "command.",
     assert: (res) => {
       const b = body200(res);
-      expect(b).toHaveProperty("command");
+      // Upstream declares a bare string; switchroom has no shell-launchable
+      // profile, so the honest answer is an empty one — not a missing key and
+      // not null.
+      expect(typeof b.command).toBe("string");
     },
   },
   {
@@ -1177,9 +1185,9 @@ describe(`Hermes REST response contract (upstream ${UPSTREAM_HERMES_SHA.slice(0,
     // Ratchet: this only moves when the adapter is fixed. Lower `gaps` (and
     // raise `green`) in the same PR that removes a `gap` field.
     expect({ total: CONTRACT.length, green, gaps }).toEqual({
-      total: 44,
-      green: 20,
-      gaps: 24,
+      total: 45,
+      green: 27,
+      gaps: 18,
     });
   });
 });

--- a/src/web/hermes-rest-parity.test.ts
+++ b/src/web/hermes-rest-parity.test.ts
@@ -1,0 +1,1185 @@
+/**
+ * Hermes REST contract-parity fixture for `handleHermesRest`.
+ *
+ * Mirror image of upstream's own parity fixture
+ * (`apps/desktop/src/hermes-parity.test.ts`, 140 ln), pointed the other way:
+ * upstream asserts that its *client* emits the right path/method/body; this
+ * file asserts that Switchroom's *adapter* answers what that client emits.
+ *
+ * ─── The pin ────────────────────────────────────────────────────────────────
+ *
+ * Every row below was derived by hand from ONE upstream commit. Hermes moves
+ * fast; a desktop bump that adds, renames, or re-verbs a route is exactly the
+ * drift this fixture exists to catch, and it can only do that if the commit it
+ * was derived from is visible and greppable.
+ *
+ * Re-derive after bumping the pin:
+ *
+ *   git clone https://github.com/NousResearch/hermes-agent
+ *   cd hermes-agent && git checkout <NEW_SHA>
+ *   # every call site the desktop emits:
+ *   grep -n "path: " apps/desktop/src/hermes.ts
+ *   # the routes the real backend actually serves:
+ *   grep -rn "^@router\.\|^@app\.\|^@[a-z_]*_router\." hermes_cli/
+ *
+ * Then reconcile CENSUS below against that grep: a row that disappears
+ * upstream should be deleted here, a new row added with its `served` verdict.
+ *
+ * @see reference/rfcs/fleet-dashboard.md — the RFC this adapter implements
+ */
+export const UPSTREAM_HERMES_SHA = "9da6d455c9e1f2bf74bb9f47766ee9fc52e17bfb";
+/** Commit date of {@link UPSTREAM_HERMES_SHA} — `fmt(js): npm run fix on merge (#84193)`. */
+export const UPSTREAM_HERMES_DATE = "2026-08-12T01:41:34Z";
+/** Upstream repo the pin refers to. */
+export const UPSTREAM_HERMES_REPO = "NousResearch/hermes-agent";
+
+/**
+ * ─── Pending-gap idiom: `it.fails` ──────────────────────────────────────────
+ *
+ * Every assertion in this file states the REAL contract. Cases the adapter
+ * does not satisfy today are declared `gap: "..."` in the table and run under
+ * vitest's `it.fails` instead of `it`, so:
+ *
+ *   - CI stays green today (the case is a known, catalogued gap), and
+ *   - the moment someone fixes the adapter the case goes RED, because
+ *     `it.fails` fails when its body passes. The fixer is forced to flip
+ *     `gap` off in the same PR. Nobody has to remember.
+ *
+ * This deviates from the repo's other pending idiom — the `it.skip()`
+ * punch-list convention documented at `tests/jtbd-talk-from-anywhere.test.ts:16-29`
+ * — and deliberately so. A `.skip` body never executes, so a `.skip` fixture
+ * cannot tell you when the gap closed; closing it depends on a human
+ * remembering to unskip. `it.fails` is the same vitest family and the same
+ * "assert the real contract, don't weaken the test" discipline, but it is
+ * self-flipping. CLAUDE.md § Development Protocol: "deterministic mechanisms
+ * over model-dependent behavior".
+ *
+ * Do NOT make a `gap` row green by weakening its assertion. Fix the adapter.
+ */
+
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleHermesRest, type HermesRestResult } from "./hermes-adapter.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+// ─── Fixture config ──────────────────────────────────────────────────────────
+
+const AGENT = "alpha";
+
+/**
+ * Two agents, each with one cron entry.
+ *
+ * The schedule entries are load-bearing, not decoration: the `?profile=`
+ * filtering case below has to be able to tell "filtered correctly" apart from
+ * "the fleet had no jobs anyway". With an empty schedule the adapter returns
+ * `[]` for every query and a filtering assertion passes vacuously.
+ */
+function fixtureConfig(): SwitchroomConfig {
+  return {
+    agents: {
+      [AGENT]: {
+        model: "sonnet",
+        schedule: [{ cron: "0 9 * * *", prompt: "alpha morning digest" }],
+      },
+      beta: {
+        schedule: [{ cron: "0 17 * * 5", prompt: "beta weekly roundup" }],
+      },
+    },
+  } as unknown as SwitchroomConfig;
+}
+
+/**
+ * Point the adapter's agent-dir resolution at a throwaway tmpdir.
+ * `~/.switchroom/agents` is the production state tree (CLAUDE.md § Vault &
+ * shared-state test discipline); `resolveAgentsDir` (`src/config/loader.ts:323`)
+ * honours `SWITCHROOM_AGENTS_DIR` when it is a non-empty absolute path, which
+ * is the only seam that keeps this suite off it.
+ */
+beforeAll(() => {
+  process.env.SWITCHROOM_AGENTS_DIR = mkdtempSync(join(tmpdir(), "sr-hermes-parity-"));
+});
+
+const CONFIG = fixtureConfig();
+
+/**
+ * Generous per-case timeout.
+ *
+ * `handleHermesRest` calls `handleGetAgents` with no injectable deps, and that
+ * bottoms out in `getAllAgentStatuses` (`src/agents/lifecycle.ts:637`), which
+ * `spawnSync`s `docker inspect` for every agent in the config. On a host with a
+ * live docker daemon that is ~2s per session-touching case — comfortably under
+ * vitest's 5s default here, but close enough that a loaded CI runner could trip
+ * it and red the suite for a reason that has nothing to do with the contract.
+ *
+ * The durable fix is a dependency seam on `handleHermesRest`; that is an
+ * adapter change and this task is tests-only, so the timeout is the honest
+ * interim. Tighten it once the seam exists.
+ */
+const CASE_TIMEOUT_MS = 30_000;
+
+function call(method: string, path: string, search = ""): Promise<HermesRestResult | null> {
+  return handleHermesRest(method, path, CONFIG, search);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PART 1 — Route census
+//
+// Every path × verb `apps/desktop/src/hermes.ts` emits at the pinned SHA,
+// with the verdict "does handleHermesRest claim this route at all?".
+//
+// `served: true`  → the adapter returns a HermesRestResult (any status).
+// `served: false` → the adapter returns null, and `src/web/server.ts:1216-1219`
+//                   turns that into a bare 404 "Not Found".
+//
+// This is a drift detector, not a shape check: it fails when a route is added
+// to or dropped from the adapter without this table being updated, and when a
+// desktop bump introduces a route nobody classified. Body shape is Part 2.
+//
+// `line` is the call site in apps/desktop/src/hermes.ts at UPSTREAM_HERMES_SHA.
+// ═══════════════════════════════════════════════════════════════════════════
+
+interface CensusRow {
+  line: number;
+  method: string;
+  /** Concrete path — template params already substituted with fixture values. */
+  path: string;
+  served: boolean;
+  /** Why this row matters, when the verdict is not self-evident. */
+  note?: string;
+}
+
+const CENSUS: CensusRow[] = [
+  // ── sessions ──────────────────────────────────────────────────────────────
+  { line: 400, method: "GET", path: "/api/sessions", served: true },
+  { line: 440, method: "GET", path: "/api/profiles/sessions", served: true },
+  { line: 578, method: "POST", path: "/api/profiles/sessions/pull-requests", served: false },
+  {
+    line: 608,
+    method: "GET",
+    path: "/api/profiles/sessions/sidebar",
+    served: true,
+    note:
+      "Served, but with the WRONG shape — see the sidebar case in Part 2. " +
+      "`pathname.includes('sessions')` inside the /api/profiles branch " +
+      "(hermes-adapter.ts:753) swallows it.",
+  },
+  {
+    line: 658,
+    method: "GET",
+    path: "/api/sessions/search",
+    served: true,
+    note:
+      "Served only by accident: the /api/sessions/:id regex " +
+      "(hermes-adapter.ts:624) matches 'search' as an id, so this 404s as " +
+      "{error:'Unknown session'} rather than falling through.",
+  },
+  { line: 671, method: "GET", path: `/api/sessions/${AGENT}`, served: true },
+  { line: 706, method: "GET", path: `/api/sessions/${AGENT}/messages`, served: true },
+  { line: 637, method: "PATCH", path: `/api/sessions/${AGENT}`, served: false, note: "setSessionArchived" },
+  { line: 650, method: "PATCH", path: `/api/sessions/${AGENT}`, served: false, note: "setSessionPinnedRemote" },
+  { line: 770, method: "PATCH", path: `/api/sessions/${AGENT}`, served: false, note: "renameSession" },
+  { line: 758, method: "DELETE", path: `/api/sessions/${AGENT}`, served: false, note: "deleteSession" },
+
+  // ── status / config / model ───────────────────────────────────────────────
+  { line: 787, method: "GET", path: "/api/status", served: true },
+  { line: 779, method: "GET", path: "/api/model/info", served: true },
+  { line: 824, method: "GET", path: "/api/logs", served: true },
+  { line: 831, method: "GET", path: "/api/config", served: true },
+  { line: 846, method: "GET", path: "/api/config/defaults", served: true },
+  { line: 854, method: "GET", path: "/api/config/schema", served: true },
+  { line: 861, method: "PUT", path: "/api/config", served: false },
+  { line: 1608, method: "GET", path: "/api/model/options", served: true },
+  { line: 1626, method: "GET", path: "/api/model/recommended-default", served: false },
+  { line: 1636, method: "POST", path: "/api/model/set", served: true },
+  { line: 1649, method: "GET", path: "/api/model/auxiliary", served: false },
+  { line: 1656, method: "GET", path: "/api/model/moa", served: false },
+  { line: 1663, method: "PUT", path: "/api/model/moa", served: false },
+
+  // ── env / providers ───────────────────────────────────────────────────────
+  { line: 887, method: "GET", path: "/api/env", served: true },
+  { line: 894, method: "PUT", path: "/api/env", served: false },
+  { line: 956, method: "DELETE", path: "/api/env", served: false },
+  { line: 965, method: "POST", path: "/api/env/reveal", served: false },
+  { line: 907, method: "POST", path: "/api/providers/validate", served: true },
+  { line: 916, method: "GET", path: "/api/providers/custom-endpoints", served: false },
+  { line: 923, method: "POST", path: "/api/providers/custom-endpoints", served: false },
+  { line: 931, method: "POST", path: "/api/providers/custom-endpoints/validate", served: false },
+  { line: 940, method: "POST", path: "/api/providers/custom-endpoints/ep1/activate", served: false },
+  { line: 948, method: "DELETE", path: "/api/providers/custom-endpoints/ep1", served: false },
+  {
+    line: 974,
+    method: "GET",
+    path: "/api/providers/oauth",
+    served: false,
+    note:
+      "The adapter serves /api/auth/providers (hermes-adapter.ts:787), which " +
+      "no desktop call site emits — a stub aimed at a route that does not exist.",
+  },
+  { line: 981, method: "DELETE", path: "/api/providers/oauth/anthropic", served: false },
+  { line: 989, method: "POST", path: "/api/providers/oauth/anthropic/start", served: false },
+  { line: 998, method: "POST", path: "/api/providers/oauth/anthropic/submit", served: false },
+  { line: 1007, method: "GET", path: "/api/providers/oauth/anthropic/poll/s1", served: false },
+  { line: 1014, method: "DELETE", path: "/api/providers/oauth/sessions/s1", served: false },
+
+  // ── memory / curator ──────────────────────────────────────────────────────
+  {
+    line: 871,
+    method: "GET",
+    path: "/api/memory/providers/hindsight/config",
+    served: false,
+    note:
+      "The adapter serves the bare /api/memory/providers (hermes-adapter.ts:767); " +
+      "no desktop call site emits that path, only this /:provider/config one.",
+  },
+  { line: 878, method: "PUT", path: "/api/memory/providers/hindsight/config", served: false },
+  { line: 1024, method: "POST", path: "/api/memory/providers/hindsight/oauth/start", served: false },
+  { line: 1032, method: "GET", path: "/api/memory/providers/hindsight/oauth/status", served: false },
+  { line: 1865, method: "GET", path: "/api/memory", served: false },
+  { line: 1872, method: "POST", path: "/api/memory/reset", served: false },
+  { line: 1881, method: "GET", path: "/api/curator", served: false },
+  { line: 1888, method: "PUT", path: "/api/curator/paused", served: false },
+  { line: 1897, method: "POST", path: "/api/curator/run", served: false },
+
+  // ── skills / learning / mcp / tools ───────────────────────────────────────
+  { line: 1039, method: "GET", path: "/api/skills", served: false },
+  { line: 1090, method: "PUT", path: "/api/skills/toggle", served: false },
+  { line: 1048, method: "GET", path: "/api/learning/graph", served: false },
+  { line: 1062, method: "GET", path: "/api/learning/node", served: false },
+  { line: 1069, method: "DELETE", path: "/api/learning/node", served: false },
+  { line: 1078, method: "PUT", path: "/api/learning/node", served: false },
+  { line: 1758, method: "GET", path: "/api/skills/hub/sources", served: false },
+  { line: 1768, method: "GET", path: "/api/skills/hub/search", served: false },
+  { line: 1776, method: "GET", path: "/api/skills/hub/preview", served: false },
+  { line: 1784, method: "GET", path: "/api/skills/hub/scan", served: false },
+  { line: 1792, method: "POST", path: "/api/skills/hub/install", served: false },
+  { line: 1801, method: "POST", path: "/api/skills/hub/uninstall", served: false },
+  { line: 1810, method: "POST", path: "/api/skills/hub/update", served: false },
+  { line: 1825, method: "GET", path: "/api/mcp/servers", served: false },
+  { line: 1131, method: "PUT", path: "/api/mcp/servers", served: false },
+  { line: 1119, method: "POST", path: "/api/mcp/servers/filesystem/test", served: false },
+  { line: 1141, method: "POST", path: "/api/mcp/servers/filesystem/auth", served: false },
+  { line: 1832, method: "PUT", path: "/api/mcp/servers/filesystem/enabled", served: false },
+  { line: 1150, method: "GET", path: "/api/mcp/oauth/flows/f1", served: false },
+  { line: 1841, method: "GET", path: "/api/mcp/catalog", served: false },
+  { line: 1851, method: "POST", path: "/api/mcp/catalog/install", served: false },
+  { line: 1157, method: "GET", path: "/api/tools/toolsets", served: false },
+  { line: 1167, method: "PUT", path: "/api/tools/toolsets/image_gen", served: false },
+  { line: 1176, method: "GET", path: "/api/tools/toolsets/image_gen/config", served: false },
+  { line: 1185, method: "GET", path: "/api/tools/toolsets/image_gen/models", served: false },
+  { line: 1196, method: "PUT", path: "/api/tools/toolsets/image_gen/model", served: false },
+  { line: 1223, method: "PUT", path: "/api/tools/toolsets/image_gen/provider", served: false },
+  { line: 1232, method: "POST", path: "/api/tools/toolsets/image_gen/post-setup", served: false },
+  { line: 1241, method: "GET", path: "/api/tools/terminal/backends", served: false },
+  { line: 1248, method: "PUT", path: "/api/tools/terminal/backend", served: false },
+  { line: 1257, method: "GET", path: "/api/tools/computer-use/status", served: false },
+  { line: 1264, method: "POST", path: "/api/tools/computer-use/permissions/grant", served: false },
+
+  // ── messaging / pairing / webhooks ────────────────────────────────────────
+  { line: 1271, method: "GET", path: "/api/messaging/platforms", served: true },
+  { line: 1280, method: "PUT", path: "/api/messaging/platforms/telegram", served: false },
+  { line: 1288, method: "POST", path: "/api/messaging/platforms/telegram/test", served: false },
+  { line: 1303, method: "GET", path: "/api/pairing", served: false },
+  { line: 1310, method: "POST", path: "/api/pairing/approve", served: false },
+  { line: 1321, method: "POST", path: "/api/pairing/revoke", served: false },
+  { line: 1335, method: "GET", path: "/api/webhooks", served: false },
+  { line: 1342, method: "POST", path: "/api/webhooks/enable", served: false },
+  { line: 1350, method: "POST", path: "/api/webhooks", served: false },
+  { line: 1359, method: "DELETE", path: "/api/webhooks/w1", served: false },
+  { line: 1370, method: "PUT", path: "/api/webhooks/w1/enabled", served: false },
+
+  // ── cron ──────────────────────────────────────────────────────────────────
+  // Everything under /api/cron is claimed by the adapter's prefix branch
+  // (hermes-adapter.ts:712) regardless of verb — including the verbs it has no
+  // handler for. See the cron cases in Part 2 for what that costs.
+  { line: 1386, method: "GET", path: "/api/cron/jobs", served: true },
+  { line: 1394, method: "GET", path: `/api/cron/jobs/${AGENT}~0`, served: true },
+  { line: 1401, method: "GET", path: `/api/cron/jobs/${AGENT}~0/runs`, served: true },
+  { line: 1413, method: "GET", path: "/api/cron/delivery-targets", served: true },
+  { line: 1483, method: "GET", path: "/api/cron/blueprints", served: true },
+  { line: 1422, method: "POST", path: "/api/cron/jobs", served: true },
+  { line: 1431, method: "PUT", path: `/api/cron/jobs/${AGENT}~0`, served: true },
+  { line: 1440, method: "POST", path: `/api/cron/jobs/${AGENT}~0/pause`, served: true },
+  { line: 1448, method: "POST", path: `/api/cron/jobs/${AGENT}~0/resume`, served: true },
+  { line: 1456, method: "POST", path: `/api/cron/jobs/${AGENT}~0/trigger`, served: true },
+  { line: 1464, method: "DELETE", path: `/api/cron/jobs/${AGENT}~0`, served: true },
+  { line: 1494, method: "POST", path: "/api/cron/blueprints/instantiate", served: true },
+
+  // ── profiles ──────────────────────────────────────────────────────────────
+  { line: 1502, method: "GET", path: "/api/profiles", served: true },
+  { line: 1509, method: "POST", path: "/api/profiles", served: false },
+  { line: 1517, method: "PATCH", path: "/api/profiles/default", served: false },
+  { line: 1525, method: "DELETE", path: "/api/profiles/default", served: false },
+  { line: 1532, method: "GET", path: "/api/profiles/default/soul", served: true },
+  { line: 1538, method: "PUT", path: "/api/profiles/default/soul", served: false },
+  { line: 1546, method: "GET", path: "/api/profiles/default/setup-command", served: true },
+  { line: 1558, method: "POST", path: "/api/profiles/default/export", served: false },
+  { line: 1573, method: "POST", path: "/api/profiles/import", served: false },
+
+  // ── analytics / ops / audio / update ──────────────────────────────────────
+  {
+    line: 1583,
+    method: "GET",
+    path: "/api/analytics/usage",
+    served: false,
+    note: "Scoped in reference/rfcs/fleet-dashboard.md:105-106; never implemented.",
+  },
+  { line: 1681, method: "POST", path: "/api/gateway/restart", served: false },
+  { line: 1689, method: "POST", path: "/api/hermes/update", served: false },
+  { line: 1700, method: "GET", path: "/api/hermes/update/check", served: false },
+  { line: 1707, method: "GET", path: "/api/actions/doctor/status", served: false },
+  { line: 1713, method: "POST", path: "/api/audio/transcribe", served: false },
+  { line: 1730, method: "POST", path: "/api/audio/speak", served: false },
+  { line: 1742, method: "GET", path: "/api/audio/elevenlabs/voices", served: false },
+  { line: 1911, method: "POST", path: "/api/ops/doctor", served: false },
+  { line: 1915, method: "POST", path: "/api/ops/security-audit", served: false },
+  { line: 1920, method: "POST", path: "/api/ops/backup", served: false },
+  { line: 1928, method: "POST", path: "/api/ops/debug-share", served: false },
+];
+
+describe(`Hermes REST route census (upstream ${UPSTREAM_HERMES_SHA.slice(0, 7)})`, () => {
+  it("the pin is a full 40-char SHA — a short pin can't be checked out reproducibly", () => {
+    expect(UPSTREAM_HERMES_SHA).toMatch(/^[0-9a-f]{40}$/);
+    expect(UPSTREAM_HERMES_REPO).toBe("NousResearch/hermes-agent");
+  });
+
+  it("census has no duplicate (method, path) rows", () => {
+    const seen = new Map<string, number>();
+    const dupes: string[] = [];
+    for (const row of CENSUS) {
+      const key = `${row.method} ${row.path}`;
+      if (seen.has(key)) dupes.push(`${key} (hermes.ts:${seen.get(key)} and :${row.line})`);
+      else seen.set(key, row.line);
+    }
+    // Three PATCH /api/sessions/:id call sites share one route (archive, pin,
+    // rename); they are deliberately NOT deduped in CENSUS because each is an
+    // independent desktop feature that breaks. Assert the known set so a new
+    // collision on some other route still fails here.
+    expect(dupes).toEqual([
+      `PATCH /api/sessions/${AGENT} (hermes.ts:637 and :650)`,
+      `PATCH /api/sessions/${AGENT} (hermes.ts:637 and :770)`,
+    ]);
+  });
+
+  for (const row of CENSUS) {
+    const label = `${row.method} ${row.path} → ${row.served ? "served" : "404 (not a Hermes route)"}`;
+    it(
+      `${label}  [hermes.ts:${row.line}]`,
+      async () => {
+        const res = await call(row.method, row.path);
+        if (row.served) {
+          expect(res, `${row.method} ${row.path} should be claimed by handleHermesRest`).not.toBeNull();
+        } else {
+          expect(res, `${row.method} ${row.path} should fall through to the 404 path`).toBeNull();
+        }
+      },
+      CASE_TIMEOUT_MS,
+    );
+  }
+
+  it("every census row cites a real call-site line in apps/desktop/src/hermes.ts", () => {
+    for (const row of CENSUS) {
+      expect(row.line, `${row.method} ${row.path}`).toBeGreaterThan(0);
+      expect(row.line, `${row.method} ${row.path}`).toBeLessThan(2000);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PART 2 — Response-shape contract
+//
+// For the routes the adapter claims, assert what the desktop actually
+// destructures off the response. Each case states the REAL contract; a case
+// carrying `gap` runs under `it.fails` (see the idiom note at the top).
+// ═══════════════════════════════════════════════════════════════════════════
+
+interface ContractCase {
+  name: string;
+  method: string;
+  path: string;
+  /** Query string the desktop sends, verbatim from the pinned call site. */
+  search?: string;
+  /** Desktop call site — apps/desktop/src/hermes.ts:NNN at the pinned SHA. */
+  client: string;
+  /** Real backend route — hermes_cli/... at the pinned SHA. */
+  server: string;
+  /** Set when the adapter does not satisfy this today. Runs under `it.fails`. */
+  gap?: string;
+  assert: (res: HermesRestResult | null) => void;
+}
+
+/** Narrow to a non-null 200 body and hand back the body as a record. */
+function body200(res: HermesRestResult | null): Record<string, unknown> {
+  expect(res).not.toBeNull();
+  expect(res!.status).toBe(200);
+  return res!.body as Record<string, unknown>;
+}
+
+const CONTRACT: ContractCase[] = [
+  // ── GET /api/sessions — PaginatedSessions ────────────────────────────────
+  {
+    name: "GET /api/sessions honours ?limit= instead of returning the whole fleet",
+    method: "GET",
+    path: "/api/sessions",
+    search: "?limit=1&offset=0&min_messages=0&archived=exclude&order=recent",
+    client: "hermes.ts:398-405 (listSessions)",
+    server: "hermes_cli/web_routers/sessions.py:54 (get_sessions)",
+    gap:
+      "hermes-adapter.ts:601-620 ignores every query param and reports " +
+      "limit = sessions.length, so the desktop's pageWindow() silently " +
+      "truncates a list the adapter claimed was a full page.",
+    assert: (res) => {
+      const b = body200(res);
+      expect((b.sessions as unknown[]).length).toBeLessThanOrEqual(1);
+      expect(b.limit).toBe(1);
+    },
+  },
+  {
+    name: "GET /api/sessions reports the real page limit, not sessions.length",
+    method: "GET",
+    path: "/api/sessions",
+    search: "?limit=40&offset=0&min_messages=0&archived=exclude&order=recent",
+    client: "hermes.ts:398-411 — spreads `...result` then re-windows to `limit`",
+    server: "hermes_cli/web_routers/sessions.py:54",
+    gap:
+      "hermes-adapter.ts:616 sets limit = sessions.length. With 2 agents the " +
+      "desktop is told the page size is 2 when it asked for 40, which makes " +
+      "`total > limit` pagination arithmetic wrong in the sidebar footer.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b.limit).toBe(40);
+      expect(b.offset).toBe(0);
+    },
+  },
+  {
+    name: "GET /api/sessions returns a numeric total and an array of sessions",
+    method: "GET",
+    path: "/api/sessions",
+    search: "?limit=40&offset=0&min_messages=0&archived=exclude&order=recent",
+    client: "hermes.ts:398-411",
+    server: "hermes_cli/web_routers/sessions.py:54",
+    assert: (res) => {
+      const b = body200(res);
+      expect(Array.isArray(b.sessions)).toBe(true);
+      expect(typeof b.total).toBe("number");
+      expect(typeof b.offset).toBe("number");
+    },
+  },
+
+  // ── GET /api/profiles/sessions — PaginatedSessions + profile_totals/errors ─
+  {
+    name: "GET /api/profiles/sessions returns real sessions (NOT the hardcoded empty page)",
+    method: "GET",
+    path: "/api/profiles/sessions",
+    search: "?limit=40&offset=0&min_messages=0&archived=exclude&order=recent&profile=all",
+    client: "hermes.ts:427-453 (listAllProfileSessions)",
+    server: "hermes_cli/web_routers/profiles.py:82",
+    assert: (res) => {
+      const b = body200(res);
+      // The exact-match branch at hermes-adapter.ts:606-621 wins over the
+      // `/api/profiles` prefix branch at :752, so the {sessions:[],total:0}
+      // literal at :754 is unreachable for THIS path. Pin that ordering: swap
+      // the two branches and the sidebar goes permanently empty.
+      expect((b.sessions as unknown[]).length).toBeGreaterThan(0);
+      expect(b.total).toBeGreaterThan(0);
+    },
+  },
+  {
+    name: "GET /api/profiles/sessions carries profile_totals",
+    method: "GET",
+    path: "/api/profiles/sessions",
+    search: "?limit=40&offset=0&min_messages=0&archived=exclude&order=recent&profile=all",
+    client: "types/hermes.ts:439-443 (PaginatedSessions.profile_totals)",
+    server: "hermes_cli/web_routers/profiles.py:82",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b.profile_totals).toBeTypeOf("object");
+    },
+  },
+  {
+    name: "GET /api/profiles/sessions carries an errors array (per-profile read failures)",
+    method: "GET",
+    path: "/api/profiles/sessions",
+    search: "?limit=40&offset=0&min_messages=0&archived=exclude&order=recent&profile=all",
+    client:
+      "hermes.ts:552 (listSidebarSessionsLegacy reads `recents.errors ?? []`); " +
+      "types/hermes.ts:444-446",
+    server: "hermes_cli/web_routers/profiles.py:82",
+    gap: "hermes-adapter.ts:611-620 emits no `errors` key at all.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(Array.isArray(b.errors)).toBe(true);
+    },
+  },
+  {
+    name: "GET /api/profiles/sessions honours ?source= scoping",
+    method: "GET",
+    path: "/api/profiles/sessions",
+    search: "?limit=40&offset=0&min_messages=1&archived=exclude&order=recent&profile=all&source=cron",
+    client: "hermes.ts:434-445 — the cron slice passes source='cron'",
+    server: "hermes_cli/web_routers/profiles.py:82",
+    gap:
+      "hermes-adapter.ts:601-620 ignores `source`, so the sidebar's cron slice " +
+      "and its recents slice return the identical unfiltered fleet list — the " +
+      "exact starvation the upstream comment at hermes.ts:418-422 describes.",
+    assert: (res) => {
+      const b = body200(res);
+      // No switchroom session has source='cron' (toHermesSession hardcodes
+      // source:'switchroom' at hermes-adapter.ts:146), so a source-scoped
+      // query must come back empty rather than returning the whole fleet.
+      expect(b.sessions).toEqual([]);
+    },
+  },
+
+  // ── GET /api/profiles/sessions/sidebar — SidebarSessionsResponse ──────────
+  {
+    name: "GET /api/profiles/sessions/sidebar returns the three-slice batched shape",
+    method: "GET",
+    path: "/api/profiles/sessions/sidebar",
+    search: "?recents_profile=all&recents_limit=40&cron_limit=20&messaging_limit=20",
+    client: "hermes.ts:596-628 (listSidebarSessions); shape at hermes.ts:487-492",
+    server: "hermes_cli/web_routers/profiles.py:232",
+    gap:
+      "The /api/profiles prefix branch's `pathname.includes('sessions')` test " +
+      "(hermes-adapter.ts:752-755) swallows this path and answers 200 with a " +
+      "PaginatedSessions-shaped literal. That is strictly WORSE than not " +
+      "implementing it: `isEndpointMissingError` (hermes.ts:520-536) only " +
+      "matches 404-ish shapes, so a 200 never trips the legacy fallback at " +
+      "hermes.ts:619-626. The sidebar reads `result.recents?.sessions ?? []` " +
+      "(hermes.ts:629) and renders three permanently-empty slices instead of " +
+      "degrading to listSidebarSessionsLegacy.",
+    assert: (res) => {
+      const b = body200(res);
+      for (const slice of ["recents", "cron", "messaging"]) {
+        expect(b[slice], `missing slice: ${slice}`).toBeTypeOf("object");
+        expect(Array.isArray((b[slice] as Record<string, unknown>).sessions)).toBe(true);
+      }
+    },
+  },
+  {
+    name: "GET /api/profiles/sessions/sidebar 404s if unimplemented, so the legacy fallback fires",
+    method: "GET",
+    path: "/api/profiles/sessions/sidebar",
+    search: "?recents_profile=all&recents_limit=40&cron_limit=20&messaging_limit=20",
+    client: "hermes.ts:520-536 (isEndpointMissingError) + hermes.ts:619-626",
+    server: "hermes_cli/web_routers/profiles.py:232",
+    gap:
+      "Same root cause as the case above, asserted from the tolerance side: " +
+      "if the adapter is not going to serve the batched route it MUST 404 so " +
+      "the desktop falls back. Today it 200s. Either this case or the one " +
+      "above goes green when the gap is fixed — never both; whichever fix " +
+      "lands, delete the other.",
+    assert: (res) => {
+      expect(res === null || res.status === 404).toBe(true);
+    },
+  },
+
+  // ── GET /api/sessions/:id/messages — SessionMessagesResponse ──────────────
+  {
+    name: "GET /api/sessions/:id/messages returns a pagination object",
+    method: "GET",
+    path: `/api/sessions/${AGENT}/messages`,
+    search: "?limit=500&offset=0&order=oldest",
+    client: "hermes.ts:679-712 (getSessionMessages); types/hermes.ts:584-593",
+    server: "hermes_cli/web_routers/sessions.py:602",
+    gap:
+      "SILENT DATA LOSS. hermes-adapter.ts:637-644 hardcodes 100 turns and " +
+      "emits no `pagination`. getAllSessionMessages (hermes.ts:744-746) treats " +
+      "a missing `pagination` as 'legacy backend returned the full transcript' " +
+      "and stops paging — so any transcript past 100 turns is silently " +
+      "truncated with no error anywhere.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b.pagination).toBeTypeOf("object");
+      const p = b.pagination as Record<string, unknown>;
+      expect(typeof p.limit).toBe("number");
+      expect(typeof p.offset).toBe("number");
+      expect(typeof p.returned).toBe("number");
+      expect(["latest", "oldest"]).toContain(p.order);
+    },
+  },
+  {
+    name: "GET /api/sessions/:id/messages honours ?limit=",
+    method: "GET",
+    path: `/api/sessions/${AGENT}/messages`,
+    search: "?limit=1&offset=0&order=oldest",
+    client: "hermes.ts:679-712",
+    server: "hermes_cli/web_routers/sessions.py:602-612 (limit/offset/order are real Query params)",
+    gap: "hermes-adapter.ts:640 passes the constant 100 and never reads `search`.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b.pagination).toBeTypeOf("object");
+      expect((b.pagination as Record<string, unknown>).limit).toBe(1);
+    },
+  },
+  {
+    name: "GET /api/sessions/:id/messages echoes session_id and returns a messages array",
+    method: "GET",
+    path: `/api/sessions/${AGENT}/messages`,
+    search: "?limit=500&order=latest",
+    client: "hermes.ts:735 (`resolvedSessionId = page.session_id`)",
+    server: "hermes_cli/web_routers/sessions.py:602",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b.session_id).toBe(AGENT);
+      expect(Array.isArray(b.messages)).toBe(true);
+    },
+  },
+  {
+    name: "GET /api/sessions/:id/messages 404s for an unknown session",
+    method: "GET",
+    path: "/api/sessions/nope/messages",
+    client: "hermes.ts:679-712",
+    server: "hermes_cli/web_routers/sessions.py:602",
+    assert: (res) => {
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(404);
+    },
+  },
+
+  // ── GET /api/sessions/search — SessionSearchResponse ──────────────────────
+  {
+    name: "GET /api/sessions/search returns { results: [] }, not an Unknown-session 404",
+    method: "GET",
+    path: "/api/sessions/search",
+    search: "?q=deploy",
+    client: "hermes.ts:656-660 (searchSessions) — no catch, the rejection propagates",
+    server: "hermes_cli/web_routers/sessions.py:169",
+    gap:
+      "Unimplemented, and worse than unimplemented: the /api/sessions/:id " +
+      "regex (hermes-adapter.ts:624) matches 'search' as a session id and " +
+      "answers 404 {error:'Unknown session'}. searchSessions has no " +
+      "client-side tolerance, so the search panel throws.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(Array.isArray(b.results)).toBe(true);
+    },
+  },
+
+  // ── PATCH / DELETE /api/sessions/:id — mutations with no tolerance ────────
+  {
+    name: "PATCH /api/sessions/:id {archived} is accepted",
+    method: "PATCH",
+    path: `/api/sessions/${AGENT}`,
+    client: "hermes.ts:634-642 (setSessionArchived) — no catch",
+    server: "hermes_cli/web_routers/sessions.py:683 (rename_session_endpoint: title|archived|pinned)",
+    gap:
+      "Unimplemented (hermes-adapter.ts has no non-GET /api/sessions branch), " +
+      "so this 404s out of src/web/server.ts:1219 and the archive action " +
+      "throws in the desktop.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b.ok).toBe(true);
+    },
+  },
+  {
+    name: "PATCH /api/sessions/:id {pinned} is accepted",
+    method: "PATCH",
+    path: `/api/sessions/${AGENT}`,
+    client: "hermes.ts:647-654 (setSessionPinnedRemote)",
+    server: "hermes_cli/web_routers/sessions.py:683",
+    gap: "Unimplemented — same branch gap as {archived}.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b.ok).toBe(true);
+    },
+  },
+  {
+    name: "PATCH /api/sessions/:id {title} echoes the new title",
+    method: "PATCH",
+    path: `/api/sessions/${AGENT}`,
+    client: "hermes.ts:763-774 (renameSession) — destructures { ok, title }",
+    server: "hermes_cli/web_routers/sessions.py:683",
+    gap: "Unimplemented — same branch gap as {archived}.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b.ok).toBe(true);
+      expect(typeof b.title).toBe("string");
+    },
+  },
+  {
+    name: "DELETE /api/sessions/:id is accepted",
+    method: "DELETE",
+    path: `/api/sessions/${AGENT}`,
+    client: "hermes.ts:755-761 (deleteSession) — no catch",
+    server: "hermes_cli/web_routers/sessions.py:655",
+    gap:
+      "Unimplemented. Switchroom sessions ARE agents, so a real delete is not " +
+      "meaningful — but a bare 404 makes the desktop throw. The contract " +
+      "answer is an explicit refusal the client can render (the 422 the cron " +
+      "branch already uses at hermes-adapter.ts:739-741), not silence.",
+    assert: (res) => {
+      expect(res).not.toBeNull();
+      // Either honoured, or refused in a way the desktop can surface.
+      expect([200, 422]).toContain(res!.status);
+    },
+  },
+
+  // ── POST /api/profiles/sessions/pull-requests ─────────────────────────────
+  {
+    name: "POST /api/profiles/sessions/pull-requests returns { pull_requests, scanned }",
+    method: "POST",
+    path: "/api/profiles/sessions/pull-requests",
+    client: "hermes.ts:565-582 (scanSessionPullRequests)",
+    server: "hermes_cli/web_routers/profiles.py:555",
+    gap:
+      "Unimplemented: the /api/profiles branch (hermes-adapter.ts:752) is " +
+      "GET-only, so this POST falls through to 404.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b.pull_requests).toBeTypeOf("object");
+      expect(Array.isArray(b.scanned)).toBe(true);
+    },
+  },
+
+  // ── SessionInfo field coverage ────────────────────────────────────────────
+  {
+    name: "session rows carry the SessionInfo fields the sidebar groups and sorts on",
+    method: "GET",
+    path: "/api/sessions",
+    search: "?limit=40&offset=0&min_messages=0&archived=exclude&order=recent",
+    client: "types/hermes.ts:464-523 (SessionInfo)",
+    server: "hermes_cli/web_routers/sessions.py:54",
+    gap:
+      "toHermesSession (hermes-adapter.ts:128-153) emits none of these. They " +
+      "are all optional in SessionInfo so nothing throws — the cost is silent " +
+      "feature loss: no Pinned section (`pinned`), no archive state " +
+      "(`archived`), no profile badge (`profile`/`is_default_profile`), no " +
+      "branch/repo grouping (`git_branch`/`git_repo_root`), no fork lineage " +
+      "(`parent_session_id`/`_lineage_root_id`), no handoff badge " +
+      "(`handoff_platform`/`handoff_state`/`handoff_error`), and no cost sort " +
+      "(`actual_cost_usd`/`estimated_cost_usd`).",
+    assert: (res) => {
+      const b = body200(res);
+      const s = (b.sessions as Record<string, unknown>[])[0];
+      for (const field of [
+        "pinned",
+        "archived",
+        "profile",
+        "is_default_profile",
+        "git_branch",
+        "git_repo_root",
+        "parent_session_id",
+        "_lineage_root_id",
+        "handoff_platform",
+        "handoff_state",
+        "handoff_error",
+        "actual_cost_usd",
+        "estimated_cost_usd",
+      ]) {
+        expect(s, `SessionInfo.${field} missing`).toHaveProperty(field);
+      }
+    },
+  },
+  {
+    name: "session rows carry the required (non-optional) SessionInfo fields",
+    method: "GET",
+    path: "/api/sessions",
+    search: "?limit=40&offset=0&min_messages=0&archived=exclude&order=recent",
+    client: "types/hermes.ts:464-523 — these have no `?`",
+    server: "hermes_cli/web_routers/sessions.py:54",
+    assert: (res) => {
+      const b = body200(res);
+      const s = (b.sessions as Record<string, unknown>[])[0];
+      for (const field of [
+        "id",
+        "title",
+        "model",
+        "source",
+        "preview",
+        "is_active",
+        "started_at",
+        "last_active",
+        "ended_at",
+        "input_tokens",
+        "output_tokens",
+        "message_count",
+        "tool_call_count",
+      ]) {
+        expect(s, `SessionInfo.${field} missing`).toHaveProperty(field);
+      }
+    },
+  },
+
+  // ── GET /api/status — StatusResponse ──────────────────────────────────────
+  {
+    name: "GET /api/status sends strings where StatusResponse declares non-null strings",
+    method: "GET",
+    path: "/api/status",
+    client: "hermes.ts:785-790 (getStatus); types/hermes.ts:1144-1160",
+    server: "hermes_cli/web_server.py",
+    gap:
+      "hermes-adapter.ts:658-661 sends null for release_date, config_path and " +
+      "env_path. StatusResponse declares all three as bare `string`, so the " +
+      "settings pane renders 'null' or throws on a string method.",
+    assert: (res) => {
+      const b = body200(res);
+      for (const field of ["config_path", "env_path", "release_date", "hermes_home", "version"]) {
+        expect(typeof b[field], `StatusResponse.${field} must be a string`).toBe("string");
+      }
+    },
+  },
+  {
+    name: "GET /api/status satisfies the rest of StatusResponse",
+    method: "GET",
+    path: "/api/status",
+    client: "types/hermes.ts:1144-1160",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      const b = body200(res);
+      expect(typeof b.active_sessions).toBe("number");
+      expect(typeof b.config_version).toBe("number");
+      expect(typeof b.latest_config_version).toBe("number");
+      expect(typeof b.gateway_running).toBe("boolean");
+      expect(b.gateway_platforms).toBeTypeOf("object");
+      // Nullable by declaration — presence is the contract, not the value.
+      for (const field of [
+        "gateway_state",
+        "gateway_exit_reason",
+        "gateway_health_url",
+        "gateway_pid",
+        "gateway_updated_at",
+      ]) {
+        expect(b, `StatusResponse.${field} missing`).toHaveProperty(field);
+      }
+    },
+  },
+
+  // ── cron ──────────────────────────────────────────────────────────────────
+  {
+    name: "GET /api/cron/jobs returns a CronJob[] with the fields the panel reads",
+    method: "GET",
+    path: "/api/cron/jobs",
+    client: "hermes.ts:1381-1389 (getCronJobs); types/hermes.ts:788-804",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      expect(res!.status).toBe(200);
+      const jobs = res!.body as Record<string, unknown>[];
+      expect(Array.isArray(jobs)).toBe(true);
+      // Both fixture agents' entries. Also the control for the ?profile= case
+      // below: it can only mean "filtered" if unfiltered is non-empty.
+      expect(jobs).toHaveLength(2);
+      for (const job of jobs) {
+        expect(typeof job.id).toBe("string");
+        expect(typeof job.enabled).toBe("boolean");
+        expect(job.schedule).toBeTypeOf("object");
+        expect(typeof (job.schedule as Record<string, unknown>).expr).toBe("string");
+        for (const field of ["name", "prompt", "schedule_display", "last_run_at", "last_error", "state"]) {
+          expect(job, `CronJob.${field} missing`).toHaveProperty(field);
+        }
+      }
+    },
+  },
+  {
+    name: "GET /api/cron/jobs?profile= filters server-side",
+    method: "GET",
+    path: "/api/cron/jobs",
+    search: "?profile=__no_such_profile__",
+    client: "hermes.ts:1381-1389 — 'list just that profile's jobs, or all'",
+    server: "hermes_cli/web_server.py",
+    gap:
+      "hermes-adapter.ts:713-717 ignores ?profile= and returns the whole " +
+      "fleet's schedule. The desktop expects endpoint-level filtering — pinned " +
+      "upstream at apps/desktop/src/hermes-cron-scope.test.ts:60-73 — so cron " +
+      "jobs from every agent leak into a single profile's panel.",
+    assert: (res) => {
+      expect(res!.status).toBe(200);
+      // The fixture fleet has 2 jobs (asserted above), none of them owned by
+      // this profile — so a filtering backend returns none.
+      expect(res!.body).toEqual([]);
+    },
+  },
+  {
+    name: "PUT /api/cron/jobs/:id is refused explicitly, not silently accepted",
+    method: "PUT",
+    path: `/api/cron/jobs/${AGENT}~0`,
+    client: "hermes.ts:1428-1434 (updateCronJob)",
+    server: "hermes_cli/web_server.py",
+    gap:
+      "The cron branch refuses POST/PATCH/DELETE with 422 " +
+      "(hermes-adapter.ts:739-741) but not PUT, so an edit falls to the " +
+      "catch-all `return {status:200, body:{}}` at :743. The desktop reads a " +
+      "200 and reports the edit saved; nothing was written. Schedules are " +
+      "YAML-owned, so PUT belongs in the same 422 list as the other verbs.",
+    assert: (res) => {
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(422);
+    },
+  },
+  {
+    name: "POST /api/cron/jobs is refused with 422 (schedules are YAML-owned)",
+    method: "POST",
+    path: "/api/cron/jobs",
+    client: "hermes.ts:1419-1425 (createCronJob)",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      expect(res!.status).toBe(422);
+    },
+  },
+  {
+    name: "DELETE /api/cron/jobs/:id is refused with 422",
+    method: "DELETE",
+    path: `/api/cron/jobs/${AGENT}~0`,
+    client: "hermes.ts:1461-1467 (deleteCronJob)",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      expect(res!.status).toBe(422);
+    },
+  },
+  {
+    name: "GET /api/cron/jobs/:id/runs honours ?limit=",
+    method: "GET",
+    path: `/api/cron/jobs/${AGENT}~0/runs`,
+    search: "?limit=5",
+    client: "hermes.ts:1398-1405 (getCronJobRuns) — destructures { runs }",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      const b = body200(res);
+      expect(Array.isArray(b.runs)).toBe(true);
+      expect((b.runs as unknown[]).length).toBeLessThanOrEqual(5);
+    },
+  },
+  {
+    name: "GET /api/cron/delivery-targets returns { targets }",
+    method: "GET",
+    path: "/api/cron/delivery-targets",
+    client: "hermes.ts:1410-1416 (getCronDeliveryTargets) — destructures { targets }",
+    server: "hermes_cli/web_server.py",
+    gap:
+      "The /api/cron prefix branch's catch-all (hermes-adapter.ts:743) answers " +
+      "200 {} for this, so `const { targets } = ...` is undefined. The caller " +
+      "coalesces (`targets ?? []`), so this degrades rather than throwing — " +
+      "but the cron editor then offers zero delivery targets.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(Array.isArray(b.targets)).toBe(true);
+    },
+  },
+
+  // ── config / model / env / misc served routes ─────────────────────────────
+  {
+    name: "GET /api/config returns a HermesConfig-shaped object",
+    method: "GET",
+    path: "/api/config",
+    client: "hermes.ts:829-834 (getConfig)",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b).toHaveProperty("provider");
+      expect(b).toHaveProperty("model");
+    },
+  },
+  {
+    name: "GET /api/model/info returns { model, provider }",
+    method: "GET",
+    path: "/api/model/info",
+    client: "hermes.ts:777-783 (getGlobalModelInfo); ModelInfoResponse",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      const b = body200(res);
+      expect(typeof b.model).toBe("string");
+      expect(typeof b.provider).toBe("string");
+    },
+  },
+  {
+    name: "GET /api/model/options returns a ModelOptionsResponse with providers[]",
+    method: "GET",
+    path: "/api/model/options",
+    search: "?session_id=alpha",
+    client: "hermes.ts:1600-1612 (getModelOptions)",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      const b = body200(res);
+      expect(typeof b.model).toBe("string");
+      expect(Array.isArray(b.providers)).toBe(true);
+      const p = (b.providers as Record<string, unknown>[])[0];
+      expect(Array.isArray(p.models)).toBe(true);
+      expect(typeof p.slug).toBe("string");
+    },
+  },
+  {
+    name: "GET /api/logs returns a LogsResponse { file, lines }",
+    method: "GET",
+    path: "/api/logs",
+    search: "?lines=200",
+    client: "hermes.ts:820-826 (getLogs); types/hermes.ts:1132-1135",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      const b = body200(res);
+      expect(typeof b.file).toBe("string");
+      expect(Array.isArray(b.lines)).toBe(true);
+    },
+  },
+  {
+    name: "GET /api/messaging/platforms returns { platforms }",
+    method: "GET",
+    path: "/api/messaging/platforms",
+    client: "hermes.ts:1269-1273 (getMessagingPlatforms)",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      const b = body200(res);
+      expect(Array.isArray(b.platforms)).toBe(true);
+    },
+  },
+  {
+    name: "GET /api/profiles returns { profiles }",
+    method: "GET",
+    path: "/api/profiles",
+    client: "hermes.ts:1500-1504 (listProfiles)",
+    server: "hermes_cli/web_routers/profiles.py:613",
+    assert: (res) => {
+      const b = body200(res);
+      expect(Array.isArray(b.profiles)).toBe(true);
+    },
+  },
+  {
+    name: "GET /api/profiles/:name/soul returns { content, exists }",
+    method: "GET",
+    path: "/api/profiles/default/soul",
+    client: "hermes.ts:1530-1534 (getProfileSoul)",
+    server: "hermes_cli/web_routers/profiles.py:871",
+    assert: (res) => {
+      const b = body200(res);
+      expect(typeof b.content).toBe("string");
+      expect(typeof b.exists).toBe("boolean");
+    },
+  },
+  {
+    name: "GET /api/profiles/:name/setup-command returns a command string",
+    method: "GET",
+    path: "/api/profiles/default/setup-command",
+    client: "hermes.ts:1544-1548 (getProfileSetupCommand)",
+    server: "hermes_cli/web_routers/profiles.py:779",
+    gap:
+      "The /api/profiles catch-all (hermes-adapter.ts:764) answers 200 {}. " +
+      "Degrades rather than throwing, but the profile pane shows no setup " +
+      "command.",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b).toHaveProperty("command");
+    },
+  },
+  {
+    name: "POST /api/providers/validate returns { ok }",
+    method: "POST",
+    path: "/api/providers/validate",
+    client: "hermes.ts:904-910 (validateProvider)",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      const b = body200(res);
+      expect(typeof b.ok).toBe("boolean");
+    },
+  },
+  {
+    name: "GET /api/env returns an object of env entries",
+    method: "GET",
+    path: "/api/env",
+    client: "hermes.ts:885-889 (getEnv)",
+    server: "hermes_cli/web_server.py",
+    assert: (res) => {
+      const b = body200(res);
+      expect(b).toBeTypeOf("object");
+    },
+  },
+  {
+    name: "PUT /api/env is answered (accepted or explicitly refused), not 404",
+    method: "PUT",
+    path: "/api/env",
+    client: "hermes.ts:891-898 (setEnv)",
+    server: "hermes_cli/web_server.py:7209",
+    gap:
+      "Unimplemented. Switchroom has no desktop-writable env — but the honest " +
+      "answer is the 422 refusal the cron branch already models, not a 404 " +
+      "the client cannot distinguish from a dead backend.",
+    assert: (res) => {
+      expect(res).not.toBeNull();
+      expect([200, 422]).toContain(res!.status);
+    },
+  },
+  {
+    name: "GET /api/memory/providers/:provider/config is answered",
+    method: "GET",
+    path: "/api/memory/providers/hindsight/config",
+    search: "?surface=declared",
+    client: "hermes.ts:868-873 (getMemoryProviderConfig)",
+    server: "hermes_cli/web_server.py:6125",
+    gap:
+      "Unimplemented. The adapter serves the bare /api/memory/providers " +
+      "(hermes-adapter.ts:767) instead — a path no desktop call site emits.",
+    assert: (res) => {
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(200);
+    },
+  },
+  {
+    name: "PUT /api/memory/providers/:provider/config is answered",
+    method: "PUT",
+    path: "/api/memory/providers/hindsight/config",
+    search: "?surface=declared",
+    client: "hermes.ts:875-882 (setMemoryProviderConfig)",
+    server: "hermes_cli/web_server.py:6170",
+    gap:
+      "Unimplemented — same root cause as the GET above: the adapter's only " +
+      "memory route is the bare /api/memory/providers, which the desktop " +
+      "never calls. The memory settings pane cannot save.",
+    assert: (res) => {
+      expect(res).not.toBeNull();
+      expect([200, 422]).toContain(res!.status);
+    },
+  },
+  {
+    name: "GET /api/analytics/usage is implemented (scoped in the fleet-dashboard RFC)",
+    method: "GET",
+    path: "/api/analytics/usage",
+    search: "?days=30",
+    client: "hermes.ts:1581-1585 (getAnalyticsUsage)",
+    server: "hermes_cli/web_server.py:14453",
+    gap: "Never implemented. Scoped at reference/rfcs/fleet-dashboard.md:105-106.",
+    assert: (res) => {
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(200);
+    },
+  },
+];
+
+describe(`Hermes REST response contract (upstream ${UPSTREAM_HERMES_SHA.slice(0, 7)})`, () => {
+  for (const c of CONTRACT) {
+    const runner = c.gap ? it.fails : it;
+    const suffix = c.gap ? "  [GAP]" : "";
+    runner(
+      `${c.name}${suffix}`,
+      async () => {
+        const res = await call(c.method, c.path, c.search ?? "");
+        c.assert(res);
+      },
+      CASE_TIMEOUT_MS,
+    );
+  }
+
+  it("every contract case cites both a desktop call site and a real backend route", () => {
+    for (const c of CONTRACT) {
+      expect(c.client, c.name).toMatch(/hermes(-cron-scope)?\.ts:\d+|types\/hermes\.ts:\d+/);
+      expect(c.server, c.name).toMatch(/hermes_cli\//);
+    }
+  });
+
+  it("every gap carries a written explanation, not a bare flag", () => {
+    for (const c of CONTRACT) {
+      if (c.gap === undefined) continue;
+      expect(c.gap.length, `${c.name}: gap note is too thin to act on`).toBeGreaterThan(40);
+    }
+  });
+
+  it("reports the green/pending split so the fixture's own progress is visible", () => {
+    const gaps = CONTRACT.filter((c) => c.gap).length;
+    const green = CONTRACT.length - gaps;
+    // Ratchet: this only moves when the adapter is fixed. Lower `gaps` (and
+    // raise `green`) in the same PR that removes a `gap` field.
+    expect({ total: CONTRACT.length, green, gaps }).toEqual({
+      total: 44,
+      green: 20,
+      gaps: 24,
+    });
+  });
+});

--- a/src/web/hermes-rest-parity.test.ts
+++ b/src/web/hermes-rest-parity.test.ts
@@ -17,13 +17,50 @@
  *
  *   git clone https://github.com/NousResearch/hermes-agent
  *   cd hermes-agent && git checkout <NEW_SHA>
- *   # every call site the desktop emits:
- *   grep -n "path: " apps/desktop/src/hermes.ts
+ *   # every call site the desktop emits — the WHOLE tree, renderer AND the
+ *   # Electron main process, not just apps/desktop/src/hermes.ts:
+ *   grep -rn "['\"\`]/api/" apps/desktop/src apps/desktop/electron \
+ *     --include='*.ts' --include='*.tsx' | grep -v '\.test\.'
  *   # the routes the real backend actually serves:
  *   grep -rn "^@router\.\|^@app\.\|^@[a-z_]*_router\." hermes_cli/
  *
  * Then reconcile CENSUS below against that grep: a row that disappears
  * upstream should be deleted here, a new row added with its `served` verdict.
+ *
+ * ─── Scope of the census (read this before trusting it) ─────────────────────
+ *
+ * This used to grep `apps/desktop/src/hermes.ts` alone, and that was wrong in
+ * a way that cost real routes. `GET /api/profiles/active` and
+ * `GET /api/profiles/projects/tree` are emitted from `src/store/*.ts`, and
+ * `GET /api/auth/providers` from the Electron MAIN process — none of them live
+ * in hermes.ts. So any "the census proves every emitted path under this prefix
+ * is handled" argument built on the old grep proved nothing about them, and
+ * narrowing the /api/profiles prefix branch to an allowlist 404'd both. The
+ * sweep is now whole-tree.
+ *
+ * What CENSUS enumerates today, stated precisely so the residual hole is a
+ * written list rather than an unstated assumption:
+ *
+ *   - every path × verb in `apps/desktop/src/hermes.ts`, in full; PLUS
+ *   - every whole-tree (`src/**` + `electron/**`) call site under the route
+ *     families this adapter claims with a PREFIX branch, and therefore has to
+ *     get exhaustively right: /api/profiles, /api/cron, /api/messaging,
+ *     /api/auth.
+ *
+ * NOT yet enumerated — emitted outside hermes.ts, under families the adapter
+ * matches by exact path only. An unlisted sibling there has always 404'd and
+ * always will; there is no prefix branch that can silently swallow one:
+ *
+ *   /api/fs/*                src/lib/desktop-fs.ts:46,97,127 (remote mode)
+ *   /api/git/*               src/lib/desktop-git.ts:42,46    (remote mode)
+ *   /api/plugins/*           src/contrib/plugin.ts, src/plugins/kanban/api.ts
+ *   /api/media               src/lib/chat-runtime.ts
+ *   /api/audio/speak-stream  src/lib/voice-playback.ts
+ *   /api/health, /api/agents electron/backend-health.ts, connection-config.ts
+ *   /api/ws                  websocket upgrade, not REST — see the WS fixture
+ *
+ * Enumerating those is a separate, larger pass. Listing them by name here is
+ * what stops this fixture overclaiming its own coverage a second time.
  *
  * @see reference/rfcs/fleet-dashboard.md — the RFC this adapter implements
  */
@@ -137,11 +174,21 @@ function call(method: string, path: string, search = ""): Promise<HermesRestResu
 // to or dropped from the adapter without this table being updated, and when a
 // desktop bump introduces a route nobody classified. Body shape is Part 2.
 //
-// `line` is the call site in apps/desktop/src/hermes.ts at UPSTREAM_HERMES_SHA.
+// `line` is the call site's line number at UPSTREAM_HERMES_SHA, in `file` —
+// which defaults to apps/desktop/src/hermes.ts and is stated explicitly for
+// every row that lives anywhere else (see the scope note at the top).
 // ═══════════════════════════════════════════════════════════════════════════
+
+/** Where a census row's `line` points when the row does not say otherwise. */
+const DEFAULT_CENSUS_FILE = "apps/desktop/src/hermes.ts";
 
 interface CensusRow {
   line: number;
+  /** Call-site file, relative to the upstream repo root. Defaults to
+   *  {@link DEFAULT_CENSUS_FILE}. Set it for every non-hermes.ts call site —
+   *  a row that lies about its file is how the old single-file grep hid
+   *  /api/profiles/active and /api/profiles/projects/tree. */
+  file?: string;
   method: string;
   /** Concrete path — template params already substituted with fixture values. */
   path: string;
@@ -150,11 +197,45 @@ interface CensusRow {
   note?: string;
 }
 
+/** The families the adapter still claims with a `pathname.startsWith(...)`
+ *  branch: /api/profiles (hermes-adapter.ts:892) and /api/cron (:810).
+ *  A prefix branch is exactly the construct that can swallow — or, once
+ *  narrowed to an allowlist, silently 404 — a call site nobody censused, so
+ *  these get the extra rails below. (/api/messaging and /api/auth are matched
+ *  by exact path; they are whole-tree censused for scope, but they cannot
+ *  swallow anything.) */
+const PREFIX_BRANCH_FAMILIES = ["/api/profiles", "/api/cron"];
+
+function censusFile(row: CensusRow): string {
+  return row.file ?? DEFAULT_CENSUS_FILE;
+}
+
+/** Shared verdict for every profile-MUTATING verb. Not a regression from the
+ *  prefix-branch narrowing and not a new decision: the /api/profiles branch
+ *  (hermes-adapter.ts:892) has always been GET-gated, so these have always
+ *  fallen through to a 404. Switchroom's fleet is YAML-owned — there is no
+ *  profile to create, rename, delete, re-soul, export or import. */
+const PROFILE_WRITE_404 =
+  "Profile mutation. The /api/profiles branch (hermes-adapter.ts:892) is " +
+  "GET-gated and always has been, so this 404'd before the narrowing too. " +
+  "Switchroom's fleet is YAML-owned: there is no profile to mutate.";
+
 const CENSUS: CensusRow[] = [
   // ── sessions ──────────────────────────────────────────────────────────────
   { line: 400, method: "GET", path: "/api/sessions", served: true },
   { line: 440, method: "GET", path: "/api/profiles/sessions", served: true },
-  { line: 578, method: "POST", path: "/api/profiles/sessions/pull-requests", served: false },
+  {
+    line: 578,
+    method: "POST",
+    path: "/api/profiles/sessions/pull-requests",
+    served: false,
+    note:
+      "The one deliberately-404'd path a client really emits under the " +
+      "narrowed /api/profiles prefix branch. Safe: recoverSessionPullRequests " +
+      "(store/pull-requests.ts:96) awaits it inside try/catch and records no " +
+      "PRs, and switchroom transcripts carry no `gh pr create` tool output to " +
+      "scan in the first place.",
+  },
   {
     line: 608,
     method: "GET",
@@ -217,10 +298,11 @@ const CENSUS: CensusRow[] = [
       "The adapter serves /api/auth/providers instead. That is NOT a stub " +
       "aimed at a dead route: /api/auth/providers is a real upstream route " +
       "(hermes_cli/dashboard_auth/routes.py:152) called by the desktop's " +
-      "Electron MAIN process — gatewayAuthProviders (electron/main.ts:4954) " +
-      "and probeRemoteAuthMode (:7590). This census only greps " +
-      "apps/desktop/src/hermes.ts, which is the renderer, so main-process " +
-      "call sites are out of its scope by construction.",
+      "Electron MAIN process, and it now has its own census row below. The " +
+      "census used to grep apps/desktop/src/hermes.ts alone, which is the " +
+      "renderer, so main-process call sites were out of scope by " +
+      "construction; the sweep is whole-tree now (see the scope note at the " +
+      "top of this file).",
   },
   { line: 981, method: "DELETE", path: "/api/providers/oauth/anthropic", served: false },
   { line: 989, method: "POST", path: "/api/providers/oauth/anthropic/start", served: false },
@@ -315,14 +397,61 @@ const CENSUS: CensusRow[] = [
 
   // ── profiles ──────────────────────────────────────────────────────────────
   { line: 1502, method: "GET", path: "/api/profiles", served: true },
-  { line: 1509, method: "POST", path: "/api/profiles", served: false },
-  { line: 1517, method: "PATCH", path: "/api/profiles/default", served: false },
-  { line: 1525, method: "DELETE", path: "/api/profiles/default", served: false },
+  {
+    line: 1509,
+    method: "POST",
+    path: "/api/profiles",
+    served: false,
+    note: PROFILE_WRITE_404,
+  },
+  { line: 1517, method: "PATCH", path: "/api/profiles/default", served: false, note: PROFILE_WRITE_404 },
+  { line: 1525, method: "DELETE", path: "/api/profiles/default", served: false, note: PROFILE_WRITE_404 },
   { line: 1532, method: "GET", path: "/api/profiles/default/soul", served: true },
-  { line: 1538, method: "PUT", path: "/api/profiles/default/soul", served: false },
+  { line: 1538, method: "PUT", path: "/api/profiles/default/soul", served: false, note: PROFILE_WRITE_404 },
   { line: 1546, method: "GET", path: "/api/profiles/default/setup-command", served: true },
-  { line: 1558, method: "POST", path: "/api/profiles/default/export", served: false },
-  { line: 1573, method: "POST", path: "/api/profiles/import", served: false },
+  { line: 1558, method: "POST", path: "/api/profiles/default/export", served: false, note: PROFILE_WRITE_404 },
+  { line: 1573, method: "POST", path: "/api/profiles/import", served: false, note: PROFILE_WRITE_404 },
+
+  // ── profiles, emitted from OUTSIDE hermes.ts ──────────────────────────────
+  // The rows the single-file grep could not see. Both are GETs, both run at
+  // startup, and both were 404'd by the narrowed prefix branch until this was
+  // caught in review. See the scope note at the top of this file.
+  {
+    line: 114,
+    file: "apps/desktop/src/store/profile.ts",
+    method: "GET",
+    path: "/api/profiles/active",
+    served: true,
+    note:
+      "refreshActiveProfile, at startup. Served for real: { active, current } " +
+      "(hermes_cli/web_routers/profiles.py:738-755), both 'default'.",
+  },
+  {
+    line: 479,
+    file: "apps/desktop/src/store/projects.ts",
+    method: "GET",
+    path: "/api/profiles/projects/tree",
+    served: true,
+    note:
+      "refreshProjectTreeAcrossProfiles, on entering all-profiles mode. " +
+      "Served as a full-shape EMPTY tree rather than 404'd: the caller's " +
+      "failure path (markProjectsRpcFailure, store/projects.ts:52-56) only " +
+      "reacts to JSON-RPC method-missing errors, so a 404 leaves " +
+      "$projectsRpcAvailable stuck at null instead of saying 'exists, empty'.",
+  },
+  // ── auth (Electron main process — also outside hermes.ts) ─────────────────
+  {
+    line: 4954,
+    file: "apps/desktop/electron/main.ts",
+    method: "GET",
+    path: "/api/auth/providers",
+    served: true,
+    note:
+      "gatewayAuthProviders (:4954) and probeRemoteAuthMode (:7590) read " +
+      "body.providers to label the sign-in button. A real upstream route " +
+      "(hermes_cli/dashboard_auth/routes.py:152); switchroom's token-auth " +
+      "gateway answers an empty list. See the /api/providers/oauth row.",
+  },
 
   // ── analytics / ops / audio / update ──────────────────────────────────────
   {
@@ -352,27 +481,31 @@ describe(`Hermes REST route census (upstream ${UPSTREAM_HERMES_SHA.slice(0, 7)})
   });
 
   it("census has no duplicate (method, path) rows", () => {
-    const seen = new Map<string, number>();
+    const seen = new Map<string, string>();
     const dupes: string[] = [];
     for (const row of CENSUS) {
       const key = `${row.method} ${row.path}`;
-      if (seen.has(key)) dupes.push(`${key} (hermes.ts:${seen.get(key)} and :${row.line})`);
-      else seen.set(key, row.line);
+      // Cite the FILE, not a bare line number: rows now come from four
+      // different desktop files, and "hermes.ts:114" for a store/profile.ts
+      // row would be a lie in the very message meant to locate the clash.
+      const at = `${censusFile(row).replace("apps/desktop/", "")}:${row.line}`;
+      if (seen.has(key)) dupes.push(`${key} (${seen.get(key)} and ${at})`);
+      else seen.set(key, at);
     }
     // Three PATCH /api/sessions/:id call sites share one route (archive, pin,
     // rename); they are deliberately NOT deduped in CENSUS because each is an
     // independent desktop feature that breaks. Assert the known set so a new
     // collision on some other route still fails here.
     expect(dupes).toEqual([
-      `PATCH /api/sessions/${AGENT} (hermes.ts:637 and :650)`,
-      `PATCH /api/sessions/${AGENT} (hermes.ts:637 and :770)`,
+      `PATCH /api/sessions/${AGENT} (src/hermes.ts:637 and src/hermes.ts:650)`,
+      `PATCH /api/sessions/${AGENT} (src/hermes.ts:637 and src/hermes.ts:770)`,
     ]);
   });
 
   for (const row of CENSUS) {
     const label = `${row.method} ${row.path} → ${row.served ? "served" : "404 (not a Hermes route)"}`;
     it(
-      `${label}  [hermes.ts:${row.line}]`,
+      `${label}  [${censusFile(row).replace("apps/desktop/", "")}:${row.line}]`,
       async () => {
         const res = await call(row.method, row.path);
         if (row.served) {
@@ -385,10 +518,46 @@ describe(`Hermes REST route census (upstream ${UPSTREAM_HERMES_SHA.slice(0, 7)})
     );
   }
 
-  it("every census row cites a real call-site line in apps/desktop/src/hermes.ts", () => {
+  it("every census row cites a plausible call-site line in a real desktop file", () => {
+    // `wc -l` at UPSTREAM_HERMES_SHA, rounded up: hermes.ts 1934,
+    // store/profile.ts 442, store/projects.ts 1263, electron/main.ts 12535.
+    // Bound each row by the file it actually claims, so a row that silently
+    // inherits the hermes.ts default while citing a main-process line number
+    // fails here instead of reading as plausible.
+    const MAX_LINE: Record<string, number> = {
+      "apps/desktop/src/hermes.ts": 1935,
+      "apps/desktop/src/store/profile.ts": 443,
+      "apps/desktop/src/store/projects.ts": 1264,
+      "apps/desktop/electron/main.ts": 12536,
+    };
     for (const row of CENSUS) {
-      expect(row.line, `${row.method} ${row.path}`).toBeGreaterThan(0);
-      expect(row.line, `${row.method} ${row.path}`).toBeLessThan(2000);
+      const where = `${row.method} ${row.path} [${censusFile(row)}]`;
+      expect(MAX_LINE, `${where}: unknown census file — add its bound`).toHaveProperty(
+        censusFile(row),
+      );
+      expect(row.line, where).toBeGreaterThan(0);
+      expect(row.line, where).toBeLessThan(MAX_LINE[censusFile(row)]);
+    }
+  });
+
+  // Under a prefix branch, a 404'd row is a DECISION — the branch claimed the
+  // path and chose to hand back null — not an accident of the route table, so
+  // it has to carry its reasoning. Elsewhere an unlisted path 404s for the
+  // ordinary reason that nothing matched, and a bare row is fine.
+  //
+  // Both prefix branches are GET-gated for reads and answer every mutating
+  // verb the same way (cron: 422; profiles: 404), so the interesting case is
+  // reads: a GET the desktop emits under a narrowed prefix branch must be
+  // served, or say in writing why the client survives without it.
+  it("every 404'd row under a prefix-branch family explains why the 404 is safe", () => {
+    for (const row of CENSUS) {
+      if (row.served) continue;
+      if (!PREFIX_BRANCH_FAMILIES.some((p) => row.path.startsWith(p))) continue;
+      expect(
+        row.note?.length ?? 0,
+        `${row.method} ${row.path} is 404'd under a prefix branch with no ` +
+          `justification — say why the desktop tolerates it, or serve it`,
+      ).toBeGreaterThan(40);
     }
   });
 });
@@ -407,10 +576,18 @@ interface ContractCase {
   path: string;
   /** Query string the desktop sends, verbatim from the pinned call site. */
   search?: string;
-  /** Desktop call site — apps/desktop/src/hermes.ts:NNN at the pinned SHA. */
+  /** Desktop call site — `<file>:NNN` under apps/desktop/src at the pinned SHA. */
   client: string;
-  /** Real backend route — hermes_cli/... at the pinned SHA. */
-  server: string;
+  /** Real backend route — `hermes_cli/...` at the pinned SHA, or null when the
+   *  case probes a path that has NO upstream route on purpose (see
+   *  {@link ContractCase.synthetic}). A citation must name the thing it is
+   *  actually about; inventing a plausible-looking `hermes_cli/` line for a
+   *  path upstream never serves is worse than admitting there isn't one. */
+  server: null | string;
+  /** True when `path` is not a route any client emits — a probe of the
+   *  adapter's fall-through behaviour rather than of a contract. Lets `server`
+   *  be null and exempts the case from the "cites a real route" rail. */
+  synthetic?: boolean;
   /** Set when the adapter does not satisfy this today. Runs under `it.fails`. */
   gap?: string;
   assert: (res: HermesRestResult | null) => void;
@@ -561,8 +738,12 @@ const CONTRACT: ContractCase[] = [
     name: "an unrecognised /api/profiles GET 404s rather than faking a 200 (synthetic probe path)",
     method: "GET",
     path: "/api/profiles/default/__not_a_route__",
-    client: "hermes.ts:520-536 (isEndpointMissingError)",
-    server: "hermes_cli/web_routers/profiles.py:232",
+    client: "hermes.ts:520-536 (isEndpointMissingError — the code that requires the 404)",
+    // No upstream route: the whole point of the probe is a path FastAPI never
+    // matches either. The previous citation here (profiles.py:232, the sidebar
+    // route) belonged to neither the probed path nor this assertion.
+    server: null,
+    synthetic: true,
     assert: (res) => {
       expect(res === null || res.status === 404).toBe(true);
     },
@@ -1062,10 +1243,47 @@ const CONTRACT: ContractCase[] = [
     server: "hermes_cli/web_routers/profiles.py:779",
     assert: (res) => {
       const b = body200(res);
-      // Upstream declares a bare string; switchroom has no shell-launchable
-      // profile, so the honest answer is an empty one — not a missing key and
-      // not null.
+      // Upstream returns an OBJECT — `{"command": _profile_setup_command(name)}`
+      // (profiles.py:779-781) — and the desktop destructures `.command` off it.
+      // Switchroom has no shell-launchable profile, so the honest answer is an
+      // empty command string: not a missing key, not null.
       expect(typeof b.command).toBe("string");
+    },
+  },
+  {
+    name: "GET /api/profiles/active returns { active, current }",
+    method: "GET",
+    path: "/api/profiles/active",
+    client: "store/profile.ts:105-118 (refreshActiveProfile, at startup)",
+    server: "hermes_cli/web_routers/profiles.py:738",
+    assert: (res) => {
+      const b = body200(res);
+      // The desktop reads `res.current || 'default'` (store/profile.ts:117).
+      // Both keys are strings upstream, including on its own error fallbacks
+      // (profiles.py:747, :753).
+      expect(typeof b.active).toBe("string");
+      expect(typeof b.current).toBe("string");
+      expect(b.current).toBe("default");
+    },
+  },
+  {
+    name: "GET /api/profiles/projects/tree returns the full empty-tree shape, not {}",
+    method: "GET",
+    path: "/api/profiles/projects/tree",
+    search: "?preview_limit=3",
+    client: "store/projects.ts:473-499 (refreshProjectTreeAcrossProfiles)",
+    server: "hermes_cli/web_routers/profiles.py:457",
+    assert: (res) => {
+      const b = body200(res);
+      // Upstream returns four keys (profiles.py:526-533). The desktop's own
+      // ProjectTreePayload (store/projects.ts:389-393) declares three of them
+      // and `applyProjectTreePayload` reads all three; `errors` rides along
+      // because upstream sends it. Switchroom has no repo/checkout grouping,
+      // so every list is empty — which is a real answer, unlike a bare 200 {}.
+      expect(Array.isArray(b.projects)).toBe(true);
+      expect(b.active_id).toBeNull();
+      expect(Array.isArray(b.scoped_session_ids)).toBe(true);
+      expect(Array.isArray(b.errors)).toBe(true);
     },
   },
   {
@@ -1165,12 +1383,59 @@ describe(`Hermes REST response contract (upstream ${UPSTREAM_HERMES_SHA.slice(0,
     );
   }
 
+  // The assertion the probe case above cannot make about itself, and the one
+  // that would have caught this branch 404-ing two live startup routes:
+  // proving the narrowed /api/profiles branch CAN 404 says nothing about
+  // whether every path a client DOES emit survived the narrowing.
+  //
+  // Driven off CENSUS so the list cannot drift from the census table, but the
+  // path SET is pinned inline as well — silently deleting a row is the other
+  // half of the failure mode, and a bare `for (row of rows)` loop over an
+  // emptied list passes vacuously.
+  it("every /api/profiles GET the desktop emits is still served after the narrowing", async () => {
+    const rows = CENSUS.filter((r) => r.method === "GET" && r.path.startsWith("/api/profiles"));
+    expect(rows.map((r) => r.path).sort()).toEqual([
+      "/api/profiles",
+      "/api/profiles/active",
+      "/api/profiles/default/setup-command",
+      "/api/profiles/default/soul",
+      "/api/profiles/projects/tree",
+      "/api/profiles/sessions",
+      "/api/profiles/sessions/sidebar",
+    ]);
+    for (const row of rows) {
+      const res = await call(row.method, row.path);
+      expect(
+        res,
+        `${row.path} (${censusFile(row)}:${row.line}) 404s — the desktop emits it`,
+      ).not.toBeNull();
+      expect(res!.status, row.path).toBe(200);
+    }
+  }, CASE_TIMEOUT_MS);
+
   it("every contract case cites both a desktop call site and a real backend route", () => {
     for (const c of CONTRACT) {
-      expect(c.client, c.name).toMatch(/hermes(-cron-scope)?\.ts:\d+|types\/hermes\.ts:\d+/);
+      expect(c.client, c.name).toMatch(
+        /(hermes(-cron-scope)?|types\/hermes|store\/[a-z-]+|electron\/main)\.tsx?:\d+/,
+      );
+      if (c.synthetic) {
+        // A probe of fall-through behaviour has no upstream route to cite, and
+        // must not invent one. `server: null` is the honest value; anything
+        // else here is a citation that describes a different route.
+        expect(c.server, `${c.name}: synthetic probes must not cite a route`).toBeNull();
+        continue;
+      }
       expect(c.server, c.name).toMatch(/hermes_cli\//);
     }
   });
+
+  // NOT checked: whether a cited `file:line` actually exists. It cannot be,
+  // cheaply or otherwise — the citations point into an upstream checkout at
+  // UPSTREAM_HERMES_SHA that this repo does not vendor and CI does not clone,
+  // so there is nothing on disk to resolve them against. Format-checking is
+  // the ceiling here; the semantic check is the human re-derive step
+  // documented at the top of this file. Said out loud so the next reader does
+  // not mistake the regex above for a verification that the line is real.
 
   it("every gap carries a written explanation, not a bare flag", () => {
     for (const c of CONTRACT) {
@@ -1185,8 +1450,8 @@ describe(`Hermes REST response contract (upstream ${UPSTREAM_HERMES_SHA.slice(0,
     // Ratchet: this only moves when the adapter is fixed. Lower `gaps` (and
     // raise `green`) in the same PR that removes a `gap` field.
     expect({ total: CONTRACT.length, green, gaps }).toEqual({
-      total: 45,
-      green: 27,
+      total: 47,
+      green: 29,
       gaps: 18,
     });
   });

--- a/src/web/hermes-ws-parity.test.ts
+++ b/src/web/hermes-ws-parity.test.ts
@@ -253,9 +253,17 @@ const CONTRACT: ContractCase[] = [
     upstream: "tui_gateway/methods_session.py:2442",
     desktopCall: null,
     params: { session_id: SESSION, limit: 50 },
-    // methods_session.py:2456-2462 → {"count": ..., "messages": [...]}
+    // methods_session.py:2457-2462 → {"count": ..., "messages": [...]}
     resultKeys: ["count", "messages"],
-    note: "adapter also echoes session_id, which upstream omits — additive, harmless",
+    note:
+      "Adapter also echoes session_id, which upstream omits — additive, " +
+      "harmless. `count` is NOT identical to upstream's: upstream's is " +
+      "len(history), the RAW pre-projection row count, while `messages` is " +
+      "_history_to_messages(history), a lossy display projection " +
+      "(tui_gateway/server.py:7136+) that drops hidden scaffolding rows and " +
+      "assistant turns carrying only tool calls — so upstream has " +
+      "count >= len(messages), strictly greater on a tool-using transcript. " +
+      "The adapter applies no projection, so the two are always equal here.",
   },
   {
     method: "session.list",
@@ -269,10 +277,18 @@ const CONTRACT: ContractCase[] = [
     upstream: "tui_gateway/methods_session.py:214",
     desktopCall: null,
     params: {},
-    resultKeys: ["session_id"],
+    resultKeys: ["session_id", "title", "started_at", "source"],
     note:
-      "upstream methods_session.py:214-235 returns {session_id}, null when no " +
-      "eligible session — the adapter now matches (it returned {session} before)",
+      "Upstream has TWO shapes. A HIT returns four keys — " +
+      "{session_id, title, started_at, source} (methods_session.py:248-256). " +
+      "Every no-answer path (no db / no eligible row / internal exception) " +
+      "returns the bare {session_id: null} (:234, :257, :260); :214-235 is the " +
+      "docstring describing that null case, not the success return. The " +
+      "adapter emits all four on a hit — the fixture config has agents, so " +
+      "this case exercises the hit path — and {session_id: null} otherwise. " +
+      "It used to return {session}, a key no caller ever found. Pinning only " +
+      "`session_id` here would have passed with the other three ABSENT: the " +
+      "check below is per-key toHaveProperty, a subset check, not exact-shape.",
   },
   {
     method: "session.close",

--- a/src/web/hermes-ws-parity.test.ts
+++ b/src/web/hermes-ws-parity.test.ts
@@ -255,8 +255,7 @@ const CONTRACT: ContractCase[] = [
     params: { session_id: SESSION, limit: 50 },
     // methods_session.py:2456-2462 → {"count": ..., "messages": [...]}
     resultKeys: ["count", "messages"],
-    gap: "shape",
-    note: "adapter returns {session_id, messages} — `count` missing (hermes-adapter.ts:1008)",
+    note: "adapter also echoes session_id, which upstream omits — additive, harmless",
   },
   {
     method: "session.list",
@@ -271,8 +270,9 @@ const CONTRACT: ContractCase[] = [
     desktopCall: null,
     params: {},
     resultKeys: ["session_id"],
-    gap: "shape",
-    note: "upstream methods_session.py:234 returns {session_id}; adapter returns {session}",
+    note:
+      "upstream methods_session.py:214-235 returns {session_id}, null when no " +
+      "eligible session — the adapter now matches (it returned {session} before)",
   },
   {
     method: "session.close",

--- a/src/web/hermes-ws-parity.test.ts
+++ b/src/web/hermes-ws-parity.test.ts
@@ -1,0 +1,944 @@
+/**
+ * WS / JSON-RPC contract-parity fixture for the Hermes-Desktop adapter.
+ *
+ * The mirror image of upstream's own REST parity fixture
+ * (`apps/desktop/src/hermes-parity.test.ts`, 140 ln): where that one pins the
+ * REST paths/bodies the desktop sends, this one pins the JSON-RPC methods,
+ * request params, and *result shapes* the real Hermes Desktop renderer
+ * destructures — asserted against Switchroom's own WS dispatcher
+ * (`onHermesOpen` / `onHermesMessage` / `onHermesClose` in `hermes-adapter.ts`).
+ *
+ * ─── UPSTREAM PIN ───────────────────────────────────────────────────────────
+ *
+ * Every row in CONTRACT below was derived by reading upstream source at the
+ * SHA in `HERMES_UPSTREAM_PIN`. Bump the pin and re-derive whenever the
+ * desktop is upgraded — that is the entire point of this file.
+ *
+ * Re-derive with (from a clone of github.com/NousResearch/hermes-agent):
+ *
+ *   git checkout <new-sha>
+ *   # 1. the authoritative RPC surface (server-side @method decorators):
+ *   grep -rho '@method("[^"]*"' tui_gateway/ | sed 's/@method("//;s/"//' | sort -u
+ *   # 2. the methods the DESKTOP can actually send (client call sites):
+ *   grep -rEoh "[A-Za-z_]*[Rr]equest[A-Za-z]*(<[^>]*>)?\(\s*'[a-z_.]+\.[a-z_.]+'" \
+ *     --include=*.ts --include=*.tsx apps/desktop/src | grep -v '\.test\.'
+ *   grep -rEoh "rpc\(\s*'[a-z_.]+'" --include=*.ts apps/desktop/src
+ *   # 3. the event names the desktop's stream handler understands:
+ *   sed -n '1,25p' apps/shared/src/json-rpc-gateway.ts
+ *
+ * ─── HOW GAPS ARE ENCODED ───────────────────────────────────────────────────
+ *
+ * Every case asserts the REAL Hermes contract, unconditionally. Cases the
+ * adapter does not yet honour are marked `gap:` in the table and run through
+ * vitest's `it.fails` instead of `it`. That keeps CI green today AND makes the
+ * marker self-retiring: the moment the adapter is fixed the assertion starts
+ * passing, `it.fails` goes RED, and whoever fixed it must delete the `gap:`
+ * flag. `it.skip` / `it.todo` would rot silently instead — they never notice
+ * the fix. (The repo has no pre-existing known-gap idiom; `it.skipIf` is used
+ * for platform gating only, e.g. `src/vault/broker/server.test.ts:603`.)
+ *
+ * Fixing the adapter is deliberately OUT of scope for this file.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+/** Upstream hermes-agent commit this contract table was derived from. */
+export const HERMES_UPSTREAM_PIN = "9da6d455c9e1f2bf74bb9f47766ee9fc52e17bfb";
+
+// ─── Test doubles for the filesystem/DB reads the adapter makes ──────────────
+
+// The REPL lane of slash.exec shells out to tmux; stub only the send, keeping
+// the real INJECT_ALLOWLIST/INJECT_BLOCKLIST routing table under test.
+vi.mock("../agents/inject.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/inject.js")>();
+  return {
+    ...actual,
+    injectSlashCommand: async () => ({ outcome: "ok" as const, output: "Hermes TUI Status" }),
+  };
+});
+
+vi.mock("./api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api.js")>();
+  return {
+    ...actual,
+    // parseHermesSessionId stays REAL — it is contract logic, not I/O.
+    agentBridgeAlive: () => true,
+    handleListThreadIds: () => [],
+    handleGetTurns: () => ({ ok: true, turns: [] }),
+    handleGetAgents: async () => [
+      {
+        name: "alpha",
+        active: "yes",
+        uptime: "1h",
+        memory: null,
+        extends: "_base",
+        topic_name: "alpha",
+        primaryAccount: "slot-a",
+        auth: { authenticated: true, subscriptionType: "max" },
+        memoryCollection: "alpha",
+        lastTurnAt: 1_700_000_000_000,
+        context: null,
+      },
+    ],
+  };
+});
+
+const {
+  onHermesOpen,
+  onHermesClose,
+  onHermesMessage,
+} = await import("./hermes-adapter.js");
+type HermesWsContext = import("./hermes-adapter.js").HermesWsContext;
+
+const CONFIG = {
+  agents: { alpha: {} },
+  switchroom: { agents_dir: "/nonexistent-agents-dir" },
+} as unknown as SwitchroomConfig;
+
+const SESSION = "alpha";
+
+interface Harness {
+  ctx: HermesWsContext;
+  sent: unknown[];
+}
+
+function harness(): Harness {
+  const sent: unknown[] = [];
+  const ctx: HermesWsContext = {
+    config: CONFIG,
+    send: (msg: string) => sent.push(JSON.parse(msg)),
+  };
+  return { ctx, sent };
+}
+
+interface RpcFrame {
+  jsonrpc: "2.0";
+  id?: unknown;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+/** Drive one JSON-RPC request through the adapter and return its response frame. */
+async function call(
+  h: Harness,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<RpcFrame> {
+  const before = h.sent.length;
+  await onHermesMessage(h.ctx, JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }));
+  const frames = h.sent.slice(before) as RpcFrame[];
+  const response = frames.find((f) => "result" in f || "error" in f);
+  if (!response) throw new Error(`no JSON-RPC response frame for ${method}`);
+  return response;
+}
+
+// ─── The contract table ──────────────────────────────────────────────────────
+
+type Gap =
+  /** Adapter answers, but the result shape is not what the desktop reads. */
+  | "shape"
+  /** Adapter has no case — falls through to the generic -32601 default. */
+  | "missing";
+
+interface ContractCase {
+  /** JSON-RPC method name as sent on the wire. */
+  method: string;
+  /** Upstream `@method(...)` decorator, path relative to the hermes repo root. */
+  upstream: string;
+  /**
+   * Desktop call site (relative to `apps/desktop/src/`), or null when no
+   * renderer code path sends it — those rows exist because the adapter
+   * implements the method and upstream still serves it (TUI / ACP callers).
+   */
+  desktopCall: string | null;
+  /** Request params a real desktop sends. */
+  params: Record<string, unknown>;
+  /**
+   * Keys the client reads off the JSON-RPC `result` object. Empty means the
+   * client only checks for a non-error response (fire-and-forget verbs).
+   */
+  resultKeys: string[];
+  /** Where the client destructures `resultKeys`. */
+  reader?: string;
+  gap?: Gap;
+  note?: string;
+}
+
+/**
+ * Rows are grouped the way upstream groups its handler modules
+ * (methods_session / methods_prompt / methods_config / methods_complete /
+ * methods_tools + server.py) so a re-derivation diff reads cleanly.
+ */
+const CONTRACT: ContractCase[] = [
+  // ── methods_session.py ─────────────────────────────────────────────────────
+  {
+    method: "session.create",
+    upstream: "tui_gateway/methods_session.py:14",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts:389",
+    params: { cols: 80 },
+    // methods_session.py:127-158 returns all five.
+    resultKeys: ["session_id", "stored_session_id", "message_count", "messages", "info"],
+    reader: "types/hermes.ts:456-462 (SessionCreateResponse)",
+    gap: "shape",
+    note: "adapter returns only {session_id, stored_session_id} (hermes-adapter.ts:981)",
+  },
+  {
+    method: "session.resume",
+    upstream: "tui_gateway/methods_session.py:306",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts:913",
+    params: { session_id: SESSION },
+    // _live_session_payload, server.py:8195-8208.
+    resultKeys: [
+      "info",
+      "message_count",
+      "messages",
+      "messages_omitted",
+      "running",
+      "session_id",
+      "session_key",
+      "started_at",
+      "status",
+    ],
+    reader: "types/hermes.ts:595-615 (SessionResumeResponse)",
+    gap: "shape",
+    note: "adapter returns only {session_id, stored_session_id} (hermes-adapter.ts:981)",
+  },
+  {
+    method: "session.activate",
+    upstream: "tui_gateway/methods_session.py:947",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts:735",
+    params: { session_id: SESSION },
+    // index.ts:765 synchronously destructures `activated.session_key`; :770-786
+    // read info / messages / messages_omitted / running / inflight / queued.
+    resultKeys: [
+      "info",
+      "message_count",
+      "messages",
+      "messages_omitted",
+      "running",
+      "session_id",
+      "session_key",
+      "started_at",
+      "status",
+    ],
+    reader: "app/session/hooks/use-session-actions/index.ts:765-786",
+    gap: "shape",
+    note: "adapter returns only {session_id, stored_session_id} (hermes-adapter.ts:981)",
+  },
+  {
+    method: "session.status",
+    upstream: "tui_gateway/methods_session.py:2366",
+    desktopCall: "lib/desktop-slash-commands.ts:304",
+    params: { session_id: SESSION },
+    // methods_session.py:2433 → {"output": "\n".join(lines)}
+    resultKeys: ["output"],
+    reader: "app/session/hooks/use-prompt-actions/utils.ts:423-425 (renderRpcResult)",
+    gap: "shape",
+    note: "adapter returns {session:{...}} (hermes-adapter.ts:947); renderRpcResult falls through to a JSON dump",
+  },
+  {
+    method: "session.usage",
+    upstream: "tui_gateway/methods_session.py:1357",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts:748",
+    params: { session_id: SESSION },
+    // methods_session.py:1375 returns the usage snapshot verbatim.
+    resultKeys: ["calls", "input", "output", "total"],
+    reader: "types/hermes.ts:653-662 (UsageStats); utils.ts:428-440",
+    gap: "shape",
+    note: "adapter returns {session_id, quota} (hermes-adapter.ts:1027)",
+  },
+  {
+    method: "session.history",
+    upstream: "tui_gateway/methods_session.py:2442",
+    desktopCall: null,
+    params: { session_id: SESSION, limit: 50 },
+    // methods_session.py:2456-2462 → {"count": ..., "messages": [...]}
+    resultKeys: ["count", "messages"],
+    gap: "shape",
+    note: "adapter returns {session_id, messages} — `count` missing (hermes-adapter.ts:1008)",
+  },
+  {
+    method: "session.list",
+    upstream: "tui_gateway/methods_session.py:162",
+    desktopCall: null,
+    params: {},
+    resultKeys: ["sessions"],
+  },
+  {
+    method: "session.most_recent",
+    upstream: "tui_gateway/methods_session.py:214",
+    desktopCall: null,
+    params: {},
+    resultKeys: ["session_id"],
+    gap: "shape",
+    note: "upstream methods_session.py:234 returns {session_id}; adapter returns {session}",
+  },
+  {
+    method: "session.close",
+    upstream: "tui_gateway/methods_session.py:2748",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts:410",
+    params: { session_id: SESSION },
+    resultKeys: [],
+  },
+  {
+    method: "session.interrupt",
+    upstream: "tui_gateway/methods_session.py:2942",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts:1395",
+    params: { session_id: SESSION },
+    resultKeys: [],
+  },
+  {
+    method: "session.active_list",
+    upstream: "tui_gateway/methods_session.py:909",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts (requestGateway)",
+    params: { current_session_id: SESSION },
+    resultKeys: ["sessions"],
+    gap: "missing",
+  },
+  {
+    method: "session.branch",
+    upstream: "tui_gateway/methods_session.py:2760",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts:1200",
+    params: { session_id: SESSION, message_index: 0 },
+    resultKeys: ["session_id"],
+    gap: "missing",
+  },
+  {
+    method: "session.context_breakdown",
+    upstream: "tui_gateway/methods_session.py:1381",
+    desktopCall: "app/session/hooks (requestGateway)",
+    params: { session_id: SESSION },
+    resultKeys: ["categories", "context_max"],
+    gap: "missing",
+  },
+  {
+    method: "session.cwd.set",
+    upstream: "tui_gateway/methods_session.py:810",
+    desktopCall: "app/session/hooks (requestGateway)",
+    params: { session_id: SESSION, cwd: "/tmp" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "session.redirect",
+    upstream: "tui_gateway/methods_session.py:3252",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts (requestGateway)",
+    params: { session_id: SESSION, text: "actually, do X" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "session.save",
+    upstream: "tui_gateway/methods_session.py:2676",
+    desktopCall: "lib/desktop-slash-commands.ts (rpc('session.save'))",
+    params: { session_id: SESSION },
+    resultKeys: ["file"],
+    reader: "app/session/hooks/use-prompt-actions/utils.ts:418-420",
+    gap: "missing",
+  },
+  {
+    method: "session.title",
+    upstream: "tui_gateway/methods_session.py:1022",
+    desktopCall: "app/session/hooks/use-session-actions/index.ts (requestGateway)",
+    params: { session_id: SESSION, title: "renamed" },
+    resultKeys: ["title"],
+    gap: "missing",
+  },
+  {
+    method: "message.react",
+    upstream: "tui_gateway/methods_session.py:1106",
+    desktopCall: "store (gateway.request)",
+    params: { session_id: SESSION, message_index: 0, reaction: "👍" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "llm.oneshot",
+    upstream: "tui_gateway/methods_session.py:1159",
+    desktopCall: "store (gatewayRequest)",
+    params: { session_id: SESSION, prompt: "summarise" },
+    resultKeys: ["text"],
+    gap: "missing",
+  },
+  {
+    method: "handoff.request",
+    upstream: "tui_gateway/methods_session.py:1218",
+    desktopCall: "app/session/hooks (requestGateway)",
+    params: { session_id: SESSION },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "handoff.state",
+    upstream: "tui_gateway/methods_session.py:1306",
+    desktopCall: "app/session/hooks (requestGateway)",
+    params: { session_id: SESSION },
+    resultKeys: ["state"],
+    gap: "missing",
+  },
+  {
+    method: "handoff.fail",
+    upstream: "tui_gateway/methods_session.py:1333",
+    desktopCall: "app/session/hooks (requestGateway)",
+    params: { session_id: SESSION, reason: "timeout" },
+    // methods_session.py:1350-1355 → {"failed": bool, "state": str}
+    resultKeys: ["failed", "state"],
+    gap: "missing",
+  },
+  {
+    method: "session.workspace.move",
+    upstream: "tui_gateway/methods_session.py (session.workspace.move)",
+    desktopCall: "store (gatewayRequest)",
+    params: { session_id: SESSION, cwd: "/tmp" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "session.compress",
+    upstream: "tui_gateway/methods_session.py (session.compress)",
+    desktopCall: "app/session/hooks/use-prompt-actions/slash.ts:534",
+    params: { session_id: SESSION },
+    resultKeys: ["summary"],
+    reader: "app/session/hooks/use-prompt-actions/utils.ts:385-398",
+    gap: "missing",
+  },
+
+  // ── methods_prompt.py ──────────────────────────────────────────────────────
+  {
+    method: "prompt.submit",
+    upstream: "tui_gateway/methods_prompt.py:67",
+    desktopCall: "app/session/hooks/use-prompt-actions/submit.ts:650",
+    // methods_prompt.py:71 reads params["text"] — NOT "content".
+    params: { session_id: SESSION, text: "hello" },
+    resultKeys: [],
+    note:
+      "adapter accepts params.content ?? params.text (hermes-adapter.ts:1039), so `text` is honoured. " +
+      "Dispatch-only assertion: the success path needs a live agent gateway.sock, so the result " +
+      "shape ({ok, prompt_key}) is covered by the integration path, not here.",
+  },
+  {
+    method: "prompt.background",
+    upstream: "tui_gateway/methods_prompt.py:783",
+    desktopCall: null,
+    params: { session_id: SESSION, text: "hello" },
+    resultKeys: [],
+  },
+  {
+    method: "clarify.respond",
+    upstream: "tui_gateway/methods_prompt.py:942",
+    desktopCall: "store/clarify.ts:137",
+    params: { request_id: "req-1", answer: "" },
+    resultKeys: [],
+    gap: "missing",
+    note: "blocking clarify card cannot be answered from the console at all",
+  },
+  {
+    method: "terminal.read.respond",
+    upstream: "tui_gateway/methods_prompt.py:951",
+    desktopCall: "store (gateway.request)",
+    params: { request_id: "req-1", text: "{}" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "preview.read.respond",
+    upstream: "tui_gateway/methods_prompt.py:960",
+    desktopCall: "store (gateway.request)",
+    params: { request_id: "req-1", text: "{}" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "window.read.respond",
+    upstream: "tui_gateway/methods_prompt.py:968",
+    desktopCall: "store (gateway.request)",
+    params: { request_id: "req-1", text: "{}" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "secret.respond",
+    upstream: "tui_gateway/methods_prompt.py:982",
+    desktopCall: "store (gateway.request)",
+    params: { request_id: "req-1", value: "" },
+    resultKeys: [],
+    gap: "missing",
+    note: "adapter's degrade list names secret.get/secret.set, which are NOT upstream methods",
+  },
+  {
+    method: "image.attach",
+    upstream: "tui_gateway/methods_prompt.py:439",
+    desktopCall: "app/chat (requestGateway)",
+    params: { session_id: SESSION, path: "/tmp/a.png" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "image.attach_bytes",
+    upstream: "tui_gateway/methods_prompt.py:482",
+    desktopCall: "app/chat (requestGateway)",
+    params: { session_id: SESSION, data: "", mime: "image/png" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "image.detach",
+    upstream: "tui_gateway/methods_prompt.py:716",
+    desktopCall: "app/chat (requestGateway)",
+    params: { session_id: SESSION },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "file.attach",
+    upstream: "tui_gateway/methods_prompt.py:669",
+    desktopCall: "app/chat (requestGateway)",
+    params: { session_id: SESSION, path: "/tmp/a.txt" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "preview.restart",
+    upstream: "tui_gateway/methods_prompt.py:829",
+    desktopCall: "app/session (requestGateway)",
+    params: { session_id: SESSION },
+    resultKeys: [],
+    gap: "missing",
+  },
+
+  // ── methods_config.py / server.py ──────────────────────────────────────────
+  {
+    method: "config.get",
+    upstream: "tui_gateway/methods_config.py:161",
+    desktopCall: "app/settings (requestGateway)",
+    params: { key: "provider" },
+    // methods_config.py:169-179
+    resultKeys: ["model", "provider", "providers"],
+    gap: "missing",
+  },
+  {
+    method: "config.set",
+    upstream: "tui_gateway/server.py:10847",
+    desktopCall: "app/chat/composer (requestGateway)",
+    params: { session_id: SESSION, key: "model", value: "sonnet --provider switchroom" },
+    resultKeys: [],
+  },
+  {
+    method: "setup.status",
+    upstream: "tui_gateway/methods_config.py:344",
+    desktopCall: "lib/runtime-readiness.ts:75",
+    params: {},
+    resultKeys: ["provider_configured"],
+  },
+  {
+    method: "setup.runtime_check",
+    upstream: "tui_gateway/methods_config.py:354",
+    desktopCall: "lib/runtime-readiness.ts:76",
+    params: {},
+    resultKeys: [],
+  },
+  {
+    method: "reload.env",
+    upstream: "tui_gateway/server.py (reload.env)",
+    desktopCall: "app/settings (requestGateway)",
+    params: {},
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "wake.status",
+    upstream: "tui_gateway/server.py:13744",
+    desktopCall: "store/wake-word.ts (request)",
+    params: {},
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "wake.feed",
+    upstream: "tui_gateway/server.py:13814",
+    desktopCall: "store/wake-word.ts (request)",
+    params: { audio: "" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "wake.pause",
+    upstream: "tui_gateway/server.py:13714",
+    desktopCall: "store/wake-word.ts (request)",
+    params: {},
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "wake.stop",
+    upstream: "tui_gateway/server.py:13687",
+    desktopCall: "store/wake-word.ts:251 (gatewayRequester)",
+    params: {},
+    resultKeys: [],
+    gap: "missing",
+  },
+
+  // ── methods_complete.py ────────────────────────────────────────────────────
+  {
+    method: "model.options",
+    upstream: "tui_gateway/methods_complete.py:357",
+    desktopCall: "app/chat/composer (request)",
+    params: { session_id: SESSION },
+    resultKeys: ["model", "provider", "providers"],
+  },
+  {
+    method: "complete.path",
+    upstream: "tui_gateway/methods_complete.py:41",
+    desktopCall: "app/session/hooks/use-context-suggestions.ts:37",
+    params: { word: "sr", session_id: SESSION },
+    resultKeys: ["items"],
+    gap: "missing",
+  },
+  {
+    method: "complete.slash",
+    upstream: "tui_gateway/methods_complete.py:218",
+    desktopCall: "app/chat/composer/hooks/use-slash-completions.ts:187",
+    params: { text: "/mem" },
+    resultKeys: ["items"],
+    gap: "missing",
+  },
+
+  // ── methods_tools.py ───────────────────────────────────────────────────────
+  {
+    method: "commands.catalog",
+    upstream: "tui_gateway/methods_tools.py:255",
+    desktopCall: "app/chat/composer (requestGateway)",
+    params: {},
+    resultKeys: ["categories"],
+  },
+  {
+    method: "slash.exec",
+    upstream: "tui_gateway/methods_tools.py:1077",
+    desktopCall: "app/session/hooks/use-prompt-actions/slash.ts",
+    // `status` is in INJECT_ALLOWLIST, so this exercises the REPL lane that
+    // actually captures output; the non-REPL lane needs a live gateway socket.
+    params: { session_id: SESSION, command: "status" },
+    resultKeys: ["output"],
+  },
+  {
+    method: "command.dispatch",
+    upstream: "tui_gateway/methods_tools.py:432",
+    desktopCall: "app/chat/composer (requestGateway)",
+    params: { session_id: SESSION, command: "/doctor" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "process.list",
+    upstream: "tui_gateway/methods_tools.py:49",
+    desktopCall: "store (gateway.request)",
+    params: { session_id: SESSION },
+    // methods_tools.py:56
+    resultKeys: ["processes"],
+    gap: "missing",
+  },
+  {
+    method: "process.kill",
+    upstream: "tui_gateway/methods_tools.py:61",
+    desktopCall: "store (gateway.request)",
+    params: { session_id: SESSION, process_id: "p1" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "reload.mcp",
+    upstream: "tui_gateway/methods_tools.py:84",
+    desktopCall: "store (gateway.request)",
+    params: { session_id: SESSION, confirm: true },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "browser.manage",
+    upstream: "tui_gateway/methods_tools.py:1352",
+    desktopCall: "store (gatewayRequest)",
+    params: { session_id: SESSION, action: "status" },
+    resultKeys: [],
+    gap: "missing",
+  },
+  {
+    method: "plugins.manage",
+    upstream: "tui_gateway/methods_tools.py (plugins.manage)",
+    desktopCall: "app/settings (gateway.request)",
+    params: { action: "list" },
+    resultKeys: [],
+    gap: "missing",
+  },
+
+  // ── Approval / sudo lane ───────────────────────────────────────────────────
+  // Note the asymmetry: upstream serves the *.respond RPCs; `approval.request`
+  // and `sudo.request` are GatewayEventName values (json-rpc-gateway.ts:16-17),
+  // not RPC methods. Switchroom deliberately never implements these — approvals
+  // stay a Telegram-only surface (hermes-adapter.ts:17) — so a -32601 here is
+  // the CORRECT answer and these rows are asserted as intentional degrades.
+  {
+    method: "approval.respond",
+    upstream: "tui_gateway/server.py (approval.respond)",
+    desktopCall: "store (gateway.request)",
+    params: { request_id: "req-1", decision: "allow" },
+    resultKeys: [],
+    note: "intentional degrade — approvals are Telegram-only by invariant",
+  },
+  {
+    method: "sudo.respond",
+    upstream: "tui_gateway/server.py (sudo.respond)",
+    desktopCall: "store (gateway.request)",
+    params: { request_id: "req-1", decision: "allow" },
+    resultKeys: [],
+    note: "intentional degrade — approvals are Telegram-only by invariant",
+  },
+];
+
+/** Methods Switchroom deliberately refuses (see the note on the rows above). */
+const INTENTIONAL_DEGRADES = new Set(["approval.respond", "sudo.respond"]);
+
+// ─── 1. Dispatch parity: every real method must be routed ────────────────────
+
+describe(`Hermes WS contract parity (upstream ${HERMES_UPSTREAM_PIN.slice(0, 7)})`, () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = harness();
+  });
+
+  it("the table only names methods that exist upstream", () => {
+    // Guards a typo'd row silently asserting nothing meaningful.
+    for (const c of CONTRACT) {
+      expect(c.upstream, `${c.method} has no upstream provenance`).toMatch(/^tui_gateway\//);
+      expect(c.method).toMatch(/^[a-z_]+(\.[a-z_]+)+$/);
+    }
+    expect(new Set(CONTRACT.map((c) => c.method)).size).toBe(CONTRACT.length);
+  });
+
+  for (const c of CONTRACT) {
+    if (INTENTIONAL_DEGRADES.has(c.method)) continue;
+
+    const pending = c.gap === "missing";
+    const dispatched = pending ? it.fails : it;
+
+    dispatched(
+      `${pending ? "[GAP] " : ""}${c.method} is dispatched (not -32601) — upstream ${c.upstream}`,
+      async () => {
+        const r = await call(h, c.method, c.params);
+        expect(r.error?.code, `${c.method}: ${c.note ?? ""}`).not.toBe(-32601);
+      },
+    );
+  }
+
+  for (const c of CONTRACT) {
+    if (c.resultKeys.length === 0) continue;
+    if (INTENTIONAL_DEGRADES.has(c.method)) continue;
+
+    const shaped = c.gap ? it.fails : it;
+
+    shaped(
+      `${c.gap ? "[GAP] " : ""}${c.method} result carries ${c.resultKeys.join(", ")} — read at ${c.reader ?? c.desktopCall ?? "upstream"}`,
+      async () => {
+        const r = await call(h, c.method, c.params);
+        expect(r.error, `${c.method} errored: ${JSON.stringify(r.error)}`).toBeUndefined();
+        for (const key of c.resultKeys) {
+          expect(r.result, `${c.method}.${key} missing — ${c.note ?? ""}`).toHaveProperty(key);
+        }
+      },
+    );
+  }
+
+  for (const method of INTENTIONAL_DEGRADES) {
+    it(`${method} degrades with -32601 by design (approvals are Telegram-only)`, async () => {
+      const r = await call(h, method, { request_id: "x" });
+      expect(r.error?.code).toBe(-32601);
+    });
+  }
+});
+
+// ─── 2. Adapter-only surface: methods with no upstream peer ──────────────────
+
+describe("adapter-only RPC surface", () => {
+  /**
+   * `model.info` has no `@method("model.info")` upstream and no desktop call
+   * site (verified by both greps in the re-derive recipe). It is dead weight
+   * the adapter answers; kept as a documented row so a future re-derive that
+   * finds it upstream flips this test.
+   */
+  const ADAPTER_ONLY = ["model.info"];
+
+  /**
+   * Names the adapter enumerates in its explicit -32601 degrade list
+   * (hermes-adapter.ts:1265-1271) that are NOT upstream RPC methods at all:
+   * `secret.get`/`secret.set` (real method is `secret.respond`,
+   * methods_prompt.py:982) and `approval.request`/`sudo.request` (both are
+   * GatewayEventName values, json-rpc-gateway.ts:16-17).
+   */
+  const BOGUS_DEGRADE_ENTRIES = [
+    "secret.get",
+    "secret.set",
+    "approval.request",
+    "sudo.request",
+  ];
+
+  it("adapter-only methods still answer (documented dead weight, harmless)", async () => {
+    const h = harness();
+    for (const m of ADAPTER_ONLY) {
+      const r = await call(h, m, { session_id: SESSION });
+      expect(r.error?.code, `${m} unexpectedly unrouted`).not.toBe(-32601);
+    }
+  });
+
+  it.fails(
+    "[GAP] the degrade list names only real upstream methods (see BOGUS_DEGRADE_ENTRIES)",
+    async () => {
+      const src = await import("node:fs").then((fs) =>
+        fs.readFileSync(new URL("./hermes-adapter.ts", import.meta.url), "utf-8"),
+      );
+      for (const bogus of BOGUS_DEGRADE_ENTRIES) {
+        expect(src, `${bogus} is not an upstream RPC method`).not.toContain(`case "${bogus}"`);
+      }
+    },
+  );
+});
+
+// ─── 3. Event contract ───────────────────────────────────────────────────────
+
+/**
+ * `GatewayEventName`, verbatim from `apps/shared/src/json-rpc-gateway.ts:1-22`
+ * at the pinned SHA (the union also has a `(string & {})` escape arm, which is
+ * not a contract value). 21 named types.
+ */
+const GATEWAY_EVENT_NAMES = [
+  "gateway.ready",
+  "session.info",
+  "message.start",
+  "message.delta",
+  "message.interim",
+  "message.complete",
+  "thinking.delta",
+  "reasoning.delta",
+  "reasoning.available",
+  "status.update",
+  "tool.start",
+  "tool.progress",
+  "tool.complete",
+  "tool.generating",
+  "clarify.request",
+  "approval.request",
+  "sudo.request",
+  "secret.request",
+  "background.complete",
+  "error",
+  "skin.changed",
+] as const;
+
+/**
+ * Event names the adapter actually emits. Derived statically from the source
+ * rather than by exercising every emitter: `message.complete` / `message.start`
+ * are produced by `startHistoryPoll`, a private `bun:sqlite` poller that cannot
+ * run under vitest (see vitest.config.ts's bun:sqlite excludes). The wire
+ * contract being asserted is still the outcome — which `type` strings can ever
+ * appear in a `{method:"event"}` frame.
+ */
+function emittedEventNames(src: string): Set<string> {
+  return new Set(
+    [...src.matchAll(/sendEvent\(\s*ctx\s*,\s*"([^"]+)"/g)].map((m) => m[1]),
+  );
+}
+
+async function adapterSource(): Promise<string> {
+  const fs = await import("node:fs");
+  return fs.readFileSync(new URL("./hermes-adapter.ts", import.meta.url), "utf-8");
+}
+
+describe("Hermes event contract", () => {
+  it("gateway.ready is the first frame on the wire", () => {
+    const h = harness();
+    onHermesOpen(h.ctx);
+    onHermesClose(h.ctx);
+    expect(h.sent[0]).toMatchObject({
+      jsonrpc: "2.0",
+      method: "event",
+      params: { type: "gateway.ready", session_id: null },
+    });
+  });
+
+  it("event frames use the {jsonrpc, method:'event', params:{type, session_id, payload}} envelope", () => {
+    const h = harness();
+    onHermesOpen(h.ctx);
+    onHermesClose(h.ctx);
+    const frame = h.sent[0] as { params: Record<string, unknown> };
+    expect(Object.keys(frame.params).sort()).toEqual(["payload", "session_id", "type"]);
+  });
+
+  it("every emitted event name is a real GatewayEventName", async () => {
+    const emitted = emittedEventNames(await adapterSource());
+    expect(emitted.size).toBeGreaterThan(0);
+    for (const name of emitted) {
+      expect(GATEWAY_EVENT_NAMES as readonly string[], `${name} is not a GatewayEventName`).toContain(
+        name,
+      );
+    }
+  });
+
+  /**
+   * Streaming lane. Switchroom's history poller only ever emits a terminal
+   * `message.complete`; the desktop's stream handler is built around
+   * delta/interim frames for live typing and around `tool.*` for the tool
+   * timeline (gateway-event.ts). Until those are emitted the console shows a
+   * spinner then a wall of text, with no tool activity at all.
+   */
+  const REQUIRED_STREAM_EVENTS = [
+    "message.delta",
+    "message.interim",
+    "tool.start",
+    "tool.progress",
+    "tool.complete",
+  ];
+
+  for (const name of REQUIRED_STREAM_EVENTS) {
+    it.fails(`[GAP] emits ${name}`, async () => {
+      expect([...emittedEventNames(await adapterSource())]).toContain(name);
+    });
+  }
+
+  /**
+   * `message.complete` payload. gateway-event.ts:751-825 reads:
+   *   text, rendered            → coerceGatewayText(payload?.text) || ...rendered
+   *   response_previewed        → completeAssistantMessage(..., payload.response_previewed, ...)
+   *   status === 'error', error, partial → terminal failure frame
+   *   billing                   → surfaceBillingBlock
+   *   usage                     → per-session UsageStats merge
+   * The adapter sends only {text, prompt_key} (hermes-adapter.ts:396-399).
+   */
+  const MESSAGE_COMPLETE_FIELDS = [
+    "text",
+    "rendered",
+    "response_previewed",
+    "status",
+    "error",
+    "partial",
+    "billing",
+    "usage",
+  ];
+
+  /** Extract the payload object literal of the message.complete emitter. */
+  async function messageCompletePayloadSrc(): Promise<string> {
+    const src = await adapterSource();
+    const at = src.indexOf('sendEvent(ctx, "message.complete"');
+    expect(at, "message.complete emitter not found").toBeGreaterThan(-1);
+    return src.slice(at, src.indexOf("});", at));
+  }
+
+  it("message.complete carries the text the desktop renders", async () => {
+    expect(await messageCompletePayloadSrc()).toContain("text:");
+  });
+
+  for (const field of MESSAGE_COMPLETE_FIELDS.filter((f) => f !== "text")) {
+    it.fails(`[GAP] message.complete carries ${field} (gateway-event.ts:751-825)`, async () => {
+      expect(await messageCompletePayloadSrc()).toContain(`${field}:`);
+    });
+  }
+});


### PR DESCRIPTION
## Why

`handleHermesRest` had three `return {status:200, body:{}}` catch-alls. Any request under `/api/cron`, `/api/profiles`, or `/api/messaging` that no branch handled got a fabricated success. The Hermes Desktop client believed writes had landed when nothing was written.

Concretely: `updateCronJob` uses `PUT /api/cron/jobs/:id`, which the cron branch never refused, so the editor reported "saved" and wrote nothing. `GET /api/profiles/sessions/sidebar` returned an empty `PaginatedSessions` literal with a 200 — and the desktop's own `isEndpointMissingError` fallback only matches 404-ish shapes, so a 200 never trips it and three sidebar slices render permanently empty with no error surfaced.

## What changed

Both classes of silent-success are gone. The prefix branches now handle their real routes explicitly and `return null` (→404) otherwise, so the desktop's existing missing-endpoint fallback can actually fire.

- `PUT /api/cron/jobs/:id` joins POST/PATCH/DELETE in the 422 refusal — schedules are YAML-owned, same justification the sibling verbs already carry
- `GET /api/profiles/sessions/sidebar` serves the real upstream `SidebarSessionsResponse` shape off the same session list `/api/profiles/sessions` uses
- `GET /api/cron/delivery-targets` and `GET /api/cron/blueprints` serve real data instead of falling through
- `GET /api/profiles/active` and `GET /api/profiles/projects/tree` are served rather than 404'd — both are emitted at desktop startup from stores outside `hermes.ts`, and a 404 would pin `$projectsRpcAvailable` at `null` forever since `isMissingRpcMethod` never matches an HTTP status
- `session.history` gains `count`; `session.most_recent` returns upstream's four-key shape instead of `{session}`
- `?source=` / `exclude_sources` filtering via one shared helper, because the sidebar's cron slice cannot be honest without it and upstream requires the batched and legacy paths to agree
- one genuinely dead stub deleted; `/api/auth/providers` kept — it is called from the Electron main process, which a renderer-only grep misses

## Tests

Two contract-parity fixtures pinned to upstream `9da6d455c9e1f2bf74bb9f47766ee9fc52e17bfb`, with re-derivation commands in the headers. A route census over the whole desktop tree, plus response-shape cases driven by a table where `const runner = c.gap ? it.fails : it` — a case flagged `gap` **must** fail, so a gap cannot be cleared without the assertion genuinely passing, and closing a gap turns the case red until the flag is removed in the same change.

REST fixture: 47 shape cases, 29 green, 18 still-open gaps enumerated by name. The narrowing is guarded by a test asserting every desktop-emitted `/api/profiles` GET is still served, verified to fail on the bug it guards.

304 tests pass; `tsc --noEmit` and all 30 lint gates clean.

## Known limits, stated rather than implied

The 18 remaining gaps are named in the fixture (sessions pagination, `SessionInfo` field coverage, session PATCH/DELETE, `/api/env` PUT, analytics). Prefixes not audited here are listed in the fixture header. `handleHermesRest` has no dependency seam and bottoms out in `spawnSync("docker inspect")`, so session-touching cases cost ~2s each; the seam is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)