### PR TITLE
fix(fleet-health): windowDays now windows the ledger's findings, not just its score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **fleet-health: the ledger's `windowDays` now actually windows the
+  findings.** `buildLedger` read `windowDays` but aggregated EVERY finding ever
+  recorded into the dedup_key map — `count` and `reach` had no time filter, so
+  the window only damped `priority_score` through `recencyFactor`, which floors
+  at 0.1 and never reaches zero. Consequence, observed on the live ledger: a
+  delivery-failure cluster whose 177 occurrences all fell between 2026-07-18
+  and 2026-07-27, fixed on 2026-07-26 with zero occurrences since, still ranked
+  #1 — and would have held that rank for a further two weeks purely because
+  nothing aged out. Findings outside the window are now excluded from `count`,
+  `reach`, `recency` and therefore from ranking. A cluster whose occurrences
+  have all aged out produces no aggregate and falls through the existing
+  close-on-zero path: it is emitted once as a zero-frequency `closed` issue so
+  `gh-sync` closes its GitHub issue, then drops out. A finding with no usable
+  timestamp (null or unparseable) is KEPT, not silently dropped — an absent
+  timestamp is not evidence of age, and such findings score recency 0 so they
+  cannot float to the top on their own.
+
 - **hermes adapter: stop reporting success for writes and reads that never
   happened.** The REST handler's `/api/cron` and `/api/profiles` prefix
   branches both ended in a catch-all `return {status: 200, body: {}}`, which

--- a/src/fleet-health/gh-sync.test.ts
+++ b/src/fleet-health/gh-sync.test.ts
@@ -7,6 +7,11 @@ import type { FleetHealthLedger } from "../web/fleet-health-read.js";
 
 const CHAT = "77770003";
 
+/** Pinned scan clock. `buildLedger` windows findings by `windowDays` (default
+ *  30) relative to `now`, so a fixture with a fixed `ts` must pin `now` too —
+ *  otherwise it silently ages out of the window as the wall clock moves. */
+const NOW = new Date("2026-07-03T00:00:00Z");
+
 function dup(agent: string, seq: number): Finding {
   return {
     signal: "duplicate-delivery-represent",
@@ -43,7 +48,9 @@ function fakeDeps(over: Partial<GhSyncDeps> = {}): {
 
 describe("gh-sync (no network — injected deps)", () => {
   it("no-ops with a clear signal when gh is unavailable", () => {
-    const led = buildLedger([dup("clerk", 1), dup("clerk", 2), dup("marko", 3)]);
+    const led = buildLedger([dup("clerk", 1), dup("clerk", 2), dup("marko", 3)], {
+      now: NOW,
+    });
     const { deps } = fakeDeps({
       run: (args) =>
         args[0] === "auth"
@@ -56,7 +63,9 @@ describe("gh-sync (no network — injected deps)", () => {
   });
 
   it("opens an issue with fleet-health + severity + job labels and stores the number", () => {
-    const led = buildLedger([dup("clerk", 1), dup("clerk", 2), dup("marko", 3)]);
+    const led = buildLedger([dup("clerk", 1), dup("clerk", 2), dup("marko", 3)], {
+      now: NOW,
+    });
     const { deps, calls } = fakeDeps();
     const r = syncLedgerIssues(led, "switchroom/switchroom", deps);
     expect(r.skipped).toBe(false);

--- a/src/fleet-health/ledger.test.ts
+++ b/src/fleet-health/ledger.test.ts
@@ -9,13 +9,36 @@ import { readFleetHealth } from "../web/fleet-health-read.js";
 
 const CHAT = "77770002";
 
-function dupFinding(agent: string, seq: number): Finding {
+function dupFinding(agent: string, seq: number, ts = "2026-07-02T21:03:00Z"): Finding {
   return {
     signal: "duplicate-delivery-represent",
     agent,
     turn_id: `${CHAT}:_#${seq}`,
     log_pointer: `logs/${agent}/gateway-supervisor.log:${seq}`,
-    ts: "2026-07-02T21:03:00Z",
+    ts,
+  };
+}
+
+/** The real-world cluster this regression is about: `reply-delivery-failure`
+ *  (severity 3) on the delivery job spec. */
+function deliveryFailFinding(agent: string, seq: number, ts: string): Finding {
+  return {
+    signal: "reply-delivery-failure",
+    agent,
+    turn_id: `${CHAT}:_#${seq}`,
+    log_pointer: `logs/${agent}/gateway-supervisor.log:${seq}`,
+    ts,
+  };
+}
+
+/** A finding on a DIFFERENT job spec, so a scenario can compare ranks. */
+function killedFinding(agent: string, seq: number, ts: string): Finding {
+  return {
+    signal: "killed-incomplete-turn",
+    agent,
+    turn_id: `${CHAT}:_#${seq}`,
+    log_pointer: `agents/${agent}/turns.jsonl:${seq}`,
+    ts,
   };
 }
 
@@ -58,6 +81,135 @@ describe("buildLedger", () => {
     )!;
     expect(nd.issues[0].gh_issue).toBe(4242);
     expect(nd.issues[0].status).toBe("resolved-pending-verify");
+  });
+});
+
+describe("buildLedger — windowDays actually windows the findings", () => {
+  const DELIVERY = "talk-to-agents-from-anywhere";
+  const KILLED = "steer-or-queue-mid-flight";
+
+  const FLEET = ["clerk", "marko", "klanker", "scout"];
+
+  /** The real regression: 177 delivery-failure occurrences fleet-wide, all
+   *  between 2026-07-18 and 2026-07-27, fixed on 2026-07-26, none since. Scanned
+   *  well past the 30-day window they must no longer count at all. */
+  function staleDeliveryBurst(): Finding[] {
+    return Array.from({ length: 177 }, (_, i) =>
+      deliveryFailFinding(
+        FLEET[i % FLEET.length],
+        i,
+        `2026-07-${String(18 + (i % 10)).padStart(2, "0")}T12:00:00Z`,
+      ),
+    );
+  }
+
+  it("drops a cluster whose every occurrence is older than the window", () => {
+    const now = new Date("2026-09-01T00:00:00Z"); // > 30d after 2026-07-27
+    const led = buildLedger(staleDeliveryBurst(), { now });
+    const delivery = led.records.find((r) => r.job_spec === DELIVERY)!;
+    expect(delivery.issues).toHaveLength(0);
+    expect(delivery.open_issue_count).toBe(0);
+    expect(delivery.priority_score).toBe(0);
+  });
+
+  it("ranks a small FRESH cluster above a large stale one", () => {
+    const now = new Date("2026-09-01T00:00:00Z");
+    const led = buildLedger(
+      [
+        ...staleDeliveryBurst(), // 177, all out of window
+        killedFinding("clerk", 1, "2026-08-31T09:00:00Z"), // 2, in window
+        killedFinding("clerk", 2, "2026-08-31T10:00:00Z"),
+      ],
+      { now },
+    );
+    const delivery = led.records.find((r) => r.job_spec === DELIVERY)!;
+    const killed = led.records.find((r) => r.job_spec === KILLED)!;
+    expect(killed.priority_score).toBeGreaterThan(delivery.priority_score);
+    // and the fresh one is genuinely at the top of the ledger
+    const top = [...led.records].sort(
+      (a, b) => b.priority_score - a.priority_score,
+    )[0];
+    expect(top.job_spec).toBe(KILLED);
+  });
+
+  it("counts only the in-window occurrences of a mixed cluster", () => {
+    const now = new Date("2026-09-01T00:00:00Z");
+    const led = buildLedger(
+      [
+        ...staleDeliveryBurst(), // 177 stale, fleet-wide
+        deliveryFailFinding("clerk", 900, "2026-08-30T12:00:00Z"), // 1 fresh
+        deliveryFailFinding("clerk", 901, "2026-08-31T12:00:00Z"), // 1 fresh
+      ],
+      { now },
+    );
+    const delivery = led.records.find((r) => r.job_spec === DELIVERY)!;
+    expect(delivery.issues).toHaveLength(1);
+    expect(delivery.issues[0].frequency).toBe(2);
+    // the other three agents appear only in the stale burst
+    expect(delivery.issues[0].reach).toEqual(["clerk"]);
+    expect(delivery.issues[0].recency).toBe("2026-08-31T12:00:00Z");
+  });
+
+  it("closes a prior-open issue whose occurrences all aged out", () => {
+    const at = new Date("2026-07-28T00:00:00Z");
+    const prior = buildLedger(staleDeliveryBurst(), { now: at });
+    const pd = prior.records.find((r) => r.job_spec === DELIVERY)!;
+    expect(pd.issues[0].frequency).toBe(177); // in-window at scan time
+    pd.issues[0].gh_issue = 4242;
+
+    // Same findings, scanned a month later — every one is now out of window.
+    const next = buildLedger(staleDeliveryBurst(), {
+      now: new Date("2026-09-01T00:00:00Z"),
+      prior,
+    });
+    const nd = next.records.find((r) => r.job_spec === DELIVERY)!;
+    expect(nd.issues).toHaveLength(1);
+    expect(nd.issues[0].status).toBe("closed");
+    expect(nd.issues[0].frequency).toBe(0);
+    expect(nd.issues[0].gh_issue).toBe(4242);
+    expect(nd.open_issue_count).toBe(0);
+  });
+
+  it("keeps an undatable finding (ts null) rather than silently dropping it", () => {
+    const now = new Date("2026-09-01T00:00:00Z");
+    const led = buildLedger(
+      [
+        { ...dupFinding("clerk", 1), ts: null },
+        { ...dupFinding("clerk", 2), ts: null },
+      ],
+      { now },
+    );
+    const delivery = led.records.find((r) => r.job_spec === DELIVERY)!;
+    expect(delivery.issues).toHaveLength(1);
+    expect(delivery.issues[0].frequency).toBe(2);
+    // …but an undatable-only cluster carries no recency, so it cannot rank.
+    expect(delivery.issues[0].recency).toBe(null);
+    expect(delivery.priority_score).toBe(0);
+  });
+
+  it("keeps an unparseable-ts finding, and it still cannot rank", () => {
+    const now = new Date("2026-09-01T00:00:00Z");
+    const led = buildLedger(
+      [{ ...dupFinding("clerk", 1), ts: "not-a-timestamp" }],
+      { now },
+    );
+    const delivery = led.records.find((r) => r.job_spec === DELIVERY)!;
+    expect(delivery.issues[0].frequency).toBe(1);
+    // `recencyFactor` cannot parse it → 0, so the cluster scores 0 regardless.
+    expect(delivery.priority_score).toBe(0);
+  });
+
+  it("honours a custom (shorter) windowDays", () => {
+    const now = new Date("2026-08-12T00:00:00Z"); // inside the default 30d
+    const findings = staleDeliveryBurst();
+    const wide = buildLedger(findings, { now });
+    const narrow = buildLedger(findings, { now, windowDays: 7 });
+    expect(
+      wide.records.find((r) => r.job_spec === DELIVERY)!.issues[0].frequency,
+    ).toBe(177);
+    expect(
+      narrow.records.find((r) => r.job_spec === DELIVERY)!.issues,
+    ).toHaveLength(0);
   });
 });
 

--- a/src/fleet-health/ledger.ts
+++ b/src/fleet-health/ledger.ts
@@ -81,6 +81,43 @@ function newer(a: string | null, b: string | null): string | null {
   return Date.parse(a) >= Date.parse(b) ? a : b;
 }
 
+/** Default scan window (days) — matches `recencyFactor`'s default. */
+export const DEFAULT_WINDOW_DAYS = 30;
+
+/**
+ * Is this finding inside the scan window ending at `now`?
+ *
+ * `Finding.ts` is an ISO-8601 string or null (`detect.isoFromTs` converts the
+ * unix-seconds `turns.jsonl` field; `detect.extractTs` lifts the gateway log
+ * line's ISO prefix; the standalone sensors stamp `now`). So the only shapes
+ * that reach here are: a parseable ISO instant, an unparseable string, or null.
+ *
+ * Fallback for an undatable finding (null or unparseable `ts`): KEEP it. An
+ * absent timestamp is not evidence of age — it is a gateway line whose prefix
+ * did not match, or a `turns.jsonl` row missing `ts`. Dropping those would
+ * silently erase live signal on a log-format change, which is the worse
+ * failure. They cost nothing in ranking (`recencyFactor(null) === 0`, so an
+ * undatable-only cluster scores 0 and cannot float to the top), but they do
+ * keep contributing their frequency/reach evidence.
+ */
+export function withinWindow(
+  ts: string | null,
+  now: Date,
+  windowDays: number,
+): boolean {
+  if (!ts) return true; // undatable → keep (see above)
+  const t = Date.parse(ts);
+  if (!Number.isFinite(t)) return true; // unparseable → keep
+  const days =
+    Number.isFinite(windowDays) && windowDays > 0
+      ? windowDays
+      : DEFAULT_WINDOW_DAYS;
+  const ageMs = now.getTime() - t;
+  // Future-dated findings (clock skew) are in-window, not stale.
+  if (ageMs < 0) return true;
+  return ageMs < days * 86_400_000;
+}
+
 export interface BuildLedgerOptions {
   ownerAgent?: string;
   now?: Date;
@@ -103,13 +140,27 @@ export function buildLedger(
   opts: BuildLedgerOptions = {},
 ): FleetHealthLedger {
   const now = opts.now ?? new Date();
-  const windowDays = opts.windowDays ?? 30;
+  const windowDays = opts.windowDays ?? DEFAULT_WINDOW_DAYS;
   const priorIdx = indexPriorIssues(opts.prior ?? null);
   const nowIso = now.toISOString();
 
-  // Aggregate findings by dedup_key.
+  // Aggregate findings by dedup_key — WITHIN THE SCAN WINDOW ONLY. `windowDays`
+  // used to damp `priority_score` via `recencyFactor` alone, which floors at
+  // 0.1 and never reaches zero, so a fixed-and-quiet cluster kept its full
+  // historical `frequency`/`reach` and could hold the #1 rank for a whole
+  // window after its last occurrence. Filtering here makes the window mean what
+  // it says: only occurrences inside it count toward frequency, reach, recency
+  // and therefore ranking.
+  //
+  // A cluster whose findings are ALL out of window produces no agg at all, so
+  // it falls through to the close-on-zero path below: if it was open in the
+  // prior ledger it is emitted once as a zero-frequency `closed` issue (so
+  // gh-sync closes its GitHub issue) and then drops out. That is the same
+  // treatment a genuinely-fixed cluster already gets, and it needs no new
+  // "historical context" concept in the ledger shape.
   const aggs = new Map<string, Agg>();
   for (const f of findings) {
+    if (!withinWindow(f.ts, now, windowDays)) continue;
     const m = mapSignal(f.signal);
     const key = dedupKeyFor(f);
     let agg = aggs.get(key);

--- a/src/fleet-health/test-agents.test.ts
+++ b/src/fleet-health/test-agents.test.ts
@@ -76,6 +76,11 @@ describe("runScan excludes test agents from the ledger", () => {
     // this fixture scan. "could not tell" ⇒ always ok, no finding.
     const res = runScan({
       base,
+      // Pin the scan clock next to the fixture's log timestamp: `buildLedger`
+      // windows findings by `windowDays` (default 30) relative to `now`, so a
+      // fixed-`ts` fixture scanned against the wall clock ages out of the
+      // window and the assertions below stop describing anything.
+      now: new Date("2026-07-03T03:00:00Z"),
       hindsightGpuDeps: {
         probe: () => ({ gpuPresent: false, containerToolkit: false, engine: "cloud", reason: "test stub" }),
         capsRead: () => ({ status: "absent", path: "/x", caps: null, detail: "" }),


### PR DESCRIPTION
## The bug

`buildLedger` read the scan window and then ignored it for everything that
determines rank.

- `src/fleet-health/ledger.ts:106` — `const windowDays = opts.windowDays ?? 30;`
- `src/fleet-health/ledger.ts:129-130` — `agg.count += 1; agg.reach.add(f.agent);`
  ran for **every** finding, with no time filter.
- `src/fleet-health/ledger.ts:210-218` — `windowDays` reached the output only
  through `issuePriority(...)`, i.e. through `recencyFactor`.
- `src/fleet-health/mapping.ts:254-268` — `recencyFactor` floors at **0.1** and
  never returns zero.

Net effect: an issue kept its full historical `frequency` and `reach` for ever,
damped by at worst a factor of ten. The window damped the score; it never aged
anything out.

Observed on the live ledger: a delivery-failure cluster whose **177 occurrences
all fall between 2026-07-18 and 2026-07-27**, fixed by `98ba1d8e` on 2026-07-26
with **zero occurrences in the sixteen days since**, still ranked **#1** — and
would have held that rank until roughly 2026-08-26 purely because nothing ages
out. Arithmetically: `severity 3 × log10(1+177) × reach 4 × 0.1 = 2.7`, which
still beats a genuinely fresh severity-3 cluster at full recency.

## The fix

One `continue` in the aggregation loop, plus the predicate behind it
(`withinWindow`). Findings outside `[now − windowDays, now]` no longer
contribute to `count`, `reach`, `recency`, and therefore not to ranking.

### Semantics, and why

I read `detect.ts` before deciding rather than assuming the timestamp shape.
`Finding.ts` is `string | null` and is **always ISO-8601 when present** — the
epoch-seconds concern in switchroom logs is real but is already converted at
the producer: `isoFromTs` (`detect.ts:276-280`) turns the unix-**seconds**
`turns.jsonl` field into ISO, `extractTs` (`detect.ts:452-455`) lifts the
gateway line's ISO prefix, and both standalone sensors stamp `now`. So the
filter parses ISO, and there is no epoch-vs-ISO ambiguity to guess at.

**A cluster whose findings have all aged out is dropped, not surfaced as
"historical context".** It produces no aggregate, so it falls through the
existing close-on-zero path (`ledger.ts:180-199`): emitted once as a
zero-frequency `closed` issue carrying the prior GH number so `gh-sync` runs
`gh issue close`, then it drops out next cycle. That is already exactly how a
genuinely fixed cluster is handled, so "aged out" needs no new concept in the
ledger shape and no new field in the read-side contract. Simplest correct
behaviour — and it means an aged-out cluster's GitHub issue actually *closes*
rather than lingering.

**A finding with no usable timestamp is KEPT, and that is documented on the
predicate, not left implicit.** A null or unparseable `ts` means "the gateway
line's prefix did not match" or "the turns row had no `ts`" — it is *not*
evidence of age. Dropping those would silently erase live signal the first time
a log format changes, which is the worse failure. They cost nothing in ranking
(`recencyFactor(null) === 0`, so an undatable-only cluster scores 0 and cannot
float to the top) while still contributing their frequency/reach evidence.

**Future-dated findings (clock skew) count as in-window** rather than being
treated as infinitely stale.

`windowDays` that is non-finite or `<= 0` falls back to the 30-day default
rather than silently dropping every finding.

## Tests

Six new cases in `src/fleet-health/ledger.test.ts`, modelling the real
177-occurrence burst (`reply-delivery-failure`, severity 3, fleet-wide reach,
all dated 2026-07-18..27). **Five fail on the pre-fix code**, verified by
stashing the `ledger.ts` change and re-running:

- a stale-only cluster still reported `frequency` 177 and a non-zero score
- the stale cluster still out-ranked a fresh one — i.e. the actual #1 bug
- a mixed cluster counted its aged-out occurrences
- an aged-out cluster never reached `closed`
- a shorter `windowDays` changed nothing

They assert outcomes (rank, `frequency`, `reach`, `status`), not that a code
path ran. Two remaining cases pin the documented undatable-`ts` fallback.

Two **existing** fixtures (`gh-sync.test.ts`, `test-agents.test.ts`) pinned a
fixed `ts` but let `now` default to the wall clock. They were already
time-bombs — silently drifting further from their fixture date every day — and
this change surfaced them. Both now pin `now`, with a comment saying why.

## Local results

- `npx vitest run src/fleet-health/ src/web/fleet-health.test.ts` — **113 passed (8 files)**
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (full guard chain, including `check-changelog-entry`
  and `check-agent-attribution-trailers`)

## Out of scope, but found

`detect.extractTs` (`detect.ts:452-455`) accepts a timestamp with **no timezone
designator** (`Z` is optional in the regex). `Date.parse` then interprets it as
*local* time, so a gateway log whose prefix omits `Z` is misdated by the host's
UTC offset. It is harmless against a 30-day window and it predates this change,
so I have not touched it — but it also skews `recencyFactor`, and it should be
normalised at the producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
