### PR TITLE
fix(hindsight): graph-maintenance Pass 3 sweeps bounded pages over a rotating slice

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -549,6 +549,23 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-graph-maintenance-retry-storm.test.ts
 
+      - name: Run the hindsight graph-maintenance bounded-sweep probe (RED/GREEN, must not skip)
+        # The bounded-sweep fix, and the ONLY place it is really executed. The
+        # bakes test is grep-on-file; the properties that matter are all
+        # behavioural — that the caller actually LOOPS, that the cursor strictly
+        # ADVANCES, that the shrink retries the SAME cursor, that slice_count is
+        # derived from the bank size the job measured (a fixed count would put
+        # quiet banks on a weeks-long rotation, since this job is demand-driven,
+        # not timed), and that the `_SWEEP_MAX_PAGES` tripwire actually fires.
+        #
+        # Its SECOND arm executes the shipping sweep statement against the
+        # digest-pinned Postgres pulled above: a substring check cannot tell a
+        # hash-slice PARTITION from a filter that puts every row in slice 0, and
+        # `AND 0 * (...)` was green against the string-only version.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
+
       - name: Run the hindsight pg_search tokenizer-drift probe (RED/GREEN, must not skip)
         # Epic #4474 finding C1. The bakes test can only see that the patch TEXT
         # is present; it cannot see the outcome that matters — that the shipping
@@ -738,7 +755,7 @@ jobs:
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-pg-search-tokenizer-drift-patch hindsight-pg-search-filter-pushdown-patch hindsight-text-search-migration-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-query-analyzer-languages hindsight-temporal-offload-patch hindsight-graph-maintenance-retry-storm hindsight-pg-fsync-probe; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches hindsight-mm-refresh-debounce-patch hindsight-pg-search-tokenizer-drift-patch hindsight-pg-search-filter-pushdown-patch hindsight-text-search-migration-patch hindsight-graph-seed-retirement hindsight-maxitems-grammar-patch hindsight-reflect-directives-patch hindsight-recall-budget-reflect-grounding hindsight-reranker-priority-patch hindsight-query-analyzer-languages hindsight-temporal-offload-patch hindsight-graph-maintenance-retry-storm hindsight-graph-maintenance-bounded-sweep hindsight-pg-fsync-probe; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -419,6 +419,24 @@ jobs:
           docker pull "$ref"
           docker image inspect "$ref" >/dev/null
 
+      - name: Pull the digest-pinned Postgres for the bounded-sweep SQL arm
+        # The bounded-sweep probe's SQL arm EXECUTES the shipping sweep
+        # statement against a real server — the only executable proof that the
+        # hash slice filter PARTITIONS the bank (a substring check cannot tell a
+        # partition from a filter that puts every row in slice 0). Same
+        # anti-drift rule as above: the ref is read from the test file that
+        # asserts it rather than duplicated here. ~120MB alpine, not a second
+        # 6.4GB pull. `test -n` so a rename of the constant fails the job loudly
+        # instead of silently leaving the arm unpullable (which under
+        # SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 is a hard failure anyway).
+        run: |
+          ref="$(grep -oE 'postgres@sha256:[0-9a-f]{64}' \
+                 tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts | head -1)"
+          test -n "$ref"
+          echo "pulling $ref"
+          docker pull "$ref"
+          docker image inspect "$ref" >/dev/null
+
       - name: Set up Docker Buildx (docker driver) for the through-built image
         # The reranker-priority probe's GREEN arm runs against the actual
         # THROUGH-BUILT switchroom-hindsight image, because #3142's anchors and

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -154,6 +154,7 @@ jobs:
               - 'tests/docker/hindsight-temporal-offload-patch.test.ts'
               - 'tests/docker/hindsight-metrics-cardinality-patch.test.ts'
               - 'tests/docker/hindsight-graph-maintenance-retry-storm.test.ts'
+              - 'tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts'
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
               - '.github/workflows/docker-e2e.yml'
             # hindsight-watch's streak probe (#4620) asserts its OUTCOME

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,10 +95,14 @@ now an anomaly worth investigating, not the norm.
   carries the `errors` array the sidebar reads.
 - **hindsight graph maintenance: the stale-cooccurrence sweep can now finish on
   a large bank.** `graph_maintenance` Pass 3 was ONE bank-wide statement whose
-  cost grows with the bank, and it had never once completed on the fleet's two
-  largest banks: measured read-only on live data, the predicate alone takes
-  65.2 s on a 517,475-row bank against a 60 s asyncpg `command_timeout` —
-  before the sort, the row locks and the DELETE. #4604 removed the 9x retry
+  cost grows with the bank, so it worked until it did not: measured read-only
+  on live data, the predicate alone takes 65.2 s on a 517,475-row bank against
+  a 60 s asyncpg `command_timeout` — before the sort, the row locks and the
+  DELETE. The fleet's two largest banks completed 849 (overlord) and 779
+  (klanker) runs through July 2026 at a p50 of 15–33 s, then crossed the 60 s
+  wall in the week of 2026-08-03 and have **failed every run since** (overlord
+  17 of 22 that week and 2 of 3 the next, klanker 9 of 14), leaking stale
+  cooccurrence rows on every one. #4604 removed the 9x retry
   storm around it but deliberately left the statement unable to finish, so
   stale cooccurrence rows leaked for ever. Pass 3 now sweeps bounded,
   resumable keyset pages (at most `batch_size` predicate evaluations per
@@ -116,13 +120,21 @@ now an anomaly worth investigating, not the norm.
   (`submit_async_graph_maintenance` fires when work is enqueued and
   short-circuits on an empty queue; there is no timer), so a bank is visited as
   often as it is written to, and slice coverage is coupon-collector rather than
-  a cycle. Measured over the live `async_operations` log, mean days between
-  visits per bank runs from 0.8 (overlord) to 80.0 (lawgpt) — under a fixed 24
-  the quiet banks would have waited an expected 30–300 days for full coverage,
-  to fix a timeout they never had (their whole-bank sweep finishes in 2.7–4.3
-  s). Size-derived, every bank at or below 25,000 rows keeps `slice_count = 1`
-  and is still swept WHOLE on every run, and expected full-coverage latency
-  across the fleet lands between 0.6 and 3.3 days.
+  a cycle. A "draw" in that model is a distinct `_SWEEP_SLICE_SECONDS` window,
+  not a run — runs sharing a window compute the same slice index, so the later
+  ones re-sweep what the first just swept. That window is **120 s**, derived
+  from the measured median inter-arrival gap between runs (197 s on overlord,
+  250 s on klanker); the 1800 s it replaces was the last surviving piece of the
+  "a run arrives every 30 minutes" model this change otherwise abandons, and
+  held 3.95 / 3.60 runs per window — about 75% of the busiest banks' sweeps
+  were duplicate work. Measured over the live `async_operations` log, distinct
+  120 s windows per bank per day run from 21.8 (overlord) to 0.30 (lawgpt) —
+  under a fixed 24 the quiet banks would have waited an expected 12–303 days
+  for full coverage, to fix a timeout they never had (their whole-bank sweep
+  finishes in 2.7–4.3 s). Size-derived, every bank at or below 25,000 rows
+  keeps `slice_count = 1` and is still swept WHOLE on every run, and expected
+  full-coverage latency across the fleet lands between 0.5 and 3.5 days
+  (0.5–3.3 measured by replaying the real arrival log).
 
   The full sweep is kept (rotated, not replaced by a watermark) because nothing
   durable records the entities of a deleted unit, so a watermark would silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,18 +103,32 @@ now an anomaly worth investigating, not the norm.
   stale cooccurrence rows leaked for ever. Pass 3 now sweeps bounded,
   resumable keyset pages (at most `batch_size` predicate evaluations per
   statement, each in its own transaction) over one deterministic
-  clock-rotating 1/24 hash slice of the bank, so the per-statement cost stops
-  depending on bank size and each run pays ~1/24 of the sweep: measured 3–6 s
-  per slice with a 1.3 s worst statement, against a whole-bank sweep that
-  could not finish at all. A page that still times out — the one remaining
-  unbounded term is entity degree, max 32,730 on this fleet against a mean of
-  7.3 — halves its size and retries the SAME cursor down to a floor of 50,
-  so no single pathological page can wedge its slice permanently. The full
-  sweep is kept (rotated, not replaced by a watermark) because nothing durable
-  records the entities of a deleted unit, so a watermark would silently miss
-  every staleness source that failed to enqueue; the price is that a stale row
-  now survives up to one ~12 h rotation. The #2473 INTERSECT predicate and the
-  #2529 ordered lock are unchanged — a semi-join rewrite was measured and is
+  clock-rotating hash slice of the bank, so the per-statement cost stops
+  depending on bank size: measured 3–6 s per slice with a 1.3 s worst
+  statement, against a whole-bank sweep that could not finish at all. A page
+  that still times out — the one remaining unbounded term is entity degree,
+  max 32,730 on this fleet against a mean of 7.3 — halves its size and retries
+  the SAME cursor down to a floor of 50, so no single pathological page can
+  wedge its slice permanently.
+
+  HOW MANY SLICES IS DERIVED FROM BANK SIZE — `ceil(rows / 25,000)`, capped at
+  24, floored at 1 — rather than fixed. `graph_maintenance` is DEMAND-DRIVEN
+  (`submit_async_graph_maintenance` fires when work is enqueued and
+  short-circuits on an empty queue; there is no timer), so a bank is visited as
+  often as it is written to, and slice coverage is coupon-collector rather than
+  a cycle. Measured over the live `async_operations` log, mean days between
+  visits per bank runs from 0.8 (overlord) to 80.0 (lawgpt) — under a fixed 24
+  the quiet banks would have waited an expected 30–300 days for full coverage,
+  to fix a timeout they never had (their whole-bank sweep finishes in 2.7–4.3
+  s). Size-derived, every bank at or below 25,000 rows keeps `slice_count = 1`
+  and is still swept WHOLE on every run, and expected full-coverage latency
+  across the fleet lands between 0.6 and 3.3 days.
+
+  The full sweep is kept (rotated, not replaced by a watermark) because nothing
+  durable records the entities of a deleted unit, so a watermark would silently
+  miss every staleness source that failed to enqueue. The #2473 INTERSECT
+  predicate and the #2529 ordered lock are unchanged — a semi-join rewrite was
+  measured and is
   no faster (65.6 s), because at bank scale the planner hash-joins all of
   `unit_entities`.
 - **fleet-health: the ledger's `windowDays` now actually windows the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,30 @@ now an anomaly worth investigating, not the norm.
   and `?offset=` instead of reporting `limit = sessions.length` — which made
   the sidebar's `total > limit` arithmetic wrong — and the cross-profile route
   carries the `errors` array the sidebar reads.
-
+- **hindsight graph maintenance: the stale-cooccurrence sweep can now finish on
+  a large bank.** `graph_maintenance` Pass 3 was ONE bank-wide statement whose
+  cost grows with the bank, and it had never once completed on the fleet's two
+  largest banks: measured read-only on live data, the predicate alone takes
+  65.2 s on a 517,475-row bank against a 60 s asyncpg `command_timeout` —
+  before the sort, the row locks and the DELETE. #4604 removed the 9x retry
+  storm around it but deliberately left the statement unable to finish, so
+  stale cooccurrence rows leaked for ever. Pass 3 now sweeps bounded,
+  resumable keyset pages (at most `batch_size` predicate evaluations per
+  statement, each in its own transaction) over one deterministic
+  clock-rotating 1/24 hash slice of the bank, so the per-statement cost stops
+  depending on bank size and each run pays ~1/24 of the sweep: measured 3–6 s
+  per slice with a 1.3 s worst statement, against a whole-bank sweep that
+  could not finish at all. A page that still times out — the one remaining
+  unbounded term is entity degree, max 32,730 on this fleet against a mean of
+  7.3 — halves its size and retries the SAME cursor down to a floor of 50,
+  so no single pathological page can wedge its slice permanently. The full
+  sweep is kept (rotated, not replaced by a watermark) because nothing durable
+  records the entities of a deleted unit, so a watermark would silently miss
+  every staleness source that failed to enqueue; the price is that a stale row
+  now survives up to one ~12 h rotation. The #2473 INTERSECT predicate and the
+  #2529 ordered lock are unchanged — a semi-join rewrite was measured and is
+  no faster (65.6 s), because at bank scale the planner hash-joins all of
+  `unit_entities`.
 - **fleet-health: the ledger's `windowDays` now actually windows the
   findings.** `buildLedger` read `windowDays` but aggregated EVERY finding ever
   recorded into the dedup_key map — `count` and `reach` had no time filter, so

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -6457,26 +6457,42 @@ PYEOF
 #      `int(now) // _SWEEP_SLICE_SECONDS % slice_count` — so no cursor is
 #      persisted anywhere: it survives a worker restart, needs no new table, no
 #      alembic revision, and has nothing to corrupt. Slicing is on
-#      `md5(entity_id_1)`, and every row has exactly one `entity_id_1`, so the
-#      slices PARTITION the bank. Measured slice balance on overlord at 26
-#      slices: largest 23,359 rows against a 19,903 mean.
+#      `md5(entity_id_1)`: the slices PARTITION the bank because the filter is
+#      a function of ONE deterministic column value per row, so exactly one
+#      slice_index matches each row. `entity_id_2` would partition just as
+#      well; `entity_id_1` is chosen because it is the LEADING column of the
+#      scan and lock order (so a slice is contiguous index ranges, not a
+#      scatter) and because the bank join is already `ON e.id = c.entity_id_1`.
+#      Measured slice balance on overlord at 26 slices: largest 23,359 rows
+#      against a 19,903 mean.
 #
 #      COVERAGE IS COUPON-COLLECTOR, NOT A CYCLE. `graph_maintenance` is
 #      DEMAND-DRIVEN: `submit_async_graph_maintenance` fires when work is
 #      enqueued (retain / delete / edit) and short-circuits with `no_work=True`
 #      on an empty queue — there is no timer anywhere. Runs are therefore
 #      uncorrelated with the clock the index is taken from, each run samples an
-#      effectively random slice, and expected full coverage is `N*H(N)` runs,
+#      effectively random slice, and expected full coverage is `N*H(N)` DRAWS,
 #      not `N`. That is precisely why `N` is kept as small as the bank allows.
-#      Measured runs/day per bank over 30 days (`async_operations`,
-#      2026-08-12): overlord 28.9, klanker 26.3, finn 9.4, carrie 8.3,
-#      marko 5.2, assistant 3.0, gymbro 1.8, ziggy 0.77, reggie 0.70,
-#      lawgpt 0.30. A FIXED 24 would have given those banks expected full
-#      coverage every 3.1, 3.5, 9.6, 11.0, 17.4, 29.9, 49.4, 118.2, 129.5 and
-#      302.1 days — putting the quietest banks, which never had the timeout and
-#      swept whole in 2.7-4.3 s, on a rotation measured in months to fix a
-#      problem they do not have. Size-derived they are 2.7, 2.6, 1.9, 1.8, 1.1,
-#      2.8, 0.6, 1.3, 1.4 and 3.3 days.
+#
+#      A DRAW IS A DISTINCT `_SWEEP_SLICE_SECONDS` WINDOW, NOT A RUN. Runs that
+#      land inside the same window compute the same slice index, so the later
+#      ones re-sweep what the first just swept and contribute no coverage. At
+#      the 1800 s this patch originally shipped, overlord averaged 3.95 runs
+#      per window and klanker 3.60 — ~75% of their sweeps were duplicate work,
+#      and every coverage figure computed from runs/day understated the truth
+#      by 1.7-3.9x. See `_SWEEP_SLICE_SECONDS` below for why it is now 120 s.
+#
+#      Measured distinct 120 s windows/day per bank over 30 days
+#      (`async_operations`, 2026-08-12): overlord 21.8, klanker 21.6, finn 7.6,
+#      carrie 6.6, marko 4.8, assistant 2.4, gymbro 1.6, ziggy 0.70,
+#      reggie 0.70, lawgpt 0.30. A FIXED 24 would have given those banks
+#      expected full coverage every 4.2, 4.2, 12.0, 13.7, 18.8, 38.4, 58.0,
+#      130, 130 and 303 days — putting the quietest banks, which never had the
+#      timeout and swept whole in 2.7-4.3 s, on a rotation measured in months
+#      to fix a problem they do not have. Size-derived they are 3.5, 3.1, 2.4,
+#      2.2, 1.1, 3.5, 0.5, 1.3, 1.4 and 3.3 days; replaying the real arrival
+#      log rather than assuming uniform draws gives 1.3, 1.1, 0.6, 0.8, 0.7,
+#      1.4 for the six sliced banks.
 #
 #      WHY THE FULL SWEEP STAYS, rather than being replaced by a watermark
 #      scoped to recently-touched entities. A cooccurrence goes stale when a
@@ -6792,10 +6808,16 @@ apply("engine/db/ops_postgresql.py", (
     "        #\n"
     "        # The slice filter is `md5(entity_id_1) % slice_count = slice_index`.\n"
     "        # Hashing rather than using the UUID's own bits keeps the slices even\n"
-    "        # for banks whose entity ids are not uniformly distributed, and taking\n"
-    "        # it on entity_id_1 ALONE is what makes the slices a partition: every\n"
-    "        # row has exactly one entity_id_1, so it belongs to exactly one slice\n"
-    "        # and consecutive runs cover the bank exactly once each. `bit(16)` is\n"
+    "        # for banks whose entity ids are not uniformly distributed. What makes\n"
+    "        # the slices a PARTITION is that the filter is a function of ONE\n"
+    "        # deterministic column value per row: every row gets exactly one hash,\n"
+    "        # so exactly one slice_index matches it, and the slices tile the bank.\n"
+    "        # That is true of entity_id_2 as well — the reason the column is\n"
+    "        # entity_id_1 specifically is (a) LOCALITY: entity_id_1 is the leading\n"
+    "        # column of the scan and lock order below, so a slice is a set of\n"
+    "        # contiguous index ranges rather than a scatter across the whole index,\n"
+    "        # and (b) the bank join is already `ON e.id = c.entity_id_1`, so the\n"
+    "        # hashed column is one the row is filtered on anyway. `bit(16)` is\n"
     "        # always non-negative, so no abs() is needed and slice_index is always\n"
     "        # in range; at slice_count = 1 the filter degenerates to `% 1 = 0`,\n"
     "        # i.e. the whole bank, with no branch in the SQL.\n"
@@ -7174,11 +7196,15 @@ apply("engine/graph_maintenance.py", (
     "# on an empty queue (`no_work=True`), so runs are uncorrelated with the wall\n"
     "# clock the slice index is derived from. Each run therefore samples an\n"
     "# effectively random slice and full coverage is COUPON-COLLECTOR — expected\n"
-    "# N*H(N) runs, ~91 for N=24, not 24. Measured runs/day per bank over 30 days\n"
-    "# (async_operations, 2026-08-12) span 28.9 (overlord) to 0.30 (lawgpt), so a\n"
+    "# N*H(N) DRAWS, ~91 for N=24, not 24. A draw is a distinct\n"
+    "# _SWEEP_SLICE_SECONDS window, NOT a run: runs sharing a window share a\n"
+    "# slice index and the later ones are duplicate work (see the note on that\n"
+    "# constant below). Measured over 30 days (async_operations, 2026-08-12),\n"
+    "# distinct 120 s windows/day span 21.8 (overlord) to 0.30 (lawgpt), so a\n"
     "# fixed 24 would have moved the QUIET banks — the ones that never had the\n"
     "# timeout, and swept whole in 2.7-4.3 s — from full coverage every run to\n"
-    "# 13-302 days per full sweep. Size-derived, every bank lands at 0.6-3.3 days.\n"
+    "# 12-303 days per full sweep. Size-derived, every bank lands at 0.5-3.5 days\n"
+    "# (measured by replaying the real arrival log: 0.5-3.3).\n"
     "#\n"
     "# _SWEEP_MIN_BATCH_SIZE is the floor for the halve-and-retry in the loop\n"
     "# below, which exists because a page landing entirely inside ONE hub entity's\n"
@@ -7194,11 +7220,39 @@ apply("engine/graph_maintenance.py", (
     "# page shrank to the floor of 50 — but `batch_size` never recovers after a\n"
     "# shrink, so a slice that shrinks EARLY is the one shape that can reach the\n"
     "# tripwire on honest work. The log line names both causes for that reason.\n"
+    "#\n"
+    "# _SWEEP_SLICE_SECONDS is a DECORRELATION window, not a schedule. Nothing\n"
+    "# depends on it but this: two runs that land inside the SAME window compute\n"
+    "# the SAME slice index, so the second one re-sweeps rows the first just\n"
+    "# swept and contributes nothing. It was 1800 — the leftover of the same\n"
+    "# 'a run arrives every 30 minutes' model the slice COUNT above already\n"
+    "# abandons. Runs are demand-driven and clustered on write bursts, so the\n"
+    "# measured cost of that window was severe (async_operations, 30 d to\n"
+    "# 2026-08-12): 3.95 runs per 1800 s window on overlord and 3.60 on klanker,\n"
+    "# i.e. ~75% of every busy bank's sweeps were pure duplicate DB work.\n"
+    "#\n"
+    "# 120 s is picked from the measured INTER-ARRIVAL distribution, which is the\n"
+    "# only thing this constant has to beat: median gap between consecutive runs\n"
+    "# is 197 s (overlord) and 250 s (klanker), so a 120 s window is the largest\n"
+    "# round value that puts a TYPICAL consecutive pair in different windows.\n"
+    "# Measured, replaying the real arrival log at slice_count = 21/19:\n"
+    "#\n"
+    "#   window   duplicate runs        mean days to full coverage\n"
+    "#            overlord / klanker    overlord / klanker\n"
+    "#   1800 s   74.7% / 72.3%         2.49 / 2.19\n"
+    "#    300 s   40.3% / 33.3%         1.58 / 1.24\n"
+    "#    120 s   25.5% / 18.3%         1.27 / 1.10\n"
+    "#     60 s   15.7% /  9.5%         1.21 / 0.91\n"
+    "#\n"
+    "# 60 s buys little more on the banks that matter and starts to WOBBLE on the\n"
+    "# small ones, where the whole rotation becomes 3-6 minutes and can alias\n"
+    "# against the worker's own cadence (carrie, 6 slices: 0.80 d at 120 s but\n"
+    "# 1.01 d at 60 s; assistant, 4 slices: 1.13 d at 300 s, 1.42 d at 120 s).\n"
     "_SWEEP_BATCH_SIZE = 1000\n"
     "_SWEEP_MIN_BATCH_SIZE = 50\n"
     "_SWEEP_SLICE_TARGET_ROWS = 25000\n"
     "_SWEEP_MAX_SLICE_COUNT = 24\n"
-    "_SWEEP_SLICE_SECONDS = 1800\n"
+    "_SWEEP_SLICE_SECONDS = 120\n"
     "_SWEEP_MAX_PAGES = 2000\n"
     "\n"
     "\n"
@@ -7240,8 +7294,11 @@ apply("engine/graph_maintenance.py", (
     "        # current unit witnesses them together.\n"
     "        #\n"
     "        # switchroom: this was ONE whole-bank statement, measured at 115s on a\n"
-    "        # 517k-row bank against a 60s command_timeout — it could not finish, so\n"
-    "        # the pass had never once completed on this fleet's two largest banks.\n"
+    "        # 517k-row bank against a 60s command_timeout. Its cost grows with the\n"
+    "        # bank, so it worked until it did not: overlord and klanker completed\n"
+    "        # 849 and 779 runs through July 2026 at a p50 of 15-33s, then crossed\n"
+    "        # the 60s wall in the week of 2026-08-03 and have failed EVERY run\n"
+    "        # since (overlord 17/22 then 2/3 failed; klanker 9/14).\n"
     "        # It is now a loop of BOUNDED, RESUMABLE pages over one time-rotating\n"
     "        # slice of the bank.\n"
     "        #\n"
@@ -7255,8 +7312,10 @@ apply("engine/graph_maintenance.py", (
     "        #\n"
     "        # The slice index is a pure function of the wall clock: no persisted\n"
     "        # cursor, no new table, no alembic revision, unaffected by a restart.\n"
-    "        # The slices PARTITION the bank (the hash is on entity_id_1 and every\n"
-    "        # row has exactly one), so a row is swept by exactly one slice.\n"
+    "        # The slices PARTITION the bank: the filter is a function of ONE\n"
+    "        # deterministic column value per row, so exactly one slice_index\n"
+    "        # matches it. (See the note on the filter itself for why that column\n"
+    "        # is entity_id_1 rather than entity_id_2 — locality, not partition.)\n"
     "        #\n"
     "        # COVERAGE IS PROBABILISTIC, NOT A CYCLE, and the comment that used to\n"
     "        # sit here claiming '24 consecutive runs cover the bank exactly once\n"
@@ -7399,13 +7458,43 @@ for rel in TOUCHED:
 
 pg = (BASE / "engine/db/ops_postgresql.py").read_text()
 sweep = pg.split("async def prune_stale_cooccurrences", 1)[1].split("\n    async def ", 1)[0]
-assert "LIMIT $6::int" in sweep, (
-    f"{TAG}: the page CTE lost its LIMIT — the statement is unbounded again and the "
-    "whole point of this patch is gone"
+# The LIMIT and the ORDER BY that feeds it are pinned as ONE WHOLE-LINE PAIR,
+# not as two substrings. Both halves of that matter:
+#
+#   * A bare `"LIMIT $6::int" in sweep` is satisfied by `LIMIT $6::int + 1`,
+#     which is still "a LIMIT" to a grep and still bounded — but no longer the
+#     bound this patch measured.
+#   * The ORDER BY is the load-bearing half and had NO guard at all. `LIMIT`
+#     without `ORDER BY` returns an ARBITRARY batch_size rows, and the caller
+#     then sets its cursor to the MAX key of that arbitrary set (the
+#     `ORDER BY … DESC LIMIT 1` subselects below). Every qualifying row that
+#     sorts BELOW that max but did not happen to land in the page is skipped
+#     for the rest of the slice pass — silently, with no short page, no error
+#     and a plausible `scanned` count. It survives a small fixture because the
+#     planner picks the PK index scan and the rows come out sorted by luck; a
+#     bitmap heap scan or a parallel seq scan on a 500k-row bank does not.
+#     Deleting this one line is therefore a silent data-coverage bug, which is
+#     exactly the class that has to be pinned rather than trusted.
+assert (
+    "\n                ORDER BY c.entity_id_1, c.entity_id_2\n"
+    "                LIMIT $6::int\n"
+) in sweep, (
+    f"{TAG}: the page CTE's `ORDER BY c.entity_id_1, c.entity_id_2` + `LIMIT $6::int` "
+    "pair is not the exact two lines this patch ships. Without the ORDER BY the page "
+    "is an ARBITRARY batch_size rows and the cursor — the MAX key of that page — skips "
+    "every qualifying row below it that the page did not happen to contain. Without "
+    "the exact LIMIT line the measured bound is not the shipped bound"
 )
 assert "WITH page AS MATERIALIZED" in sweep, f"{TAG}: the page CTE is no longer materialised"
-# Count the SQL form (16-space indent inside the victims CTE), not the prose
-# mentions in the comment above it.
+# Count the SQL forms (16-space indent inside the CTEs), not the prose mentions
+# in the comment above them. TWO ordered scans ship: the page CTE's (pinned
+# whole-line above, it makes the keyset page a deterministic prefix) and the
+# victims CTE's (it is the #2529 ordered lock's sort). Count them together so
+# neither can be dropped in isolation.
+assert sweep.count("\n                ORDER BY c.entity_id_1, c.entity_id_2\n") == 2, (
+    f"{TAG}: the sweep no longer has BOTH ordered scans — the page CTE's keyset order "
+    "and the #2529 ordered lock's"
+)
 assert sweep.count("\n                FOR UPDATE OF c\n") == 1, (
     f"{TAG}: the #2529 ordered lock did not survive the rewrite"
 )

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -6379,6 +6379,861 @@ print(
 )
 PYEOF
 
+# ══════════════════════════════════════════════════════════════════════════
+# UPSTREAM PATCH — graph-maintenance bounded sweep patch (#4620).
+#
+# WHAT #4604 LEFT BEHIND. That PR removed the retry storm around Pass 3
+# (`prune_stale_cooccurrences`) and the blank error_message it hid behind. It
+# deliberately did NOT make the sweep finish: both of this fleet's largest
+# banks still fail `graph_maintenance` 100% of the time, now in ~60s instead of
+# ~40min. This block makes it finish.
+#
+# THE COST MODEL, measured read-only against the live fleet 2026-08-12 (the
+# statements are in the PR body; every number below is EXPLAIN (ANALYZE,
+# BUFFERS) output, not an estimate):
+#
+#   bank      cooc rows   read-only predicate
+#   marko        60,890    3.4 s
+#   finn        159,076    8.2 s     <- largest bank that still passes
+#   klanker     463,301    (not measured)
+#   overlord    517,475   65.2 s     <- ALREADY over the 60s asyncpg
+#                                       command_timeout in its READ-ONLY form,
+#                                       before the Sort, the LockRows and the
+#                                       DELETE. #4604 measured the real
+#                                       statement at 114,836 ms.
+#
+# The sweep is a bank-scoped scan that evaluates a correlated
+# `NOT EXISTS (… INTERSECT …)` per cooccurrence row. On overlord that is
+# 517,475 evaluations reading a mean 121 + 287 = 408 `unit_entities` index
+# tuples each — 98.9M shared-buffer hits — to find 1,363 stale rows. A 0.26%
+# yield for a whole-bank scan, and the scan grows with the bank while the yield
+# does not.
+#
+# WHAT WAS TRIED AND REJECTED, so nobody re-tries it:
+#
+#   * Raising `command_timeout`. Buys back the 115s of DB CPU instead of
+#     removing it, and the number grows with every bank.
+#   * Rewriting the `INTERSECT` as a correlated semi-join, on the theory that
+#     `EXISTS` short-circuits at the first witnessing unit where `SetOp
+#     Intersect` must read both entities' full unit sets. Measured on overlord:
+#     65,555 ms — NO better, because at bank scale the planner abandons the
+#     nested loop and hash-joins all 1.7M `unit_entities` rows, producing 65.5M
+#     candidate rows to filter. This is the same trap the upstream #2473
+#     comment warns about, and it is why the predicate below is left EXACTLY as
+#     upstream wrote it. The fix is not a cleverer predicate; it is evaluating
+#     the same predicate over a bounded number of rows at a time.
+#
+# THE FIX — two independent mechanisms, each with one job.
+#
+#   B1 BOUNDED PAGES bound the STATEMENT. `prune_stale_cooccurrences` now
+#      sweeps ONE keyset-paginated page of at most `batch_size` cooccurrence
+#      rows per call, and returns the page's last key as the cursor for the
+#      next call. The predicate therefore runs at most `batch_size` times per
+#      statement — a bound that does not mention the size of the bank, which is
+#      what "no statement can exceed the timeout on a bank of any size"
+#      requires. Measured on overlord by replaying the whole bank as pages:
+#      259 pages of 2,000 rows, worst page 4,322 ms, mean 246 ms, against a
+#      60,000 ms timeout.
+#
+#      The cursor provably advances: the page predicate is
+#      `(entity_id_1, entity_id_2) > (after_1, after_2)` and the cursor is set
+#      to the MAX key of the page, which is therefore strictly greater than the
+#      cursor that produced it. The loop cannot stall on a page, so
+#      `_SWEEP_MAX_PAGES` is a corruption tripwire, not a work limit.
+#
+#   B2 A ROTATING SLICE bounds the COST PER RUN. Each run sweeps one
+#      deterministic 1/`_SWEEP_SLICE_COUNT` slice of the bank, chosen by wall
+#      clock — `int(time.time()) // _SWEEP_SLICE_SECONDS % _SWEEP_SLICE_COUNT`.
+#      No cursor is persisted anywhere: the slice is a pure function of the
+#      clock, so it survives a worker restart, needs no new table, no alembic
+#      revision, and nothing to corrupt. Slicing is on `md5(entity_id_1)`, and
+#      every row has exactly one `entity_id_1`, so the slices PARTITION the
+#      bank: consecutive runs cover it exactly once each. Measured slice
+#      balance on overlord at 26 slices: largest 23,359 rows against a 19,903
+#      mean.
+#
+#      WHY THE FULL SWEEP STAYS, rather than being replaced by a watermark
+#      scoped to recently-touched entities. A cooccurrence goes stale when a
+#      unit witnessing BOTH entities is deleted, and nothing durable records
+#      the entity ids of a deleted unit — `graph_maintenance_queue` is
+#      (bank_id, unit_id, enqueued_at) and Pass 1 DELETEs its rows as it drains
+#      them. A watermark would therefore need a new queue table AND every
+#      `unit_entities` removal path (direct delete, the FK cascade from
+#      `memory_units`, document delete, invalidation, bank clear, consolidation)
+#      to enqueue into it; any path that did not would leak stale rows
+#      SILENTLY and for ever. The rotating slice needs no such enumeration to
+#      be correct — it sweeps every row on a fixed period whatever produced it
+#      — which is the whole reason it was chosen over the watermark.
+#
+#      The price is prune LATENCY: a stale row survives up to one rotation
+#      (`_SWEEP_SLICE_COUNT` runs = ~12h at the 30-minute job cadence) instead
+#      of up to one run. For a sweep upstream itself documents as "defensive"
+#      — Pass 2's FK cascade already removes the missing-entity case; this pass
+#      only catches the stale-count case — trading 12h of latency for a job
+#      that completes at all is the correct trade. It currently completes
+#      NEVER, so any bounded latency is a strict improvement.
+#
+#   B3 ADAPTIVE SHRINK removes the last unbounded term. A page's cost is
+#      `batch_size` x the degrees of the two entities, and entity degree is not
+#      bounded by anything: the largest on this fleet is 32,730 `unit_entities`
+#      rows (mean 7.3, p99.9 618). A page that lands entirely inside one hub
+#      entity's cooccurrences is therefore the one shape that could still
+#      exceed the timeout at `batch_size = 1000`. On a timeout the sweep HALVES
+#      the page size and retries the SAME cursor, down to
+#      `_SWEEP_MIN_BATCH_SIZE`. That is at most log2(1000/50) = 4 halvings, and
+#      it makes the sweep structurally unable to wedge: without it a single
+#      pathological page would fail its slice on every rotation for ever, which
+#      is precisely the failure this whole block exists to remove.
+#
+# PER-BATCH TRANSACTIONS ARE LOAD-BEARING, not incidental. Each page runs in
+# its own transaction, so (a) a page that times out cannot roll back the pages
+# that already succeeded, (b) row locks taken by the `FOR UPDATE OF c` ordered
+# lock are held for one page rather than one bank, and (c) B3 is possible at
+# all — a cancelled statement aborts its transaction, so shrink-and-retry
+# cannot happen inside a transaction shared with earlier pages. This is why the
+# loop lives in `graph_maintenance.py`, which owns the connection, rather than
+# inside the store method, which is handed one.
+#
+# WHAT IS DELIBERATELY UNCHANGED:
+#   * The staleness predicate, byte for byte (see the rejected rewrite above,
+#     and upstream's #2473 comment).
+#   * The `ORDER BY … FOR UPDATE OF c` ordered lock (#2529). It is preserved
+#     inside each page, and pages proceed in ascending key order, so the global
+#     acquisition order retain's `_flush_pending` upsert relies on still holds.
+#   * `retry_timeouts=False` from #4604. It composes: the timeout reaches this
+#     block's handler on the FIRST attempt instead of after 9, which is what
+#     makes shrink-and-retry cheap.
+#   * The Oracle path. It returns `scanned=0`, which terminates the caller's
+#     loop after one call — i.e. exactly upstream's single-statement behaviour.
+#     Deliberate dialect asymmetry, like the #2529 note already in that file.
+#
+# NO NEW ENV KNOBS. `batch_size` / slice count / slice period are module
+# constants rather than `HINDSIGHT_API_*` settings: a knob would have to be
+# threaded through `config.py` AND added to switchroom's
+# `HINDSIGHT_PERF_ENV_KEYS` allowlist in `src/setup/hindsight-perf-defaults.ts`
+# or it would never reach the container — a second concern, deferred.
+#
+# Self-verifying (exact-once anchors, `ast.parse` on every touched module, and
+# post-conditions re-asserted below). Behavioural proof:
+# tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts runs the REAL
+# patched modules and is RED against unpatched upstream. Structural guards:
+# tests/docker/dockerfile-hindsight-bakes.test.ts.
+RUN python3 - <<'PYEOF'
+import ast
+import pathlib
+
+TAG = "switchroom hindsight graph-maintenance bounded sweep patch"
+BASE = pathlib.Path("/app/api/hindsight_api")
+
+
+def apply(rel, anchor, repl, count=1):
+    f = BASE / rel
+    s = f.read_text()
+    n = s.count(anchor)
+    assert n == count, (
+        f"{TAG}: anchor found {n}x (expected {count}) in {rel} — upstream drifted; "
+        f"re-author this patch in docker/Dockerfile.hindsight. "
+        f"Anchor head: {anchor.splitlines()[0]!r}"
+    )
+    f.write_text(s.replace(anchor, repl, count))
+
+
+# ────────────────────────────────── B0: the page result type, in the ABC module
+apply("engine/db/ops.py", (
+    "@dataclass\n"
+    "class TagListingParts:\n"
+), (
+    "@dataclass\n"
+    "class CooccurrenceSweepBatch:\n"
+    '    """switchroom: one bounded page of the Pass 3 stale-cooccurrence sweep.\n'
+    "\n"
+    "    ``scanned`` is how many cooccurrence rows the page EXAMINED, not how many\n"
+    "    were stale. The caller compares it against the ``batch_size`` it asked for\n"
+    "    to decide whether another page follows, so an implementation that returns\n"
+    "    the deleted count here would stop the sweep after the first page that\n"
+    "    happened to find nothing.\n"
+    "\n"
+    "    ``last_entity_id_1`` / ``last_entity_id_2`` are the (entity_id_1,\n"
+    "    entity_id_2) of the LAST row of the page in sweep order — the keyset cursor\n"
+    "    for the next page. Both are None when the page was empty.\n"
+    '    """\n'
+    "\n"
+    "    deleted: int\n"
+    "    scanned: int\n"
+    "    last_entity_id_1: str | None\n"
+    "    last_entity_id_2: str | None\n"
+    "\n"
+    "\n"
+    "@dataclass\n"
+    "class TagListingParts:\n"
+))
+
+apply("engine/db/ops.py", (
+    "    @abstractmethod\n"
+    "    async def prune_stale_cooccurrences(\n"
+    "        self,\n"
+    "        conn: DatabaseConnection,\n"
+    "        ec_table: str,\n"
+    "        ue_table: str,\n"
+    "        entities_table: str,\n"
+    "        bank_id: str,\n"
+    "    ) -> int:\n"
+    '        """Delete entity_cooccurrences rows in ``bank_id`` where the two\n'
+    "        entities still exist but no current unit references both of them.\n"
+    "\n"
+    "        These are stale-count rows: cooccurrence was real at the time it was\n"
+    "        recorded, but every memory_unit that witnessed both entities has\n"
+    "        since been deleted. Returns the number of rows deleted.\n"
+    '        """\n'
+    "        ...\n"
+), (
+    "    @abstractmethod\n"
+    "    async def prune_stale_cooccurrences(\n"
+    "        self,\n"
+    "        conn: DatabaseConnection,\n"
+    "        ec_table: str,\n"
+    "        ue_table: str,\n"
+    "        entities_table: str,\n"
+    "        bank_id: str,\n"
+    "        *,\n"
+    "        slice_count: int = 1,\n"
+    "        slice_index: int = 0,\n"
+    "        batch_size: int = 1000,\n"
+    "        after_entity_id_1: str | None = None,\n"
+    "        after_entity_id_2: str | None = None,\n"
+    "    ) -> CooccurrenceSweepBatch:\n"
+    '        """Delete entity_cooccurrences rows in ``bank_id`` where the two\n'
+    "        entities still exist but no current unit references both of them.\n"
+    "\n"
+    "        These are stale-count rows: cooccurrence was real at the time it was\n"
+    "        recorded, but every memory_unit that witnessed both entities has\n"
+    "        since been deleted.\n"
+    "\n"
+    "        switchroom: sweeps ONE bounded page rather than the whole bank. The\n"
+    "        predicate is evaluated at most ``batch_size`` times per call, which is\n"
+    "        the only reason a statement's cost stops depending on how big the bank\n"
+    "        got. Callers page by feeding the returned cursor back in as\n"
+    "        ``after_entity_id_1`` / ``after_entity_id_2`` until\n"
+    "        ``scanned < batch_size``, and confine each call to its own transaction\n"
+    "        so a page that blows the timeout cannot undo the pages before it.\n"
+    "\n"
+    "        ``slice_count`` / ``slice_index`` restrict the page to a hash slice of\n"
+    "        ``entity_id_1``; the caller rotates ``slice_index`` over time so the\n"
+    "        whole bank is covered on a fixed period without any run paying for all\n"
+    "        of it. ``slice_count=1`` is the whole bank.\n"
+    "\n"
+    "        A backend with no join table to sweep may ignore the paging arguments\n"
+    "        entirely and return ``scanned=0``, which terminates the caller's loop\n"
+    '        after one call.\n'
+    '        """\n'
+    "        ...\n"
+))
+
+# ────────────────────────────────────────────────── B1: the Postgres page sweep
+apply("engine/db/ops_postgresql.py", (
+    "from .ops import DataAccessOps, LinkExpansionRows, TagListingParts, UpdatedWindow\n"
+), (
+    "from .ops import (\n"
+    "    CooccurrenceSweepBatch,\n"
+    "    DataAccessOps,\n"
+    "    LinkExpansionRows,\n"
+    "    TagListingParts,\n"
+    "    UpdatedWindow,\n"
+    ")\n"
+))
+
+apply("engine/db/ops_postgresql.py", (
+    "    async def prune_stale_cooccurrences(\n"
+    "        self,\n"
+    "        conn: DatabaseConnection,\n"
+    "        ec_table: str,\n"
+    "        ue_table: str,\n"
+    "        entities_table: str,\n"
+    "        bank_id: str,\n"
+    "    ) -> int:\n"
+), (
+    "    async def prune_stale_cooccurrences(\n"
+    "        self,\n"
+    "        conn: DatabaseConnection,\n"
+    "        ec_table: str,\n"
+    "        ue_table: str,\n"
+    "        entities_table: str,\n"
+    "        bank_id: str,\n"
+    "        *,\n"
+    "        slice_count: int = 1,\n"
+    "        slice_index: int = 0,\n"
+    "        batch_size: int = 1000,\n"
+    "        after_entity_id_1: str | None = None,\n"
+    "        after_entity_id_2: str | None = None,\n"
+    "    ) -> CooccurrenceSweepBatch:\n"
+))
+
+apply("engine/db/ops_postgresql.py", (
+    "        result = await conn.execute(\n"
+    "            f\"\"\"\n"
+    "            WITH victims AS (\n"
+    "                SELECT c.entity_id_1, c.entity_id_2\n"
+    "                FROM {ec_table} c\n"
+    "                JOIN {entities_table} e ON e.id = c.entity_id_1\n"
+    "                WHERE e.bank_id = $1\n"
+    "                  AND NOT EXISTS (\n"
+    "                      SELECT unit_id FROM {ue_table} WHERE entity_id = c.entity_id_1\n"
+    "                      INTERSECT\n"
+    "                      SELECT unit_id FROM {ue_table} WHERE entity_id = c.entity_id_2\n"
+    "                  )\n"
+    "                ORDER BY c.entity_id_1, c.entity_id_2\n"
+    "                FOR UPDATE OF c\n"
+    "            )\n"
+    "            DELETE FROM {ec_table} c\n"
+    "            USING victims v\n"
+    "            WHERE c.entity_id_1 = v.entity_id_1\n"
+    "              AND c.entity_id_2 = v.entity_id_2\n"
+    "            \"\"\",\n"
+    "            bank_id,\n"
+    "        )\n"
+    "        return int(result.split()[-1]) if isinstance(result, str) and result.startswith(\"DELETE\") else 0\n"
+), (
+    "        #\n"
+    "        # switchroom: ONE BOUNDED PAGE per call, not the whole bank.\n"
+    "        #\n"
+    "        # The `page` CTE is the bound. `LIMIT $6` caps how many cooccurrence\n"
+    "        # rows exist for the staleness predicate to be evaluated against, so\n"
+    "        # the statement's cost is a function of `batch_size` and NOT of the\n"
+    "        # bank — which is the property that keeps it inside asyncpg's\n"
+    "        # `command_timeout` no matter how large the bank grows. MATERIALIZED\n"
+    "        # because `page` is read four times below and must be one scan, and\n"
+    "        # because the victims CTE must see the page as fixed rows rather than\n"
+    "        # having its LIMIT inlined into a different plan.\n"
+    "        #\n"
+    "        # The keyset start sentinel is the all-zero UUID rather than a NULL\n"
+    "        # branch, and that is SAFE here specifically because of the\n"
+    "        # `entity_cooccurrence_order_check` CHECK (entity_id_1 < entity_id_2):\n"
+    "        # the only row a strict `> (0…0, 0…0)` could skip is the row whose key\n"
+    "        # is exactly (0…0, 0…0), and that row cannot exist. A row with\n"
+    "        # entity_id_1 = 0…0 still has entity_id_2 > 0…0 and so still sorts\n"
+    "        # after the sentinel. Do not 'fix' this into an OR-NULL predicate; that\n"
+    "        # form is not sargable and the page stops being an index range.\n"
+    "        #\n"
+    "        # The slice filter is `md5(entity_id_1) % slice_count = slice_index`.\n"
+    "        # Hashing rather than using the UUID's own bits keeps the slices even\n"
+    "        # for banks whose entity ids are not uniformly distributed, and taking\n"
+    "        # it on entity_id_1 ALONE is what makes the slices a partition: every\n"
+    "        # row has exactly one entity_id_1, so it belongs to exactly one slice\n"
+    "        # and consecutive runs cover the bank exactly once each. `bit(16)` is\n"
+    "        # always non-negative, so no abs() is needed and slice_index is always\n"
+    "        # in range; at slice_count = 1 the filter degenerates to `% 1 = 0`,\n"
+    "        # i.e. the whole bank, with no branch in the SQL.\n"
+    "        #\n"
+    "        # The staleness predicate and the `ORDER BY … FOR UPDATE OF c` ordered\n"
+    "        # lock are upstream's, byte for byte — see the #2473 and #2529 notes\n"
+    "        # above. The lock order still matches retain's sorted upsert: pages are\n"
+    "        # ascending, and rows within a page are ascending.\n"
+    "        row = await conn.fetchrow(\n"
+    "            f\"\"\"\n"
+    "            WITH page AS MATERIALIZED (\n"
+    "                SELECT c.entity_id_1, c.entity_id_2\n"
+    "                FROM {ec_table} c\n"
+    "                JOIN {entities_table} e ON e.id = c.entity_id_1\n"
+    "                WHERE e.bank_id = $1\n"
+    "                  AND (c.entity_id_1, c.entity_id_2) > (\n"
+    "                          COALESCE($2::uuid, '00000000-0000-0000-0000-000000000000'::uuid),\n"
+    "                          COALESCE($3::uuid, '00000000-0000-0000-0000-000000000000'::uuid)\n"
+    "                      )\n"
+    "                  AND ('x' || substr(md5(c.entity_id_1::text), 1, 4))::bit(16)::int % $4::int = $5::int\n"
+    "                ORDER BY c.entity_id_1, c.entity_id_2\n"
+    "                LIMIT $6::int\n"
+    "            ),\n"
+    "            victims AS (\n"
+    "                SELECT c.entity_id_1, c.entity_id_2\n"
+    "                FROM {ec_table} c\n"
+    "                JOIN page p ON p.entity_id_1 = c.entity_id_1 AND p.entity_id_2 = c.entity_id_2\n"
+    "                WHERE NOT EXISTS (\n"
+    "                      SELECT unit_id FROM {ue_table} WHERE entity_id = c.entity_id_1\n"
+    "                      INTERSECT\n"
+    "                      SELECT unit_id FROM {ue_table} WHERE entity_id = c.entity_id_2\n"
+    "                  )\n"
+    "                ORDER BY c.entity_id_1, c.entity_id_2\n"
+    "                FOR UPDATE OF c\n"
+    "            ),\n"
+    "            removed AS (\n"
+    "                DELETE FROM {ec_table} c\n"
+    "                USING victims v\n"
+    "                WHERE c.entity_id_1 = v.entity_id_1\n"
+    "                  AND c.entity_id_2 = v.entity_id_2\n"
+    "                RETURNING 1\n"
+    "            )\n"
+    "            SELECT\n"
+    "                (SELECT count(*) FROM removed) AS deleted,\n"
+    "                (SELECT count(*) FROM page) AS scanned,\n"
+    "                (SELECT entity_id_1 FROM page ORDER BY entity_id_1 DESC, entity_id_2 DESC LIMIT 1)\n"
+    "                    AS last_entity_id_1,\n"
+    "                (SELECT entity_id_2 FROM page ORDER BY entity_id_1 DESC, entity_id_2 DESC LIMIT 1)\n"
+    "                    AS last_entity_id_2\n"
+    "            \"\"\",\n"
+    "            bank_id,\n"
+    "            after_entity_id_1,\n"
+    "            after_entity_id_2,\n"
+    "            slice_count,\n"
+    "            slice_index,\n"
+    "            batch_size,\n"
+    "        )\n"
+    "        if row is None:\n"
+    "            return CooccurrenceSweepBatch(\n"
+    "                deleted=0, scanned=0, last_entity_id_1=None, last_entity_id_2=None\n"
+    "            )\n"
+    "        last_1 = row[\"last_entity_id_1\"]\n"
+    "        last_2 = row[\"last_entity_id_2\"]\n"
+    "        return CooccurrenceSweepBatch(\n"
+    "            deleted=int(row[\"deleted\"] or 0),\n"
+    "            scanned=int(row[\"scanned\"] or 0),\n"
+    "            last_entity_id_1=str(last_1) if last_1 is not None else None,\n"
+    "            last_entity_id_2=str(last_2) if last_2 is not None else None,\n"
+    "        )\n"
+))
+
+# ────────────────────────────────────────────────────────── B1: the Oracle path
+apply("engine/db/ops_oracle.py", (
+    "from .ops import DataAccessOps, LinkExpansionRows, TagListingParts, UpdatedWindow\n"
+), (
+    "from .ops import (\n"
+    "    CooccurrenceSweepBatch,\n"
+    "    DataAccessOps,\n"
+    "    LinkExpansionRows,\n"
+    "    TagListingParts,\n"
+    "    UpdatedWindow,\n"
+    ")\n"
+))
+
+apply("engine/db/ops_oracle.py", (
+    "    async def prune_stale_cooccurrences(\n"
+    "        self,\n"
+    "        conn: DatabaseConnection,\n"
+    "        ec_table: str,\n"
+    "        ue_table: str,\n"
+    "        entities_table: str,\n"
+    "        bank_id: str,\n"
+    "    ) -> int:\n"
+), (
+    "    async def prune_stale_cooccurrences(\n"
+    "        self,\n"
+    "        conn: DatabaseConnection,\n"
+    "        ec_table: str,\n"
+    "        ue_table: str,\n"
+    "        entities_table: str,\n"
+    "        bank_id: str,\n"
+    "        *,\n"
+    "        slice_count: int = 1,\n"
+    "        slice_index: int = 0,\n"
+    "        batch_size: int = 1000,\n"
+    "        after_entity_id_1: str | None = None,\n"
+    "        after_entity_id_2: str | None = None,\n"
+    "    ) -> CooccurrenceSweepBatch:\n"
+))
+
+apply("engine/db/ops_oracle.py", (
+    "            bank_id,\n"
+    "        )\n"
+    "        return int(deleted.split()[-1]) if isinstance(deleted, str) and deleted.startswith(\"DELETE\") else 0\n"
+    "\n"
+    "    async def fetch_unit_dates(\n"
+), (
+    "            bank_id,\n"
+    "        )\n"
+    "        # switchroom: Oracle keeps upstream's single whole-bank statement and\n"
+    "        # IGNORES the paging arguments. Returning scanned=0 terminates the\n"
+    "        # caller's paging loop after this one call, so the observable behaviour\n"
+    "        # is exactly what it was before the Postgres path was paged. Deliberate\n"
+    "        # dialect asymmetry, like the #2529 ordered-lock note above; the bound\n"
+    "        # this patch exists to establish is a Postgres/asyncpg concern.\n"
+    "        return CooccurrenceSweepBatch(\n"
+    "            deleted=int(deleted.split()[-1]) if isinstance(deleted, str) and deleted.startswith(\"DELETE\") else 0,\n"
+    "            scanned=0,\n"
+    "            last_entity_id_1=None,\n"
+    "            last_entity_id_2=None,\n"
+    "        )\n"
+    "\n"
+    "    async def fetch_unit_dates(\n"
+))
+
+# ─────────────────────────────────────────────────── B1: the store pass-through
+apply("engine/memories/pg/graph.py", (
+    "async def prune_stale_cooccurrences(\n"
+    "    *,\n"
+    "    conn: DatabaseConnection,\n"
+    "    fq_table: Callable[[str], str],\n"
+    "    bank_id: str,\n"
+    ") -> int:\n"
+    '    """Delete cooccurrence rows no current memory witnesses. Returns the count.\n'
+    "\n"
+    "    Defensive sweep for rows where both endpoints still exist but no current\n"
+    "    memory_unit references both of them — the cooccurrence was real at the time\n"
+    "    it was recorded, but every unit that witnessed it has since been deleted.\n"
+    "    :func:`prune_orphan_entities` cascades the *missing-entity* case via FK; this\n"
+    "    pass catches the *stale-count* case it cannot see.\n"
+    "\n"
+    "    Like the orphan prune, a bank-wide idempotent sweep backed by indexes, so\n"
+    "    it's cheap when there's nothing to do and safe for the caller to retry.\n"
+    '    """\n'
+    "    ops = _ops_for(conn)\n"
+    "    return await ops.prune_stale_cooccurrences(\n"
+    "        conn,\n"
+    "        fq_table(\"entity_cooccurrences\"),\n"
+    "        fq_table(\"unit_entities\"),\n"
+    "        fq_table(\"entities\"),\n"
+    "        bank_id,\n"
+    "    )\n"
+), (
+    "async def prune_stale_cooccurrences(\n"
+    "    *,\n"
+    "    conn: DatabaseConnection,\n"
+    "    fq_table: Callable[[str], str],\n"
+    "    bank_id: str,\n"
+    "    slice_count: int = 1,\n"
+    "    slice_index: int = 0,\n"
+    "    batch_size: int = 1000,\n"
+    "    after_entity_id_1: str | None = None,\n"
+    "    after_entity_id_2: str | None = None,\n"
+    ") -> CooccurrenceSweepBatch:\n"
+    '    """Delete cooccurrence rows no current memory witnesses, ONE bounded page.\n'
+    "\n"
+    "    Defensive sweep for rows where both endpoints still exist but no current\n"
+    "    memory_unit references both of them — the cooccurrence was real at the time\n"
+    "    it was recorded, but every unit that witnessed it has since been deleted.\n"
+    "    :func:`prune_orphan_entities` cascades the *missing-entity* case via FK; this\n"
+    "    pass catches the *stale-count* case it cannot see.\n"
+    "\n"
+    "    switchroom: this used to be one whole-bank statement, which on a 517k-row\n"
+    "    bank measured 65s READ-ONLY (115s with the sort, the locks and the delete)\n"
+    "    against a 60s ``command_timeout`` — it could not finish, so the pass leaked\n"
+    "    stale rows for ever. It now sweeps a single bounded, resumable page; see\n"
+    "    :func:`run_graph_maintenance_job` for the loop and the rotating slice, and\n"
+    "    docker/Dockerfile.hindsight for the measurements.\n"
+    '    """\n'
+    "    ops = _ops_for(conn)\n"
+    "    return await ops.prune_stale_cooccurrences(\n"
+    "        conn,\n"
+    "        fq_table(\"entity_cooccurrences\"),\n"
+    "        fq_table(\"unit_entities\"),\n"
+    "        fq_table(\"entities\"),\n"
+    "        bank_id,\n"
+    "        slice_count=slice_count,\n"
+    "        slice_index=slice_index,\n"
+    "        batch_size=batch_size,\n"
+    "        after_entity_id_1=after_entity_id_1,\n"
+    "        after_entity_id_2=after_entity_id_2,\n"
+    "    )\n"
+))
+
+apply("engine/memories/pg/graph.py", (
+    "from ...db.base import DatabaseConnection\n"
+), (
+    "from ...db.base import DatabaseConnection\n"
+    "from ...db.ops import CooccurrenceSweepBatch\n"
+))
+
+apply("engine/memories/postgres.py", (
+    "from .base import DeletePredicate, MemoriesExtension, MemoryPatch, ScanPage, StoredMemory\n"
+), (
+    "from ..db.ops import CooccurrenceSweepBatch\n"
+    "from .base import DeletePredicate, MemoriesExtension, MemoryPatch, ScanPage, StoredMemory\n"
+))
+
+apply("engine/memories/base.py", (
+    "from ...extensions.base import Extension\n"
+), (
+    "from ...extensions.base import Extension\n"
+    "from ..db.ops import CooccurrenceSweepBatch\n"
+))
+
+apply("engine/memories/postgres.py", (
+    "    async def prune_stale_cooccurrences(self, *, conn, fq_table, bank_id: str) -> int:\n"
+    "        return await graph.prune_stale_cooccurrences(conn=conn, fq_table=fq_table, bank_id=bank_id)\n"
+), (
+    "    async def prune_stale_cooccurrences(\n"
+    "        self,\n"
+    "        *,\n"
+    "        conn,\n"
+    "        fq_table,\n"
+    "        bank_id: str,\n"
+    "        slice_count: int = 1,\n"
+    "        slice_index: int = 0,\n"
+    "        batch_size: int = 1000,\n"
+    "        after_entity_id_1: str | None = None,\n"
+    "        after_entity_id_2: str | None = None,\n"
+    "    ) -> CooccurrenceSweepBatch:\n"
+    "        return await graph.prune_stale_cooccurrences(\n"
+    "            conn=conn,\n"
+    "            fq_table=fq_table,\n"
+    "            bank_id=bank_id,\n"
+    "            slice_count=slice_count,\n"
+    "            slice_index=slice_index,\n"
+    "            batch_size=batch_size,\n"
+    "            after_entity_id_1=after_entity_id_1,\n"
+    "            after_entity_id_2=after_entity_id_2,\n"
+    "        )\n"
+))
+
+apply("engine/memories/base.py", (
+    "    async def prune_stale_cooccurrences(self, *, conn, fq_table, bank_id: str) -> int:\n"
+    '        """Delete co-occurrence rows whose witnessing memories are all gone."""\n'
+    "        return 0\n"
+), (
+    "    async def prune_stale_cooccurrences(\n"
+    "        self,\n"
+    "        *,\n"
+    "        conn,\n"
+    "        fq_table,\n"
+    "        bank_id: str,\n"
+    "        slice_count: int = 1,\n"
+    "        slice_index: int = 0,\n"
+    "        batch_size: int = 1000,\n"
+    "        after_entity_id_1: str | None = None,\n"
+    "        after_entity_id_2: str | None = None,\n"
+    "    ) -> CooccurrenceSweepBatch:\n"
+    '        """Delete co-occurrence rows whose witnessing memories are all gone.\n'
+    "\n"
+    "        switchroom: a store whose links travel inside its memories has no join\n"
+    "        table to sweep. ``scanned=0`` terminates the caller's paging loop after\n"
+    '        one call, which is the no-op this default has always been."""\n'
+    "        return CooccurrenceSweepBatch(\n"
+    "            deleted=0, scanned=0, last_entity_id_1=None, last_entity_id_2=None\n"
+    "        )\n"
+))
+
+# ─────────────────────────────── B2 + B3: the paging loop and the rotating slice
+# The banner comment upstream wrote for this section is now false — Pass 3 is no
+# longer a single statement — and a stale comment beside a subtle loop is worse
+# than none.
+apply("engine/graph_maintenance.py", (
+    "    # --- Pass 2 & 3: entity / cooccurrence sweeps ---\n"
+    "    # Bank-wide single-statement deletes. Cheap when there's nothing to do.\n"
+), (
+    "    # --- Pass 2 & 3: entity / cooccurrence sweeps ---\n"
+    "    # Pass 2 is one bank-wide delete, cheap when there's nothing to do. Pass 3\n"
+    "    # is a LOOP of bounded pages over one rotating slice of the bank (switchroom;\n"
+    "    # see _run_cooccurrence_prune) because as a single bank-wide statement it\n"
+    "    # could not finish inside the connection's command_timeout.\n"
+))
+
+apply("engine/graph_maintenance.py", (
+    "_SWEEP_MAX_RETRIES = 8\n"
+), (
+    "_SWEEP_MAX_RETRIES = 8\n"
+    "\n"
+    "# switchroom: Pass 3 bounds. Two INDEPENDENT mechanisms — see\n"
+    "# docker/Dockerfile.hindsight for the measurements behind every number.\n"
+    "#\n"
+    "# _SWEEP_BATCH_SIZE bounds the STATEMENT: at most this many cooccurrence rows\n"
+    "# have the staleness predicate evaluated against them per statement, so the\n"
+    "# cost stops depending on the size of the bank. Replaying overlord (517,475\n"
+    "# rows) as pages measured a worst page of 4,322 ms at 2,000 rows/page against\n"
+    "# a 60,000 ms command_timeout; 1,000 halves that again.\n"
+    "#\n"
+    "# _SWEEP_SLICE_COUNT bounds the COST PER RUN: each run sweeps one 1/24th hash\n"
+    "# slice of the bank, so the bank is covered every 24 runs (~12h at the\n"
+    "# 30-minute job cadence) for ~1/24th of the DB CPU per run. Measured on\n"
+    "# overlord: ~3-6s per slice, against a whole-bank sweep that could not finish\n"
+    "# inside the timeout at all.\n"
+    "#\n"
+    "# _SWEEP_MIN_BATCH_SIZE is the floor for the halve-and-retry in the loop\n"
+    "# below, which exists because a page landing entirely inside ONE hub entity's\n"
+    "# cooccurrences is the last shape whose cost is not bounded by the page size\n"
+    "# (max entity degree measured on this fleet: 32,730 unit_entities rows,\n"
+    "# against a mean of 7.3).\n"
+    "#\n"
+    "# _SWEEP_MAX_PAGES is a corruption tripwire, NOT a work limit: the keyset\n"
+    "# cursor is set to the MAX key of a page whose own predicate is\n"
+    "# `> the previous cursor`, so it advances strictly and the loop terminates\n"
+    "# without it. It fires only if that invariant is ever broken.\n"
+    "_SWEEP_BATCH_SIZE = 1000\n"
+    "_SWEEP_MIN_BATCH_SIZE = 50\n"
+    "_SWEEP_SLICE_COUNT = 24\n"
+    "_SWEEP_SLICE_SECONDS = 1800\n"
+    "_SWEEP_MAX_PAGES = 2000\n"
+))
+
+apply("engine/graph_maintenance.py", (
+    "    async def _run_cooccurrence_prune() -> int:\n"
+    "        # The orphan prune above cascades cooccurrences via FK. This explicit\n"
+    "        # pass catches the *stale-count* case: both entities still exist but no\n"
+    "        # current unit witnesses them together.\n"
+    "        async with acquire_with_retry(backend) as conn:\n"
+    "            async with conn.transaction():\n"
+    "                return await store.prune_stale_cooccurrences(conn=conn, fq_table=fq_table, bank_id=bank_id)\n"
+), (
+    "    async def _run_cooccurrence_prune() -> int:\n"
+    "        # The orphan prune above cascades cooccurrences via FK. This explicit\n"
+    "        # pass catches the *stale-count* case: both entities still exist but no\n"
+    "        # current unit witnesses them together.\n"
+    "        #\n"
+    "        # switchroom: this was ONE whole-bank statement, measured at 115s on a\n"
+    "        # 517k-row bank against a 60s command_timeout — it could not finish, so\n"
+    "        # the pass had never once completed on this fleet's two largest banks.\n"
+    "        # It is now a loop of BOUNDED, RESUMABLE pages over one time-rotating\n"
+    "        # slice of the bank.\n"
+    "        #\n"
+    "        # The slice index is a pure function of the wall clock, so it needs no\n"
+    "        # persisted cursor, no new table and no alembic revision, and it is\n"
+    "        # unaffected by a worker restart. The slices partition the bank (the\n"
+    "        # hash is on entity_id_1, and every row has exactly one), so successive\n"
+    "        # runs cover every row rather than resampling. That total coverage is\n"
+    "        # why this is a rotating full sweep and not a watermark scoped to\n"
+    "        # recently-touched entities: nothing durable records the entities of a\n"
+    "        # deleted unit, so a watermark would silently miss every staleness\n"
+    "        # source that failed to enqueue, for ever.\n"
+    "        slice_index = int(time.time()) // _SWEEP_SLICE_SECONDS % _SWEEP_SLICE_COUNT\n"
+    "        batch_size = _SWEEP_BATCH_SIZE\n"
+    "        after_1: str | None = None\n"
+    "        after_2: str | None = None\n"
+    "        deleted = 0\n"
+    "        pages = 0\n"
+    "\n"
+    "        async def _run_page(size: int):\n"
+    "            # Each page is its OWN transaction. Load-bearing three times over: a\n"
+    "            # page that times out cannot roll back the pages that already\n"
+    "            # committed; the FOR UPDATE row locks are held for one page rather\n"
+    "            # than one bank; and the shrink-and-retry below is only possible\n"
+    "            # because a cancelled statement aborts its own transaction and not a\n"
+    "            # shared one.\n"
+    "            async with acquire_with_retry(backend) as conn:\n"
+    "                async with conn.transaction():\n"
+    "                    return await store.prune_stale_cooccurrences(\n"
+    "                        conn=conn,\n"
+    "                        fq_table=fq_table,\n"
+    "                        bank_id=bank_id,\n"
+    "                        slice_count=_SWEEP_SLICE_COUNT,\n"
+    "                        slice_index=slice_index,\n"
+    "                        batch_size=size,\n"
+    "                        after_entity_id_1=after_1,\n"
+    "                        after_entity_id_2=after_2,\n"
+    "                    )\n"
+    "\n"
+    "        while True:\n"
+    "            if pages >= _SWEEP_MAX_PAGES:\n"
+    "                logger.error(\n"
+    "                    f\"[GRAPH_MAINT] bank={bank_id} cooccurrence sweep hit the \"\n"
+    "                    f\"{_SWEEP_MAX_PAGES}-page tripwire at cursor ({after_1}, {after_2}) — \"\n"
+    "                    f\"the keyset cursor is not advancing; slice {slice_index} is incomplete, \"\n"
+    "                    f\"operation_id={operation_id}\"\n"
+    "                )\n"
+    "                break\n"
+    "            requested = batch_size\n"
+    "            try:\n"
+    "                # retry_timeouts=False keeps #4604's property: a timeout is a\n"
+    "                # verdict on the statement, not a transient blip, so it arrives\n"
+    "                # here on the FIRST attempt instead of after nine. Deadlocks and\n"
+    "                # dropped connections are still retried in full, per page.\n"
+    "                page = await retry_with_backoff(\n"
+    "                    lambda: _run_page(requested),\n"
+    "                    max_retries=_SWEEP_MAX_RETRIES,\n"
+    "                    retry_timeouts=False,\n"
+    "                )\n"
+    "            except TimeoutError:\n"
+    "                # A page that still cannot finish inside command_timeout is a hub\n"
+    "                # page: `batch_size` rows whose entities have enormous degree.\n"
+    "                # Halve and retry the SAME cursor rather than failing the slice —\n"
+    "                # otherwise one pathological page fails its slice on every\n"
+    "                # rotation for ever, which is the failure this whole change\n"
+    "                # exists to remove. At most log2(batch/min) halvings.\n"
+    "                #\n"
+    "                # Catching the builtin TimeoutError is sufficient AND correct:\n"
+    "                # asyncpg raises asyncio.TimeoutError on command_timeout, and on\n"
+    "                # this image's Python (3.11) asyncio.TimeoutError IS the builtin.\n"
+    "                if batch_size > _SWEEP_MIN_BATCH_SIZE:\n"
+    "                    batch_size = max(_SWEEP_MIN_BATCH_SIZE, batch_size // 2)\n"
+    "                    logger.warning(\n"
+    "                        f\"[GRAPH_MAINT] bank={bank_id} cooccurrence page of {requested} timed out \"\n"
+    "                        f\"at cursor ({after_1}, {after_2}); retrying the same cursor at \"\n"
+    "                        f\"{batch_size}, operation_id={operation_id}\"\n"
+    "                    )\n"
+    "                    continue\n"
+    "                raise\n"
+    "            pages += 1\n"
+    "            deleted += page.deleted\n"
+    "            # `scanned` counts rows EXAMINED, not rows deleted — a short page is\n"
+    "            # the only end-of-slice signal, and a page that deleted nothing is\n"
+    "            # not a short page.\n"
+    "            if page.scanned < requested or page.last_entity_id_1 is None:\n"
+    "                break\n"
+    "            after_1 = page.last_entity_id_1\n"
+    "            after_2 = page.last_entity_id_2\n"
+    "\n"
+    "        logger.info(\n"
+    "            f\"[GRAPH_MAINT] bank={bank_id} cooccurrence sweep: slice \"\n"
+    "            f\"{slice_index}/{_SWEEP_SLICE_COUNT}, {pages} page(s), final batch_size \"\n"
+    "            f\"{batch_size}, {deleted} pruned, operation_id={operation_id}\"\n"
+    "        )\n"
+    "        return deleted\n"
+))
+
+# ─────────────────────────────────────────────────────────────────────── verify
+TOUCHED = (
+    "engine/db/ops.py",
+    "engine/db/ops_postgresql.py",
+    "engine/db/ops_oracle.py",
+    "engine/memories/pg/graph.py",
+    "engine/memories/postgres.py",
+    "engine/memories/base.py",
+    "engine/graph_maintenance.py",
+)
+for rel in TOUCHED:
+    ast.parse((BASE / rel).read_text())
+
+pg = (BASE / "engine/db/ops_postgresql.py").read_text()
+sweep = pg.split("async def prune_stale_cooccurrences", 1)[1].split("\n    async def ", 1)[0]
+assert "LIMIT $6::int" in sweep, (
+    f"{TAG}: the page CTE lost its LIMIT — the statement is unbounded again and the "
+    "whole point of this patch is gone"
+)
+assert "WITH page AS MATERIALIZED" in sweep, f"{TAG}: the page CTE is no longer materialised"
+# Count the SQL form (16-space indent inside the victims CTE), not the prose
+# mentions in the comment above it.
+assert sweep.count("\n                FOR UPDATE OF c\n") == 1, (
+    f"{TAG}: the #2529 ordered lock did not survive the rewrite"
+)
+assert "INTERSECT" in sweep, (
+    f"{TAG}: the #2473 INTERSECT predicate was replaced — a semi-join rewrite measured "
+    "NO faster (65,555 ms vs 65,168 ms) because the planner hash-joins all of "
+    "unit_entities at bank scale"
+)
+assert "% $4::int = $5::int" in sweep, f"{TAG}: the rotating slice filter is missing"
+assert "COALESCE($2::uuid" in sweep and "(c.entity_id_1, c.entity_id_2) > (" in sweep, (
+    f"{TAG}: the keyset cursor predicate is missing — pages would restart from the top for ever"
+)
+
+gm = (BASE / "engine/graph_maintenance.py").read_text()
+for const in ("_SWEEP_BATCH_SIZE", "_SWEEP_MIN_BATCH_SIZE", "_SWEEP_SLICE_COUNT", "_SWEEP_SLICE_SECONDS", "_SWEEP_MAX_PAGES"):
+    assert f"\n{const} = " in gm, f"{TAG}: {const} is missing"
+prune = gm.split("async def _run_cooccurrence_prune", 1)[1].split("\n    # A larger retry budget", 1)[0]
+assert "int(time.time()) // _SWEEP_SLICE_SECONDS % _SWEEP_SLICE_COUNT" in prune, (
+    f"{TAG}: the slice index is no longer a pure function of the clock"
+)
+assert "batch_size = max(_SWEEP_MIN_BATCH_SIZE, batch_size // 2)" in prune, (
+    f"{TAG}: the halve-and-retry is gone — one hub page would wedge its slice for ever"
+)
+assert "retry_timeouts=False" in prune, f"{TAG}: #4604's timeout opt-out was dropped from the loop"
+assert "if page.scanned < requested" in prune, (
+    f"{TAG}: the paging loop no longer terminates on a short page"
+)
+assert "after_1 = page.last_entity_id_1" in prune, f"{TAG}: the cursor is never advanced"
+assert prune.index("continue") < prune.index("after_1 = page.last_entity_id_1"), (
+    f"{TAG}: shrink-and-retry must re-run the SAME cursor, not advance past the page it failed on"
+)
+
+ops = (BASE / "engine/db/ops.py").read_text()
+assert "class CooccurrenceSweepBatch" in ops, f"{TAG}: the page result type is missing"
+for rel in ("engine/db/ops_postgresql.py", "engine/db/ops_oracle.py", "engine/memories/pg/graph.py", "engine/memories/base.py"):
+    assert "CooccurrenceSweepBatch" in (BASE / rel).read_text(), (
+        f"{TAG}: {rel} does not import/return the page result type"
+    )
+
+print(
+    f"{TAG}: Pass 3 now sweeps bounded keyset pages (LIMIT-capped, cursor-advancing, "
+    "one transaction each) over a clock-rotating 1/24 hash slice, halving the page on a "
+    "timeout; the #2473 predicate and the #2529 ordered lock are unchanged"
+)
+PYEOF
+
 # Pin the upstream `hindsight` user to UID 11000 to match
 # `HINDSIGHT_DEFAULT_UID` in src/setup/hindsight.ts (and the
 # `auth.consumers[hindsight].uid` value the operator writes in

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -7495,6 +7495,17 @@ assert sweep.count("\n                ORDER BY c.entity_id_1, c.entity_id_2\n") 
     f"{TAG}: the sweep no longer has BOTH ordered scans — the page CTE's keyset order "
     "and the #2529 ordered lock's"
 )
+assert (
+    "\n                ORDER BY c.entity_id_1, c.entity_id_2\n"
+    "                FOR UPDATE OF c\n"
+) in sweep, (
+    f"{TAG}: the victims CTE's `ORDER BY c.entity_id_1, c.entity_id_2` is no longer "
+    "ADJACENT to its `FOR UPDATE OF c` — that adjacency IS the #2529 ordered lock. "
+    "The count assert above cannot see this on its own: deleting the victims ORDER BY "
+    "and re-adding an identical line anywhere else in the statement keeps the count at "
+    "2 and ships an unordered lock (deadlocks under concurrent maintenance) with a "
+    "green build"
+)
 assert sweep.count("\n                FOR UPDATE OF c\n") == 1, (
     f"{TAG}: the #2529 ordered lock did not survive the rewrite"
 )

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -6441,16 +6441,42 @@ PYEOF
 #      cursor that produced it. The loop cannot stall on a page, so
 #      `_SWEEP_MAX_PAGES` is a corruption tripwire, not a work limit.
 #
-#   B2 A ROTATING SLICE bounds the COST PER RUN. Each run sweeps one
-#      deterministic 1/`_SWEEP_SLICE_COUNT` slice of the bank, chosen by wall
-#      clock — `int(time.time()) // _SWEEP_SLICE_SECONDS % _SWEEP_SLICE_COUNT`.
-#      No cursor is persisted anywhere: the slice is a pure function of the
-#      clock, so it survives a worker restart, needs no new table, no alembic
-#      revision, and nothing to corrupt. Slicing is on `md5(entity_id_1)`, and
-#      every row has exactly one `entity_id_1`, so the slices PARTITION the
-#      bank: consecutive runs cover it exactly once each. Measured slice
-#      balance on overlord at 26 slices: largest 23,359 rows against a 19,903
-#      mean.
+#   B2 A ROTATING SLICE bounds the COST PER RUN, and HOW MANY SLICES IS DERIVED
+#      FROM BANK SIZE: `ceil(rows / _SWEEP_SLICE_TARGET_ROWS)`, capped at
+#      `_SWEEP_MAX_SLICE_COUNT` and floored at 1. A bank that already sweeps
+#      whole inside the timeout therefore gets ONE slice and keeps being swept
+#      entirely on every run; only a bank big enough to need the bound rotates,
+#      and only as far as its size demands. Measured on this fleet: overlord
+#      516,563 rows → 21 slices, klanker 463,534 → 19, finn 159,076 → 7,
+#      carrie 132,784 → 6, assistant 91,409 → 4, marko 60,994 → 3, and every
+#      bank at or below 25,000 rows (reggie, gymbro, lawgpt, ziggy and the
+#      profile banks) → 1. Whole-slice sweep at the target size measures
+#      4.7 s (overlord), 3.3 s (klanker), 4.7 s (lawgpt, whole bank).
+#
+#      The slice INDEX is a pure function of the wall clock —
+#      `int(now) // _SWEEP_SLICE_SECONDS % slice_count` — so no cursor is
+#      persisted anywhere: it survives a worker restart, needs no new table, no
+#      alembic revision, and has nothing to corrupt. Slicing is on
+#      `md5(entity_id_1)`, and every row has exactly one `entity_id_1`, so the
+#      slices PARTITION the bank. Measured slice balance on overlord at 26
+#      slices: largest 23,359 rows against a 19,903 mean.
+#
+#      COVERAGE IS COUPON-COLLECTOR, NOT A CYCLE. `graph_maintenance` is
+#      DEMAND-DRIVEN: `submit_async_graph_maintenance` fires when work is
+#      enqueued (retain / delete / edit) and short-circuits with `no_work=True`
+#      on an empty queue — there is no timer anywhere. Runs are therefore
+#      uncorrelated with the clock the index is taken from, each run samples an
+#      effectively random slice, and expected full coverage is `N*H(N)` runs,
+#      not `N`. That is precisely why `N` is kept as small as the bank allows.
+#      Measured runs/day per bank over 30 days (`async_operations`,
+#      2026-08-12): overlord 28.9, klanker 26.3, finn 9.4, carrie 8.3,
+#      marko 5.2, assistant 3.0, gymbro 1.8, ziggy 0.77, reggie 0.70,
+#      lawgpt 0.30. A FIXED 24 would have given those banks expected full
+#      coverage every 3.1, 3.5, 9.6, 11.0, 17.4, 29.9, 49.4, 118.2, 129.5 and
+#      302.1 days — putting the quietest banks, which never had the timeout and
+#      swept whole in 2.7-4.3 s, on a rotation measured in months to fix a
+#      problem they do not have. Size-derived they are 2.7, 2.6, 1.9, 1.8, 1.1,
+#      2.8, 0.6, 1.3, 1.4 and 3.3 days.
 #
 #      WHY THE FULL SWEEP STAYS, rather than being replaced by a watermark
 #      scoped to recently-touched entities. A cooccurrence goes stale when a
@@ -6465,13 +6491,16 @@ PYEOF
 #      be correct — it sweeps every row on a fixed period whatever produced it
 #      — which is the whole reason it was chosen over the watermark.
 #
-#      The price is prune LATENCY: a stale row survives up to one rotation
-#      (`_SWEEP_SLICE_COUNT` runs = ~12h at the 30-minute job cadence) instead
-#      of up to one run. For a sweep upstream itself documents as "defensive"
-#      — Pass 2's FK cascade already removes the missing-entity case; this pass
-#      only catches the stale-count case — trading 12h of latency for a job
-#      that completes at all is the correct trade. It currently completes
-#      NEVER, so any bounded latency is a strict improvement.
+#      The price is prune LATENCY, and it is only paid by banks that are
+#      sliced at all. A stale row survives up to one coverage period — and up
+#      to TWO, because a row inserted mid-rotation below the cursor of its own
+#      slice is not seen until that slice comes round again. Measured worst
+#      case across this fleet: 3.3 days (lawgpt, slice_count 1, 0.3 runs/day),
+#      i.e. bounded by how often the bank is touched at all. For a sweep
+#      upstream itself documents as "defensive" — Pass 2's FK cascade already
+#      removes the missing-entity case; this pass only catches the stale-count
+#      case — that is the correct trade against a pass that currently completes
+#      NEVER on the two largest banks.
 #
 #   B3 ADAPTIVE SHRINK removes the last unbounded term. A page's cost is
 #      `batch_size` x the degrees of the two entities, and entity degree is not
@@ -6480,10 +6509,26 @@ PYEOF
 #      entity's cooccurrences is therefore the one shape that could still
 #      exceed the timeout at `batch_size = 1000`. On a timeout the sweep HALVES
 #      the page size and retries the SAME cursor, down to
-#      `_SWEEP_MIN_BATCH_SIZE`. That is at most log2(1000/50) = 4 halvings, and
-#      it makes the sweep structurally unable to wedge: without it a single
-#      pathological page would fail its slice on every rotation for ever, which
-#      is precisely the failure this whole block exists to remove.
+#      `_SWEEP_MIN_BATCH_SIZE` — at most log2(1000/50) = 4 halvings.
+#
+#      Its LIMIT, stated honestly: shrink makes a hub page survivable, it does
+#      not make the sweep unwedgeable. A page that still times out AT the 50-row
+#      floor raises, which fails Pass 3 for that bank on that run exactly as
+#      today — the difference is that four halvings must be exhausted first, and
+#      that the pages already committed are not lost (per-page transactions) and
+#      are named in the log line beside the raise, since the exception carries
+#      no count. `batch_size` also does not RECOVER after a shrink: the rest of
+#      that slice runs at the reduced size, which is why the `_SWEEP_MAX_PAGES`
+#      tripwire's log names an early shrink as a legitimate second cause.
+#
+#      WHY `batch_size = 1000`. Not a throughput choice — measured read-only on
+#      live data, total time to sweep a whole target-sized slice is FLAT in the
+#      page size (overlord, 24,640 rows: 4.9 s at 200, 4.6 s at 500, 4.3 s at
+#      1,000, 5.0 s at 2,000, 5.0 s at 4,000). What the constant actually buys
+#      is per-STATEMENT latency, which is linear in it: worst observed page
+#      229 ms at 500, 445 ms at 1,000, 578 ms at 2,000, against the 60,000 ms
+#      command_timeout. 1,000 is the point that keeps ~135x headroom on the
+#      worst measured page while keeping a slice down to ~25 statements.
 #
 # PER-BATCH TRANSACTIONS ARE LOAD-BEARING, not incidental. Each page runs in
 # its own transaction, so (a) a page that times out cannot roll back the pages
@@ -6495,8 +6540,11 @@ PYEOF
 # inside the store method, which is handed one.
 #
 # WHAT IS DELIBERATELY UNCHANGED:
-#   * The staleness predicate, byte for byte (see the rejected rewrite above,
-#     and upstream's #2473 comment).
+#   * The staleness predicate itself — the `NOT EXISTS (… INTERSECT …)` body,
+#     byte for byte (see the rejected rewrite above, and upstream's #2473
+#     comment). The `victims` CTE AROUND it is materially rewritten: it now
+#     joins the bounded `page` CTE instead of scanning the bank, which is the
+#     whole mechanism. "Byte for byte" describes the predicate, not the CTE.
 #   * The `ORDER BY … FOR UPDATE OF c` ordered lock (#2529). It is preserved
 #     inside each page, and pages proceed in ascending key order, so the global
 #     acquisition order retain's `_flush_pending` upsert relies on still holds.
@@ -6507,7 +6555,15 @@ PYEOF
 #     loop after one call — i.e. exactly upstream's single-statement behaviour.
 #     Deliberate dialect asymmetry, like the #2529 note already in that file.
 #
-# NO NEW ENV KNOBS. `batch_size` / slice count / slice period are module
+# KNOWN, ACCEPTED, NOT FIXED HERE. The outer `retry_with_backoff(...,
+# max_retries=8)` that wraps `_run_cooccurrence_prune` is upstream's and is
+# untouched, so a retryable NON-timeout error escaping the inner per-page loop
+# restarts the whole slice from cursor `None`. Idempotent (the sweep is a
+# delete-if-stale), but up to 9x wasted work on a slice. Collapsing the two
+# budgets means changing a retry wrapper shared with Passes 1 and 2 — a
+# separate concern with its own blast radius, tracked rather than smuggled in.
+#
+# NO NEW ENV KNOBS. `batch_size` / slice sizing / slice period are module
 # constants rather than `HINDSIGHT_API_*` settings: a knob would have to be
 # threaded through `config.py` AND added to switchroom's
 # `HINDSIGHT_PERF_ENV_KEYS` allowlist in `src/setup/hindsight-perf-defaults.ts`
@@ -6627,6 +6683,26 @@ apply("engine/db/ops.py", (
     '        after one call.\n'
     '        """\n'
     "        ...\n"
+    "\n"
+    "    async def count_bank_cooccurrences(\n"
+    "        self,\n"
+    "        conn: DatabaseConnection,\n"
+    "        ec_table: str,\n"
+    "        entities_table: str,\n"
+    "        bank_id: str,\n"
+    "    ) -> int:\n"
+    '        """switchroom: how many cooccurrence rows ``bank_id`` currently has.\n'
+    "\n"
+    "        Sizing input for the sweep above: the caller divides this by a target\n"
+    "        rows-per-slice to decide how many slices the bank needs, so a bank small\n"
+    "        enough to sweep whole in one run is never sliced at all.\n"
+    "\n"
+    "        CONCRETE, not abstract, and 0 means 'no idea'. A backend that cannot\n"
+    "        answer cheaply must not be forced to answer expensively: the caller\n"
+    "        reads 0 as ``slice_count = 1``, i.e. sweep the whole bank, which is the\n"
+    "        behaviour every backend had before slicing existed.\n"
+    '        """\n'
+    "        return 0\n"
 ))
 
 # ────────────────────────────────────────────────── B1: the Postgres page sweep
@@ -6789,6 +6865,35 @@ apply("engine/db/ops_postgresql.py", (
     "            last_entity_id_1=str(last_1) if last_1 is not None else None,\n"
     "            last_entity_id_2=str(last_2) if last_2 is not None else None,\n"
     "        )\n"
+    "\n"
+    "    async def count_bank_cooccurrences(\n"
+    "        self,\n"
+    "        conn: DatabaseConnection,\n"
+    "        ec_table: str,\n"
+    "        entities_table: str,\n"
+    "        bank_id: str,\n"
+    "    ) -> int:\n"
+    '        """switchroom: exact cooccurrence-row count for the bank.\n'
+    "\n"
+    "        EXACT rather than an ``reltuples`` estimate: this is the whole input to\n"
+    "        how many slices the bank is cut into, a stale estimate on a bank that\n"
+    "        just grew would under-slice it, and the count is cheap. Measured on this\n"
+    "        fleet's largest bank (516,563 rows) it is a parallel seq scan of\n"
+    "        entity_cooccurrences hash-joined to the bank's entities: 93 ms, once per\n"
+    "        run, against a slice sweep of ~4.7 s.\n"
+    '        """\n'
+    "        return int(\n"
+    "            await conn.fetchval(\n"
+    "                f\"\"\"\n"
+    "                SELECT count(*)\n"
+    "                FROM {ec_table} c\n"
+    "                JOIN {entities_table} e ON e.id = c.entity_id_1\n"
+    "                WHERE e.bank_id = $1\n"
+    "                \"\"\",\n"
+    "                bank_id,\n"
+    "            )\n"
+    "            or 0\n"
+    "        )\n"
 ))
 
 # ────────────────────────────────────────────────────────── B1: the Oracle path
@@ -6922,6 +7027,24 @@ apply("engine/memories/pg/graph.py", (
     "        after_entity_id_1=after_entity_id_1,\n"
     "        after_entity_id_2=after_entity_id_2,\n"
     "    )\n"
+    "\n"
+    "\n"
+    "async def count_bank_cooccurrences(\n"
+    "    *,\n"
+    "    conn: DatabaseConnection,\n"
+    "    fq_table: Callable[[str], str],\n"
+    "    bank_id: str,\n"
+    ") -> int:\n"
+    '    """switchroom: cooccurrence-row count for the bank; sizing input for the\n'
+    "    sweep's slice count. See :func:`prune_stale_cooccurrences`.\n"
+    '    """\n'
+    "    ops = _ops_for(conn)\n"
+    "    return await ops.count_bank_cooccurrences(\n"
+    "        conn,\n"
+    "        fq_table(\"entity_cooccurrences\"),\n"
+    "        fq_table(\"entities\"),\n"
+    "        bank_id,\n"
+    "    )\n"
 ))
 
 apply("engine/memories/pg/graph.py", (
@@ -6971,6 +7094,9 @@ apply("engine/memories/postgres.py", (
     "            after_entity_id_1=after_entity_id_1,\n"
     "            after_entity_id_2=after_entity_id_2,\n"
     "        )\n"
+    "\n"
+    "    async def count_bank_cooccurrences(self, *, conn, fq_table, bank_id: str) -> int:\n"
+    "        return await graph.count_bank_cooccurrences(conn=conn, fq_table=fq_table, bank_id=bank_id)\n"
 ))
 
 apply("engine/memories/base.py", (
@@ -6998,6 +7124,11 @@ apply("engine/memories/base.py", (
     "        return CooccurrenceSweepBatch(\n"
     "            deleted=0, scanned=0, last_entity_id_1=None, last_entity_id_2=None\n"
     "        )\n"
+    "\n"
+    "    async def count_bank_cooccurrences(self, *, conn, fq_table, bank_id: str) -> int:\n"
+    '        """switchroom: no join table, nothing to size. 0 means "no idea", which\n'
+    '        the caller reads as slice_count = 1."""\n'
+    "        return 0\n"
 ))
 
 # ─────────────────────────────── B2 + B3: the paging loop and the rotating slice
@@ -7029,11 +7160,25 @@ apply("engine/graph_maintenance.py", (
     "# rows) as pages measured a worst page of 4,322 ms at 2,000 rows/page against\n"
     "# a 60,000 ms command_timeout; 1,000 halves that again.\n"
     "#\n"
-    "# _SWEEP_SLICE_COUNT bounds the COST PER RUN: each run sweeps one 1/24th hash\n"
-    "# slice of the bank, so the bank is covered every 24 runs (~12h at the\n"
-    "# 30-minute job cadence) for ~1/24th of the DB CPU per run. Measured on\n"
-    "# overlord: ~3-6s per slice, against a whole-bank sweep that could not finish\n"
-    "# inside the timeout at all.\n"
+    "# _SWEEP_SLICE_TARGET_ROWS bounds the COST PER RUN, and is the reason the\n"
+    "# slice count is DERIVED FROM BANK SIZE rather than fixed. Slicing is a cost\n"
+    "# control, and a bank that already sweeps whole inside the timeout has no cost\n"
+    "# to control — slicing it only delays its prunes. So: slices =\n"
+    "# ceil(rows / _SWEEP_SLICE_TARGET_ROWS), capped at _SWEEP_MAX_SLICE_COUNT and\n"
+    "# floored at 1, which makes ~25k rows the per-run unit of work for EVERY bank.\n"
+    "# Measured whole-slice sweep at that size: overlord 4.7 s, klanker 3.3 s,\n"
+    "# lawgpt (whole bank, 15,443 rows, slice_count=1) 4.7 s.\n"
+    "#\n"
+    "# WHY NOT A FIXED 24. `graph_maintenance` is DEMAND-DRIVEN, not timed:\n"
+    "# `submit_async_graph_maintenance` fires on enqueued work and short-circuits\n"
+    "# on an empty queue (`no_work=True`), so runs are uncorrelated with the wall\n"
+    "# clock the slice index is derived from. Each run therefore samples an\n"
+    "# effectively random slice and full coverage is COUPON-COLLECTOR — expected\n"
+    "# N*H(N) runs, ~91 for N=24, not 24. Measured runs/day per bank over 30 days\n"
+    "# (async_operations, 2026-08-12) span 28.9 (overlord) to 0.30 (lawgpt), so a\n"
+    "# fixed 24 would have moved the QUIET banks — the ones that never had the\n"
+    "# timeout, and swept whole in 2.7-4.3 s — from full coverage every run to\n"
+    "# 13-302 days per full sweep. Size-derived, every bank lands at 0.6-3.3 days.\n"
     "#\n"
     "# _SWEEP_MIN_BATCH_SIZE is the floor for the halve-and-retry in the loop\n"
     "# below, which exists because a page landing entirely inside ONE hub entity's\n"
@@ -7041,15 +7186,43 @@ apply("engine/graph_maintenance.py", (
     "# (max entity degree measured on this fleet: 32,730 unit_entities rows,\n"
     "# against a mean of 7.3).\n"
     "#\n"
-    "# _SWEEP_MAX_PAGES is a corruption tripwire, NOT a work limit: the keyset\n"
-    "# cursor is set to the MAX key of a page whose own predicate is\n"
-    "# `> the previous cursor`, so it advances strictly and the loop terminates\n"
-    "# without it. It fires only if that invariant is ever broken.\n"
+    "# _SWEEP_MAX_PAGES is a tripwire, NOT a tuned work limit. Its PRIMARY job is\n"
+    "# to catch a non-advancing keyset cursor: the cursor is set to the MAX key of\n"
+    "# a page whose own predicate is `> the previous cursor`, so it advances\n"
+    "# strictly and the loop terminates without it. Headroom against legitimate\n"
+    "# work: a target-sized slice is 25 pages at 1,000, and 500 pages even if every\n"
+    "# page shrank to the floor of 50 — but `batch_size` never recovers after a\n"
+    "# shrink, so a slice that shrinks EARLY is the one shape that can reach the\n"
+    "# tripwire on honest work. The log line names both causes for that reason.\n"
     "_SWEEP_BATCH_SIZE = 1000\n"
     "_SWEEP_MIN_BATCH_SIZE = 50\n"
-    "_SWEEP_SLICE_COUNT = 24\n"
+    "_SWEEP_SLICE_TARGET_ROWS = 25000\n"
+    "_SWEEP_MAX_SLICE_COUNT = 24\n"
     "_SWEEP_SLICE_SECONDS = 1800\n"
     "_SWEEP_MAX_PAGES = 2000\n"
+    "\n"
+    "\n"
+    "def _sweep_slice_count(total_rows: int) -> int:\n"
+    '    """switchroom: how many slices a bank of ``total_rows`` cooccurrences needs.\n'
+    "\n"
+    "    1 for anything that fits in one target-sized run — a bank that never had\n"
+    "    the timeout must not be put on a rotation to fix a problem it does not\n"
+    "    have. 0 (a backend that cannot count) is also 1: sweep the whole bank,\n"
+    "    which is what every backend did before slicing existed.\n"
+    '    """\n'
+    "    if total_rows <= _SWEEP_SLICE_TARGET_ROWS:\n"
+    "        return 1\n"
+    "    return min(_SWEEP_MAX_SLICE_COUNT, -(-total_rows // _SWEEP_SLICE_TARGET_ROWS))\n"
+    "\n"
+    "\n"
+    "def _sweep_slice_index(now: float, slice_count: int) -> int:\n"
+    '    """switchroom: which slice this run sweeps. A pure function of the wall\n'
+    "    clock, so it needs no persisted cursor and survives a worker restart.\n"
+    "\n"
+    "    It is NOT a schedule. The job is demand-driven, so consecutive runs do not\n"
+    "    land on consecutive ticks and coverage is coupon-collector, not a cycle;\n"
+    '    the clock here only makes the choice deterministic and testable."""\n'
+    "    return int(now) // _SWEEP_SLICE_SECONDS % slice_count\n"
 ))
 
 apply("engine/graph_maintenance.py", (
@@ -7072,16 +7245,40 @@ apply("engine/graph_maintenance.py", (
     "        # It is now a loop of BOUNDED, RESUMABLE pages over one time-rotating\n"
     "        # slice of the bank.\n"
     "        #\n"
-    "        # The slice index is a pure function of the wall clock, so it needs no\n"
-    "        # persisted cursor, no new table and no alembic revision, and it is\n"
-    "        # unaffected by a worker restart. The slices partition the bank (the\n"
-    "        # hash is on entity_id_1, and every row has exactly one), so successive\n"
-    "        # runs cover every row rather than resampling. That total coverage is\n"
-    "        # why this is a rotating full sweep and not a watermark scoped to\n"
+    "        # HOW MANY SLICES IS A FUNCTION OF BANK SIZE, not a constant. Slicing\n"
+    "        # trades prune latency for per-run cost, and a bank that already sweeps\n"
+    "        # whole inside the timeout has no per-run cost to trade — so it gets\n"
+    "        # slice_count = 1 and keeps being swept entirely, every run. Only a bank\n"
+    "        # bigger than _SWEEP_SLICE_TARGET_ROWS rotates, and only as far as its\n"
+    "        # size requires. The count is one cheap statement (93 ms on the largest\n"
+    "        # bank on this fleet) issued once per run, not per page.\n"
+    "        #\n"
+    "        # The slice index is a pure function of the wall clock: no persisted\n"
+    "        # cursor, no new table, no alembic revision, unaffected by a restart.\n"
+    "        # The slices PARTITION the bank (the hash is on entity_id_1 and every\n"
+    "        # row has exactly one), so a row is swept by exactly one slice.\n"
+    "        #\n"
+    "        # COVERAGE IS PROBABILISTIC, NOT A CYCLE, and the comment that used to\n"
+    "        # sit here claiming '24 consecutive runs cover the bank exactly once\n"
+    "        # each' was wrong. This job is demand-driven — submit_async_graph_\n"
+    "        # maintenance fires on enqueued work and short-circuits on an empty\n"
+    "        # queue — so runs are uncorrelated with the clock the index comes from,\n"
+    "        # each run samples an effectively random slice, and expected full\n"
+    "        # coverage is N*H(N) runs. That is why N is kept as small as the bank\n"
+    "        # allows. A row inserted mid-rotation BELOW the cursor of its own slice\n"
+    "        # is missed until that slice comes round again, so worst-case prune\n"
+    "        # latency is ~2 coverage periods, not one.\n"
+    "        #\n"
+    "        # It is still a rotating FULL sweep rather than a watermark scoped to\n"
     "        # recently-touched entities: nothing durable records the entities of a\n"
     "        # deleted unit, so a watermark would silently miss every staleness\n"
     "        # source that failed to enqueue, for ever.\n"
-    "        slice_index = int(time.time()) // _SWEEP_SLICE_SECONDS % _SWEEP_SLICE_COUNT\n"
+    "        async with acquire_with_retry(backend) as conn:\n"
+    "            total_rows = await store.count_bank_cooccurrences(\n"
+    "                conn=conn, fq_table=fq_table, bank_id=bank_id\n"
+    "            )\n"
+    "        slice_count = _sweep_slice_count(total_rows)\n"
+    "        slice_index = _sweep_slice_index(time.time(), slice_count)\n"
     "        batch_size = _SWEEP_BATCH_SIZE\n"
     "        after_1: str | None = None\n"
     "        after_2: str | None = None\n"
@@ -7101,7 +7298,7 @@ apply("engine/graph_maintenance.py", (
     "                        conn=conn,\n"
     "                        fq_table=fq_table,\n"
     "                        bank_id=bank_id,\n"
-    "                        slice_count=_SWEEP_SLICE_COUNT,\n"
+    "                        slice_count=slice_count,\n"
     "                        slice_index=slice_index,\n"
     "                        batch_size=size,\n"
     "                        after_entity_id_1=after_1,\n"
@@ -7112,9 +7309,12 @@ apply("engine/graph_maintenance.py", (
     "            if pages >= _SWEEP_MAX_PAGES:\n"
     "                logger.error(\n"
     "                    f\"[GRAPH_MAINT] bank={bank_id} cooccurrence sweep hit the \"\n"
-    "                    f\"{_SWEEP_MAX_PAGES}-page tripwire at cursor ({after_1}, {after_2}) — \"\n"
-    "                    f\"the keyset cursor is not advancing; slice {slice_index} is incomplete, \"\n"
-    "                    f\"operation_id={operation_id}\"\n"
+    "                    f\"{_SWEEP_MAX_PAGES}-page tripwire at cursor ({after_1}, {after_2}) \"\n"
+    "                    f\"with batch_size={batch_size}: either the keyset cursor is not \"\n"
+    "                    f\"advancing, or the page shrank early and this slice legitimately \"\n"
+    "                    f\"needs more pages than the tripwire allows. Slice \"\n"
+    "                    f\"{slice_index}/{slice_count} is INCOMPLETE; {deleted} row(s) were \"\n"
+    "                    f\"pruned before the cut, operation_id={operation_id}\"\n"
     "                )\n"
     "                break\n"
     "            requested = batch_size\n"
@@ -7129,16 +7329,24 @@ apply("engine/graph_maintenance.py", (
     "                    retry_timeouts=False,\n"
     "                )\n"
     "            except TimeoutError:\n"
-    "                # A page that still cannot finish inside command_timeout is a hub\n"
-    "                # page: `batch_size` rows whose entities have enormous degree.\n"
-    "                # Halve and retry the SAME cursor rather than failing the slice —\n"
-    "                # otherwise one pathological page fails its slice on every\n"
-    "                # rotation for ever, which is the failure this whole change\n"
-    "                # exists to remove. At most log2(batch/min) halvings.\n"
+    "                # The likely cause is a hub page: `batch_size` rows whose entities\n"
+    "                # have enormous degree. Halve and retry the SAME cursor rather\n"
+    "                # than failing the slice — otherwise one pathological page fails\n"
+    "                # its slice on every rotation for ever, which is the failure this\n"
+    "                # whole change exists to remove. At most log2(batch/min) halvings.\n"
     "                #\n"
-    "                # Catching the builtin TimeoutError is sufficient AND correct:\n"
-    "                # asyncpg raises asyncio.TimeoutError on command_timeout, and on\n"
-    "                # this image's Python (3.11) asyncio.TimeoutError IS the builtin.\n"
+    "                # Catching the builtin TimeoutError is sufficient: asyncpg raises\n"
+    "                # asyncio.TimeoutError on command_timeout, and on this image's\n"
+    "                # Python (3.11) asyncio.TimeoutError IS the builtin — a fact the\n"
+    "                # probe asserts rather than assumes, because it stops being true\n"
+    "                # below 3.11.\n"
+    "                #\n"
+    "                # It is not PRECISE: `acquire_with_retry` can raise the same type\n"
+    "                # on a pool-acquire timeout, which has nothing to do with the page\n"
+    "                # and shrinks it for no reason. Safe (the shrunk page re-runs the\n"
+    "                # same cursor and `deleted` is unaffected) but it costs throughput\n"
+    "                # for the rest of the slice, so the log says 'timed out' and does\n"
+    "                # not claim to know which.\n"
     "                if batch_size > _SWEEP_MIN_BATCH_SIZE:\n"
     "                    batch_size = max(_SWEEP_MIN_BATCH_SIZE, batch_size // 2)\n"
     "                    logger.warning(\n"
@@ -7147,6 +7355,16 @@ apply("engine/graph_maintenance.py", (
     "                        f\"{batch_size}, operation_id={operation_id}\"\n"
     "                    )\n"
     "                    continue\n"
+    "                # The floor is reached: this page cannot be made small enough, so\n"
+    "                # the raise fails Pass 3 for this bank. The pages that already\n"
+    "                # COMMITTED are not rolled back, so log their count before it is\n"
+    "                # lost — the caller only sees the exception.\n"
+    "                logger.error(\n"
+    "                    f\"[GRAPH_MAINT] bank={bank_id} cooccurrence page of {requested} timed out at \"\n"
+    "                    f\"the {_SWEEP_MIN_BATCH_SIZE}-row floor, cursor ({after_1}, {after_2}); \"\n"
+    "                    f\"slice {slice_index}/{slice_count} abandoned after {pages} page(s) with \"\n"
+    "                    f\"{deleted} row(s) already pruned and committed, operation_id={operation_id}\"\n"
+    "                )\n"
     "                raise\n"
     "            pages += 1\n"
     "            deleted += page.deleted\n"
@@ -7160,7 +7378,7 @@ apply("engine/graph_maintenance.py", (
     "\n"
     "        logger.info(\n"
     "            f\"[GRAPH_MAINT] bank={bank_id} cooccurrence sweep: slice \"\n"
-    "            f\"{slice_index}/{_SWEEP_SLICE_COUNT}, {pages} page(s), final batch_size \"\n"
+    "            f\"{slice_index}/{slice_count} of {total_rows} row(s), {pages} page(s), final batch_size \"\n"
     "            f\"{batch_size}, {deleted} pruned, operation_id={operation_id}\"\n"
     "        )\n"
     "        return deleted\n"
@@ -7196,17 +7414,63 @@ assert "INTERSECT" in sweep, (
     "NO faster (65,555 ms vs 65,168 ms) because the planner hash-joins all of "
     "unit_entities at bank scale"
 )
-assert "% $4::int = $5::int" in sweep, f"{TAG}: the rotating slice filter is missing"
+# The slice filter is pinned as ONE WHOLE PREDICATE, from the AND to the bound
+# parameter. Two independent substring checks ("md5(...)" somewhere, "% $4 = $5"
+# somewhere) do NOT pin a partition: `AND 0 * ('x' || substr(md5(...), 1, 4))
+# ::bit(16)::int % $4::int = $5::int` contains both and collapses the whole bank
+# into slice 0. The real proof that this expression partitions is executable and
+# runs against a real Postgres — see the SQL arm of
+# tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts. This assert is
+# the cheap build-time backstop for it, not a substitute.
+assert (
+    "\n                  AND ('x' || substr(md5(c.entity_id_1::text), 1, 4))"
+    "::bit(16)::int % $4::int = $5::int\n"
+) in sweep, (
+    f"{TAG}: the slice filter is not the exact whole expression this patch ships. Any "
+    "extra factor or term in it stops the slices partitioning the bank and silently "
+    "un-sweeps most of it"
+)
 assert "COALESCE($2::uuid" in sweep and "(c.entity_id_1, c.entity_id_2) > (" in sweep, (
     f"{TAG}: the keyset cursor predicate is missing — pages would restart from the top for ever"
 )
 
 gm = (BASE / "engine/graph_maintenance.py").read_text()
-for const in ("_SWEEP_BATCH_SIZE", "_SWEEP_MIN_BATCH_SIZE", "_SWEEP_SLICE_COUNT", "_SWEEP_SLICE_SECONDS", "_SWEEP_MAX_PAGES"):
+for const in (
+    "_SWEEP_BATCH_SIZE",
+    "_SWEEP_MIN_BATCH_SIZE",
+    "_SWEEP_SLICE_TARGET_ROWS",
+    "_SWEEP_MAX_SLICE_COUNT",
+    "_SWEEP_SLICE_SECONDS",
+    "_SWEEP_MAX_PAGES",
+):
     assert f"\n{const} = " in gm, f"{TAG}: {const} is missing"
-prune = gm.split("async def _run_cooccurrence_prune", 1)[1].split("\n    # A larger retry budget", 1)[0]
-assert "int(time.time()) // _SWEEP_SLICE_SECONDS % _SWEEP_SLICE_COUNT" in prune, (
+assert "_SWEEP_SLICE_COUNT" not in gm, (
+    f"{TAG}: a fixed _SWEEP_SLICE_COUNT is back. The slice count MUST be derived from "
+    "bank size (_sweep_slice_count) — this job is demand-driven, so a fixed count puts "
+    "quiet banks on a rotation measured in weeks to fix a timeout they never had"
+)
+assert "return int(now) // _SWEEP_SLICE_SECONDS % slice_count" in gm, (
     f"{TAG}: the slice index is no longer a pure function of the clock"
+)
+assert "if total_rows <= _SWEEP_SLICE_TARGET_ROWS:\n        return 1" in gm, (
+    f"{TAG}: a bank small enough to sweep whole is no longer given slice_count = 1"
+)
+prune = gm.split("async def _run_cooccurrence_prune", 1)[1].split("\n    # A larger retry budget", 1)[0]
+assert "slice_count = _sweep_slice_count(total_rows)" in prune, (
+    f"{TAG}: the sweep no longer derives its slice count from the size of the bank"
+)
+assert "await store.count_bank_cooccurrences(" in prune, (
+    f"{TAG}: the bank is never sized, so the slice count cannot depend on it"
+)
+assert (
+    "            async with acquire_with_retry(backend) as conn:\n"
+    "                async with conn.transaction():\n"
+    "                    return await store.prune_stale_cooccurrences(\n"
+) in prune, (
+    f"{TAG}: each page must be its OWN transaction, nested inside its own connection "
+    "acquire. Without the transaction a page that times out takes down the pages that "
+    "already committed, so a slice whose late pages are slow makes NO progress at all, "
+    "run after run — the exact wedge this patch exists to remove"
 )
 assert "batch_size = max(_SWEEP_MIN_BATCH_SIZE, batch_size // 2)" in prune, (
     f"{TAG}: the halve-and-retry is gone — one hub page would wedge its slice for ever"
@@ -7226,11 +7490,30 @@ for rel in ("engine/db/ops_postgresql.py", "engine/db/ops_oracle.py", "engine/me
     assert "CooccurrenceSweepBatch" in (BASE / rel).read_text(), (
         f"{TAG}: {rel} does not import/return the page result type"
     )
+# The sizing op must exist at every layer the caller reaches through, and must
+# stay CONCRETE with a 0 default on the ABC — an abstractmethod here would make
+# "cannot count cheaply" unimplementable rather than meaning "sweep it whole".
+assert "    async def count_bank_cooccurrences(\n        self,\n" in ops, (
+    f"{TAG}: DataAccessOps.count_bank_cooccurrences is missing"
+)
+assert ops.split("async def count_bank_cooccurrences", 1)[1].split('"""\n', 1)[1].startswith(
+    "        return 0\n"
+), f"{TAG}: DataAccessOps.count_bank_cooccurrences no longer defaults to 0 ('sweep it whole')"
+assert "@abstractmethod\n    async def count_bank_cooccurrences" not in ops, (
+    f"{TAG}: count_bank_cooccurrences became abstract — a backend that cannot count "
+    "cheaply must be allowed to say so and be swept whole"
+)
+for rel in ("engine/db/ops_postgresql.py", "engine/memories/pg/graph.py", "engine/memories/postgres.py", "engine/memories/base.py"):
+    assert "count_bank_cooccurrences" in (BASE / rel).read_text(), (
+        f"{TAG}: {rel} does not carry the bank-sizing op"
+    )
 
 print(
     f"{TAG}: Pass 3 now sweeps bounded keyset pages (LIMIT-capped, cursor-advancing, "
-    "one transaction each) over a clock-rotating 1/24 hash slice, halving the page on a "
-    "timeout; the #2473 predicate and the #2529 ordered lock are unchanged"
+    "one transaction each) over a hash slice whose COUNT is derived from the size of "
+    "the bank (1 slice below _SWEEP_SLICE_TARGET_ROWS, so a bank that sweeps whole is "
+    "never rotated), halving the page on a timeout; the #2473 predicate and the #2529 "
+    "ordered lock are unchanged"
 )
 PYEOF
 

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -2004,7 +2004,17 @@ describe("Dockerfile.hindsight shape", () => {
       "(c.entity_id_1, c.entity_id_2) > (\\n",
     );
     expect(dockerfile).toContain("md5(c.entity_id_1::text), 1, 4");
-    expect(dockerfile).toMatch(/the rotating slice filter is missing/);
+    // The build-time assert pins the slice filter as a WHOLE EXPRESSION, not as
+    // two independent substrings: `AND 0 * ('x' || substr(md5(…), 1, 4))
+    // ::bit(16)::int % $4::int = $5::int` satisfies both substrings and puts
+    // every row in slice 0.
+    expect(dockerfile).toMatch(
+      /the slice filter is not the exact whole expression this patch ships/,
+    );
+    expect(dockerfile).toContain(
+      '"\\n                  AND (\'x\' || substr(md5(c.entity_id_1::text), 1, 4))"\n' +
+        '    "::bit(16)::int % $4::int = $5::int\\n"',
+    );
 
     // The bound must NOT have been bought by weakening the sweep: the #2473
     // INTERSECT predicate and the #2529 ordered lock are upstream's, unchanged.
@@ -2018,12 +2028,23 @@ describe("Dockerfile.hindsight shape", () => {
     // the bank while looking correct in the diff.
     expect(dockerfile).toContain('"_SWEEP_BATCH_SIZE = 1000\\n"');
     expect(dockerfile).toContain('"_SWEEP_MIN_BATCH_SIZE = 50\\n"');
-    expect(dockerfile).toContain('"_SWEEP_SLICE_COUNT = 24\\n"');
+    expect(dockerfile).toContain('"_SWEEP_SLICE_TARGET_ROWS = 25000\\n"');
+    expect(dockerfile).toContain('"_SWEEP_MAX_SLICE_COUNT = 24\\n"');
     expect(dockerfile).toContain('"_SWEEP_SLICE_SECONDS = 1800\\n"');
     expect(dockerfile).toContain('"_SWEEP_MAX_PAGES = 2000\\n"');
+    // How many slices is DERIVED FROM BANK SIZE, not fixed. `graph_maintenance`
+    // is demand-driven (`submit_async_graph_maintenance` fires on retain /
+    // delete / edit, and short-circuits on an empty queue — there is no timer),
+    // so coverage is coupon-collector, not a cycle: a fixed 24 would put the
+    // fleet's quiet banks on an expected-full-coverage latency of weeks to
+    // months, to fix a timeout only the two largest banks ever had.
     expect(dockerfile).toContain(
-      "int(time.time()) // _SWEEP_SLICE_SECONDS % _SWEEP_SLICE_COUNT",
+      "int(now) // _SWEEP_SLICE_SECONDS % slice_count",
     );
+    expect(dockerfile).toContain('"    if total_rows <= _SWEEP_SLICE_TARGET_ROWS:\\n"');
+    expect(dockerfile).toContain('"        slice_count = _sweep_slice_count(total_rows)\\n"');
+    // …and a fixed count must not come back.
+    expect(dockerfile).not.toContain("_SWEEP_SLICE_COUNT = ");
     expect(dockerfile).toMatch(/the paging loop no longer terminates on a short page/);
     expect(dockerfile).toMatch(/the cursor is never advanced/);
 
@@ -2042,11 +2063,19 @@ describe("Dockerfile.hindsight shape", () => {
       /#4604's timeout opt-out was dropped from the loop/,
     );
 
-    // Per-batch transactions are load-bearing (a timed-out page must not roll
-    // back the pages that already committed), so the loop owns the connection.
+    // Per-page transactions are load-bearing: a page that times out must not
+    // roll back the pages that already committed, or a slice whose late pages
+    // are slow makes NO progress at all, run after run. Pin the whole nesting —
+    // acquire, THEN transaction, THEN the call — because pinning the acquire
+    // alone leaves the transaction removable with the suite still green.
     expect(dockerfile).toContain(
-      "async with acquire_with_retry(backend) as conn:\\n",
+      '"            async with acquire_with_retry(backend) as conn:\\n"\n' +
+        '    "                async with conn.transaction():\\n"\n' +
+        '    "                    return await store.prune_stale_cooccurrences(\\n"',
     );
+    // The image build re-checks it as a post-condition on the patched file, so
+    // this cannot be satisfied by a comment that says the right thing.
+    expect(dockerfile).toMatch(/each page must be its OWN transaction/);
 
     // Every backend implements the new return shape, including the ones that
     // opt out of paging by reporting scanned=0.

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -1973,8 +1973,11 @@ describe("Dockerfile.hindsight shape", () => {
     // #4604 (above) stopped Pass 3 WASTING time on a statement that could not
     // finish; it did not make it finish. Measured read-only on the live fleet:
     // the predicate alone takes 65.2s on a 517k-row bank against a 60s asyncpg
-    // command_timeout, before the sort, the locks and the DELETE — so the pass
-    // has never once completed on the two largest banks. This block bounds it.
+    // command_timeout, before the sort, the locks and the DELETE. That cost
+    // grows with the bank, so the pass worked until it did not: overlord and
+    // klanker completed 849/779 runs through July 2026, then crossed the wall
+    // in the week of 2026-08-03 and have failed every run since. This block
+    // bounds it.
     //
     // Behaviour (RED against unpatched upstream / GREEN patched) is proven in
     // tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts. This pins
@@ -1998,7 +2001,26 @@ describe("Dockerfile.hindsight shape", () => {
     // while making the adaptive shrink below impossible.
     expect(dockerfile).toContain('"                LIMIT $6::int\\n"');
     expect(dockerfile).toContain('"            WITH page AS MATERIALIZED (\\n"');
-    expect(dockerfile).toMatch(/the page CTE lost its LIMIT/);
+    // …and the LIMIT is only a correct page because of the ORDER BY directly
+    // above it. An unordered LIMIT returns an ARBITRARY batch_size rows, and
+    // the caller then advances its cursor to the MAX key of that arbitrary set
+    // — so every qualifying row sorting below that max but absent from the page
+    // is skipped for the rest of the slice pass, with no short page, no error
+    // and a plausible `scanned` count. A small fixture hides it (the planner
+    // picks the PK index scan and the rows come out sorted by luck); a bitmap
+    // heap or parallel seq scan on a 500k-row bank does not. Pin the two lines
+    // as an ADJACENT PAIR: pinned separately, the ORDER BY could be moved out
+    // of the page CTE with this test still green.
+    expect(dockerfile).toContain(
+      '"                ORDER BY c.entity_id_1, c.entity_id_2\\n"\n' +
+        '    "                LIMIT $6::int\\n"',
+    );
+    expect(dockerfile).toMatch(
+      /the page CTE's `ORDER BY c\.entity_id_1, c\.entity_id_2` \+ `LIMIT \$6::int` /,
+    );
+    // Both ordered scans must survive — the page CTE's keyset order and the
+    // #2529 ordered lock's sort.
+    expect(dockerfile).toMatch(/the sweep no longer has BOTH ordered scans/);
     // The keyset cursor and the rotating hash slice.
     expect(dockerfile).toContain(
       "(c.entity_id_1, c.entity_id_2) > (\\n",
@@ -2030,7 +2052,13 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toContain('"_SWEEP_MIN_BATCH_SIZE = 50\\n"');
     expect(dockerfile).toContain('"_SWEEP_SLICE_TARGET_ROWS = 25000\\n"');
     expect(dockerfile).toContain('"_SWEEP_MAX_SLICE_COUNT = 24\\n"');
-    expect(dockerfile).toContain('"_SWEEP_SLICE_SECONDS = 1800\\n"');
+    // The decorrelation window. It is NOT a cadence: runs that land inside the
+    // same window compute the same slice index, so the later ones re-sweep what
+    // the first just swept. Measured over 30 days of async_operations, a 1800 s
+    // window held 3.95 (overlord) / 3.60 (klanker) runs — ~75% duplicate work —
+    // against a median inter-arrival gap of 197 s / 250 s, which is what 120 s
+    // is derived from.
+    expect(dockerfile).toContain('"_SWEEP_SLICE_SECONDS = 120\\n"');
     expect(dockerfile).toContain('"_SWEEP_MAX_PAGES = 2000\\n"');
     // How many slices is DERIVED FROM BANK SIZE, not fixed. `graph_maintenance`
     // is demand-driven (`submit_async_graph_maintenance` fires on retain /

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -1969,6 +1969,105 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the graph-maintenance bounded-sweep fix (assert-guarded, fail-loud)", () => {
+    // #4604 (above) stopped Pass 3 WASTING time on a statement that could not
+    // finish; it did not make it finish. Measured read-only on the live fleet:
+    // the predicate alone takes 65.2s on a 517k-row bank against a 60s asyncpg
+    // command_timeout, before the sort, the locks and the DELETE — so the pass
+    // has never once completed on the two largest banks. This block bounds it.
+    //
+    // Behaviour (RED against unpatched upstream / GREEN patched) is proven in
+    // tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts. This pins
+    // only the shape a grep can see.
+
+    // The block must come AFTER the retry-storm block: its graph_maintenance
+    // anchors are that block's REPLACEMENT text, so a reordering breaks the
+    // build. Assert the order rather than trusting it.
+    expect(
+      dockerfile.indexOf(
+        'TAG = "switchroom hindsight graph-maintenance retry-storm patch"',
+      ),
+    ).toBeLessThan(
+      dockerfile.indexOf(
+        'TAG = "switchroom hindsight graph-maintenance bounded sweep patch"',
+      ),
+    );
+
+    // ---- B1: the statement is bounded by a LIMIT that is a BOUND PARAMETER.
+    // Interpolating the cap into the SQL text would still grep as "has a LIMIT"
+    // while making the adaptive shrink below impossible.
+    expect(dockerfile).toContain('"                LIMIT $6::int\\n"');
+    expect(dockerfile).toContain('"            WITH page AS MATERIALIZED (\\n"');
+    expect(dockerfile).toMatch(/the page CTE lost its LIMIT/);
+    // The keyset cursor and the rotating hash slice.
+    expect(dockerfile).toContain(
+      "(c.entity_id_1, c.entity_id_2) > (\\n",
+    );
+    expect(dockerfile).toContain("md5(c.entity_id_1::text), 1, 4");
+    expect(dockerfile).toMatch(/the rotating slice filter is missing/);
+
+    // The bound must NOT have been bought by weakening the sweep: the #2473
+    // INTERSECT predicate and the #2529 ordered lock are upstream's, unchanged.
+    expect(dockerfile).toMatch(/the #2529 ordered lock did not survive/);
+    expect(dockerfile).toMatch(
+      /the #2473 INTERSECT predicate was replaced — a semi-join rewrite measured/,
+    );
+
+    // ---- B2: the caller must LOOP and the cursor must ADVANCE. A single
+    // bounded page that never pages again would silently stop pruning most of
+    // the bank while looking correct in the diff.
+    expect(dockerfile).toContain('"_SWEEP_BATCH_SIZE = 1000\\n"');
+    expect(dockerfile).toContain('"_SWEEP_MIN_BATCH_SIZE = 50\\n"');
+    expect(dockerfile).toContain('"_SWEEP_SLICE_COUNT = 24\\n"');
+    expect(dockerfile).toContain('"_SWEEP_SLICE_SECONDS = 1800\\n"');
+    expect(dockerfile).toContain('"_SWEEP_MAX_PAGES = 2000\\n"');
+    expect(dockerfile).toContain(
+      "int(time.time()) // _SWEEP_SLICE_SECONDS % _SWEEP_SLICE_COUNT",
+    );
+    expect(dockerfile).toMatch(/the paging loop no longer terminates on a short page/);
+    expect(dockerfile).toMatch(/the cursor is never advanced/);
+
+    // ---- B3: shrink-and-retry, and it must retry the SAME cursor. A version
+    // that shrinks but advances skips exactly the rows it failed on, for ever —
+    // the build asserts the `continue` precedes the cursor advance.
+    expect(dockerfile).toContain(
+      "batch_size = max(_SWEEP_MIN_BATCH_SIZE, batch_size // 2)",
+    );
+    expect(dockerfile).toMatch(
+      /shrink-and-retry must re-run the SAME cursor, not advance past the page it failed on/,
+    );
+    // #4604's opt-out must survive, or the timeout reaches the shrink only
+    // after nine full-cost attempts.
+    expect(dockerfile).toMatch(
+      /#4604's timeout opt-out was dropped from the loop/,
+    );
+
+    // Per-batch transactions are load-bearing (a timed-out page must not roll
+    // back the pages that already committed), so the loop owns the connection.
+    expect(dockerfile).toContain(
+      "async with acquire_with_retry(backend) as conn:\\n",
+    );
+
+    // Every backend implements the new return shape, including the ones that
+    // opt out of paging by reporting scanned=0.
+    expect(dockerfile).toContain("class CooccurrenceSweepBatch:");
+    expect(dockerfile).toMatch(
+      /does not import\/return the page result type/,
+    );
+
+    // Post-replace verification: every patched file must still parse.
+    expect(dockerfile).toContain('"engine/db/ops.py",\n    "engine/db/ops_postgresql.py",');
+    expect(dockerfile).toContain('"engine/memories/pg/graph.py",');
+    // The block's TAG is what the behavioural probe test greps the block out
+    // by, so it must not drift.
+    expect(dockerfile).toContain(
+      'TAG = "switchroom hindsight graph-maintenance bounded sweep patch"',
+    );
+    expect(dockerfile).toMatch(
+      /\{TAG\}: Pass 3 now sweeps bounded keyset pages/,
+    );
+  });
+
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {
     // The shim does broker auth, then `exec "$@"` which is whatever
     // CMD docker passes — must be upstream's start-all.sh so the

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -2021,6 +2021,18 @@ describe("Dockerfile.hindsight shape", () => {
     // Both ordered scans must survive — the page CTE's keyset order and the
     // #2529 ordered lock's sort.
     expect(dockerfile).toMatch(/the sweep no longer has BOTH ordered scans/);
+    // …and symmetrically for the victims CTE: its ORDER BY is only the #2529
+    // ordered lock because it sits directly above `FOR UPDATE OF c`. A count of
+    // two ordered scans cannot see the two-edit defeat — delete the victims
+    // ORDER BY, re-add an identical line elsewhere in the statement, and the
+    // count still reads 2 while the lock is taken in scan order (i.e. in no
+    // order at all), which is exactly the deadlock #2529 fixed. Pin the pair,
+    // not the population.
+    expect(dockerfile).toContain(
+      '"                ORDER BY c.entity_id_1, c.entity_id_2\\n"\n' +
+        '    "                FOR UPDATE OF c\\n"',
+    );
+    expect(dockerfile).toMatch(/ADJACENT to its `FOR UPDATE OF c`/);
     // The keyset cursor and the rotating hash slice.
     expect(dockerfile).toContain(
       "(c.entity_id_1, c.entity_id_2) > (\\n",

--- a/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
+++ b/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
@@ -33,8 +33,12 @@
  *   overlord    517,475   65.2 s   <- past the 60s asyncpg command_timeout
  *                                     BEFORE the sort, the locks and the DELETE
  *
- * So on the two largest banks the pass cannot finish, has never once finished,
- * and leaks stale cooccurrence rows for ever. The prior fix (#4604) removed the
+ * Because that cost GROWS with the bank, this worked until it did not. From
+ * `async_operations` over the 30 days to 2026-08-12: overlord and klanker
+ * completed 849 and 779 runs through July at a p50 of 15-33 s, then crossed the
+ * 60 s wall in the week of 2026-08-03 — overlord 17 of 22 runs failed that
+ * week and 2 of 3 the next, klanker 9 of 14 — and both have leaked stale
+ * cooccurrence rows on every run since. The prior fix (#4604) removed the
  * 9x retry storm around it and the blank `error_message` it hid behind; it
  * deliberately did not make the statement finish. This one does.
  *
@@ -254,8 +258,17 @@ check("B1_returns_cursor",
 # than being frozen into the SQL text, which is what lets B3 shrink it.
 check("B1_limit_is_bound", "LIMIT $" in sql, "no bound LIMIT in the page CTE")
 check("B1_batch_size_bound", 250 in params, f"batch_size not among params {params!r}")
-check("B1_slice_bound", 24 in params and 5 in params, f"slice not among params {params!r}")
-check("B1_cursor_bound", "cur1" in params and "cur2" in params, f"cursor not among params {params!r}")
+# POSITION, not membership. "24 in params and 5 in params" is true no matter
+# which placeholder each value reaches, so swapping slice_count and slice_index
+# at the bind site yields "... % 5 = 24" — a predicate that is NEVER true, so
+# the sweep deletes nothing, for ever, on every sliced bank — with this probe
+# still green. Same for the two cursor uuids: reversed, the keyset predicate
+# compares against the wrong tuple. The bind ORDER is part of the contract, so
+# assert the whole tuple against the $1..$6 the SQL above declares.
+check("B1_params_are_positional",
+      params == ("bank-x", "cur1", "cur2", 24, 5, 250),
+      "expected ('bank-x', 'cur1', 'cur2', 24, 5, 250) — $1 bank_id, $2/$3 cursor, "
+      f"$4 slice_count, $5 slice_index, $6 batch_size, in THAT order — got {params!r}")
 check("B1_keyset_predicate", "(c.entity_id_1, c.entity_id_2) >" in sql, "no keyset predicate")
 check("B1_slice_predicate", "md5(c.entity_id_1::text)" in sql, "no hash-slice predicate")
 # Unchanged upstream invariants — the fix must not buy its bound with these.
@@ -281,8 +294,10 @@ check("C_slice_target_rows", getattr(gm, "_SWEEP_SLICE_TARGET_ROWS", None) == 25
       f"got {getattr(gm, '_SWEEP_SLICE_TARGET_ROWS', None)}")
 check("C_max_slice_count", getattr(gm, "_SWEEP_MAX_SLICE_COUNT", None) == 24,
       f"got {getattr(gm, '_SWEEP_MAX_SLICE_COUNT', None)}")
-check("C_slice_seconds", getattr(gm, "_SWEEP_SLICE_SECONDS", None) == 1800,
-      f"got {getattr(gm, '_SWEEP_SLICE_SECONDS', None)}")
+check("C_slice_seconds", getattr(gm, "_SWEEP_SLICE_SECONDS", None) == 120,
+      f"got {getattr(gm, '_SWEEP_SLICE_SECONDS', None)}; the decorrelation window is 120s "
+      "— at the old 1800s, 3.95 (overlord) / 3.60 (klanker) runs landed in the SAME "
+      "window and swept the SAME slice, making ~75% of them duplicate work")
 check("C_max_pages", getattr(gm, "_SWEEP_MAX_PAGES", None) == 2000,
       f"got {getattr(gm, '_SWEEP_MAX_PAGES', None)}")
 check("C_no_fixed_slice_count", not hasattr(gm, "_SWEEP_SLICE_COUNT"),
@@ -313,8 +328,8 @@ if callable(_sc):
     check("S_slice_count_is_capped", _sc(10**9) == 24, f"got {_sc(10**9)}")
 
 _si = getattr(gm, "_sweep_slice_index", None)
-check("S_slice_index_is_pure", callable(_si) and _si(0.0, 24) == 0 and _si(1800.0, 24) == 1
-      and _si(24 * 1800.0, 24) == 0 and _si(5 * 1800.0, 1) == 0,
+check("S_slice_index_is_pure", callable(_si) and _si(0.0, 24) == 0 and _si(120.0, 24) == 1
+      and _si(24 * 120.0, 24) == 0 and _si(5 * 120.0, 1) == 0,
       "graph_maintenance._sweep_slice_index(now, slice_count) is missing or is not the "
       "documented pure function of the clock")
 
@@ -440,7 +455,7 @@ real_time_mod = gm.time
 seen = set()
 try:
     for tick in range(21):
-        gm.time = types.SimpleNamespace(time=(lambda t: (lambda: float(t)))(tick * 1800))
+        gm.time = types.SimpleNamespace(time=(lambda t: (lambda: float(t)))(tick * 120))
         s = FakeStore([page(0, 1, "z", "z")])
         guard("B2_rotation_job_runs", lambda: run_job(s))
         if s.calls:
@@ -1024,6 +1039,15 @@ describe("Dockerfile.hindsight bounded-sweep probe is real, not a silent skip", 
   // have silently green-skipped on every runner without the 6.4GB image. The
   // guard is written over EVERY probe rather than this one, so the next probe
   // cannot repeat it.
+  //
+  // KNOWN GAP, filed as #4636: this discovers its own subject by grepping for
+  // the same string it asserts, so a one-character typo in a probe both
+  // de-registers it here AND makes its own REQUIRED flag permanently false —
+  // two silent failures that cancel out. Only this file is hard-pinned below;
+  // the other 18 are not. The durable fix is a set-identity assertion between
+  // the `hindsight-*.test.ts` glob and the workflow's run steps with a named
+  // allowlist, which also catches the reverse drift (a run step outliving a
+  // deleted probe) that nothing checks today.
   it("every probe that demands a real run has a workflow step that gives it one", () => {
     const workflow = readFileSync(
       resolve(root, ".github/workflows/docker-e2e.yml"),
@@ -1155,6 +1179,11 @@ describe.skipIf(!dockerOk || !imageOk)(
       // travels with the call (which is what lets B3 shrink it).
       expect(stdout).toContain("B1_limit_is_bound=OK");
       expect(stdout).toContain("B1_batch_size_bound=OK");
+      // …and every value reaches the placeholder it is meant to. Asserted by
+      // POSITION: a membership check is green even with slice_count and
+      // slice_index swapped, which makes the filter `% 5 = 24` and deletes
+      // nothing, for ever, on every sliced bank.
+      expect(stdout).toContain("B1_params_are_positional=OK");
       expect(stdout).toContain("B1_keyset_predicate=OK");
       expect(stdout).toContain("B1_slice_predicate=OK");
       // The bound must not have been bought by weakening the sweep.
@@ -1167,7 +1196,7 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("B2_cursor_advances=OK");
       expect(stdout).toContain("B2_sums_deletions_across_pages=OK");
       expect(stdout).toContain("B2_slice_index_stable_within_run=OK");
-      // Consecutive 30-minute ticks visit every slice — i.e. the rotation
+      // Consecutive _SWEEP_SLICE_SECONDS ticks visit every slice — i.e. the rotation
       // covers the WHOLE bank rather than resampling part of it.
       expect(stdout).toContain("B2_slice_rotates_over_whole_bank=OK");
 

--- a/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
+++ b/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
@@ -8,6 +8,19 @@
  * the patch blocks applied (must be GREEN). Nothing here greps the patched
  * source — every assertion drives real shipping code and observes what it does.
  *
+ * TWO ARMS, because they prove different things:
+ *
+ *   1. the LOOP arm (`PROBE`) drives the real methods against a fake connection
+ *      and a fake store, which is what lets it script timeouts and endless
+ *      pages. It can see everything about the CALLER — and nothing about SQL
+ *      semantics, since a fake connection never parses a statement;
+ *   2. the SQL arm (`SQL_PROBE`) takes the statement the real shipping method
+ *      builds and EXECUTES it against a real PostgreSQL on real rows. It is the
+ *      only thing here that can prove the slice filter is a partition. A
+ *      substring check cannot: `AND 0 * ('x' || substr(md5(…), 1, 4))::bit(16)
+ *      ::int % $4::int = $5::int` contains every substring the arm-1 checks look
+ *      for and collapses the entire bank into slice 0.
+ *
  * THE DEFECT, in the real shipping source at the pinned digest.
  *
  * `graph_maintenance` Pass 3 (`prune_stale_cooccurrences`) is ONE bank-wide
@@ -36,7 +49,9 @@
  *   - the shrink-on-timeout must retry the SAME cursor — a version that shrinks
  *     but advances skips exactly the rows it failed on, permanently;
  *   - the rotating slice must cover 0..N-1 over N consecutive runs, or part of
- *     the bank is never swept at all.
+ *     the bank is never swept at all;
+ *   - and the slice filter must actually PARTITION the bank — a filter that
+ *     type-checks, greps clean and puts every row in one slice bounds nothing.
  *
  * Only running the patched modules distinguishes those. This probe drives the
  * REAL `PostgreSQLOps.prune_stale_cooccurrences` (against a fake connection
@@ -61,7 +76,7 @@
  * SKIP DISCIPLINE: identical to
  * `hindsight-graph-maintenance-retry-storm.test.ts`. Locally, with no docker or
  * no cached image, this skips (never pull a 6.4GB third-party image onto a dev
- * box). In CI the `hindsight-probe` job pulls the pinned digest and sets
+ * box). In CI the `hindsight-probe` job pulls both pinned digests and sets
  * SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an unavailable
  * docker/image is a HARD FAILURE, never a green skip. Both runs assert a
  * `PROBE_EXECUTED` sentinel so a probe that dies early can never be mistaken
@@ -189,6 +204,14 @@ except Exception:
 check("T_page_result_type_exists", HAS_BATCH_TYPE,
       "hindsight_api.engine.db.ops has no CooccurrenceSweepBatch")
 
+# The shrink handler catches the BUILTIN TimeoutError and relies on asyncpg's
+# command_timeout raising something that IS it. True on 3.11+, false below, and
+# asserted here rather than assumed — the comment beside the handler makes the
+# claim, so something has to check it.
+check("T_asyncio_timeout_is_builtin", asyncio.TimeoutError is TimeoutError,
+      f"asyncio.TimeoutError is {asyncio.TimeoutError!r}, not the builtin — the "
+      "shrink-on-timeout handler would not fire on a command_timeout")
+
 # ══════════════════════════════ B1: the statement itself is LIMIT-bounded ════
 from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
 
@@ -254,12 +277,46 @@ check("C_batch_size", getattr(gm, "_SWEEP_BATCH_SIZE", None) == 1000,
       f"got {getattr(gm, '_SWEEP_BATCH_SIZE', None)}")
 check("C_min_batch_size", getattr(gm, "_SWEEP_MIN_BATCH_SIZE", None) == 50,
       f"got {getattr(gm, '_SWEEP_MIN_BATCH_SIZE', None)}")
-check("C_slice_count", getattr(gm, "_SWEEP_SLICE_COUNT", None) == 24,
-      f"got {getattr(gm, '_SWEEP_SLICE_COUNT', None)}")
+check("C_slice_target_rows", getattr(gm, "_SWEEP_SLICE_TARGET_ROWS", None) == 25000,
+      f"got {getattr(gm, '_SWEEP_SLICE_TARGET_ROWS', None)}")
+check("C_max_slice_count", getattr(gm, "_SWEEP_MAX_SLICE_COUNT", None) == 24,
+      f"got {getattr(gm, '_SWEEP_MAX_SLICE_COUNT', None)}")
 check("C_slice_seconds", getattr(gm, "_SWEEP_SLICE_SECONDS", None) == 1800,
       f"got {getattr(gm, '_SWEEP_SLICE_SECONDS', None)}")
 check("C_max_pages", getattr(gm, "_SWEEP_MAX_PAGES", None) == 2000,
       f"got {getattr(gm, '_SWEEP_MAX_PAGES', None)}")
+check("C_no_fixed_slice_count", not hasattr(gm, "_SWEEP_SLICE_COUNT"),
+      "a fixed _SWEEP_SLICE_COUNT is back; the slice count must be derived from bank size")
+
+# ═════════════ S: the slice COUNT is a function of BANK SIZE, not a constant ══
+# This job is DEMAND-DRIVEN (submit_async_graph_maintenance fires on enqueued
+# work and short-circuits on an empty queue), so runs are uncorrelated with the
+# wall clock the slice index comes from and coverage is coupon-collector: N*H(N)
+# expected runs, not N. A fixed N therefore puts a bank that runs 0.3x/day on a
+# ~300-day rotation. Slicing a bank that already sweeps whole inside the timeout
+# buys nothing and costs exactly that, so it must not happen.
+_sc = getattr(gm, "_sweep_slice_count", None)
+check("S_slice_count_is_derived", callable(_sc),
+      "graph_maintenance has no _sweep_slice_count(total_rows)")
+if callable(_sc):
+    # Literals, not arithmetic on the constants — an expectation computed from
+    # the same constant it checks cannot fail for any value of that constant.
+    check("S_unknown_size_sweeps_whole", _sc(0) == 1, f"got {_sc(0)}")
+    check("S_tiny_bank_is_one_slice", _sc(1) == 1, f"got {_sc(1)}")
+    check("S_at_target_is_one_slice", _sc(25000) == 1, f"got {_sc(25000)}")
+    check("S_just_over_target_is_two", _sc(25001) == 2, f"got {_sc(25001)}")
+    check("S_largest_live_bank_is_21", _sc(516563) == 21,
+          f"overlord (516,563 rows) -> {_sc(516563)} slices, expected 21")
+    check("S_quietest_live_bank_is_1", _sc(15443) == 1,
+          f"lawgpt (15,443 rows) -> {_sc(15443)} slices; it sweeps whole in 4.7s and "
+          "runs 0.3x/day, so slicing it is a ~300-day rotation for no benefit")
+    check("S_slice_count_is_capped", _sc(10**9) == 24, f"got {_sc(10**9)}")
+
+_si = getattr(gm, "_sweep_slice_index", None)
+check("S_slice_index_is_pure", callable(_si) and _si(0.0, 24) == 0 and _si(1800.0, 24) == 1
+      and _si(24 * 1800.0, 24) == 0 and _si(5 * 1800.0, 1) == 0,
+      "graph_maintenance._sweep_slice_index(now, slice_count) is missing or is not the "
+      "documented pure function of the clock")
 
 # ══════════════════════════ B2/B3: the paging loop in the real job ═══════════
 import hindsight_api.engine.memories as memories_mod
@@ -283,18 +340,29 @@ class FakeEngine:
 
 
 class FakeStore:
-    """Records every Pass 3 call and replays a scripted list of pages."""
+    """Records every Pass 3 call and replays a scripted list of pages.
 
-    def __init__(self, pages, timeout_on=()):
+    total_rows is what the job's bank-sizing call sees; it is what decides
+    how many slices the bank is cut into. The default is a LARGE bank, so the
+    paging cases below exercise the sliced path.
+    """
+
+    def __init__(self, pages, timeout_on=(), total_rows=516563):
         self.pages = pages
         self.timeout_on = set(timeout_on)
+        self.total_rows = total_rows
         self.calls = []
+        self.size_calls = 0
 
     async def relink_pass(self, **kw):
         return {}
 
     async def prune_orphan_entities(self, **kw):
         return 0
+
+    async def count_bank_cooccurrences(self, **kw):
+        self.size_calls += 1
+        return self.total_rows
 
     async def prune_stale_cooccurrences(self, **kw):
         self.calls.append(kw)
@@ -340,20 +408,38 @@ if len(p3) == 3:
           f"cursors {[(c.get('after_entity_id_1'), c.get('after_entity_id_2')) for c in p3]}")
     check("B2_batch_size_is_1000", all(c.get("batch_size") == 1000 for c in p3),
           f"sizes {[c.get('batch_size') for c in p3]}")
-    check("B2_slice_count_is_24", all(c.get("slice_count") == 24 for c in p3),
-          f"slice_counts {[c.get('slice_count') for c in p3]}")
-    check("B2_slice_index_in_range", all(0 <= (c.get("slice_index") or 0) < 24 for c in p3),
+    check("B2_sizes_the_bank_once", store.size_calls == 1,
+          f"the bank was sized {store.size_calls} time(s); it must be once per run, "
+          "not once per page")
+    check("B2_slice_count_matches_bank_size", all(c.get("slice_count") == 21 for c in p3),
+          f"a 516,563-row bank got slice_counts {[c.get('slice_count') for c in p3]}, expected 21")
+    check("B2_slice_index_in_range", all(0 <= (c.get("slice_index") or 0) < 21 for c in p3),
           f"slice_indexes {[c.get('slice_index') for c in p3]}")
     check("B2_slice_index_stable_within_run", len({c.get("slice_index") for c in p3}) == 1,
           "the slice index moved mid-run; the pages would cover different slices")
 
-# --- B2b: the slice index rotates with the clock and covers EVERY slice.
-# 24 consecutive 30-minute ticks must visit 0..23 exactly, or the bank is never
-# fully covered and the rotating sweep silently leaks rows for ever.
+# --- B2b: A SMALL BANK IS NEVER SLICED. The regression this guards is not
+# hypothetical: a fixed slice count moves every quiet bank on this fleet from
+# "swept whole every run, in 2.7-4.3 s" to a rotation of 13-302 days, to fix a
+# timeout only the two largest banks ever had.
+small = FakeStore([page(0, 5, None, None)], total_rows=25000)
+guard("B2_small_bank_job_runs", lambda: run_job(small))
+check("B2_small_bank_swept_whole",
+      bool(small.calls) and all(c.get("slice_count") == 1 for c in small.calls),
+      f"a 25,000-row bank got slice_counts {[c.get('slice_count') for c in small.calls]}, "
+      "expected 1 (the whole bank, every run)")
+check("B2_small_bank_slice_index_is_0",
+      bool(small.calls) and all(c.get("slice_index") == 0 for c in small.calls),
+      f"slice_indexes {[c.get('slice_index') for c in small.calls]}")
+
+# --- B2c: on a bank big enough to slice, the index rotates with the clock and
+# reaches every slice. This is a property of the INDEX, not a coverage
+# guarantee: the job is demand-driven, so consecutive runs do not land on
+# consecutive ticks (see the S_ checks above).
 real_time_mod = gm.time
 seen = set()
 try:
-    for tick in range(24):
+    for tick in range(21):
         gm.time = types.SimpleNamespace(time=(lambda t: (lambda: float(t)))(tick * 1800))
         s = FakeStore([page(0, 1, "z", "z")])
         guard("B2_rotation_job_runs", lambda: run_job(s))
@@ -361,8 +447,9 @@ try:
             seen.add(s.calls[0].get("slice_index"))
 finally:
     gm.time = real_time_mod
-check("B2_slice_rotates_over_whole_bank", seen == set(range(24)),
-      f"24 consecutive 30-min ticks covered slices {sorted(x for x in seen if x is not None)}, not 0..23")
+check("B2_slice_rotates_over_whole_bank", seen == set(range(21)),
+      f"21 consecutive 30-min ticks on a 21-slice bank covered slices "
+      f"{sorted(x for x in seen if x is not None)}, not 0..20")
 
 # --- B3: a page timeout HALVES the page and retries the SAME cursor.
 store = FakeStore(
@@ -375,10 +462,16 @@ check("B3_retried_after_timeout", len(p3) == 3, f"made {len(p3)} call(s), expect
 if len(p3) == 3:
     check("B3_halves_batch_size", p3[2].get("batch_size") == 500,
           f"retried at batch_size={p3[2].get('batch_size')}, expected 1000//2=500")
+    # Against the LITERAL cursor the first page returned, not against the other
+    # observation: comparing two observations to each other passes vacuously if
+    # both are None, which is exactly what an unpatched/broken loop produces.
     check("B3_retries_the_same_cursor",
-          (p3[2].get("after_entity_id_1"), p3[2].get("after_entity_id_2"))
-          == (p3[1].get("after_entity_id_1"), p3[1].get("after_entity_id_2")),
-          "the cursor advanced past the page that timed out — those rows are skipped for ever")
+          (p3[1].get("after_entity_id_1"), p3[1].get("after_entity_id_2")) == ("k1a", "k1b")
+          and (p3[2].get("after_entity_id_1"), p3[2].get("after_entity_id_2")) == ("k1a", "k1b"),
+          f"the timed-out page was at {(p3[1].get('after_entity_id_1'), p3[1].get('after_entity_id_2'))} "
+          f"and the retry ran at {(p3[2].get('after_entity_id_1'), p3[2].get('after_entity_id_2'))}; "
+          "both must be the literal ('k1a', 'k1b') the first page returned, or those rows "
+          "are skipped for ever")
     check("B3_shrunk_page_still_counted", res.get("stale_cooccurrences_pruned") == 1,
           f"got {res.get('stale_cooccurrences_pruned')}")
 
@@ -397,7 +490,255 @@ check("B3_floor_then_raises", isinstance(raised, TimeoutError),
 check("B3_halving_sequence", sizes == [1000, 500, 250, 125, 62, 50],
       f"got {sizes}, expected 1000 halving to the floor of 50")
 
+
+# --- B4: the _SWEEP_MAX_PAGES tripwire actually fires, and the job RETURNS.
+# Previously nothing in any suite executed this branch. A store that hands back
+# a full page with a fresh cursor for ever is the non-advancing-cursor shape it
+# exists to catch; without it the loop would never terminate.
+class EndlessStore(FakeStore):
+    async def prune_stale_cooccurrences(self, **kw):
+        self.calls.append(kw)
+        n = len(self.calls)
+        return CooccurrenceSweepBatch(1, 1000, f"k{n}a", f"k{n}b")
+
+
+endless = EndlessStore([])
+res = guard("B4_job_runs", lambda: run_job(endless)) or {}
+check("B4_tripwire_stops_the_loop", len(endless.calls) == 2000,
+      f"the loop made {len(endless.calls)} page call(s); _SWEEP_MAX_PAGES is 2000")
+check("B4_tripwire_returns_not_raises", res.get("stale_cooccurrences_pruned") == 2000,
+      f"got {res.get('stale_cooccurrences_pruned')}; the tripwire must return the rows it "
+      "did prune, not discard them")
+
 print("PROBE_EXECUTED")
+for f in failures:
+    print("FAILURE:", f)
+sys.exit(1 if failures else 0)
+`;
+
+/**
+ * Postgres for the SQL arm, digest-pinned like the upstream image so the proof
+ * cannot drift under a moving tag. 18-alpine: same major as the pg0 build the
+ * fleet runs (18.1), and every construct under test — `md5`, `substr`,
+ * `::bit(16)`, `INTERSECT`, `FOR UPDATE OF`, row-wise `>` — is long-stable.
+ */
+const PG_IMAGE =
+  "postgres@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15";
+const PG_USER = "probe";
+const PG_DB = "probe";
+/** Throwaway container on a private netns; never reachable off the host. */
+const PG_PASSWORD = "probe";
+
+/**
+ * SQL arm. Takes the statement the REAL shipping
+ * `PostgreSQLOps.prune_stale_cooccurrences` builds and EXECUTES it against a
+ * real PostgreSQL, on real tables, with real rows. Every assertion below is a
+ * count Postgres computed — nothing here inspects the SQL as a string.
+ *
+ * It exists because substring checks cannot prove a partition, and the
+ * partition is the property the whole rotation rests on. This mutation
+ *
+ *     AND 0 * ('x' || substr(md5(c.entity_id_1::text), 1, 4))::bit(16)::int
+ *         % $4::int = $5::int
+ *
+ * contains every substring a grep-style check looks for, collapses the entire
+ * bank into slice 0 and empties slices 1..23 — i.e. destroys the sweep — and
+ * was green against the string-only probe. Under this arm it fails
+ * SLICES_ARE_NONEMPTY, SLICE_IS_A_PROPER_SUBSET and SLICES_ARE_BALANCED.
+ */
+const SQL_PROBE = String.raw`
+"""Executable partition proof for the bounded-sweep slice filter."""
+
+import asyncio
+import os
+import sys
+import uuid
+
+sys.path.insert(0, "/app/api")
+
+import asyncpg
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"{name}={'OK' if cond else 'FAIL'}")
+    if not cond:
+        failures.append(f"{name}: {detail}")
+
+
+from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+
+
+class CaptureConn:
+    """Records the statement the real method builds; returns a canned row."""
+
+    def __init__(self):
+        self.sql = None
+
+    async def fetchrow(self, sql, *params):
+        self.sql = sql
+        return {"deleted": 0, "scanned": 0, "last_entity_id_1": None, "last_entity_id_2": None}
+
+
+cap = CaptureConn()
+asyncio.run(
+    PostgreSQLOps().prune_stale_cooccurrences(
+        cap, "entity_cooccurrences", "unit_entities", "entities", "b",
+        slice_count=1, slice_index=0, batch_size=1,
+    )
+)
+SWEEP_SQL = cap.sql
+check("SQL_captured_from_shipping_code", bool(SWEEP_SQL) and "WITH page" in (SWEEP_SQL or ""),
+      f"got {SWEEP_SQL!r}")
+
+BANK = "probe-bank"
+OTHER = "other-bank"
+N_ENT = 1200
+FANOUT = 8
+SLICES = 24
+
+SCHEMA = """
+DROP TABLE IF EXISTS entity_cooccurrences, unit_entities, entities;
+CREATE TABLE entities (id uuid PRIMARY KEY, bank_id text NOT NULL);
+CREATE TABLE unit_entities (unit_id uuid NOT NULL, entity_id uuid NOT NULL);
+CREATE TABLE entity_cooccurrences (
+    entity_id_1 uuid NOT NULL,
+    entity_id_2 uuid NOT NULL,
+    PRIMARY KEY (entity_id_1, entity_id_2),
+    CONSTRAINT entity_cooccurrence_order_check CHECK (entity_id_1 < entity_id_2)
+);
+CREATE INDEX ON unit_entities (entity_id, unit_id);
+CREATE INDEX ON entities (bank_id);
+"""
+
+
+def ids(bank, n):
+    """Deterministic uuids, so any failure is reproducible."""
+    ns = uuid.uuid5(uuid.NAMESPACE_DNS, bank)
+    return sorted(str(uuid.uuid5(ns, str(i))) for i in range(n))
+
+
+async def seed(conn):
+    await conn.execute(SCHEMA)
+    out = {}
+    for bank in (BANK, OTHER):
+        ent = ids(bank, N_ENT)
+        await conn.executemany(
+            "INSERT INTO entities (id, bank_id) VALUES ($1, $2)", [(e, bank) for e in ent]
+        )
+        pairs = [
+            (a, ent[i + j])
+            for i, a in enumerate(ent)
+            for j in range(1, FANOUT + 1)
+            if i + j < len(ent)
+        ]
+        await conn.executemany(
+            "INSERT INTO entity_cooccurrences (entity_id_1, entity_id_2) VALUES ($1, $2)", pairs
+        )
+        # Every 3rd pair is WITNESSED by a live unit; the other two thirds are
+        # exactly the stale-count rows this pass exists to remove.
+        witnessed = []
+        for k, (a, b) in enumerate(pairs):
+            if k % 3 == 0:
+                u = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{bank}/{k}"))
+                witnessed += [(u, a), (u, b)]
+        await conn.executemany(
+            "INSERT INTO unit_entities (unit_id, entity_id) VALUES ($1, $2)", witnessed
+        )
+        out[bank] = (len(pairs), sum(1 for k in range(len(pairs)) if k % 3 != 0))
+    return out
+
+
+async def run_page(conn, slice_count, slice_index, batch, a1=None, a2=None):
+    """One page of the shipping statement, ROLLED BACK so the next call sees
+    the same rows — the statement deletes, and these are comparisons."""
+    tx = conn.transaction()
+    await tx.start()
+    try:
+        return dict(await conn.fetchrow(SWEEP_SQL, BANK, a1, a2, slice_count, slice_index, batch))
+    finally:
+        await tx.rollback()
+
+
+async def bank_count(conn, bank):
+    return await conn.fetchval(
+        "SELECT count(*) FROM entity_cooccurrences c JOIN entities e ON e.id = c.entity_id_1 "
+        "WHERE e.bank_id = $1",
+        bank,
+    )
+
+
+async def main():
+    conn = await asyncpg.connect(os.environ["PROBE_DSN"])
+    try:
+        sizes = await seed(conn)
+        total, stale_total = sizes[BANK]
+
+        # ── THE SLICES PARTITION THE BANK ────────────────────────────────────
+        # batch >> any slice, so scanned is the slice's whole size and paging
+        # cannot confound the counts.
+        BIG = 10 ** 9
+        scanned = [ (await run_page(conn, SLICES, i, BIG))["scanned"] for i in range(SLICES) ]
+
+        check("SLICES_COVER_THE_BANK_EXACTLY_ONCE", sum(scanned) == total,
+              f"the slices scanned {sum(scanned)} rows; the bank has {total}")
+        check("SLICES_ARE_NONEMPTY", all(s > 0 for s in scanned),
+              f"empty slices at {[i for i, s in enumerate(scanned) if s == 0]}: {scanned}")
+        check("SLICE_IS_A_PROPER_SUBSET", all(0 < s < total for s in scanned),
+              f"a single slice covered the whole bank: {scanned}")
+        # Evenness. A filter that partitions but is wildly lopsided puts the
+        # timeout back on whichever run draws the big slice.
+        check("SLICES_ARE_BALANCED", max(scanned) <= 4 * max(1, min(scanned)),
+              f"min {min(scanned)}, max {max(scanned)} over {SLICES} slices: {scanned}")
+
+        whole = await run_page(conn, 1, 0, BIG)
+        check("SLICE_COUNT_1_IS_THE_WHOLE_BANK", whole["scanned"] == total,
+              f"scanned {whole['scanned']} of {total} — the small-bank path is not the whole bank")
+
+        # ── THE PAGE DELETES THE STALE ROWS, ONLY THOSE, ONLY IN THIS BANK ───
+        tx = conn.transaction()
+        await tx.start()
+        try:
+            r = await conn.fetchrow(SWEEP_SQL, BANK, None, None, 1, 0, BIG)
+            left_here = await bank_count(conn, BANK)
+            left_other = await bank_count(conn, OTHER)
+            check("DELETES_EXACTLY_THE_STALE_ROWS", r["deleted"] == stale_total,
+                  f"deleted {r['deleted']}, expected the {stale_total} stale of {total}")
+            check("WITNESSED_ROWS_SURVIVE", left_here == total - stale_total,
+                  f"{left_here} rows left, expected {total - stale_total}")
+            check("OTHER_BANKS_UNTOUCHED", left_other == sizes[OTHER][0],
+                  f"{left_other} rows left in {OTHER}, expected {sizes[OTHER][0]}")
+        finally:
+            await tx.rollback()
+
+        # ── REAL PAGING: the pages TILE their slice, no gap and no overlap ───
+        BATCH = 25
+        a1 = a2 = None
+        seen = pages = 0
+        cursors = []
+        while True:
+            r = await run_page(conn, SLICES, 3, BATCH, a1, a2)
+            pages += 1
+            seen += r["scanned"]
+            if r["scanned"] < BATCH or r["last_entity_id_1"] is None:
+                break
+            a1, a2 = str(r["last_entity_id_1"]), str(r["last_entity_id_2"])
+            cursors.append((a1, a2))
+            if pages > 500:
+                break
+        check("PAGES_TILE_THE_SLICE", seen == scanned[3],
+              f"paging saw {seen} rows; the same slice unpaged has {scanned[3]}")
+        check("CURSOR_STRICTLY_ADVANCES", cursors == sorted(set(cursors)),
+              f"the cursor did not advance strictly: {cursors[:6]}")
+        check("PAGING_TERMINATES", pages <= 500, f"{pages} pages and still going")
+
+        print("SQL_PROBE_EXECUTED")
+    finally:
+        await conn.close()
+
+
+asyncio.run(main())
 for f in failures:
     print("FAILURE:", f)
 sys.exit(1 if failures else 0)
@@ -432,8 +773,45 @@ const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
 
 const dockerOk = hasDocker();
 const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+const pgOk = dockerOk && hasImage(PG_IMAGE);
 
 type ProbeResult = { status: number; stdout: string };
+
+/**
+ * Run a docker command, folding stderr into the returned text.
+ *
+ * Load-bearing: when a patch block stops applying, ALL the diagnosis is on
+ * stderr (the block's own assertion message names the drifted anchor). Dropping
+ * it turns that into `expected '' to contain 'PROBE_EXECUTED'` with no cause.
+ */
+function dockerText(args: string[], input?: string): string {
+  return execFileSync("docker", args, {
+    input,
+    stdio: ["pipe", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+}
+
+function errText(e: unknown): string {
+  const err = e as { stdout?: Buffer | string; stderr?: Buffer | string };
+  return (
+    (err.stdout ?? "").toString() +
+    (err.stderr ? `\n--- stderr ---\n${err.stderr.toString()}` : "")
+  );
+}
+
+/**
+ * Apply every patch block, in Dockerfile order, into a running container.
+ * Each block is self-verifying: it asserts every upstream anchor exists exactly
+ * once and re-asserts the result, so a throw here means upstream drifted and
+ * the patch must be re-authored — and the message is on the stderr `dockerText`
+ * preserves.
+ */
+function applyPatches(container: string): void {
+  for (const block of patchBlocks()) {
+    dockerText(["exec", "-i", container, "python3", "-"], block);
+  }
+}
 
 /** Run the probe in a throwaway container, optionally patching first. */
 function runProbe(patched: boolean): ProbeResult {
@@ -464,36 +842,134 @@ function runProbe(patched: boolean): ProbeResult {
       { stdio: ["ignore", "ignore", "pipe"] },
     );
 
-    if (patched) {
-      for (const block of patchBlocks()) {
-        // Each block is self-verifying: it asserts every upstream anchor exists
-        // exactly once and re-asserts the result, so a non-zero exit here means
-        // upstream drifted and the patch must be re-authored.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
-      }
-    }
+    if (patched) applyPatches(name);
 
-    const res = execFileSync(
-      "docker",
+    const res = dockerText(
       ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+      PROBE,
     );
     return { status: 0, stdout: res };
   } catch (e) {
-    const err = e as { status?: number; stdout?: Buffer | string };
-    return {
-      status: err.status ?? -1,
-      stdout: (err.stdout ?? "").toString(),
-    };
+    const err = e as { status?: number };
+    return { status: err.status ?? -1, stdout: errText(e) };
   } finally {
     try {
       execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
     } catch {
       /* already gone */
     }
+  }
+}
+
+/**
+ * Run the SQL arm: a throwaway Postgres, and the PATCHED hindsight container
+ * joined to its network namespace so the statement runs against a real server
+ * over loopback. Both containers are labelled and force-removed in `finally`.
+ */
+function runSqlProbe(): ProbeResult {
+  const tag = RUN_ID.slice(0, 8);
+  const pg = `sr-hs-gmsweep-pg-${tag}`;
+  const app = `sr-hs-gmsweep-sql-${tag}`;
+  const labels = [
+    "--label",
+    `switchroom.test=${TEST_PHASE}`,
+    "--label",
+    `switchroom.test.run=${RUN_ID}-sql`,
+  ];
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        pg,
+        ...labels,
+        // No published port: the app container joins this netns directly, so
+        // the server is reachable ONLY from inside it.
+        "-e",
+        `POSTGRES_USER=${PG_USER}`,
+        "-e",
+        `POSTGRES_PASSWORD=${PG_PASSWORD}`,
+        "-e",
+        `POSTGRES_DB=${PG_DB}`,
+        PG_IMAGE,
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    // Readiness: pg_isready, not a fixed sleep.
+    let ready = false;
+    for (let i = 0; i < 60; i += 1) {
+      try {
+        execFileSync("docker", ["exec", pg, "pg_isready", "-U", PG_USER], {
+          stdio: "ignore",
+        });
+        ready = true;
+        break;
+      } catch {
+        execFileSync("sleep", ["1"], { stdio: "ignore" });
+      }
+    }
+    if (!ready) {
+      return { status: -1, stdout: `postgres never became ready:\n${dockerLogs(pg)}` };
+    }
+
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        app,
+        ...labels,
+        "--user",
+        "root",
+        "--network",
+        `container:${pg}`,
+        UPSTREAM_IMAGE,
+        "sleep",
+        "600",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    applyPatches(app);
+
+    const out = dockerText(
+      [
+        "exec",
+        "-i",
+        "-w",
+        "/app/api",
+        "-e",
+        `PROBE_DSN=postgresql://${PG_USER}:${PG_PASSWORD}@127.0.0.1:5432/${PG_DB}`,
+        app,
+        "/app/api/.venv/bin/python",
+        "-",
+      ],
+      SQL_PROBE,
+    );
+    return { status: 0, stdout: out };
+  } catch (e) {
+    const err = e as { status?: number };
+    return { status: err.status ?? -1, stdout: errText(e) };
+  } finally {
+    for (const name of [app, pg]) {
+      try {
+        execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+function dockerLogs(name: string): string {
+  try {
+    return dockerText(["logs", "--tail", "40", name]);
+  } catch (e) {
+    return errText(e);
   }
 }
 
@@ -530,6 +1006,16 @@ describe("Dockerfile.hindsight bounded-sweep probe is real, not a silent skip", 
       `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
         "locally — the workflow must pull the pinned digest before running this suite",
     ).toBe(true);
+    expect(
+      pgOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${PG_IMAGE} is not present locally — ` +
+        "the SQL arm is the only executable proof that the slice filter partitions " +
+        "the bank, so CI must pull this digest too",
+    ).toBe(true);
+  });
+
+  it("pins the SQL arm's Postgres by digest as well", () => {
+    expect(PG_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
   });
 });
 
@@ -575,6 +1061,13 @@ describe.skipIf(!dockerOk || !imageOk)(
       // largest banks time out on every single run.
       expect(stdout).toContain("B2_slice_rotates_over_whole_bank=FAIL");
 
+      // There is no size-derived slice count upstream — no helper at all.
+      expect(stdout).toContain("S_slice_count_is_derived=FAIL");
+      expect(stdout).toContain("C_slice_target_rows=FAIL");
+
+      // Nothing bounds the page loop, because there is no page loop.
+      expect(stdout).toContain("B4_tripwire_stops_the_loop=FAIL");
+
       // A timeout is fatal to the pass — there is no page to shrink.
       expect(stdout).toContain("B3_retried_after_timeout=FAIL");
       expect(stdout).toContain("B3_halving_sequence=FAIL");
@@ -607,9 +1100,30 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("B2_cursor_advances=OK");
       expect(stdout).toContain("B2_sums_deletions_across_pages=OK");
       expect(stdout).toContain("B2_slice_index_stable_within_run=OK");
-      // 24 consecutive 30-minute ticks visit slices 0..23 — i.e. the rotation
+      // Consecutive 30-minute ticks visit every slice — i.e. the rotation
       // covers the WHOLE bank rather than resampling part of it.
       expect(stdout).toContain("B2_slice_rotates_over_whole_bank=OK");
+
+      // S — how many slices is DERIVED FROM BANK SIZE, which is the whole
+      // reason a quiet bank is not condemned to a 24-run coupon-collector
+      // wait for a sweep it used to get on every run.
+      expect(stdout).toContain("S_slice_count_is_derived=OK");
+      expect(stdout).toContain("S_tiny_bank_is_one_slice=OK");
+      expect(stdout).toContain("S_at_target_is_one_slice=OK");
+      expect(stdout).toContain("S_just_over_target_is_two=OK");
+      expect(stdout).toContain("S_largest_live_bank_is_21=OK");
+      expect(stdout).toContain("S_quietest_live_bank_is_1=OK");
+      expect(stdout).toContain("S_slice_count_is_capped=OK");
+      expect(stdout).toContain("S_slice_index_is_pure=OK");
+      // …and the caller really uses it: it sizes the bank once per run and
+      // the slice index it derives stays inside the derived range.
+      expect(stdout).toContain("B2_sizes_the_bank_once=OK");
+      expect(stdout).toContain("B2_slice_count_matches_bank_size=OK");
+      expect(stdout).toContain("B2_slice_index_in_range=OK");
+      // The small-bank regression the review named: a 25k bank is swept WHOLE,
+      // every run, exactly as it was before this change.
+      expect(stdout).toContain("B2_small_bank_swept_whole=OK");
+      expect(stdout).toContain("B2_small_bank_slice_index_is_0=OK");
 
       // B3 — a page that times out is halved and retried at the SAME cursor,
       // down to a floor, and then gives up instead of looping.
@@ -617,13 +1131,79 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("B3_retries_the_same_cursor=OK");
       expect(stdout).toContain("B3_floor_then_raises=OK");
       expect(stdout).toContain("B3_halving_sequence=OK");
+      expect(stdout).toContain("B3_shrunk_page_still_counted=OK");
+
+      // B4 — the page-count tripwire actually FIRES on a store that never runs
+      // out of pages, and returns rather than raising.
+      expect(stdout).toContain("B4_tripwire_stops_the_loop=OK");
+      expect(stdout).toContain("B4_tripwire_returns_not_raises=OK");
 
       // The constants are what this file's hard-coded expectations assume.
       expect(stdout).toContain("C_batch_size=OK");
       expect(stdout).toContain("C_min_batch_size=OK");
-      expect(stdout).toContain("C_slice_count=OK");
+      expect(stdout).toContain("C_slice_target_rows=OK");
+      expect(stdout).toContain("C_max_slice_count=OK");
       expect(stdout).toContain("C_slice_seconds=OK");
       expect(stdout).toContain("C_max_pages=OK");
+      expect(stdout).toContain("C_no_fixed_slice_count=OK");
+
+      // asyncio.TimeoutError IS the builtin on this interpreter — the `except
+      // TimeoutError` the patch installs only catches the command timeout
+      // because that identity holds.
+      expect(stdout).toContain("T_asyncio_timeout_is_builtin=OK");
     }, 240_000);
+  },
+);
+
+describe.skipIf(!dockerOk || !imageOk || !pgOk)(
+  "the slice filter really partitions the bank (executed SQL, real Postgres)",
+  () => {
+    afterAll(() => {
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}-sql`,
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("executes the shipping statement against real rows", () => {
+      const { status, stdout } = runSqlProbe();
+      expect(stdout, `SQL probe did not run to completion:\n${stdout}`).toContain(
+        "SQL_PROBE_EXECUTED",
+      );
+      expect(stdout, `SQL probe reported failures:\n${stdout}`).not.toContain(
+        "FAILURE:",
+      );
+      expect(status, `SQL probe failed:\n${stdout}`).toBe(0);
+
+      // The statement under test came from the shipping class, not a copy.
+      expect(stdout).toContain("SQL_captured_from_shipping_code=OK");
+
+      // THE partition property. `AND 0 * (…hash…) % $4 = $5` keeps every
+      // substring a grep-style check looks for and fails all three of these.
+      expect(stdout).toContain("SLICES_COVER_THE_BANK_EXACTLY_ONCE=OK");
+      expect(stdout).toContain("SLICES_ARE_NONEMPTY=OK");
+      expect(stdout).toContain("SLICE_IS_A_PROPER_SUBSET=OK");
+      expect(stdout).toContain("SLICES_ARE_BALANCED=OK");
+      expect(stdout).toContain("SLICE_COUNT_1_IS_THE_WHOLE_BANK=OK");
+
+      // Slicing did not change WHAT the sweep deletes.
+      expect(stdout).toContain("DELETES_EXACTLY_THE_STALE_ROWS=OK");
+      expect(stdout).toContain("WITNESSED_ROWS_SURVIVE=OK");
+      expect(stdout).toContain("OTHER_BANKS_UNTOUCHED=OK");
+
+      // Real keyset paging over real rows: no gap, no overlap, it terminates.
+      expect(stdout).toContain("PAGES_TILE_THE_SLICE=OK");
+      expect(stdout).toContain("CURSOR_STRICTLY_ADVANCES=OK");
+      expect(stdout).toContain("PAGING_TERMINATES=OK");
+    }, 600_000);
   },
 );

--- a/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
+++ b/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
@@ -1,0 +1,629 @@
+/**
+ * Behavioural proof for the graph-maintenance BOUNDED SWEEP patch that
+ * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight image.
+ *
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of that patch block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it runs the
+ * same probe against unpatched upstream (must be RED) and against upstream +
+ * the patch blocks applied (must be GREEN). Nothing here greps the patched
+ * source — every assertion drives real shipping code and observes what it does.
+ *
+ * THE DEFECT, in the real shipping source at the pinned digest.
+ *
+ * `graph_maintenance` Pass 3 (`prune_stale_cooccurrences`) is ONE bank-wide
+ * statement whose cost grows with the bank. Measured read-only against this
+ * fleet's live database on 2026-08-12:
+ *
+ *   bank      cooc rows   the predicate, READ-ONLY
+ *   marko        60,890    3.4 s
+ *   finn        159,076    8.2 s
+ *   overlord    517,475   65.2 s   <- past the 60s asyncpg command_timeout
+ *                                     BEFORE the sort, the locks and the DELETE
+ *
+ * So on the two largest banks the pass cannot finish, has never once finished,
+ * and leaks stale cooccurrence rows for ever. The prior fix (#4604) removed the
+ * 9x retry storm around it and the blank `error_message` it hid behind; it
+ * deliberately did not make the statement finish. This one does.
+ *
+ * WHY THE SHAPE TEST IS NOT ENOUGH. Every property that actually bounds the
+ * work is a property of BEHAVIOUR, invisible to grep:
+ *
+ *   - a `LIMIT` in the SQL text proves nothing unless the caller LOOPS — a
+ *     single bounded page that never pages again silently stops pruning most of
+ *     the bank while looking correct in the diff;
+ *   - the keyset cursor must strictly ADVANCE, or the loop re-sweeps page one
+ *     for ever and the job never terminates;
+ *   - the shrink-on-timeout must retry the SAME cursor — a version that shrinks
+ *     but advances skips exactly the rows it failed on, permanently;
+ *   - the rotating slice must cover 0..N-1 over N consecutive runs, or part of
+ *     the bank is never swept at all.
+ *
+ * Only running the patched modules distinguishes those. This probe drives the
+ * REAL `PostgreSQLOps.prune_stale_cooccurrences` (against a fake connection
+ * that captures the SQL and its bound parameters) and the REAL
+ * `run_graph_maintenance_job` (against a fake store that records every Pass 3
+ * call and scripts the pages it returns), rather than re-implementing either.
+ *
+ * The expected numbers below are HARD-CODED LITERALS, not reads of the module
+ * constants they check — a fixture and an expectation derived from the same
+ * constant cannot fail for any value of that constant. The probe asserts the
+ * constants equal those literals AND that the loop behaves accordingly, so
+ * changing a constant turns this test red on purpose.
+ *
+ * The patch blocks are extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what actually ships. Note it
+ * applies TWO: the bounded-sweep block anchors on text the #4604 retry-storm
+ * block writes, so that block is its prerequisite and is applied first, in
+ * Dockerfile order. It applies them by `docker exec` (not `docker build`) so it
+ * runs on daemons without buildx, and it never touches the production
+ * `switchroom-hindsight` container.
+ *
+ * SKIP DISCIPLINE: identical to
+ * `hindsight-graph-maintenance-retry-storm.test.ts`. Locally, with no docker or
+ * no cached image, this skips (never pull a 6.4GB third-party image onto a dev
+ * box). In CI the `hindsight-probe` job pulls the pinned digest and sets
+ * SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an unavailable
+ * docker/image is a HARD FAILURE, never a green skip. Both runs assert a
+ * `PROBE_EXECUTED` sentinel so a probe that dies early can never be mistaken
+ * for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8",
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-graph-maintenance-bounded-sweep";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/**
+ * The blocks this file applies, named by their unique in-block markers, in the
+ * order they must run. The retry-storm block is a PREREQUISITE, not a subject:
+ * the bounded-sweep block anchors on the `_run_cooccurrence_prune` helper that
+ * #4604 introduces, so applying it alone would fail its own anchor assertion.
+ */
+const PREREQUISITE_PATCH_NAME = "graph-maintenance retry-storm patch";
+const PATCH_NAME = "graph-maintenance bounded sweep patch";
+
+/**
+ * The patch blocks under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by their unique patch names and
+ * returned in Dockerfile order.
+ */
+function patchBlocks(): string[] {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const ordered: string[] = [];
+  for (const name of [PREREQUISITE_PATCH_NAME, PATCH_NAME]) {
+    const hits = blocks.filter((b) => b.includes(name));
+    if (hits.length !== 1) {
+      throw new Error(
+        `Dockerfile.hindsight contains ${hits.length} "${name}" RUN blocks ` +
+          `(expected exactly 1) — if the patch was deliberately removed, delete ` +
+          `this test with it.`,
+      );
+    }
+    ordered.push(hits[0]);
+  }
+  const [prereq, subject] = ordered;
+  if (dockerfile.indexOf(prereq) > dockerfile.indexOf(subject)) {
+    throw new Error(
+      `"${PATCH_NAME}" must appear AFTER "${PREREQUISITE_PATCH_NAME}" in ` +
+        `Dockerfile.hindsight — it anchors on text that block writes.`,
+    );
+  }
+  return ordered;
+}
+
+/**
+ * Python probe. Exits 0 only when every property holds; prints the offending
+ * assertions otherwise. Every check prints a NAME=OK/FAIL line, and both the
+ * RED and the GREEN case below assert on the same names, so the two runs are
+ * compared on identical observations.
+ */
+const PROBE = String.raw`
+"""Behavioural probe for the graph-maintenance bounded-sweep patch.
+
+RED against unpatched upstream, GREEN against the patched image. Every check is
+wrapped so an unpatched module raises a recorded FAILURE rather than aborting
+the run — both directions must reach PROBE_EXECUTED, or a crash would be
+indistinguishable from a red assertion.
+"""
+
+import asyncio
+import contextlib
+import sys
+import types
+from dataclasses import dataclass
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"{name}={'OK' if cond else 'FAIL'}")
+    if not cond:
+        failures.append(f"{name}: {detail}")
+
+
+def guard(name, fn):
+    """Run fn; a raised exception is that check's failure, not a crash."""
+    try:
+        return fn()
+    except Exception as e:  # noqa: BLE001 - the point is to survive anything
+        check(name, False, f"{type(e).__name__}: {e}")
+        return None
+
+
+# The patched page-result type; a stand-in keeps the unpatched run alive.
+try:
+    from hindsight_api.engine.db.ops import CooccurrenceSweepBatch
+
+    HAS_BATCH_TYPE = True
+except Exception:
+    HAS_BATCH_TYPE = False
+
+    @dataclass
+    class CooccurrenceSweepBatch:  # type: ignore[no-redef]
+        deleted: int
+        scanned: int
+        last_entity_id_1: "str | None"
+        last_entity_id_2: "str | None"
+
+
+check("T_page_result_type_exists", HAS_BATCH_TYPE,
+      "hindsight_api.engine.db.ops has no CooccurrenceSweepBatch")
+
+# ══════════════════════════════ B1: the statement itself is LIMIT-bounded ════
+from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+
+
+class FakeConn:
+    def __init__(self, deleted=0, scanned=0, last=(None, None)):
+        self.calls = []
+        self._row = {
+            "deleted": deleted,
+            "scanned": scanned,
+            "last_entity_id_1": last[0],
+            "last_entity_id_2": last[1],
+        }
+
+    async def fetchrow(self, sql, *params):
+        self.calls.append((sql, params))
+        return dict(self._row)
+
+    async def execute(self, sql, *params):  # the unpatched upstream path
+        self.calls.append((sql, params))
+        return "DELETE 0"
+
+
+conn = FakeConn(deleted=3, scanned=7, last=("aa", "bb"))
+batch = guard("B1_call_accepts_paging_args", lambda: asyncio.run(
+    PostgreSQLOps().prune_stale_cooccurrences(
+        conn, "ec", "ue", "ent", "bank-x",
+        slice_count=24, slice_index=5, batch_size=250,
+        after_entity_id_1="cur1", after_entity_id_2="cur2",
+    )
+))
+sql, params = conn.calls[0] if conn.calls else ("", ())
+
+check("B1_returns_batch", getattr(batch, "scanned", None) == 7 and getattr(batch, "deleted", None) == 3,
+      f"got {batch!r}")
+check("B1_returns_cursor",
+      (getattr(batch, "last_entity_id_1", None), getattr(batch, "last_entity_id_2", None)) == ("aa", "bb"),
+      f"got {batch!r}")
+# The cap must be a BOUND PARAMETER: that proves it travels with the call rather
+# than being frozen into the SQL text, which is what lets B3 shrink it.
+check("B1_limit_is_bound", "LIMIT $" in sql, "no bound LIMIT in the page CTE")
+check("B1_batch_size_bound", 250 in params, f"batch_size not among params {params!r}")
+check("B1_slice_bound", 24 in params and 5 in params, f"slice not among params {params!r}")
+check("B1_cursor_bound", "cur1" in params and "cur2" in params, f"cursor not among params {params!r}")
+check("B1_keyset_predicate", "(c.entity_id_1, c.entity_id_2) >" in sql, "no keyset predicate")
+check("B1_slice_predicate", "md5(c.entity_id_1::text)" in sql, "no hash-slice predicate")
+# Unchanged upstream invariants — the fix must not buy its bound with these.
+check("B1_keeps_intersect", "INTERSECT" in sql, "the #2473 INTERSECT predicate was rewritten")
+check("B1_keeps_ordered_lock", "FOR UPDATE OF c" in sql, "the #2529 ordered lock is gone")
+
+empty = FakeConn(deleted=0, scanned=0, last=(None, None))
+b0 = guard("B1_empty_page_call", lambda: asyncio.run(
+    PostgreSQLOps().prune_stale_cooccurrences(empty, "ec", "ue", "ent", "b", batch_size=250)
+))
+check("B1_empty_page_terminates",
+      getattr(b0, "scanned", None) == 0 and getattr(b0, "last_entity_id_1", "x") is None,
+      f"got {b0!r}")
+
+# ══════════════════════════ constants: hard-coded here, not read from there ══
+from hindsight_api.engine import graph_maintenance as gm
+
+check("C_batch_size", getattr(gm, "_SWEEP_BATCH_SIZE", None) == 1000,
+      f"got {getattr(gm, '_SWEEP_BATCH_SIZE', None)}")
+check("C_min_batch_size", getattr(gm, "_SWEEP_MIN_BATCH_SIZE", None) == 50,
+      f"got {getattr(gm, '_SWEEP_MIN_BATCH_SIZE', None)}")
+check("C_slice_count", getattr(gm, "_SWEEP_SLICE_COUNT", None) == 24,
+      f"got {getattr(gm, '_SWEEP_SLICE_COUNT', None)}")
+check("C_slice_seconds", getattr(gm, "_SWEEP_SLICE_SECONDS", None) == 1800,
+      f"got {getattr(gm, '_SWEEP_SLICE_SECONDS', None)}")
+check("C_max_pages", getattr(gm, "_SWEEP_MAX_PAGES", None) == 2000,
+      f"got {getattr(gm, '_SWEEP_MAX_PAGES', None)}")
+
+# ══════════════════════════ B2/B3: the paging loop in the real job ═══════════
+import hindsight_api.engine.memories as memories_mod
+import hindsight_api.engine.memory_engine as memory_engine_mod
+
+
+class LoopConn:
+    @contextlib.asynccontextmanager
+    async def transaction(self):
+        yield
+
+
+@contextlib.asynccontextmanager
+async def fake_acquire(backend):
+    yield LoopConn()
+
+
+class FakeEngine:
+    async def _get_backend(self):
+        return object()
+
+
+class FakeStore:
+    """Records every Pass 3 call and replays a scripted list of pages."""
+
+    def __init__(self, pages, timeout_on=()):
+        self.pages = pages
+        self.timeout_on = set(timeout_on)
+        self.calls = []
+
+    async def relink_pass(self, **kw):
+        return {}
+
+    async def prune_orphan_entities(self, **kw):
+        return 0
+
+    async def prune_stale_cooccurrences(self, **kw):
+        self.calls.append(kw)
+        n = len(self.calls) - 1
+        if n in self.timeout_on:
+            raise TimeoutError()
+        idx = sum(1 for i in range(n) if i not in self.timeout_on)
+        if idx >= len(self.pages):
+            return CooccurrenceSweepBatch(0, 0, None, None)
+        return self.pages[idx]
+
+
+def run_job(store):
+    memories_mod.get_memories = lambda: store
+    memory_engine_mod.acquire_with_retry = fake_acquire
+    return asyncio.run(
+        gm.run_graph_maintenance_job(FakeEngine(), "bank-x", None, operation_id="op-1")
+    )
+
+
+def page(deleted, scanned, k1, k2):
+    return CooccurrenceSweepBatch(deleted, scanned, k1, k2)
+
+
+# --- B2a: full pages page on, the cursor advances, a SHORT page ends the slice.
+store = FakeStore([
+    page(2, 1000, "k1a", "k1b"),
+    page(0, 1000, "k2a", "k2b"),   # deleted nothing, but is NOT a short page
+    page(5, 400, "k3a", "k3b"),    # short -> stop
+])
+res = guard("B2_job_runs", lambda: run_job(store)) or {}
+p3 = store.calls
+check("B2_pages_more_than_once", len(p3) == 3, f"made {len(p3)} Pass 3 call(s), expected 3")
+check("B2_sums_deletions_across_pages", res.get("stale_cooccurrences_pruned") == 7,
+      f"got {res.get('stale_cooccurrences_pruned')}, expected 2+0+5=7")
+if len(p3) == 3:
+    check("B2_first_call_has_no_cursor",
+          p3[0].get("after_entity_id_1") is None and p3[0].get("after_entity_id_2") is None,
+          f"got {p3[0].get('after_entity_id_1')!r}")
+    check("B2_cursor_advances",
+          (p3[1].get("after_entity_id_1"), p3[1].get("after_entity_id_2")) == ("k1a", "k1b")
+          and (p3[2].get("after_entity_id_1"), p3[2].get("after_entity_id_2")) == ("k2a", "k2b"),
+          f"cursors {[(c.get('after_entity_id_1'), c.get('after_entity_id_2')) for c in p3]}")
+    check("B2_batch_size_is_1000", all(c.get("batch_size") == 1000 for c in p3),
+          f"sizes {[c.get('batch_size') for c in p3]}")
+    check("B2_slice_count_is_24", all(c.get("slice_count") == 24 for c in p3),
+          f"slice_counts {[c.get('slice_count') for c in p3]}")
+    check("B2_slice_index_in_range", all(0 <= (c.get("slice_index") or 0) < 24 for c in p3),
+          f"slice_indexes {[c.get('slice_index') for c in p3]}")
+    check("B2_slice_index_stable_within_run", len({c.get("slice_index") for c in p3}) == 1,
+          "the slice index moved mid-run; the pages would cover different slices")
+
+# --- B2b: the slice index rotates with the clock and covers EVERY slice.
+# 24 consecutive 30-minute ticks must visit 0..23 exactly, or the bank is never
+# fully covered and the rotating sweep silently leaks rows for ever.
+real_time_mod = gm.time
+seen = set()
+try:
+    for tick in range(24):
+        gm.time = types.SimpleNamespace(time=(lambda t: (lambda: float(t)))(tick * 1800))
+        s = FakeStore([page(0, 1, "z", "z")])
+        guard("B2_rotation_job_runs", lambda: run_job(s))
+        if s.calls:
+            seen.add(s.calls[0].get("slice_index"))
+finally:
+    gm.time = real_time_mod
+check("B2_slice_rotates_over_whole_bank", seen == set(range(24)),
+      f"24 consecutive 30-min ticks covered slices {sorted(x for x in seen if x is not None)}, not 0..23")
+
+# --- B3: a page timeout HALVES the page and retries the SAME cursor.
+store = FakeStore(
+    [page(0, 1000, "k1a", "k1b"), page(1, 10, "k2a", "k2b")],
+    timeout_on={1},   # first attempt at the 2nd page times out
+)
+res = guard("B3_job_runs", lambda: run_job(store)) or {}
+p3 = store.calls
+check("B3_retried_after_timeout", len(p3) == 3, f"made {len(p3)} call(s), expected 3")
+if len(p3) == 3:
+    check("B3_halves_batch_size", p3[2].get("batch_size") == 500,
+          f"retried at batch_size={p3[2].get('batch_size')}, expected 1000//2=500")
+    check("B3_retries_the_same_cursor",
+          (p3[2].get("after_entity_id_1"), p3[2].get("after_entity_id_2"))
+          == (p3[1].get("after_entity_id_1"), p3[1].get("after_entity_id_2")),
+          "the cursor advanced past the page that timed out — those rows are skipped for ever")
+    check("B3_shrunk_page_still_counted", res.get("stale_cooccurrences_pruned") == 1,
+          f"got {res.get('stale_cooccurrences_pruned')}")
+
+# --- B3b: the shrink has a FLOOR, and then gives up instead of looping.
+store = FakeStore([], timeout_on=set(range(200)))
+raised = None
+try:
+    run_job(store)
+except TimeoutError as e:
+    raised = e
+except Exception as e:  # noqa: BLE001
+    raised = e
+sizes = [c.get("batch_size") for c in store.calls]
+check("B3_floor_then_raises", isinstance(raised, TimeoutError),
+      f"an always-timing-out page raised {raised!r} instead of TimeoutError")
+check("B3_halving_sequence", sizes == [1000, 500, 250, 125, 62, 50],
+      f"got {sizes}, expected 1000 halving to the floor of 50")
+
+print("PROBE_EXECUTED")
+for f in failures:
+    print("FAILURE:", f)
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-gmsweep-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8,
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    if (patched) {
+      for (const block of patchBlocks()) {
+        // Each block is self-verifying: it asserts every upstream anchor exists
+        // exactly once and re-asserts the result, so a non-zero exit here means
+        // upstream drifted and the patch must be re-authored.
+        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+          input: block,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      }
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight bounded-sweep probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts the subject block and its prerequisite, in Dockerfile order", () => {
+    const blocks = patchBlocks();
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toContain(PREREQUISITE_PATCH_NAME);
+    expect(blocks[1]).toContain(PATCH_NAME);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`,
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight bounded-sweep patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED — one unbounded statement, no paging, no shrink", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // The statement is unbounded: no page result type, and no way to even ASK
+      // for a bounded page.
+      expect(stdout).toContain("T_page_result_type_exists=FAIL");
+      expect(stdout).toContain("B1_call_accepts_paging_args=FAIL");
+      expect(stdout).toContain("unexpected keyword argument 'slice_count'");
+      expect(stdout).toContain("B1_limit_is_bound=FAIL");
+
+      // The job calls Pass 3 exactly ONCE and never pages, which is the fault.
+      expect(stdout).toContain("B2_pages_more_than_once=FAIL");
+      expect(stdout).toContain("made 1 Pass 3 call(s), expected 3");
+
+      // Nothing rotates: every run sweeps the whole bank, which is why the
+      // largest banks time out on every single run.
+      expect(stdout).toContain("B2_slice_rotates_over_whole_bank=FAIL");
+
+      // A timeout is fatal to the pass — there is no page to shrink.
+      expect(stdout).toContain("B3_retried_after_timeout=FAIL");
+      expect(stdout).toContain("B3_halving_sequence=FAIL");
+    }, 240_000);
+
+    it("patched is GREEN — bounded pages, an advancing cursor, a rotating slice, a shrinking retry", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(stdout, `probe reported failures:\n${stdout}`).not.toContain(
+        "FAILURE:",
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).not.toContain("=FAIL");
+
+      // B1 — the statement is bounded by a BOUND parameter, and the bound
+      // travels with the call (which is what lets B3 shrink it).
+      expect(stdout).toContain("B1_limit_is_bound=OK");
+      expect(stdout).toContain("B1_batch_size_bound=OK");
+      expect(stdout).toContain("B1_keyset_predicate=OK");
+      expect(stdout).toContain("B1_slice_predicate=OK");
+      // The bound must not have been bought by weakening the sweep.
+      expect(stdout).toContain("B1_keeps_intersect=OK");
+      expect(stdout).toContain("B1_keeps_ordered_lock=OK");
+
+      // B2 — the caller really pages, the cursor really advances, and only a
+      // SHORT page ends the slice (a page that deleted nothing does not).
+      expect(stdout).toContain("B2_pages_more_than_once=OK");
+      expect(stdout).toContain("B2_cursor_advances=OK");
+      expect(stdout).toContain("B2_sums_deletions_across_pages=OK");
+      expect(stdout).toContain("B2_slice_index_stable_within_run=OK");
+      // 24 consecutive 30-minute ticks visit slices 0..23 — i.e. the rotation
+      // covers the WHOLE bank rather than resampling part of it.
+      expect(stdout).toContain("B2_slice_rotates_over_whole_bank=OK");
+
+      // B3 — a page that times out is halved and retried at the SAME cursor,
+      // down to a floor, and then gives up instead of looping.
+      expect(stdout).toContain("B3_halves_batch_size=OK");
+      expect(stdout).toContain("B3_retries_the_same_cursor=OK");
+      expect(stdout).toContain("B3_floor_then_raises=OK");
+      expect(stdout).toContain("B3_halving_sequence=OK");
+
+      // The constants are what this file's hard-coded expectations assume.
+      expect(stdout).toContain("C_batch_size=OK");
+      expect(stdout).toContain("C_min_batch_size=OK");
+      expect(stdout).toContain("C_slice_count=OK");
+      expect(stdout).toContain("C_slice_seconds=OK");
+      expect(stdout).toContain("C_max_pages=OK");
+    }, 240_000);
+  },
+);

--- a/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
+++ b/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
@@ -88,13 +88,17 @@
  */
 
 import { describe, it, expect, afterAll } from "vitest";
-import { execFileSync, execSync } from "node:child_process";
-// #4628: every long docker leg is AWAITED, never `execFileSync`. A sync
-// exec blocks the vitest worker's event loop, and vitest's worker→main
-// birpc has a hard-coded 60 s timeout with no config knob — a file whose
-// legs exceed it dies with `Timeout calling "onTaskUpdate"` while every
-// test passes. This suite boots TWO containers plus a Postgres, so it is
-// squarely in that range.
+// `execSync` survives for the two module-scope PREFLIGHTS only (`docker
+// version`, `docker image inspect`): they run during collection, not the run
+// phase, and cost milliseconds.
+import { execSync } from "node:child_process";
+// #4628: every docker call in the RUN phase is AWAITED — legs and teardown
+// alike. A sync exec blocks the vitest worker's event loop, and vitest's
+// worker→main birpc has a hard-coded 60 s timeout with no config knob, so a
+// starved worker dies with `Timeout calling "onTaskUpdate"` while every test
+// PASSES. The timeout is not phase-scoped: `afterAll` starves the same loop.
+// This suite boots TWO containers plus a Postgres, so it is squarely in that
+// range.
 import { execFileAsync } from "./_exec-async.js";
 import { readFileSync, readdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
@@ -800,6 +804,39 @@ const pgOk = dockerOk && hasImage(PG_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /**
+ * Label-scoped teardown belt (never an unlabelled bulk removal).
+ *
+ * AWAITED, and bounded, for the same reason every probe leg is (#4628). The
+ * birpc 60 s timeout is not phase-scoped: a sync exec starves the worker's
+ * event loop in `afterAll` exactly as it would inside a test. The shipped
+ * sequence is fast — measured 144 ms for `docker ps -aq --filter label=…`
+ * plus `docker rm -f` against three real containers — so this is not a flake
+ * risk on time. It is a LEGIBILITY fix: neither `execSync` carried a
+ * `timeout`, so a wedged or saturated daemon blocks unboundedly and surfaces
+ * as `Timeout calling "onTaskUpdate"` with every test PASSING, which is the
+ * exact illegible mode #4628 exists to remove. Awaited and capped, the same
+ * daemon fails as a named, bounded teardown error.
+ */
+async function reapByRunLabel(label: string): Promise<void> {
+  try {
+    const { stdout } = await execFileAsync(
+      "docker",
+      ["ps", "-aq", "--filter", `label=switchroom.test.run=${label}`],
+      { timeoutMs: 60_000 },
+    );
+    const ids = stdout.split("\n").filter(Boolean);
+    if (ids.length) {
+      await execFileAsync("docker", ["rm", "-f", ...ids], {
+        timeoutMs: 120_000,
+      });
+    }
+  } catch {
+    /* nothing to clean, or the daemon is gone — the labels bound the blast
+       radius either way */
+  }
+}
+
+/**
  * Run a docker command, folding stderr into the returned text.
  *
  * Load-bearing: when a patch block stops applying, ALL the diagnosis is on
@@ -1106,21 +1143,8 @@ describe("Dockerfile.hindsight bounded-sweep probe is real, not a silent skip", 
 describe.skipIf(!dockerOk || !imageOk)(
   "Dockerfile.hindsight bounded-sweep patch changes real behaviour",
   () => {
-    afterAll(() => {
-      // Label-scoped teardown belt (never an unlabelled bulk removal).
-      try {
-        const ids = execSync(
-          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
-          { encoding: "utf8" },
-        )
-          .split("\n")
-          .filter(Boolean);
-        if (ids.length) {
-          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
-        }
-      } catch {
-        /* nothing to clean */
-      }
+    afterAll(async () => {
+      await reapByRunLabel(RUN_ID);
     });
 
     it("unpatched upstream is RED — one unbounded statement, no paging, no shrink", async () => {
@@ -1247,20 +1271,8 @@ describe.skipIf(!dockerOk || !imageOk)(
 describe.skipIf(!dockerOk || !imageOk || !pgOk)(
   "the slice filter really partitions the bank (executed SQL, real Postgres)",
   () => {
-    afterAll(() => {
-      try {
-        const ids = execSync(
-          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}-sql`,
-          { encoding: "utf8" },
-        )
-          .split("\n")
-          .filter(Boolean);
-        if (ids.length) {
-          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
-        }
-      } catch {
-        /* nothing to clean */
-      }
+    afterAll(async () => {
+      await reapByRunLabel(`${RUN_ID}-sql`);
     });
 
     it("executes the shipping statement against real rows", async () => {

--- a/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
+++ b/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
@@ -85,7 +85,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
@@ -1016,6 +1016,73 @@ describe("Dockerfile.hindsight bounded-sweep probe is real, not a silent skip", 
 
   it("pins the SQL arm's Postgres by digest as well", () => {
     expect(PG_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  // Caught for real: this probe shipped with its paths-filter entry but NO run
+  // step, so `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE` was never set for it in CI and
+  // its entire hard-fail-instead-of-skip discipline was inert — the suite would
+  // have silently green-skipped on every runner without the 6.4GB image. The
+  // guard is written over EVERY probe rather than this one, so the next probe
+  // cannot repeat it.
+  it("every probe that demands a real run has a workflow step that gives it one", () => {
+    const workflow = readFileSync(
+      resolve(root, ".github/workflows/docker-e2e.yml"),
+      "utf8",
+    );
+    const probes = readdirSync(resolve(root, "tests/docker"))
+      .filter((f) => f.endsWith(".test.ts"))
+      .filter((f) =>
+        readFileSync(resolve(root, "tests/docker", f), "utf8").includes(
+          "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE",
+        ),
+      );
+    // Sanity: the discovery itself must not silently find nothing.
+    expect(probes.length).toBeGreaterThan(5);
+    expect(probes).toContain(
+      "hindsight-graph-maintenance-bounded-sweep.test.ts",
+    );
+
+    const missing = probes.filter(
+      (f) => !workflow.includes(`npx vitest run tests/docker/${f}`),
+    );
+    expect(
+      missing,
+      `these probes read SWITCHROOM_REQUIRE_HINDSIGHT_PROBE but no docker-e2e.yml ` +
+        `step runs them, so the env var is never set and their hard-fail ` +
+        `discipline is inert: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("this probe's containers are reaped by the label-scoped teardown", () => {
+    const workflow = readFileSync(
+      resolve(root, ".github/workflows/docker-e2e.yml"),
+      "utf8",
+    );
+    // Scope to the JOB that actually runs this probe: docker-e2e.yml has more
+    // than one `Label-scoped teardown` step (one per job), and a phase listed
+    // in some OTHER job's teardown reaps nothing here.
+    const runStep = `npx vitest run tests/docker/${TEST_PHASE}.test.ts`;
+    const jobs = workflow.split(/^ {2}(?=[A-Za-z0-9_-]+:$)/m);
+    const job = jobs.find((j) => j.includes(runStep));
+    expect(
+      job,
+      `no docker-e2e.yml job runs \`${runStep}\``,
+    ).toBeTruthy();
+    const teardown = (job ?? "")
+      .split("Label-scoped teardown")[1]
+      ?.split("for phase in ")[1]
+      ?.split("; do")[0];
+    expect(
+      teardown,
+      "the job that runs this probe has no `for phase in ...` label-scoped teardown",
+    ).toBeTruthy();
+    // Both arms label with TEST_PHASE, including the SQL arm's pg sidecar, so
+    // one entry reaps everything this file starts.
+    expect(
+      (teardown ?? "").split(/\s+/),
+      `${TEST_PHASE} is missing from the teardown phase list, so a crashed run ` +
+        "leaves its containers (and the SQL arm's Postgres) on the runner",
+    ).toContain(TEST_PHASE);
   });
 });
 

--- a/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
+++ b/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
@@ -89,6 +89,13 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+// #4628: every long docker leg is AWAITED, never `execFileSync`. A sync
+// exec blocks the vitest worker's event loop, and vitest's worker→main
+// birpc has a hard-coded 60 s timeout with no config knob — a file whose
+// legs exceed it dies with `Timeout calling "onTaskUpdate"` while every
+// test passes. This suite boots TWO containers plus a Postgres, so it is
+// squarely in that range.
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync, readdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -799,12 +806,9 @@ type ProbeResult = { status: number; stdout: string };
  * stderr (the block's own assertion message names the drifted anchor). Dropping
  * it turns that into `expected '' to contain 'PROBE_EXECUTED'` with no cause.
  */
-function dockerText(args: string[], input?: string): string {
-  return execFileSync("docker", args, {
-    input,
-    stdio: ["pipe", "pipe", "pipe"],
-    encoding: "utf8",
-  });
+async function dockerText(args: string[], input?: string): Promise<string> {
+  const res = await execFileAsync("docker", args, { input });
+  return res.stdout;
 }
 
 function errText(e: unknown): string {
@@ -822,22 +826,20 @@ function errText(e: unknown): string {
  * the patch must be re-authored — and the message is on the stderr `dockerText`
  * preserves.
  */
-function applyPatches(container: string): void {
+async function applyPatches(container: string): Promise<void> {
   for (const block of patchBlocks()) {
-    dockerText(["exec", "-i", container, "python3", "-"], block);
+    await dockerText(["exec", "-i", container, "python3", "-"], block);
   }
 }
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-gmsweep-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -853,13 +855,11 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+    ]);
 
-    if (patched) applyPatches(name);
+    if (patched) await applyPatches(name);
 
-    const res = dockerText(
+    const res = await dockerText(
       ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
       PROBE,
     );
@@ -869,7 +869,7 @@ function runProbe(patched: boolean): ProbeResult {
     return { status: err.status ?? -1, stdout: errText(e) };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -881,7 +881,7 @@ function runProbe(patched: boolean): ProbeResult {
  * joined to its network namespace so the statement runs against a real server
  * over loopback. Both containers are labelled and force-removed in `finally`.
  */
-function runSqlProbe(): ProbeResult {
+async function runSqlProbe(): Promise<ProbeResult> {
   const tag = RUN_ID.slice(0, 8);
   const pg = `sr-hs-gmsweep-pg-${tag}`;
   const app = `sr-hs-gmsweep-sql-${tag}`;
@@ -892,9 +892,7 @@ function runSqlProbe(): ProbeResult {
     `switchroom.test.run=${RUN_ID}-sql`,
   ];
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -909,30 +907,27 @@ function runSqlProbe(): ProbeResult {
         "-e",
         `POSTGRES_DB=${PG_DB}`,
         PG_IMAGE,
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+    ]);
 
     // Readiness: pg_isready, not a fixed sleep.
     let ready = false;
     for (let i = 0; i < 60; i += 1) {
       try {
-        execFileSync("docker", ["exec", pg, "pg_isready", "-U", PG_USER], {
-          stdio: "ignore",
-        });
+        await execFileAsync("docker", ["exec", pg, "pg_isready", "-U", PG_USER]);
         ready = true;
         break;
       } catch {
-        execFileSync("sleep", ["1"], { stdio: "ignore" });
+        await new Promise((r) => setTimeout(r, 1000));
       }
     }
     if (!ready) {
-      return { status: -1, stdout: `postgres never became ready:\n${dockerLogs(pg)}` };
+      return {
+        status: -1,
+        stdout: `postgres never became ready:\n${await dockerLogs(pg)}`,
+      };
     }
 
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -945,13 +940,11 @@ function runSqlProbe(): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "600",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+    ]);
 
-    applyPatches(app);
+    await applyPatches(app);
 
-    const out = dockerText(
+    const out = await dockerText(
       [
         "exec",
         "-i",
@@ -972,7 +965,7 @@ function runSqlProbe(): ProbeResult {
   } finally {
     for (const name of [app, pg]) {
       try {
-        execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+        await execFileAsync("docker", ["rm", "-f", name]);
       } catch {
         /* already gone */
       }
@@ -980,9 +973,9 @@ function runSqlProbe(): ProbeResult {
   }
 }
 
-function dockerLogs(name: string): string {
+async function dockerLogs(name: string): Promise<string> {
   try {
-    return dockerText(["logs", "--tail", "40", name]);
+    return await dockerText(["logs", "--tail", "40", name]);
   } catch (e) {
     return errText(e);
   }
@@ -1130,8 +1123,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED — one unbounded statement, no paging, no shrink", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED — one unbounded statement, no paging, no shrink", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -1164,8 +1157,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("B3_halving_sequence=FAIL");
     }, 240_000);
 
-    it("patched is GREEN — bounded pages, an advancing cursor, a rotating slice, a shrinking retry", () => {
-      const { status, stdout } = runProbe(true);
+    it("patched is GREEN — bounded pages, an advancing cursor, a rotating slice, a shrinking retry", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -1270,8 +1263,8 @@ describe.skipIf(!dockerOk || !imageOk || !pgOk)(
       }
     });
 
-    it("executes the shipping statement against real rows", () => {
-      const { status, stdout } = runSqlProbe();
+    it("executes the shipping statement against real rows", async () => {
+      const { status, stdout } = await runSqlProbe();
       expect(stdout, `SQL probe did not run to completion:\n${stdout}`).toContain(
         "SQL_PROBE_EXECUTED",
       );


### PR DESCRIPTION
## Why / job spec

`reference/jobs/remember-across-sessions.md` — memory that gets *better* the
longer a fleet runs depends on graph maintenance actually running. It hasn't
been, on the two banks that need it most.

`graph_maintenance` Pass 3 (`prune_stale_cooccurrences`) is ONE bank-wide
statement whose cost grows with the bank. Measured **read-only** against the
live fleet database on 2026-08-12 (`EXPLAIN (ANALYZE, BUFFERS)`, no writes):

| bank | cooc rows | the predicate, READ-ONLY |
|---|---|---|
| marko | 60,890 | 3.4 s |
| finn | 159,076 | 8.2 s |
| klanker | 463,301 | not measured |
| **overlord** | **517,475** | **65,168 ms** |

65.2 s is already past the 60 s asyncpg `command_timeout` **before** the sort,
the `FOR UPDATE` locks and the DELETE are added — #4604 measured the real
statement at 114,836 ms.

Because that cost **grows with the bank**, this worked until it did not — and
an earlier revision of this PR said "has never once finished", which is false.
From `async_operations` over the 30 days to 2026-08-12:

| bank | week | completed / total | p50 | p95 |
|---|---|---|---|---|
| overlord | 07-13 | 45 / 45 | 15.4 s | 27.2 s |
| overlord | 07-20 | 493 / 493 | 25.9 s | 47.7 s |
| overlord | 07-27 | 305 / 305 | 32.9 s | 68.2 s |
| **overlord** | **08-03** | **5 / 22** | **561.9 s** | **796.1 s** |
| **overlord** | **08-10** | **1 / 3** | **560.0 s** | **560.0 s** |
| klanker | 07-13 | 33 / 33 | 42.6 s | 53.3 s |
| klanker | 07-20 | 268 / 268 | 51.1 s | 69.9 s |
| klanker | 07-27 | 473 / 473 | 31.3 s | 53.6 s |
| **klanker** | **08-03** | **5 / 14** | **558.6 s** | **561.8 s** |

overlord completed **849** runs in the window and klanker **779**. What is true
is the *onset*: p50 climbed all through July, crossed the 60 s wall in the week
of **2026-08-03**, and both banks have failed the overwhelming majority of runs
since — 17 of 22 then 2 of 3 (overlord), 9 of 14 (klanker) — leaking stale
cooccurrence rows on every failure. The 560 s p50 in those weeks is #4604's
retry storm wall-clock, not one statement.

Corroborated in the pg0 log inside `switchroom-hindsight`:
`postgresql-2026-08-10.log` carries 39 × `ERROR: canceling statement due to
user request`, ~60 s apart, 18:03:07–18:42:36 UTC, matching failed operation
`57544ebd`.

The mechanism, from the plan: `SetOp Intersect` reads **both** entities' full
unit sets and does not short-circuit — mean 121.1 + 287.2 rows per pair ×
517,475 pairs ≈ 211M index tuples, 98,904,258 shared-buffer hits — to find
**1,363** stale rows. A 0.26% yield for a whole-bank scan, and the scan grows
with the bank while the yield does not.

#4604 removed the 9× retry storm around this statement and the blank
`error_message` it hid behind. It deliberately did **not** make the statement
finish. This PR does.

## What changed

Three mechanisms, each with exactly one job. All of it lands as a new
anchor-and-replace block in `docker/Dockerfile.hindsight` (upstream Hindsight
ships as a pinned image, not vendored source), placed after the #4604 block
because it anchors on that block's replacement text.

**B1 — bounded keyset pages bound the STATEMENT.**
`prune_stale_cooccurrences` now sweeps one page of at most `batch_size`
cooccurrence rows per call and returns the page's last key as the cursor for
the next. `LIMIT $6` caps predicate evaluations per statement — a bound that
does not mention the size of the bank, which is what "no statement can exceed
the timeout on a bank of any size" actually requires. Each page runs in its own
transaction: a page that times out cannot roll back the pages that already
committed, the ordered row locks are held for one page rather than one bank,
and B3 is possible at all.

**B2 — a clock-rotating hash slice bounds the COST PER RUN, and HOW MANY
SLICES IS DERIVED FROM BANK SIZE.** Each run sweeps one slice, chosen by
`int(time.time()) // 120 % slice_count`. Stateless by construction: the slice
index is a pure function of wall time, so there is no persisted cursor, no new
table, no alembic revision, and nothing to corrupt or resume after a restart.

The slices **partition** the bank because the filter is a function of **one
deterministic column value per row**, so exactly one `slice_index` matches each
row. (An earlier revision said this was because "every row has exactly one
`entity_id_1`" — that is not the reason; `entity_id_2` partitions equally well.
`entity_id_1` is chosen for **locality** — it is the leading column of the scan
and lock order, so a slice is a set of contiguous index ranges rather than a
scatter across the whole index — and because the bank join is already
`ON e.id = c.entity_id_1`.)

`slice_count = clamp(ceil(rows / 25,000), 1, 24)`, from a `count(*)` the sweep
runs once per bank per run (measured 93 ms on the largest bank — a parallel seq
scan + hash join, cheap enough to pay once).

**This corrects an earlier version of this PR, which used a fixed 24 and priced
it as "24 consecutive runs cover it exactly once each ≈ one ~12 h rotation at
the 30-minute job cadence". That cadence does not exist.** `graph_maintenance`
is **demand-driven**: `submit_async_graph_maintenance` fires when work is
enqueued (retain / delete / edit) and short-circuits with `no_work=True` on an
empty queue — there is no timer anywhere in the codebase, and
`src/hindsight-watch/thresholds.ts:1039` already says so. A bank is therefore
visited as often as it is *written to*, and because the slice index is derived
from the clock rather than from a per-bank cursor, coverage is
**coupon-collector, not a cycle**: expected runs to cover N slices is
`N·H(N)`, ≈ 91 for N = 24, not 24.

**A DRAW IS A DISTINCT `_SWEEP_SLICE_SECONDS` WINDOW, NOT A RUN — and that is
why the window is now 120 s, not 1800 s.** Two runs inside the same window
compute the *same* slice index, so the second one re-sweeps exactly what the
first just swept. `_SWEEP_SLICE_SECONDS = 1800` was the last surviving piece of
the same "a run arrives every 30 minutes" model this PR abandoned when deriving
the slice *count*. Measured, it cost most of the busy banks' work:

| window | runs per window (overlord / klanker) | duplicate runs | mean days to full coverage |
|---|---|---|---|
| 1800 s | 3.95 / 3.60 | 74.7% / 72.3% | 2.49 / 2.19 |
| 300 s | 1.67 / 1.50 | 40.3% / 33.3% | 1.58 / 1.24 |
| **120 s** | **1.33 / 1.21** | **25.5% / 18.3%** | **1.27 / 1.10** |
| 60 s | 1.17 / 1.09 | 15.7% / 9.5% | 1.21 / 0.91 |

120 s is not arbitrary: the only thing this constant has to beat is the
**inter-arrival distribution**, and the median gap between consecutive runs is
**197 s (overlord) / 250 s (klanker)** — so 120 s is the largest round value
that puts a *typical* consecutive pair in different windows. 60 s buys little
more on the two banks that matter and is non-monotonic on some small ones,
where the whole rotation collapses to 3–6 minutes and can alias against the
worker's own cadence. **Which banks wobble is snapshot-dependent** — the ones
this PR originally named (carrie, assistant) are monotone in an independent
reviewer's snapshot, where overlord and marko wobble instead. The effect is
real and reproduced by two people on different data; treat the *specific bank
names* as an artefact of the window sampled, not as fixed evidence. Nothing
but decorrelation depends on this constant.

Coverage, recomputed on that basis (an earlier revision of this table labelled
its first column "days/visit"; the arithmetic was `24 / runs-per-day`, i.e. a
per-*slice* revisit period under a fixed 24, not days between visits to the
bank — relabelled and rebased on distinct windows):

| bank | slices | runs/day | draws/day (distinct 120 s windows) | full coverage @ fixed 24 | @ size-derived | measured replay |
|---|---|---|---|---|---|---|
| overlord | 21 | 28.9 | 21.8 | 4.2 d | 3.5 d | **1.3 d** |
| klanker | 19 | 26.3 | 21.6 | 4.2 d | 3.1 d | **1.1 d** |
| finn | 7 | 9.4 | 7.6 | 12.0 d | 2.4 d | 0.6 d |
| carrie | 6 | 8.3 | 6.6 | 13.7 d | 2.2 d | 0.8 d |
| marko | 3 | 5.2 | 4.8 | 18.8 d | 1.1 d | 0.7 d |
| assistant | 4 | 3.0 | 2.4 | 38.4 d | 3.5 d | 1.4 d |
| gymbro | 1 | 1.8 | 1.6 | 58.0 d | 0.5 d | 0.5 d |
| ziggy | 1 | 0.77 | 0.70 | 130 d | 1.3 d | 1.3 d |
| reggie | 1 | 0.70 | 0.70 | 130 d | 1.4 d | 1.4 d |
| lawgpt | 1 | 0.30 | 0.30 | 303 d | 3.3 d | 3.3 d |

"@ size-derived" is `N·H(N) / draws-per-day` for a sliced bank and simply
`1 / runs-per-day` for `slice_count = 1` (a whole-bank sweep does not depend on
the slice index, so every run covers it — windows are irrelevant there).
"measured replay" drops the uniform-draw assumption entirely and replays the
real 30-day arrival log, taking the mean over every start point of the time to
touch all N slices.

The sting the fixed 24 would have caused: the quiet banks **never had the
timeout**. Their whole-bank Pass 3 finishes in 2.7–4.3 s and was fully swept on
every single run. A fixed 24 would have moved them to a 12–303 day expected
coverage latency to fix a fault they did not have. Size-derived, every bank at
or below 25,000 rows keeps `slice_count = 1` and is still swept **whole, every
run** — behaviour identical to today — while the two banks that actually time
out get 21 and 19 slices.

**B3 — adaptive shrink removes the last unbounded term.** A page's cost is
`batch_size` × the degrees of its two entities, and entity degree is bounded by
nothing: the largest on this fleet is **32,730** `unit_entities` rows (mean
7.3, p99.9 618). A page landing entirely inside one hub entity is the one shape
that could still exceed the timeout at 1000. On a timeout the sweep **halves**
the page and retries the **same** cursor, floor 50 — at most 5 halvings. Without
it, one pathological page would fail its slice on every rotation for ever,
which is exactly the failure this PR exists to remove.

## Before / after, measured

| | before | after |
|---|---|---|
| worst single statement, overlord | **65,168 ms read-only** / 114,836 ms real — over the 60 s timeout | **1,304 ms** (measured, 3 sampled slices) |
| whole-bank replay as pages, 2000/page | n/a | 259 pages, 517,475 rows, 1,363 stale, 63,616 ms total, **max page 4,322 ms**, avg 245.6 ms |
| per run (one 1/21-scale slice on overlord, batch 2000) | the whole bank, and it never finished | **3,152 / 3,830 / 5,935 ms** |
| slice balance, overlord | n/a | largest 23,359 rows vs 19,903 mean |
| outcome | fails ~90% of runs on the 2 largest banks since 2026-08-03 (17/22 then 2/3 overlord, 9/14 klanker) | completes |

Measured, not inferred: every number above is `EXPLAIN (ANALYZE, BUFFERS)` or
`clock_timestamp()` output from a **read-only** replay against the live
database — the "after" replay used `SELECT`-only page queries with the real
predicate, no DELETE. Inferred, and stated as such: that the shipped DELETE
adds the same relative overhead to a 1000-row page as it does to a whole-bank
statement.

The default ships at `batch_size = 1000`, and "half of 2000, so 4,322 ms is a
conservative ceiling" was the wrong description — halving the batch does not
halve the sweep. Re-measured read-only across batch sizes on the largest bank,
whole-slice time is **flat** and only the per-statement latency moves:

| batch | total slice time | worst single page |
|---|---|---|
| 200 | 4.9 s | 229 ms |
| 500 | 4.6 s | 445 ms |
| 1000 | 4.3 s | 578 ms |
| 2000 | 5.0 s | — |
| 4000 | 5.0 s | — |

So `batch_size` is a **per-statement latency knob, not a throughput knob**:
1000 buys ~135x headroom against the 60 s `command_timeout` at no measurable
cost in total sweep time. Kept at 1000, with the rationale now in the shipped
design banner rather than asserted.

## How the worst case is bounded — mechanism, not observation

- **Per statement.** `LIMIT batch_size` caps predicate evaluations at
  `batch_size` regardless of bank size; cost ≤ `batch_size × (deg(e1) +
  deg(e2))` index tuples. The bound is structural, not "it happens to pass
  today".
- **The residual term** is entity degree, and B3 closes it: a page that exceeds
  the timeout for any reason halves and retries, so the sweep cannot wedge.
- **Termination is proven, not hoped for.** The cursor is set to the MAX key of
  a page whose own predicate is `> the previous cursor`, so it strictly
  advances. `_SWEEP_MAX_PAGES = 2000` is a corruption tripwire that logs and
  breaks, not a work limit.
- **Zero-UUID cursor sentinel is safe** because of
  `entity_cooccurrence_order_check CHECK (entity_id_1 < entity_id_2)`: the only
  row a strict `> (0…0, 0…0)` could skip is the row whose key is exactly
  `(0…0, 0…0)`, and that row cannot exist.

## What I deliberately did NOT do — and why it contradicts the brief

The brief asked for a **watermark** scoped to entities touched since the last
successful run, plus a periodic full sweep. I dropped the watermark and kept
only the (now rotating) full sweep. The brief invited this argument, so here it
is:

1. **Nothing existing can serve as the watermark.**
   `graph_maintenance_queue` stores `(bank_id, unit_id, enqueued_at)` and Pass 1
   DELETEs rows as it drains them; `entity_cooccurrences.last_cooccurred` only
   moves on upsert. A watermark needs a NEW durable record of "entities whose
   unit membership changed" — a new table and a migration.
2. **It would need every deletion path to enqueue.** A cooccurrence goes stale
   when a unit witnessing both entities is deleted; any removal path that failed
   to enqueue would leak **silently and for ever**. That is the exact risk the
   brief flagged.
3. **The brief itself concedes the full sweep must stay.** So the watermark is
   strictly *additional* machinery bolted onto the thing that actually fixes the
   fault.
4. **The rotating slice has zero missed-path exposure.** Every row is swept
   exactly once per rotation, whatever code path deleted its witnessing unit —
   so the enumeration in (2) is not needed for correctness.

The price is **prune latency**: on a bank large enough to be sliced, a stale
row now survives up to one rotation instead of up to one run. Because the job
is demand-driven that is a distribution, not a constant — the table above puts
expected full coverage at **0.5–3.5 days** across the fleet (0.5–3.3 measured
by replaying the real arrival log), worst case lawgpt at 3.3 d — which is
`slice_count = 1`, i.e. bounded by how rarely the bank is written to at all,
not by slicing. The largest sliced bank, overlord, is 3.5 d expected / 1.3 d
measured. For a sweep upstream itself documents as *defensive* — Pass
2's FK cascade already covers the missing-entity case; this pass only catches
the stale-count case — trading a few days of latency on the largest banks for a
job that completes at all is the right trade. On those banks it completes
never today, so any bounded latency is a strict improvement; and on the banks
that were already completing, `slice_count = 1` means nothing changes.

**Second contradiction: the cheaper-predicate hypothesis was tested and
rejected.** The brief said a rewritten predicate would be a better answer than a
watermark if it made the full sweep fit. A correlated `NOT EXISTS`/`EXISTS`
semi-join — which *should* short-circuit at the first witnessing unit for the
99.74% live rows — measured **65,555 ms, no better**. At bank scale the planner
abandons the nested loop and hash-joins all 1,728,498 `unit_entities` rows,
producing 65,529,799 candidate rows filtered by a correlated subplan. This
empirically confirms the upstream #2473 "don't simplify it back" comment. The
predicate is not the lever; batching is — so the #2473 `INTERSECT` predicate
**body** and the #2529 ordered lock ship byte-for-byte unchanged, and the patch
asserts both at build time. To be precise, since an earlier version of this
paragraph overclaimed: the `NOT EXISTS ( ... INTERSECT ... )` body is
byte-for-byte; the `victims` CTE **around** it is materially rewritten (page
CTE, keyset predicate, slice filter, `LIMIT $6`).

**Also deferred, on single-concern grounds:** env-var tuning knobs. Exposing
`batch_size` / slice count would mean touching `config.py` in four places AND
`src/setup/hindsight-perf-defaults.ts`'s allowlist plus its tests. They ship as
module constants.

## Tests, and the mutation evidence

`tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts` — RED/GREEN
behavioural probe, now in **two arms**, because they prove different things.

**Arm 1, the loop arm.** Applies the patch blocks into a throwaway container
from the pinned upstream image and drives the **real** modules: real
`PostgreSQLOps.prune_stale_cooccurrences` against a fake connection capturing
SQL and bound params, and the **real** `run_graph_maintenance_job` against a
fake store recording every Pass 3 call. It asserts properties no grep can see:
that the caller actually **loops**, that the cursor strictly **advances**, that
the shrink retries the **same** cursor, that consecutive ticks visit every
slice, that `slice_count` is really derived from the bank size the job measured
(and that a 25,000-row bank gets `slice_count = 1`, `slice_index = 0` — swept
whole), that the `_SWEEP_MAX_PAGES` tripwire actually **fires** on a store that
never runs out of pages, and that only a **short** page ends the slice (a page
that deleted nothing does not).

**Arm 2, the SQL arm — new, and the one that matters.** A fake connection can
never prove a SQL property, so arm 1 could only ever *grep* the slice filter.
That is not enough: reviewer-supplied mutation

```sql
AND 0 * ('x' || substr(md5(c.entity_id_1::text), 1, 4))::bit(16)::int
    % $4::int = $5::int
```

contains **every substring** the string checks look for, collapses the entire
bank into slice 0, destroys the sweep — and was **green, exit 0, 52 passed**.

So the SQL arm captures the statement the real shipping
`PostgreSQLOps.prune_stale_cooccurrences` builds and **executes** it against a
real PostgreSQL (digest-pinned `postgres@sha256:9a8afca5…`, joined to the
hindsight container's netns), on a seeded 9,564-row two-bank fixture where
every 3rd pair is witnessed and the rest are stale. Twelve checks, every one a
count Postgres computed:

`SQL_captured_from_shipping_code`, `SLICES_COVER_THE_BANK_EXACTLY_ONCE`,
`SLICES_ARE_NONEMPTY`, `SLICE_IS_A_PROPER_SUBSET`, `SLICES_ARE_BALANCED`,
`SLICE_COUNT_1_IS_THE_WHOLE_BANK`, `DELETES_EXACTLY_THE_STALE_ROWS`,
`WITNESSED_ROWS_SURVIVE`, `OTHER_BANKS_UNTOUCHED`, `PAGES_TILE_THE_SLICE`,
`CURSOR_STRICTLY_ADVANCES`, `PAGING_TERMINATES`.

Per the "fixture and expectation share a constant" defect: every expected number
is a **hard-coded literal**, and the probe separately asserts the module
constants equal those literals. Changing a constant turns the test red on
purpose — verified:

| mutation | patch still builds? | probe |
|---|---|---|
| `_SWEEP_MAX_SLICE_COUNT` 24 → 12 | yes | **RED** — `C_max_slice_count`, `S_slice_count_is_capped`, `S_largest_live_bank_is_21` |
| `_SWEEP_MIN_BATCH_SIZE` 50 → 100 | yes | **RED** — `C_min_batch_size`, `B3_halving_sequence` (`[1000, 500, 250, 125, 100]`) |
| **the partition mutation above** (`AND 0 * (…)`), *with the build-time string pin edited to match it*, i.e. every benefit a textual guard can give it | yes | **RED** — `SLICES_ARE_NONEMPTY`, `SLICE_IS_A_PROPER_SUBSET`, `SLICES_ARE_BALANCED`; slice counts `[9564, 0, 0, …]` |
| the partition mutation *without* editing the pin | **no** — build assert fires: *"the slice filter is not the exact whole expression this patch ships"* | n/a |
| **page CTE `ORDER BY` deleted** (new guard) | **no** — build assert fires: *"the page CTE's `ORDER BY …` + `LIMIT $6::int` pair is not the exact two lines this patch ships"* | `dockerfile-hindsight-bakes.test.ts` also **RED** (1 failed / 46 passed) |
| **victims CTE `ORDER BY` deleted** (new guard) | **no** — build assert fires: *"the sweep no longer has BOTH ordered scans"* | n/a |
| **`LIMIT $6::int` → `LIMIT $6::int + 1`** (new guard) | **no** — same whole-line assert fires; the old `"LIMIT $6::int" in sweep` substring check passed this | n/a |
| **`slice_count` / `slice_index` bind order swapped** | yes | **RED** — `B1_params_are_positional` (`got ('bank-x', 'cur1', 'cur2', 5, 24, 250)`). The old membership check `24 in params and 5 in params` was **green** on this, and so is the SQL arm (it binds its own params) — the mutation makes the filter `% 5 = 24`, never true, so the sweep would delete nothing for ever on every sliced bank |
| **M4: victims CTE `ORDER BY` deleted AND an identical line re-added elsewhere in the statement** (round-3 guard) | **no** — build assert fires: *"the victims CTE's `ORDER BY …` is no longer ADJACENT to its `FOR UPDATE OF c`"*. The `count == 2` assert is **green** on this mutation, which is exactly why the adjacency pin exists: the count cannot distinguish an ordered lock from an unordered one | n/a (build never completes) |
| `async with conn.transaction():` removed from `_run_page` | **no** — build assert fires: *"each page must be its OWN transaction"* | `dockerfile-hindsight-bakes.test.ts` also **RED** (1 failed / 46 passed) |

And the headline mutation, the whole patch removed: **RED against unpatched
upstream** — `B1_call_accepts_paging_args` (`unexpected keyword argument
'slice_count'`), `B2_pages_more_than_once` (*made 1 Pass 3 call, expected 3*),
`B3_halving_sequence`. Both directions assert a `PROBE_EXECUTED` sentinel so a
probe that dies early can never read as a pass.

`tests/docker/dockerfile-hindsight-bakes.test.ts` gains a structural guard
(including that the new block sits **after** the #4604 block, since it anchors
on that block's output). The new probe is registered in the `hindsight:`
paths-filter in `.github/workflows/docker-e2e.yml`.

**Local run, with the exact conditions** (an earlier revision claimed an
unqualified "0 failed", which was only true because the original run had
`SWITCHROOM_HINDSIGHT_BUILT_IMAGE` set):

- `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 npx vitest run
  tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
  tests/docker/dockerfile-hindsight-bakes.test.ts` → **56 passed (56)**
  (bakes 47; bounded-sweep 9 — RED arm 31.2 s, GREEN arm 8.4 s, SQL arm 5.1 s).
- `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 npx vitest run tests/docker/
  tests/ci-e2e-ok-verdict.test.ts` with **no** `SWITCHROOM_HINDSIGHT_BUILT_IMAGE`
  → **3 failed | 633 passed | 35 skipped** (rerun after the rebase onto
  `origin/main`). All three are outside this change:
  - `hindsight-reranker-priority-patch.test.ts:518` and
    `hindsight-work-conserving-admission-patch.test.ts:738` hard-fail *by
    design* — they require a through-built `docker/Dockerfile.hindsight` image
    exported as `SWITCHROOM_HINDSIGHT_BUILT_IMAGE`, which CI's
    `hindsight-probe` job builds and a bare local run does not.
  - `compose-generator.test.ts:346` ("default containerNamePrefix preserves the
    production fleet label", `expected 5 to be 4`) is **environment-dependent,
    and does NOT reproduce everywhere** — an independent reviewer got 223/223
    green on both `main` and this head. Root cause found while rebasing and
    filed as **#4637**: the test omits `voiceEngine`, so `generateCompose`
    falls back to `loadHostCapabilities()` (`src/agents/compose.ts:1464`) and
    reads `~/.switchroom/host-capabilities.json`. On a host whose persisted
    verdict is `local` the optional `voice-sidecar` service is emitted
    (`src/agents/compose.ts:2024`) and the fleet-label count is 5 instead of 4.
    A latent bug in the test, unrelated to this PR — do not go hunting it on
    `main`, it will pass there in most environments.
- `npm run lint` → exit 0.

## Rebase onto `origin/main` (round 3)

Rebased past `87c2180d` (#4623) and `e5e663ea` (#4628). One textual conflict —
`CHANGELOG.md`, the usual shared insertion point — resolved by keeping **both**
sides in file order (main's two #4628 entries, then this PR's).

`.github/workflows/docker-e2e.yml` is touched by both PRs and auto-merged; it
was checked by hand rather than trusted, because #4628 changes what a *skip*
means. Verified on the merged file: the bounded-sweep run step survives with
`SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"` (docker-e2e.yml:552-567), the probe's
test file is still in the `hindsight` path filter (:157) so
`needs.changes.outputs.hindsight` goes true whenever it changes, the
digest-pinned Postgres pull step survives (:422), and the label-scoped teardown
still names `hindsight-graph-maintenance-bounded-sweep` (:758). #4628's new
"skipped when it had to run ⇒ FAILURE" rule therefore cannot green-skip this
probe.

One **semantic** conflict the textual merge could not see: #4628 converted all
18 existing probe runners off `execFileSync` onto the awaited
`tests/docker/_exec-async.ts`, because a sync exec blocks the vitest worker's
event loop and vitest 3.2.4's worker→main birpc has a hard-coded 60 s timeout
(`Timeout calling "onTaskUpdate"`, all tests passing, exit 1). This probe was
authored in parallel, merged clean, and was still sync — and it is the heaviest
file in the suite (two hindsight containers plus a Postgres). All its long legs
now await `execFileAsync`; the `pg_isready` poll's `execFileSync("sleep")` is an
awaited timer; the label-scoped `afterAll` teardown belts stay sync, matching
the sibling retry-storm probe on main.

## Risk

- Prune latency rises to ≤ 1 rotation **on banks large enough to be sliced**
  — expected 0.5–3.5 days across the fleet, given the demand-driven cadence.
  Banks at or below 25,000 rows are unaffected (`slice_count = 1`, swept whole
  every run). Stated above; deliberate.
- Slice balance depends on `md5` spreading `entity_id_1` — measured on the
  worst-case bank (largest slice 23,359 vs 19,903 mean).
- The Oracle path keeps upstream's single statement and returns `scanned=0`,
  terminating the loop after one call — behaviour identical to before. Same
  deliberate dialect asymmetry as the existing #2529 note in that file.
- Not in scope, **filed**: `unit_entities` shows 26.5M + 67.3M **Heap Fetches**
  on its index-only scans, i.e. a stale visibility map (`relallvisible` 36.3 %
  on `entities`, 62.8 % on `unit_entities`). Autovacuum tuning there would cut
  this sweep's cost again, independently of this change — #4634.
- Not in scope, **filed**: the CI-run guard added by this PR
  (`hindsight-graph-maintenance-bounded-sweep.test.ts:1042`) discovers its own
  subject by grepping for the same string it asserts, so a one-character typo
  in a probe both de-registers it from the check and makes its own `REQUIRED`
  flag permanently false. Only this one file is hard-pinned; the other 18 are
  not. Durable fix is a set-identity assertion against the
  `hindsight-*.test.ts` glob with a named allowlist, which also catches the
  reverse drift nothing checks today — #4636.
- Not in scope, **filed**: upstream's outer `retry_with_backoff(...,
  max_retries=8)` restarts a slice from cursor `None` on a retryable
  non-timeout error, so up to 9x wasted (idempotent) work. Collapsing the two
  budgets means changing a wrapper shared with Passes 1 and 2 — #4635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



