### PR TITLE
fix(hindsight-watch): floor the streak scan at the retention horizon

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -81,6 +81,7 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
       hindsight: ${{ steps.filter.outputs.hindsight }}
+      hindsightwatch: ${{ steps.filter.outputs.hindsightwatch }}
     steps:
       # merge_group: no diff base exists on a queue ref, so skip the
       # filter (the job still reports `success`, which `e2e-ok` requires)
@@ -149,6 +150,20 @@ jobs:
               - 'tests/docker/hindsight-metrics-cardinality-patch.test.ts'
               - 'tests/docker/hindsight-graph-maintenance-retry-storm.test.ts'
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
+              - '.github/workflows/docker-e2e.yml'
+            # hindsight-watch's streak probe (#4620) asserts its OUTCOME
+            # against a real PostgreSQL, because the defect lives in SQL and no
+            # cheaper layer can see which rows the server actually aggregates.
+            # That test `skipIf`s without docker, so the ordinary vitest shards
+            # (which have docker but never set the require flag) would let a
+            # semantics regression through on the hermetic string pins alone.
+            # It gets a job here — the only workflow that already treats a
+            # docker-dependent probe as a gate.
+            hindsightwatch:
+              - 'src/hindsight-watch/probe.ts'
+              - 'src/hindsight-watch/evaluate.ts'
+              - 'src/hindsight-watch/thresholds.ts'
+              - 'src/hindsight-watch/streak-retention-floor.pg.test.ts'
               - '.github/workflows/docker-e2e.yml'
 
   # ─── Sharded docker e2e run ───────────────────────────────────────
@@ -693,6 +708,54 @@ jobs:
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done
 
+  # ─── hindsight-watch streak probe against a real PostgreSQL (#4620) ─
+  # Cheap by design: no image build, no 6.4GB pull — one throwaway
+  # `postgres:16-alpine` (~80MB), booted and torn down by the test
+  # itself, on `--network none`.
+  #
+  # SWITCHROOM_REQUIRE_PG_PROBE=1 is the whole point. Without it the
+  # test `skipIf`s when docker is unavailable, which is right on a dev
+  # box and useless as a gate: the remaining hermetic assertions in
+  # probe.test.ts are TEXT PINS, so a rewrite that preserved the
+  # strings while breaking the semantics would pass everywhere. With
+  # it, an absent docker or image FAILS the job instead of skipping,
+  # so the only assertions in the repo that can fail on the #4620
+  # outcome always run.
+  #
+  # merge_group and push run it unconditionally, same reasoning as
+  # hindsight-probe: a job that exists so a probe cannot silently skip
+  # must not silently skip on candidate-main.
+  hindsight-watch-pg-probe:
+    needs: changes
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.hindsightwatch == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup-switchroom
+
+      - name: Pull postgres:16-alpine
+        # Pulled HERE rather than left to the test: the test deliberately
+        # refuses to pull (it must not drag an image onto a dev box), and with
+        # SWITCHROOM_REQUIRE_PG_PROBE=1 a cache miss is a hard failure.
+        run: |
+          docker pull postgres:16-alpine
+          docker image inspect postgres:16-alpine >/dev/null
+
+      - name: Streak retention floor, against a real PostgreSQL
+        env:
+          SWITCHROOM_REQUIRE_PG_PROBE: "1"
+        run: npx vitest run src/hindsight-watch/streak-retention-floor.pg.test.ts
+
+      - name: Teardown any orphaned probe container
+        if: always()
+        run: |
+          ids=$(docker ps -aq --filter "name=swr-streak-floor-" 2>/dev/null || true)
+          if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
+
   # ─── Sentinel ─────────────────────────────────────────────────────
   # Branch-protection-required context (see ci-lint.yml header for the
   # pattern). ALWAYS runs and aggregates the path-gated jobs above:
@@ -710,7 +773,7 @@ jobs:
   # can never silently skip; it only actually gates via this sentinel.
   # Keep this `needs` list complete when adding jobs.
   e2e-ok:
-    needs: [changes, e2e-shard, hindsight-probe]
+    needs: [changes, e2e-shard, hindsight-probe, hindsight-watch-pg-probe]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -725,7 +788,8 @@ jobs:
           fail=0
           for pair in \
             "e2e-shard=${{ needs.e2e-shard.result }}" \
-            "hindsight-probe=${{ needs.hindsight-probe.result }}"; do
+            "hindsight-probe=${{ needs.hindsight-probe.result }}" \
+            "hindsight-watch-pg-probe=${{ needs.hindsight-watch-pg-probe.result }}"; do
             job="${pair%%=*}"; r="${pair#*=}"
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
               echo "::error::${job}=${r} — real e2e failure, blocking"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,28 @@ now an anomaly worth investigating, not the norm.
   timestamp is not evidence of age, and such findings score recency 0 so they
   cannot float to the top on their own.
 
+- **hindsight-watch: `consolidation-failure-streak` can no longer count
+  failures that predate a completion the retention prune deleted (#4620), and
+  its recency boundary is pinned (#4621).** `docker/hindsight-maintenance.sh`
+  deletes `status='completed'` rows past `SWITCHROOM_HINDSIGHT_RETENTION_DAYS`
+  and, per its own header, never touches failed ones — measured live on the
+  production bank: oldest `completed` row 30.01 days, oldest `failed` row 25.16
+  days and ageing without bound. So the streak query's unbounded
+  `coalesce(…, '-infinity')` fallback swept in every historical failure once a
+  pair's successes aged out, reporting a large streak with no completion on
+  record. The evaluator's null arm cannot discriminate that shape (those
+  retained failures are ancient by construction), so it would have paged for
+  ever on a bank that is merely idle, with nothing left that could ever
+  complete to clear it. The failure scan is now floored at the SAME horizon the
+  pruner uses — read from the container's own env at probe time rather than
+  hard-coded, so an operator who lowers retention moves the floor with it — and
+  a pair whose failures have all aged past that horizon drops out of the
+  candidate list entirely. Behaviour-neutral on the fleet today: the fixed and
+  unbounded statements return byte-identical rows against production. Separately,
+  the recency arm's `newestFailureAgeS <= CONSOLIDATION_STREAK_RECENCY_S`
+  survived mutation to `<` with the suite green; a 7,199 / 7,200 / 7,201 s
+  boundary trio now pins it.
+
 - **hermes adapter: stop reporting success for writes and reads that never
   happened.** The REST handler's `/api/cron` and `/api/profiles` prefix
   branches both ended in a catch-all `return {status: 200, body: {}}`, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,18 +58,28 @@ now an anomaly worth investigating, not the norm.
   deletes `status='completed'` rows past `SWITCHROOM_HINDSIGHT_RETENTION_DAYS`
   and, per its own header, never touches failed ones — measured live on the
   production bank: oldest `completed` row 30.01 days, oldest `failed` row 25.16
-  days and ageing without bound. So the streak query's unbounded
-  `coalesce(…, '-infinity')` fallback swept in every historical failure once a
+  days and ageing without bound. So the streak query's unbounded failure scan
+  swept in every historical failure once a
   pair's successes aged out, reporting a large streak with no completion on
   record. The evaluator's null arm cannot discriminate that shape (those
   retained failures are ancient by construction), so it would have paged for
   ever on a bank that is merely idle, with nothing left that could ever
   complete to clear it. The failure scan is now floored at the SAME horizon the
   pruner uses — read from the container's own env at probe time rather than
-  hard-coded, so an operator who lowers retention moves the floor with it — and
+  hard-coded (and clamped to 1–36,500 days, since an out-of-range value makes
+  `make_interval` raise and degrades both bank signals to `no-data`), so an
+  operator who lowers retention moves the floor with it — and
   a pair whose failures have all aged past that horizon drops out of the
   candidate list entirely. Behaviour-neutral on the fleet today: the fixed and
-  unbounded statements return byte-identical rows against production. Separately,
+  unbounded statements return byte-identical rows against production. The floor
+  costs coverage in one documented direction: the streak COUNT is truncated at
+  the horizon too, so a never-completed pair failing slower than three attempts
+  per retention window can fall below the warn line and read `ok` where the
+  unbounded count breached. That is accepted on soundness — a failure older
+  than the horizon cannot be shown to be consecutive with the ones after it,
+  because the completion that would have broken the streak is exactly what the
+  prune deletes — and it is pinned against a real PostgreSQL rather than left
+  to prose. Separately,
   the recency arm's `newestFailureAgeS <= CONSOLIDATION_STREAK_RECENCY_S`
   survived mutation to `<` with the suite green; a 7,199 / 7,200 / 7,201 s
   boundary trio now pins it.

--- a/src/hindsight-watch/evaluate.test.ts
+++ b/src/hindsight-watch/evaluate.test.ts
@@ -830,6 +830,40 @@ describe("evaluateConsolidationFailureStreak — the signal that was missing", (
     });
   });
 
+  // ── the recency arm's own boundary (#4621) ───────────────────────────────
+  //
+  // Pre-existing on `main`: `newestFailureAgeS <= CONSOLIDATION_STREAK_RECENCY_S`
+  // survived mutation to `<` with the whole suite green — nothing pinned a
+  // streak whose newest failure is EXACTLY 7,200 s old. The mutation is
+  // behaviourally real: at the boundary the `<` variant drops through to the
+  // sparse arm, where this pair (a recent success) reads `ok` instead of
+  // `breach`. Same discipline as the block above — literal seconds, pinned
+  // against the constant rather than derived from it.
+  it("holds a streak whose newest failure is EXACTLY at the recency line", () => {
+    expect(CONSOLIDATION_STREAK_RECENCY_S).toBe(7_200); // 2h — the fixtures below are written against this
+    const at = (newestFailureAgeS: number) =>
+      evaluateConsolidationFailureStreak([
+        sample(0, {
+          banks: banks({
+            streaks: [
+              {
+                bank: "overlord",
+                operationType: "consolidation",
+                streak: 5,
+                newestFailureAgeS,
+                // A success 1h ago, so the SPARSE arm cannot fire and the
+                // recency arm is the only thing deciding this verdict.
+                lastCompletedAgeS: 3_600,
+              },
+            ],
+          }),
+        }),
+      ]).state;
+    expect(at(7_199)).toBe("breach"); // inside the window
+    expect(at(7_200)).toBe("breach"); // exactly at it — the comparison is inclusive
+    expect(at(7_201)).toBe("ok"); // past it, with no other arm satisfied
+  });
+
   it("reports no-data — never a pass — when the per-bank block is missing", () => {
     expect(evaluateConsolidationFailureStreak([sample(0)]).state).toBe("no-data");
     expect(evaluateConsolidationFailureStreak([sample(0, { banks: null })]).state).toBe("no-data");

--- a/src/hindsight-watch/evaluate.ts
+++ b/src/hindsight-watch/evaluate.ts
@@ -924,18 +924,22 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
  *    failed/pending/processing rows**. So the two halves of a streak age
  *    differently: successes are swept, the failures that define the streak are
  *    immortal. `null` can therefore mean "the successes were deleted while the
- *    failures were kept", and the streak query's `coalesce(…, '-infinity')`
- *    then counts failures that predate a completion which no longer exists.
+ *    failures were kept", and an unbounded `coalesce(…, '-infinity')` would
+ *    then count failures that predate a completion which no longer exists.
  *
  *    The null arm carries the same age evidence the numeric arm does rather
  *    than firing on absence alone, which covers the honest cases — a new pair,
- *    or a pair still actively retrying. It does NOT cover the asymmetry: those
- *    retained failures are ancient by construction, so an age guard cannot
- *    discriminate them. The residual is a bank that still exists and has been
- *    idle on one op type past the retention window; a deleted bank takes its
- *    rows with it via the cascade-delete migration. It is latent — no such pair
- *    exists on the production bank — and closing it belongs in the streak
- *    query, by bounding the failure scan to the retention horizon, not here.
+ *    or a pair still actively retrying. It cannot cover the asymmetry itself:
+ *    those retained failures are ancient by construction, so an age guard here
+ *    cannot discriminate them. That is closed one layer down instead (#4620):
+ *    the streak scan is floored at the SAME retention horizon the pruner uses
+ *    (`bankConsolidationQuery` in `probe.ts`), so a pair whose failures are all
+ *    older than the horizon produces no row at all and can never reach this
+ *    function. What survives is bounded rather than permanent: a pair whose
+ *    successes were swept while its failures are still INSIDE the window does
+ *    still page here, and that page clears when those failures cross the
+ *    horizon. Distinguishing "swept success" from "never succeeded" inside the
+ *    window is impossible once the row is gone.
  */
 function lastSuccessPhrase(lastCompletedAgeS: number | null | undefined): string {
   if (lastCompletedAgeS === undefined) return "unknown (state predates the field)";

--- a/src/hindsight-watch/evaluate.ts
+++ b/src/hindsight-watch/evaluate.ts
@@ -924,8 +924,8 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
  *    failed/pending/processing rows**. So the two halves of a streak age
  *    differently: successes are swept, the failures that define the streak are
  *    immortal. `null` can therefore mean "the successes were deleted while the
- *    failures were kept", and an unbounded `coalesce(…, '-infinity')` would
- *    then count failures that predate a completion which no longer exists.
+ *    failures were kept", and an unbounded scan would then count failures that
+ *    predate a completion which no longer exists.
  *
  *    The null arm carries the same age evidence the numeric arm does rather
  *    than firing on absence alone, which covers the honest cases — a new pair,
@@ -940,6 +940,21 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
  *    still page here, and that page clears when those failures cross the
  *    horizon. Distinguishing "swept success" from "never succeeded" inside the
  *    window is impossible once the row is gone.
+ *
+ *    **The floor also narrows THIS arm, and the narrowing is not all-or-
+ *    nothing.** `s.streak` arrives already truncated to the horizon, so a pair
+ *    with failures on both sides of it can arrive BELOW
+ *    `CONSOLIDATION_FAILURE_STREAK_WARN` and be rejected two lines down. Five
+ *    failures over 60 days with two inside 30 arrives as `streak = 2`, fails
+ *    `2 >= 3`, and reads `ok` where the unbounded count breached at 5. That is
+ *    a real reduction in this arm's reach for very sparse pairs — roughly,
+ *    ones failing slower than three attempts per retention window — and it is
+ *    accepted on soundness: a failure older than the horizon cannot be shown
+ *    to be consecutive with the ones after it, because the completion that
+ *    would have broken the streak is exactly what the prune deletes. Do NOT
+ *    "fix" it by widening the scan; that is #4620. `pending-consolidation-
+ *    depth` (R7) covers the same pair from the depth side. Pinned in
+ *    `streak-retention-floor.pg.test.ts` (fixture 5, `sparsebank`).
  */
 function lastSuccessPhrase(lastCompletedAgeS: number | null | undefined): string {
   if (lastCompletedAgeS === undefined) return "unknown (state predates the field)";

--- a/src/hindsight-watch/probe.test.ts
+++ b/src/hindsight-watch/probe.test.ts
@@ -357,6 +357,58 @@ describe("probeBankConsolidation", () => {
   });
 });
 
+// ── the retention floor on the streak scan (#4620) ──────────────────────
+
+import { spawnSync } from "node:child_process";
+import { BANK_CONSOLIDATION_SH, RETENTION_DAYS_SH, bankConsolidationQuery } from "./probe.js";
+
+describe("the streak scan's retention floor", () => {
+  /** Run the real derivation under `sh` and read back the days it resolved. */
+  const resolve = (env: Record<string, string>): string =>
+    spawnSync("sh", ["-c", `${RETENTION_DAYS_SH}\nprintf '%s' "$RD"`], {
+      encoding: "utf8",
+      env: { PATH: process.env.PATH ?? "/usr/bin:/bin", ...env },
+    }).stdout;
+
+  it("derives the horizon from the pruner's own knob, not from a constant here", () => {
+    // Unset is the fleet's actual state, and 30 is what
+    // `docker/hindsight-maintenance.sh:63` then prunes at.
+    expect(resolve({})).toBe("30");
+    // The case the review note flagged: an operator who tunes the knob down
+    // must move the floor with it, or completions in the 7–30 day band are
+    // already deleted while failures in that band still count.
+    expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: "7" })).toBe("7");
+    expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: "90" })).toBe("90");
+  });
+
+  it("refuses anything that is not a plain number — the value is spliced into SQL", () => {
+    for (const bad of ["", "abc", "30x", "-5", "7 OR 1=1", "$(id)", "1;DROP TABLE async_operations"]) {
+      expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: bad })).toBe("30");
+    }
+  });
+
+  it("clamps 0 to one day — a floor of now() would delete this signal", () => {
+    // RETENTION_DAYS=0 prunes every completion on sight. Flooring at now()
+    // would empty the candidate list and report health for ever.
+    expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: "0" })).toBe("1");
+    expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: "1" })).toBe("1");
+  });
+
+  it("the shipped statement floors the fallback with the resolved horizon", () => {
+    // The unbounded `-infinity` fallback is what #4620 is about: it must not
+    // survive as the OUTER bound, and the floor must be the shell-resolved
+    // value rather than a literal baked in here.
+    expect(BANK_CONSOLIDATION_SH).toContain("now() - make_interval(days => $RD)");
+    expect(BANK_CONSOLIDATION_SH).toMatch(/greatest\(coalesce\(/);
+    expect(BANK_CONSOLIDATION_SH).not.toMatch(/created_at > coalesce\(/);
+    // …and `-infinity` is still the INNER fallback, so a pair that has never
+    // completed is bounded by the floor and by nothing else. (The OUTCOME of
+    // all of this is asserted against a real PostgreSQL in
+    // streak-retention-floor.pg.test.ts.)
+    expect(bankConsolidationQuery("$RD")).toContain("'-infinity'::timestamptz");
+  });
+});
+
 describe("probeVectorIndexes", () => {
   const notice = (probed: number, bad: string[]) =>
     `NOTICE:  VECIDX|${probed}|${bad.length}|${bad.map((b) => b + ";").join("")}\n`;

--- a/src/hindsight-watch/probe.test.ts
+++ b/src/hindsight-watch/probe.test.ts
@@ -394,18 +394,35 @@ describe("the streak scan's retention floor", () => {
     expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: "1" })).toBe("1");
   });
 
-  it("the shipped statement floors the fallback with the resolved horizon", () => {
-    // The unbounded `-infinity` fallback is what #4620 is about: it must not
-    // survive as the OUTER bound, and the floor must be the shell-resolved
-    // value rather than a literal baked in here.
+  it("clamps an absurdly large horizon — make_interval takes an int, not a bigint", () => {
+    // All-digits is not enough. `make_interval(days => 3000000000)` raises
+    // `function make_interval(days => bigint) does not exist` (verified on
+    // pg16), psql exits non-zero, and BOTH bank signals degrade to `no-data`
+    // off one knob typo.
+    expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: "3000000000" })).toBe("30");
+    // A value too large for the shell to compare at all takes the same branch.
+    expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: "9".repeat(40) })).toBe("30");
+    // The boundary itself: a century is allowed, a century and a day is not.
+    expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: "36500" })).toBe("36500");
+    expect(resolve({ SWITCHROOM_HINDSIGHT_RETENTION_DAYS: "36501" })).toBe("30");
+  });
+
+  it("the shipped statement floors the failure scan with the resolved horizon", () => {
+    // The unbounded scan is what #4620 is about: it must not survive as the
+    // bound, and the floor must be the shell-resolved value rather than a
+    // literal baked in here.
     expect(BANK_CONSOLIDATION_SH).toContain("now() - make_interval(days => $RD)");
-    expect(BANK_CONSOLIDATION_SH).toMatch(/greatest\(coalesce\(/);
+    expect(BANK_CONSOLIDATION_SH).toMatch(/created_at > greatest\(\(SELECT max\(b\.created_at\)/);
     expect(BANK_CONSOLIDATION_SH).not.toMatch(/created_at > coalesce\(/);
-    // …and `-infinity` is still the INNER fallback, so a pair that has never
-    // completed is bounded by the floor and by nothing else. (The OUTCOME of
-    // all of this is asserted against a real PostgreSQL in
+    // No `-infinity` sentinel: `greatest` ignores NULLs, so one inside the
+    // `greatest` would be INERT while reading as though it widened the window
+    // for a never-completed pair. Verified on pg16 —
+    // `greatest(coalesce(NULL::timestamptz,'-infinity'), now()-interval '30 days')`
+    // is `IS NOT DISTINCT FROM` the same expression without the coalesce. This
+    // asserts it does not come back as documentation-by-dead-code. (The
+    // OUTCOME of all of this is asserted against a real PostgreSQL in
     // streak-retention-floor.pg.test.ts.)
-    expect(bankConsolidationQuery("$RD")).toContain("'-infinity'::timestamptz");
+    expect(bankConsolidationQuery("$RD")).not.toContain("-infinity");
   });
 });
 

--- a/src/hindsight-watch/probe.ts
+++ b/src/hindsight-watch/probe.ts
@@ -406,11 +406,18 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
  *  - **Grouped by the PAIR, not the bank.** During the incident `overlord`
  *    completed 3,753 retains while its consolidation failed 112 times; a
  *    bank-wide streak would have been reset by every one of them.
- *  - **`-infinity` for a pair that has never completed, FLOORED at the
- *    retention horizon.** `coalesce` to a fixed finite date would silently
- *    window the count, and a pair whose very first op failed must still
- *    register a streak — which is why the fallback is `-infinity` and not a
- *    constant. But an UNBOUNDED fallback counts failures that predate a
+ *  - **A pair that has never completed is bounded by the retention floor and
+ *    by nothing else.** `greatest` in PostgreSQL IGNORES NULLs (verified on
+ *    pg16: `greatest(NULL::timestamptz, now() - interval '30 days')` is the
+ *    timestamp, not NULL), so the "no completion on record" case needs no
+ *    sentinel at all — the subselect returns NULL and the floor is what
+ *    remains. An explicit `coalesce(…, '-infinity')` inside the `greatest`
+ *    would be inert, which is why there isn't one: it read as though it
+ *    widened the window for such a pair, and it cannot. A pair whose very
+ *    first op failed therefore still registers a streak, bounded like every
+ *    other pair's.
+ *
+ *    The bound is the point. An UNBOUNDED scan counts failures that predate a
  *    completion which has since been swept: `docker/hindsight-maintenance.sh`
  *    deletes `status='completed'` rows older than the retention horizon and,
  *    per its own header, NEVER touches failed rows. So a pair that succeeded
@@ -466,13 +473,23 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
  * the streak, and #4620 survives in miniature. Deriving it costs one `case`
  * statement and cannot drift.
  *
- * Two guards on the expansion, because it is spliced into SQL:
+ * Three guards on the expansion, because it is spliced into SQL:
  *
  *  - **Non-numeric → 30.** The value is `case`-matched against `*[!0-9]*` and
  *    replaced with the documented default. This is what makes the splice safe
  *    rather than an injection point; it is also the pruner's own behaviour, in
  *    the sense that `make_interval(days => garbage)` fails there too and the
  *    prune silently no-ops.
+ *  - **Clamped to ≤ 36500 days (a century) → 30.** All-digits is not enough:
+ *    `make_interval` takes an `int`, so `SWITCHROOM_HINDSIGHT_RETENTION_DAYS=3000000000`
+ *    passes the `case` and the `≥ 1` test (the shell's arithmetic is 64-bit)
+ *    and then PostgreSQL raises `function make_interval(days => bigint) does
+ *    not exist` — verified on pg16. psql exits non-zero, `probeBankConsolidation`
+ *    returns `null`, and both bank signals degrade to `no-data`. That is
+ *    contained (`no-data` never reads as a pass) but it is a silent loss of
+ *    two signals from a knob typo, so the upper bound is clamped here. The
+ *    same test also catches a value too large for the shell to compare at all,
+ *    since the failed comparison takes the same branch.
  *  - **Clamped to ≥ 1 day.** `RETENTION_DAYS=0` prunes every completion on
  *    sight; a 0-day floor would be `now()`, which would empty the candidate
  *    list and DELETE this signal. One day is the tightest floor that still
@@ -493,6 +510,30 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
  * is the whole of the defect. Making it invisible sooner would need the
  * evaluator to distinguish "swept success" from "never succeeded", and the two
  * are indistinguishable by construction once the row is gone.
+ *
+ * ### The floor also TRUNCATES a count, and that can cross the warn line
+ *
+ * The third case is neither of the two above and is the one worth stating
+ * plainly, because the count — not just the window — is bounded. A pair with
+ * no visible completion and failures on BOTH sides of the horizon reports only
+ * the ones inside it. Five failures over 60 days, two of them inside 30, is
+ * `streak = 2` where it used to be `5`. `evaluate.ts`'s sparse arm is gated on
+ * `streak >= CONSOLIDATION_FAILURE_STREAK_WARN` (3), so that pair reads `ok`
+ * where it would previously have breached — a real narrowing of #4618's sparse
+ * coverage, not a hypothetical one. `streak-retention-floor.pg.test.ts` pins
+ * it against a real database (fixture 5, `sparsebank`).
+ *
+ * It is accepted rather than worked around, on soundness. A failure older than
+ * the horizon cannot be shown to be CONSECUTIVE with the ones after it: the
+ * completion that would have broken the streak is exactly the kind of row the
+ * prune deletes, so counting across the horizon asserts a consecutiveness the
+ * surviving evidence does not support. Restoring the old count would restore
+ * #4620 itself. What the truncated count under-reports is a genuinely sparse
+ * pair failing more slowly than the retention window can accumulate three
+ * attempts — for a 30-day horizon, slower than roughly one attempt per 10
+ * days. That pair is still caught the moment a third attempt lands inside the
+ * window, and `pending-consolidation-depth` (R7) covers it from the other
+ * side, on rising unconsolidated depth rather than on failure counting.
  */
 export function bankConsolidationQuery(retentionDaysSql: string): string {
   return `SELECT 'S|'||a.bank_id||'|'||a.operation_type||'|'||count(*)||'|'||extract(epoch from (now()-max(a.created_at)))::bigint
@@ -502,10 +543,10 @@ export function bankConsolidationQuery(retentionDaysSql: string): string {
                                                         AND c.status = 'completed')))::bigint::text, '')
      FROM async_operations a
     WHERE a.status = 'failed'
-      AND a.created_at > greatest(coalesce((SELECT max(b.created_at) FROM async_operations b
-                                             WHERE b.bank_id = a.bank_id
-                                               AND b.operation_type = a.operation_type
-                                               AND b.status = 'completed'), '-infinity'::timestamptz),
+      AND a.created_at > greatest((SELECT max(b.created_at) FROM async_operations b
+                                    WHERE b.bank_id = a.bank_id
+                                      AND b.operation_type = a.operation_type
+                                      AND b.status = 'completed'),
                                   now() - make_interval(days => ${retentionDaysSql}))
     GROUP BY a.bank_id, a.operation_type
     UNION ALL
@@ -525,6 +566,7 @@ export function bankConsolidationQuery(retentionDaysSql: string): string {
  */
 export const RETENTION_DAYS_SH = `RD="\${SWITCHROOM_HINDSIGHT_RETENTION_DAYS:-30}"
 case "$RD" in ''|*[!0-9]*) RD=30 ;; esac
+[ "$RD" -le 36500 ] 2>/dev/null || RD=30
 [ "$RD" -ge 1 ] 2>/dev/null || RD=1`;
 
 export const BANK_CONSOLIDATION_SH = `${PSQL_BOOTSTRAP_SH}

--- a/src/hindsight-watch/probe.ts
+++ b/src/hindsight-watch/probe.ts
@@ -406,9 +406,20 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
  *  - **Grouped by the PAIR, not the bank.** During the incident `overlord`
  *    completed 3,753 retains while its consolidation failed 112 times; a
  *    bank-wide streak would have been reset by every one of them.
- *  - **`-infinity` for a pair that has never completed.** `coalesce` to a
- *    finite date would silently window the count; a pair whose very first
- *    op failed must still register a streak.
+ *  - **`-infinity` for a pair that has never completed, FLOORED at the
+ *    retention horizon.** `coalesce` to a fixed finite date would silently
+ *    window the count, and a pair whose very first op failed must still
+ *    register a streak — which is why the fallback is `-infinity` and not a
+ *    constant. But an UNBOUNDED fallback counts failures that predate a
+ *    completion which has since been swept: `docker/hindsight-maintenance.sh`
+ *    deletes `status='completed'` rows older than the retention horizon and,
+ *    per its own header, NEVER touches failed rows. So a pair that succeeded
+ *    35 days ago and failed 40 days ago reads as "112 consecutive failures,
+ *    never completed" — a page nothing can ever clear, because nothing is
+ *    left to complete (#4620). `greatest(…, now() - retention)` bounds the
+ *    scan to the window in which the two halves of a streak are still
+ *    comparable. See {@link bankConsolidationQuery} for where the horizon
+ *    comes from and what it does and does not close.
  *
  * The row also carries the age of the pair's most recent `completed` op —
  * EMPTY when the pair has never completed one. That is the field that lets
@@ -431,24 +442,95 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
  * fetched over N HTTP calls: measured 0.284 s for the whole fleet, against
  * ~1.4-2.1 s PER BANK for the `/stats` endpoint.
  */
-const BANK_CONSOLIDATION_SH = `${PSQL_BOOTSTRAP_SH}
-PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
-  "SELECT 'S|'||a.bank_id||'|'||a.operation_type||'|'||count(*)||'|'||extract(epoch from (now()-max(a.created_at)))::bigint
+/**
+ * The streak + depth statement, with the retention floor left as a SQL
+ * expression the caller supplies.
+ *
+ * ### Why the floor is a parameter, and where the value comes from
+ *
+ * The floor closes #4620 only if it is the SAME horizon the pruner uses.
+ * `docker/hindsight-maintenance.sh:63` reads
+ * `SWITCHROOM_HINDSIGHT_RETENTION_DAYS` (default 30) from its own process
+ * environment, and that script runs INSIDE the hindsight container
+ * (`docker/hindsight-entrypoint.sh:82`). This probe reaches the same table
+ * through `docker exec` on the same container, and `docker exec` inherits the
+ * container's environment — verified live: `HINDSIGHT_API_PORT` reads back
+ * `18888` through `docker exec`, and `SWITCHROOM_HINDSIGHT_RETENTION_DAYS`
+ * reads back unset, which is exactly what the fleet has and why the pruner is
+ * on its 30-day default.
+ *
+ * So the shell expands the knob itself rather than this module hard-coding a
+ * number. A hard-coded 30 would be silently wrong on precisely the deployment
+ * that tuned the knob: at `RETENTION_DAYS=7`, completions in the 7–30 day band
+ * are already deleted while failures in that band would still be swept into
+ * the streak, and #4620 survives in miniature. Deriving it costs one `case`
+ * statement and cannot drift.
+ *
+ * Two guards on the expansion, because it is spliced into SQL:
+ *
+ *  - **Non-numeric → 30.** The value is `case`-matched against `*[!0-9]*` and
+ *    replaced with the documented default. This is what makes the splice safe
+ *    rather than an injection point; it is also the pruner's own behaviour, in
+ *    the sense that `make_interval(days => garbage)` fails there too and the
+ *    prune silently no-ops.
+ *  - **Clamped to ≥ 1 day.** `RETENTION_DAYS=0` prunes every completion on
+ *    sight; a 0-day floor would be `now()`, which would empty the candidate
+ *    list and DELETE this signal. One day is the tightest floor that still
+ *    lets a genuinely live streak register.
+ *
+ * ### What the floor closes, and what it does not
+ *
+ * It closes the unbounded case: a pair whose failures are ALL older than the
+ * horizon drops out of the candidate list entirely (no row, streak 0), so a
+ * retired pair cannot page for ever off failures whose matching completions
+ * were swept.
+ *
+ * It does NOT make a pre-sweep streak invisible while those failures are still
+ * inside the window. A pair that last succeeded 35 days ago and failed 20 days
+ * ago still reports 20-day-old failures with no visible completion, and the
+ * evaluator's null arm still pages on it. That page is now BOUNDED — it clears
+ * when the failures themselves cross the horizon — instead of permanent, which
+ * is the whole of the defect. Making it invisible sooner would need the
+ * evaluator to distinguish "swept success" from "never succeeded", and the two
+ * are indistinguishable by construction once the row is gone.
+ */
+export function bankConsolidationQuery(retentionDaysSql: string): string {
+  return `SELECT 'S|'||a.bank_id||'|'||a.operation_type||'|'||count(*)||'|'||extract(epoch from (now()-max(a.created_at)))::bigint
           ||'|'||coalesce(extract(epoch from (now()-(SELECT max(c.created_at) FROM async_operations c
                                                       WHERE c.bank_id = a.bank_id
                                                         AND c.operation_type = a.operation_type
                                                         AND c.status = 'completed')))::bigint::text, '')
      FROM async_operations a
     WHERE a.status = 'failed'
-      AND a.created_at > coalesce((SELECT max(b.created_at) FROM async_operations b
-                                    WHERE b.bank_id = a.bank_id
-                                      AND b.operation_type = a.operation_type
-                                      AND b.status = 'completed'), '-infinity'::timestamptz)
+      AND a.created_at > greatest(coalesce((SELECT max(b.created_at) FROM async_operations b
+                                             WHERE b.bank_id = a.bank_id
+                                               AND b.operation_type = a.operation_type
+                                               AND b.status = 'completed'), '-infinity'::timestamptz),
+                                  now() - make_interval(days => ${retentionDaysSql}))
     GROUP BY a.bank_id, a.operation_type
     UNION ALL
    SELECT 'P|'||m.bank_id||'|'||count(*) FILTER (WHERE m.consolidated_at IS NULL AND m.fact_type IN ('experience','world'))
      FROM memory_units m
-    GROUP BY m.bank_id"
+    GROUP BY m.bank_id`;
+}
+
+/**
+ * Resolve `$RD`, the retention horizon in days, from the SAME environment
+ * variable the pruner reads — see {@link bankConsolidationQuery} for why it is
+ * derived rather than hard-coded, and for the two guards below.
+ *
+ * Exported so its behaviour can be tested by running it, rather than by
+ * reading it: it is three lines of `sh` and the interesting cases (garbage, 0,
+ * unset) are exactly the ones a static assertion would get wrong.
+ */
+export const RETENTION_DAYS_SH = `RD="\${SWITCHROOM_HINDSIGHT_RETENTION_DAYS:-30}"
+case "$RD" in ''|*[!0-9]*) RD=30 ;; esac
+[ "$RD" -ge 1 ] 2>/dev/null || RD=1`;
+
+export const BANK_CONSOLIDATION_SH = `${PSQL_BOOTSTRAP_SH}
+${RETENTION_DAYS_SH}
+PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
+  "${bankConsolidationQuery("$RD")}"
 `;
 
 /**

--- a/src/hindsight-watch/streak-retention-floor.pg.test.ts
+++ b/src/hindsight-watch/streak-retention-floor.pg.test.ts
@@ -1,0 +1,218 @@
+/**
+ * #4620, end to end against a REAL PostgreSQL: a pair whose completions were
+ * swept by the retention prune, and whose failures were kept, must not page.
+ *
+ * ### Why this test needs a database
+ *
+ * The defect lives in SQL and nowhere else. `docker/hindsight-maintenance.sh`
+ * deletes `status='completed'` rows past the retention horizon and never
+ * touches `failed` ones, so the two halves of a streak age differently. With
+ * an unbounded `coalesce(…, '-infinity')` fallback the streak query then counts
+ * failures that predate a completion which no longer exists: the pair reports a
+ * large streak with no visible success, the evaluator's null arm cannot
+ * discriminate it (those failures are ancient by construction — that is the
+ * whole point), and nothing will ever complete to clear the page.
+ *
+ * Every cheaper layer is blind to this. A fixture fed to `probeBankConsolidation`
+ * asserts the PARSER; a fixture fed to `evaluateConsolidationFailureStreak`
+ * asserts the EVALUATOR; neither can see which rows PostgreSQL actually
+ * aggregates, which is the only thing that decides the outcome. So this test
+ * seeds real rows, runs the real statement, and carries the result through the
+ * real parser into the real evaluator.
+ *
+ * ### Both arms run
+ *
+ * The floored query (GREEN) and the pre-#4620 unbounded one (RED) run against
+ * the SAME seeded rows. The RED arm is the mutation, built in: it is the exact
+ * `-infinity` semantics this PR replaced, reproduced by handing the query
+ * builder a floor so wide it cannot bind, and it must PAGE. Without it, a
+ * fixture that stopped discriminating (say, seeded inside the window) would
+ * leave the GREEN arm green for ever.
+ *
+ * ### Skip discipline
+ *
+ * Same shape as the `tests/docker/` probes: no docker, or no cached
+ * `postgres:16-alpine`, and this skips rather than pulling an image onto a dev
+ * box. Set `SWITCHROOM_REQUIRE_PG_PROBE=1` to make that a hard failure instead
+ * — that is the switch a CI job wires up. It is not wired into a workflow yet
+ * (this PR is scoped to `src/hindsight-watch/`); tracked as follow-up.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { bankConsolidationQuery, probeBankConsolidation } from "./probe.js";
+import type { Runner } from "./probe.js";
+import { evaluateConsolidationFailureStreak } from "./evaluate.js";
+import type { Sample } from "./types.js";
+
+const IMAGE = "postgres:16-alpine";
+const CONTAINER = `swr-streak-floor-${randomUUID().slice(0, 8)}`;
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_PG_PROBE === "1";
+
+function have(): boolean {
+  const r = spawnSync("docker", ["image", "inspect", IMAGE], { stdio: "ignore" });
+  return r.status === 0;
+}
+
+const available = have();
+if (REQUIRED && !available) {
+  throw new Error(`SWITCHROOM_REQUIRE_PG_PROBE=1 but docker or ${IMAGE} is unavailable`);
+}
+
+/**
+ * The retention horizon the fixture is written against, in days. Hard-coded
+ * here rather than imported: the floor is derived at runtime from the
+ * container's `SWITCHROOM_HINDSIGHT_RETENTION_DAYS`, and a fixture that moved
+ * with it could never fail for any value of it.
+ */
+const RETENTION_DAYS = 30;
+
+function psql(sql: string): string {
+  return execFileSync("docker", ["exec", CONTAINER, "psql", "-U", "postgres", "-tAc", sql], {
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+}
+
+/** A `Runner` that answers the probe's `docker exec` with a real psql run. */
+function runnerFor(query: string): Runner {
+  return () => {
+    try {
+      return { status: 0, stdout: psql(query), stderr: "" };
+    } catch (e) {
+      return { status: 1, stdout: "", stderr: String(e) };
+    }
+  };
+}
+
+function sampleWith(banks: ReturnType<typeof probeBankConsolidation>): Sample {
+  return {
+    ts: Date.now(),
+    pending: 0,
+    dead: 0,
+    evicted: 0,
+    drops: 0,
+    restartCount: 0,
+    startedAt: "2026-08-12T00:00:00Z",
+    health: "healthy",
+    banks,
+  };
+}
+
+describe.skipIf(!available)("#4620 — the streak query cannot count across a pruned completion", () => {
+  beforeAll(() => {
+    execFileSync("docker", ["run", "-d", "--name", CONTAINER, "--network", "none", "-e", "POSTGRES_PASSWORD=probe", IMAGE], {
+      encoding: "utf8",
+      timeout: 120_000,
+    });
+    let up = false;
+    for (let i = 0; i < 60; i++) {
+      if (spawnSync("docker", ["exec", CONTAINER, "pg_isready", "-q"], { stdio: "ignore" }).status === 0) {
+        up = true;
+        break;
+      }
+      // Deliberate busy-wait: no timers inside beforeAll, and 60 tries at
+      // ~150ms of spawn overhead each is ~10s of budget for a cold pg.
+      spawnSync("sh", ["-c", "sleep 0.25"], { stdio: "ignore" });
+    }
+    if (!up) throw new Error("throwaway postgres never became ready");
+
+    psql(`
+      CREATE TABLE async_operations(bank_id text, operation_type text, status text, created_at timestamptz);
+      CREATE TABLE memory_units(bank_id text, consolidated_at timestamptz, fact_type text);
+
+      -- (1) THE DEFECT'S SHAPE. 112 failures from the 2026-07-18→07-29 incident
+      -- (the real count, off production), aged past the horizon, and NO
+      -- completed row: its successes were swept by the prune, which never
+      -- touches these failures. 40 days back — a day-level literal, not
+      -- RETENTION_DAYS ± 1, so the fixture does not move with the knob.
+      INSERT INTO async_operations
+        SELECT 'overlord', 'consolidation', 'failed', now() - interval '40 days' + (g || ' minutes')::interval
+          FROM generate_series(1, 112) g;
+
+      -- (2) THE PROPERTY '-infinity' EXISTS FOR. A genuinely new pair whose
+      -- very first ops failed, an hour ago, with no completion ever. It must
+      -- still register — a floor that swallowed this would trade one blind
+      -- spot for another.
+      INSERT INTO async_operations
+        SELECT 'newbank', 'graph_maintenance', 'failed', now() - interval '1 hour' FROM generate_series(1, 4);
+
+      -- (3) A LIVE, DENSE STREAK with a completion 2h ago: unchanged behaviour.
+      INSERT INTO async_operations
+        SELECT 'klanker', 'consolidation', 'failed', now() - interval '10 minutes' FROM generate_series(1, 6);
+      INSERT INTO async_operations VALUES ('klanker', 'consolidation', 'completed', now() - interval '2 hours');
+
+      -- (4) A pair that completed AFTER its failures: no streak at all.
+      INSERT INTO async_operations VALUES ('carrie', 'consolidation', 'failed', now() - interval '3 hours');
+      INSERT INTO async_operations VALUES ('carrie', 'consolidation', 'completed', now() - interval '1 hour');
+
+      INSERT INTO memory_units VALUES ('overlord', NULL, 'experience');
+    `);
+  }, 180_000);
+
+  afterAll(() => {
+    spawnSync("docker", ["rm", "-f", CONTAINER], { stdio: "ignore" });
+  });
+
+  /** The shipped query, with the floor the container's env resolves to. */
+  const floored = () => probeBankConsolidation("unused", runnerFor(bankConsolidationQuery(String(RETENTION_DAYS))));
+
+  /**
+   * The pre-#4620 query. `now() - make_interval(days => 100000)` is ~274 years
+   * back — older than every row any Hindsight database will ever hold, so the
+   * `greatest(…)` can never bind and this is `-infinity` semantics exactly, on
+   * the same statement. (A literally astronomical figure is not usable:
+   * PostgreSQL raises `timestamp out of range` well before `-infinity`.)
+   */
+  const unbounded = () => probeBankConsolidation("unused", runnerFor(bankConsolidationQuery("100000")));
+
+  it("RED — the unbounded fallback pages, permanently, on the swept pair", () => {
+    const banks = unbounded();
+    const retired = banks?.streaks.find((s) => s.bank === "overlord");
+    expect(retired).toBeDefined();
+    // Every failure the pair ever had, and no success on record: the exact
+    // reading the issue predicted.
+    expect(retired?.streak).toBe(112);
+    expect(retired?.lastCompletedAgeS).toBeNull();
+    // …and it is at least 40 days old, so no recency guard can discriminate it.
+    expect(retired?.newestFailureAgeS).toBeGreaterThan(39 * 86_400);
+
+    const v = evaluateConsolidationFailureStreak([sampleWith(banks)]);
+    expect(v.state).toBe("breach");
+    expect(v.severity).toBe("page");
+    expect(v.measured?.bank).toBe("overlord");
+    expect(v.measured?.streak).toBe(112);
+  });
+
+  it("GREEN — floored at the retention horizon, the swept pair does not page", () => {
+    const banks = floored();
+    // Not merely below the warn line: it is not a candidate at all, because
+    // none of its failures survive the floor.
+    expect(banks?.streaks.find((s) => s.bank === "overlord")).toBeUndefined();
+
+    const v = evaluateConsolidationFailureStreak([sampleWith(banks)]);
+    expect(v.measured?.bank).not.toBe("overlord");
+    expect(v.detail).not.toContain("overlord");
+  });
+
+  it("GREEN — a brand-new pair whose FIRST ops failed still registers", () => {
+    const newbank = floored()?.streaks.find((s) => s.bank === "newbank");
+    expect(newbank?.streak).toBe(4);
+    expect(newbank?.lastCompletedAgeS).toBeNull();
+    // 4 ≥ warn(3) and the failures are an hour old, so this one DOES page —
+    // the floor must not have made new pairs invisible.
+    const v = evaluateConsolidationFailureStreak([sampleWith(floored())]);
+    expect(v.state).toBe("breach");
+  });
+
+  it("GREEN — a live streak with a recent completion is counted exactly as before", () => {
+    const banks = floored();
+    const klanker = banks?.streaks.find((s) => s.bank === "klanker");
+    expect(klanker?.streak).toBe(6); // only the failures newer than the 2h-old completion
+    expect(klanker?.lastCompletedAgeS).toBeGreaterThan(7_000);
+    // A pair that completed after failing has no streak under either query.
+    expect(banks?.streaks.find((s) => s.bank === "carrie")).toBeUndefined();
+    expect(unbounded()?.streaks.find((s) => s.bank === "carrie")).toBeUndefined();
+  });
+});

--- a/src/hindsight-watch/streak-retention-floor.pg.test.ts
+++ b/src/hindsight-watch/streak-retention-floor.pg.test.ts
@@ -7,7 +7,7 @@
  * The defect lives in SQL and nowhere else. `docker/hindsight-maintenance.sh`
  * deletes `status='completed'` rows past the retention horizon and never
  * touches `failed` ones, so the two halves of a streak age differently. With
- * an unbounded `coalesce(…, '-infinity')` fallback the streak query then counts
+ * an unbounded failure scan the streak query then counts
  * failures that predate a completion which no longer exists: the pair reports a
  * large streak with no visible success, the evaluator's null arm cannot
  * discriminate it (those failures are ancient by construction — that is the
@@ -24,18 +24,20 @@
  *
  * The floored query (GREEN) and the pre-#4620 unbounded one (RED) run against
  * the SAME seeded rows. The RED arm is the mutation, built in: it is the exact
- * `-infinity` semantics this PR replaced, reproduced by handing the query
- * builder a floor so wide it cannot bind, and it must PAGE. Without it, a
- * fixture that stopped discriminating (say, seeded inside the window) would
- * leave the GREEN arm green for ever.
+ * pre-fix semantics this PR replaced, reproduced by handing the query builder
+ * a floor so wide it cannot bind, and it must PAGE. Without it, a fixture that
+ * stopped discriminating (say, seeded inside the window) would leave the GREEN
+ * arm green for ever.
  *
  * ### Skip discipline
  *
  * Same shape as the `tests/docker/` probes: no docker, or no cached
  * `postgres:16-alpine`, and this skips rather than pulling an image onto a dev
- * box. Set `SWITCHROOM_REQUIRE_PG_PROBE=1` to make that a hard failure instead
- * — that is the switch a CI job wires up. It is not wired into a workflow yet
- * (this PR is scoped to `src/hindsight-watch/`); tracked as follow-up.
+ * box. Set `SWITCHROOM_REQUIRE_PG_PROBE=1` to make that a hard failure instead.
+ * `.github/workflows/docker-e2e.yml`'s `hindsight-watch-pg-probe` job sets it,
+ * so on CI this file cannot silently skip: the outcome assertions here are the
+ * only ones in the repo that can fail on a semantics regression rather than on
+ * a changed string.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
@@ -67,6 +69,73 @@ if (REQUIRED && !available) {
  * with it could never fail for any value of it.
  */
 const RETENTION_DAYS = 30;
+
+/**
+ * The line the `postgres:*` entrypoint prints AFTER the temporary init server
+ * is gone and BEFORE the real one starts. See {@link waitForRealServer}.
+ */
+const INIT_COMPLETE = "PostgreSQL init process complete; ready for start up.";
+
+/** One quantum of waiting. No timers inside `beforeAll`, so this is a spawn. */
+function nap(): void {
+  spawnSync("sh", ["-c", "sleep 0.25"], { stdio: "ignore" });
+}
+
+function poll(what: string, ready: () => boolean, tries: number): void {
+  for (let i = 0; i < tries; i++) {
+    if (ready()) return;
+    nap();
+  }
+  throw new Error(`throwaway postgres: ${what} (gave up after ~${Math.round(tries / 4)}s)`);
+}
+
+/**
+ * Wait for the REAL server, not the init one — the reason this file used to be
+ * flaky.
+ *
+ * The `postgres:16-alpine` entrypoint runs a TEMPORARY server on the same unix
+ * socket while it runs `initdb` and the `/docker-entrypoint-initdb.d` hooks,
+ * then shuts it down and execs the real one. `pg_isready` returns 0 against
+ * that temporary server, and so does `psql`. A readiness loop that breaks on
+ * the FIRST success therefore returns while the socket is about to disappear,
+ * and the next `docker exec … psql` dies with
+ * `connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed:
+ * No such file or directory` — either in the seed (a broken run) or in
+ * `beforeAll` itself (four skipped tests). Measured at 3 failures in 8 runs on
+ * review; reproduced here with the old discipline at 1 seed failure in 10.
+ * Retrying the seed would paper over it; two consecutive readies would still
+ * be a race, just a narrower one.
+ *
+ * So the wait is deterministic instead. The entrypoint logs, in this order:
+ *
+ *     LOG:  database system is ready to accept connections   ← temp server
+ *     PostgreSQL init process complete; ready for start up.  ← init done
+ *     LOG:  database system is ready to accept connections   ← real server
+ *
+ * (verified on `postgres:16-alpine`.) The middle line is printed only once and
+ * only after the temporary server has exited, so blocking on it first removes
+ * the ambiguity entirely: any connection that succeeds after it is talking to
+ * the real server. `select 1` rather than `pg_isready` for the second phase,
+ * because a real query is the thing the seed is about to do.
+ */
+function waitForRealServer(): void {
+  poll(
+    "the entrypoint never finished initdb",
+    () => {
+      const r = spawnSync("docker", ["logs", CONTAINER], { encoding: "utf8" });
+      return `${r.stdout ?? ""}${r.stderr ?? ""}`.includes(INIT_COMPLETE);
+    },
+    240,
+  );
+  poll(
+    "the post-init server never accepted a query",
+    () =>
+      spawnSync("docker", ["exec", CONTAINER, "psql", "-U", "postgres", "-tAc", "select 1"], {
+        stdio: "ignore",
+      }).status === 0,
+    120,
+  );
+}
 
 function psql(sql: string): string {
   return execFileSync("docker", ["exec", CONTAINER, "psql", "-U", "postgres", "-tAc", sql], {
@@ -106,17 +175,7 @@ describe.skipIf(!available)("#4620 — the streak query cannot count across a pr
       encoding: "utf8",
       timeout: 120_000,
     });
-    let up = false;
-    for (let i = 0; i < 60; i++) {
-      if (spawnSync("docker", ["exec", CONTAINER, "pg_isready", "-q"], { stdio: "ignore" }).status === 0) {
-        up = true;
-        break;
-      }
-      // Deliberate busy-wait: no timers inside beforeAll, and 60 tries at
-      // ~150ms of spawn overhead each is ~10s of budget for a cold pg.
-      spawnSync("sh", ["-c", "sleep 0.25"], { stdio: "ignore" });
-    }
-    if (!up) throw new Error("throwaway postgres never became ready");
+    waitForRealServer();
 
     psql(`
       CREATE TABLE async_operations(bank_id text, operation_type text, status text, created_at timestamptz);
@@ -131,10 +190,12 @@ describe.skipIf(!available)("#4620 — the streak query cannot count across a pr
         SELECT 'overlord', 'consolidation', 'failed', now() - interval '40 days' + (g || ' minutes')::interval
           FROM generate_series(1, 112) g;
 
-      -- (2) THE PROPERTY '-infinity' EXISTS FOR. A genuinely new pair whose
-      -- very first ops failed, an hour ago, with no completion ever. It must
-      -- still register — a floor that swallowed this would trade one blind
-      -- spot for another.
+      -- (2) THE NEVER-COMPLETED CASE. A genuinely new pair whose very first
+      -- ops failed, an hour ago, with no completion ever. greatest() ignores
+      -- the NULL subselect, so the floor is the only bound and this must still
+      -- register — a floor that swallowed it would trade one blind spot for
+      -- another. (This pair clears the floor trivially; fixture 5 is the one
+      -- that STRADDLES it.)
       INSERT INTO async_operations
         SELECT 'newbank', 'graph_maintenance', 'failed', now() - interval '1 hour' FROM generate_series(1, 4);
 
@@ -146,6 +207,20 @@ describe.skipIf(!available)("#4620 — the streak query cannot count across a pr
       -- (4) A pair that completed AFTER its failures: no streak at all.
       INSERT INTO async_operations VALUES ('carrie', 'consolidation', 'failed', now() - interval '3 hours');
       INSERT INTO async_operations VALUES ('carrie', 'consolidation', 'completed', now() - interval '1 hour');
+
+      -- (5) THE COST OF THE FLOOR, pinned. A never-completed pair failing too
+      -- slowly to accumulate 3 attempts inside a 30-day horizon: 5 failures
+      -- over 60 days, THREE outside the horizon and TWO inside it. Unbounded
+      -- it is a streak of 5 and breaches; floored it is a streak of 2, below
+      -- CONSOLIDATION_FAILURE_STREAK_WARN, and reads ok. Day literals on both
+      -- sides of the edge, deliberately far from it, so the fixture does not
+      -- move with the knob.
+      INSERT INTO async_operations VALUES
+        ('sparsebank', 'graph_maintenance', 'failed', now() - interval '55 days'),
+        ('sparsebank', 'graph_maintenance', 'failed', now() - interval '50 days'),
+        ('sparsebank', 'graph_maintenance', 'failed', now() - interval '45 days'),
+        ('sparsebank', 'graph_maintenance', 'failed', now() - interval '20 days'),
+        ('sparsebank', 'graph_maintenance', 'failed', now() - interval '10 days');
 
       INSERT INTO memory_units VALUES ('overlord', NULL, 'experience');
     `);
@@ -204,6 +279,40 @@ describe.skipIf(!available)("#4620 — the streak query cannot count across a pr
     // the floor must not have made new pairs invisible.
     const v = evaluateConsolidationFailureStreak([sampleWith(floored())]);
     expect(v.state).toBe("breach");
+  });
+
+  /**
+   * The verdict for ONE pair. The evaluator reports the worst live streak in
+   * the fleet, so a pair-level claim has to be asked pair-by-pair or the loud
+   * fixtures (klanker, newbank) answer for it.
+   */
+  const verdictFor = (banks: ReturnType<typeof probeBankConsolidation>, bank: string) =>
+    evaluateConsolidationFailureStreak([
+      sampleWith(banks === null ? null : { ...banks, streaks: banks.streaks.filter((s) => s.bank === bank) }),
+    ]);
+
+  it("CAVEAT — truncation drops a straddling sparse pair BELOW the warn line", () => {
+    // This is a documented COST of the floor, not a bug, and it is pinned here
+    // so it cannot widen unnoticed: the count is truncated at the horizon, not
+    // just the window, so a pair failing slower than 3 attempts per retention
+    // window loses the sparse arm (`probe.ts`, "The floor also TRUNCATES a
+    // count"; `evaluate.ts`, the null-arm doc block). Restoring the old count
+    // would restore #4620 itself, so the narrowing is accepted — but silently
+    // reopening #4618's sparse blind spot further is not.
+    const before = unbounded()?.streaks.find((s) => s.bank === "sparsebank");
+    expect(before?.streak).toBe(5);
+    expect(before?.lastCompletedAgeS).toBeNull();
+    expect(verdictFor(unbounded(), "sparsebank").state).toBe("breach");
+
+    const after = floored()?.streaks.find((s) => s.bank === "sparsebank");
+    // Present — the pair is NOT the all-or-nothing case the docs used to
+    // describe as the only narrowing — but truncated to what survives.
+    expect(after?.streak).toBe(2);
+    expect(after?.lastCompletedAgeS).toBeNull();
+    expect(after?.newestFailureAgeS).toBeGreaterThan(9 * 86_400);
+    const v = verdictFor(floored(), "sparsebank");
+    expect(v.state).toBe("ok");
+    expect(v.severity).toBeUndefined();
   });
 
   it("GREEN — a live streak with a recent completion is counted exactly as before", () => {

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -1129,21 +1129,28 @@ export const CONSOLIDATION_STREAK_RECENCY_S = 2 * 60 * 60;
  * the status quo of *never*, and against a 24 h line that a measured 27.67 h
  * self-heal would have false-paged.
  *
- * **The retention asymmetry leaves a second, LATENT residual.** Because
- * completions are pruned at 30 days while failures are immortal, a
+ * **The retention asymmetry left a second residual, since closed (#4620).**
+ * Because completions are pruned at 30 days while failures are immortal, a
  * `lastCompletedAgeS` of `null` does not symmetrically mean "no completion in
  * the retention window" — it can mean the successes were swept while the
- * failures defining the streak were kept, and the streak query's
- * `coalesce(…, '-infinity')` then counts every historical failure, including
+ * failures defining the streak were kept, and an unbounded
+ * `coalesce(…, '-infinity')` then counted every historical failure, including
  * ones that predate a now-deleted success. The `newestFailureAgeS` guard on
  * the null arm cannot catch that, because those retained failures are ancient
- * by construction. The exposure is a bank that still EXISTS but has been idle
- * on one op type for longer than the retention window; a deleted bank takes
- * its rows with it via the cascade-delete migration. Latent, not live:
- * simulating the prune at 5- and 12-day horizons surfaces no pair other than
- * the two live `graph_maintenance` ones. Closing it properly belongs in the
- * streak query — bounding the failure scan to the retention horizon — not in
- * the evaluator, and is tracked separately rather than widened into this fix.
+ * by construction. It is fixed where the issue said it belonged — in the
+ * streak query, not here: the failure scan is now floored at the SAME horizon
+ * the pruner uses, read from `SWITCHROOM_HINDSIGHT_RETENTION_DAYS` in the
+ * hindsight container rather than hard-coded (see `bankConsolidationQuery` in
+ * `probe.ts`), so a pair whose failures have all aged past the horizon never
+ * reaches this constant at all. No new threshold is introduced by that fix,
+ * deliberately: the horizon is an operator knob with a documented default, not
+ * a measured rate, and duplicating it here as a constant would be the drift
+ * the fix exists to avoid.
+ *
+ * The floor bounds the exposure rather than erasing it. A pair whose successes
+ * were swept while its failures are still INSIDE the window still breaches on
+ * the null arm, and that breach now clears when those failures cross the
+ * horizon instead of persisting for ever.
  *
  * That is a documented limitation, not a safety claim: the alternative is the
  * status quo, where a permanently-broken sparse type reads green for ever.

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -1133,9 +1133,8 @@ export const CONSOLIDATION_STREAK_RECENCY_S = 2 * 60 * 60;
  * Because completions are pruned at 30 days while failures are immortal, a
  * `lastCompletedAgeS` of `null` does not symmetrically mean "no completion in
  * the retention window" — it can mean the successes were swept while the
- * failures defining the streak were kept, and an unbounded
- * `coalesce(…, '-infinity')` then counted every historical failure, including
- * ones that predate a now-deleted success. The `newestFailureAgeS` guard on
+ * failures defining the streak were kept, and an unbounded scan then counted
+ * every historical failure, including ones that predate a now-deleted success. The `newestFailureAgeS` guard on
  * the null arm cannot catch that, because those retained failures are ancient
  * by construction. It is fixed where the issue said it belonged — in the
  * streak query, not here: the failure scan is now floored at the SAME horizon
@@ -1151,6 +1150,16 @@ export const CONSOLIDATION_STREAK_RECENCY_S = 2 * 60 * 60;
  * were swept while its failures are still INSIDE the window still breaches on
  * the null arm, and that breach now clears when those failures cross the
  * horizon instead of persisting for ever.
+ *
+ * It costs this constant some reach in one direction, stated here because it
+ * is the sparse arm's own coverage that shrinks: the streak arriving here is
+ * TRUNCATED at the horizon, so a pair failing slower than
+ * `CONSOLIDATION_FAILURE_STREAK_WARN` attempts per retention window can arrive
+ * below the warn line and read `ok` even with no completion on record. Five
+ * failures over 60 days, two inside 30, arrives as 2. Accepted deliberately —
+ * counting across the horizon would assert a consecutiveness the surviving
+ * rows cannot support, which is #4620 — and pinned against a real database in
+ * `streak-retention-floor.pg.test.ts`.
  *
  * That is a documented limitation, not a safety claim: the alternative is the
  * status quo, where a permanently-broken sparse type reads green for ever.


### PR DESCRIPTION
Closes #4620
Closes #4621

## Why / job spec

`reference/jobs/fleet-stays-healthy.md` — *"the fleet detects, ranks, and tracks its own recurring failures… the operator sees the worst-affecting issues first — with frequency, evidence"*.

A page whose cited evidence has been deleted by retention is the exact failure mode that spec exists to prevent: it is unactionable, it never clears, and once the operator learns to ignore one watchdog verdict the rest of the surface loses its authority. #4620 is that bug in the consolidation-failure streak scan; #4621 is an unguarded boundary in the evaluator that decides whether such a streak is still live.

## What changed

**#4620 — the streak window is floored at the retention horizon.**

`docker/hindsight-maintenance.sh:136` prunes only `status='completed'` rows older than `SWITCHROOM_HINDSIGHT_RETENTION_DAYS` (default 30); `failed` / `pending` / `processing` are never touched. The two statuses therefore age out asymmetrically — measured on the live bank today:

| status | rows | oldest |
|---|---|---|
| completed | 42,199 | 30.01 days |
| failed | 209 | 25.16 days |
| cancelled | 5 | 15.67 days |

The streak query bounded each pair's failures at `coalesce((last completed), '-infinity')`. Once a pair's last completion is swept, that subquery returns NULL, the window opens to the beginning of time, and every failure ever recorded for the pair collapses into one streak that no future success can clear. The pair pages permanently, citing rows that no longer exist.

The window is now `greatest(<last completed>, now() - make_interval(days => $RD))`.

**Correction on review:** the first push kept a `coalesce(…, '-infinity')` inside the `greatest` and this section claimed it let a never-completed pair "report its real streak". That was wrong on both counts. PostgreSQL's `greatest` **ignores NULLs** — verified on a throwaway pg16, `greatest(coalesce(NULL::timestamptz,'-infinity'), now()-interval '30 days')` is `IS NOT DISTINCT FROM` the same expression with the `coalesce` removed — so the sentinel was semantically inert, and a never-completed pair is bounded by the floor exactly like every other pair, reporting at most `RETENTION_DAYS` of streak rather than its "real" one. The `coalesce` is deleted; the string pin that asserted its presence now asserts its absence, so it cannot come back as documentation-by-dead-code.

**The retention coupling (the open question on #4620) is resolved by deriving, not hard-coding.** The floor reads `SWITCHROOM_HINDSIGHT_RETENTION_DAYS` from the same environment the prune reads it from. Both run against the same container: `hindsight-maintenance.sh:63` reads the knob inside `switchroom-hindsight`, and the probe reaches the same table via `docker exec` on that container, which inherits its env — verified live on the running container. A hard-coded `30` would silently over-count on any fleet running a shorter horizon, which is the drift the fix exists to remove. Three guards make the splice safe: a non-numeric or empty value falls back to `30`, a value above 36,500 days (or too large for the shell to compare) falls back to `30`, and the value clamps to `>= 1` day (a `0`-day floor would erase the signal entirely rather than bound it).

**No new threshold constant was added, deliberately** — the horizon is an operator knob with a documented default, not a measured rate, so duplicating it in `thresholds.ts` would reintroduce exactly the coupling drift being fixed. `thresholds.ts`'s residual note is updated to record that and to point at the fix.

**#4621 — the recency boundary is pinned.** `isLiveStreak`'s recency arm (`newestFailureAgeS <= CONSOLIDATION_STREAK_RECENCY_S`) survived mutation to `<`. The boundary trio now asserts `at(7_199) → breach`, `at(7_200) → breach`, `at(7_201) → ok` in hard-coded seconds, with `expect(CONSOLIDATION_STREAK_RECENCY_S).toBe(7_200)` so a constant change is a loud failure rather than a silently self-adjusting test.

## Honest scope of the fix

The floor **bounds** the failure; it does not erase it for failures still inside the window. The concrete instantiation cited on #4620 (`overlord/consolidation`, 112 failures dated 07-18 → 07-29) is still within a 30-day horizon and still pages today. What changes is that it now clears when those rows age out, instead of persisting forever on a completion that no longer exists. That is the intended semantics — a bounded page on real recent failures beats a permanent page on deleted evidence — and it is documented at the query site, in `evaluate.ts`, and in `thresholds.ts`.

Production comparison, read-only: the fixed and the unbounded statements return identical rows today (`S|klanker|graph_maintenance|9|…`, `S|overlord|graph_maintenance|19|…`). The change is behaviour-neutral on the live bank and closes a latent trap, which matches #4620's "verified latent, not live" framing.

## Test plan

- [x] `vitest run src/hindsight-watch/` — 10 files, 275 tests, green.
- [x] `npm run lint` (~35 checks incl. changelog + attribution trailers) and `npm run lint:tsc` — clean.
- [x] **#4621 mutation:** `<=` → `<` in `isLiveStreak` fails exactly the new test (`AssertionError: expected 'ok' to be 'breach'` at `expect(at(7_200))`), 1 failed / 67 passed. Reverted.
- [x] **#4620 mutation:** floor replaced with `'-infinity'::timestamptz` fails 2 tests — the outcome assertion (`expected { bank: 'overlord', … } to be undefined`) and the statement pin — 2 failed / 38 passed. Reverted.
- [x] Live read-only verification of the prune asymmetry, of `docker exec` env inheritance, and of the fixed-vs-unbounded row equality. No writes, no restarts.

`streak-retention-floor.pg.test.ts` boots a throwaway `postgres:16-alpine` (`--network none`), seeds five fixture pairs with literal ages that do not derive from the constant, and runs the **real** query through the real probe into the real evaluator — asserting the pruned-completion pair breaches under `-infinity` semantics and is **absent** under the floored query, while the never-completed pair breaches under both. It `skipIf`s when Docker is unavailable; `SWITCHROOM_REQUIRE_PG_PROBE=1` turns that into a hard failure, and the new `hindsight-watch-pg-probe` job in `docker-e2e.yml` sets it — so the only assertions in the repo that can fail on the #4620 OUTCOME (rather than on a changed string) can no longer silently skip in CI. The `sh`-executed env-derivation tests in `probe.test.ts` are hermetic and always run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Review round 2 — what changed

- **The pg probe's flake (3 failures in 8 runs on review) is fixed, and the root cause is confirmed.** The `postgres:16-alpine` entrypoint runs a TEMPORARY server on the same unix socket during initdb, then shuts it down; `pg_isready` (and `psql`) succeed against it, so breaking on the first ready races the shutdown and the seed dies with `No such file or directory` on `.s.PGSQL.5432`. Reproduced with the old discipline here: **1 seed failure in 10 runs**. The wait is now deterministic rather than merely narrower — block on the entrypoint's one-shot `PostgreSQL init process complete; ready for start up.` marker (printed after the temp server exits and before the real one starts), then poll `select 1`. **10 consecutive runs of the file: 10 passes, 0 failures, no leaked containers.**
- **The inert `-infinity` is deleted and all four prose sites corrected** (see the strike-through above; `probe.ts`, `probe.test.ts`, `evaluate.ts`, `thresholds.ts`, CHANGELOG, and both commit messages).
- **The partial-truncation narrowing is real, and is now documented and pinned.** The floor truncates the streak COUNT, not only the window: a never-completed pair with 5 failures over 60 days, 2 inside 30, arrives as `streak = 2`, fails `evaluate.ts`'s `streak >= CONSOLIDATION_FAILURE_STREAK_WARN` gate, and reads `ok` where the unbounded count breached at 5. Verified reachable, not hypothetical. It is accepted on soundness — a failure older than the horizon cannot be shown to be *consecutive* with the ones after it, because the completion that would have broken the streak is exactly what the prune deletes, so widening it back IS #4620 — documented at `probe.ts`, `evaluate.ts` and `thresholds.ts`, and pinned by a new fixture (`sparsebank`: 3 failures outside the horizon, 2 inside) asserting breach-at-5 unbounded and ok-at-2 floored.
- **Upper clamp on the retention knob.** `SWITCHROOM_HINDSIGHT_RETENTION_DAYS=3000000000` passed the all-digits `case` and the 64-bit `-ge 1` test, then PostgreSQL raised `function make_interval(days => bigint) does not exist` (verified) → psql non-zero → both bank signals silently `no-data`. `[ "$RD" -le 36500 ] || RD=30`, ordered *before* the lower clamp so a value too large for the shell to compare takes the same branch, with boundary tests at 36500/36501.
- **CI wiring landed in this PR.** New `hindsight-watch-pg-probe` job in `docker-e2e.yml` on its own path filter, aggregated by the `e2e-ok` sentinel; pulls `postgres:16-alpine` (~80 MB, no image build) and runs the file with `SWITCHROOM_REQUIRE_PG_PROBE=1`, so an absent docker/image fails rather than skips.
- **Rebased onto `origin/main`** (`8bd552b2`); the CHANGELOG conflict with #4622 is resolved keeping both entries.

### Mutation evidence (all reverted)

| mutation | result |
|---|---|
| floor removed from the shipped query (restores #4620) | pg **2 failed** / 3 passed; `probe.test.ts` **1 failed** / 36 passed |
| upper clamp line removed | `probe.test.ts` **1 failed** / 36 passed |
| `coalesce(…, '-infinity')` reintroduced inside the `greatest` | `probe.test.ts` **1 failed** / 36 passed; pg **5/5 PASSED** — which is the finding: it is inert, and only the pin catches it |
| pre-fix readiness discipline restored (break on first `pg_isready`) | 1 seed failure / 10 runs, the exact socket error from the review |
