### PR TITLE
fix: two correctness fixes — vacuous root-only test guards, and a timezone-less finding timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ now an anomaly worth investigating, not the norm.
   now await a small `execFileAsync` helper (`tests/docker/_exec-async.ts`)
   that keeps the loop turning, so the RPC reply is read as it arrives. No
   retry was added: a retry would equally hide a real hang.
+- **fleet-health: a gateway finding's timestamp is no longer read as local
+  time.** `detect.extractTs` lifted the ISO prefix off a gateway log line with
+  the `Z` designator OPTIONAL and handed the raw string to `Date.parse`, which
+  reads a designator-less timestamp as LOCAL time — a finding misdated by the
+  host's UTC offset (ten hours on the Melbourne host). That skewed
+  `recencyFactor` and, now that the ledger windows its findings, could shift one
+  across the window boundary. Every producer in the repo stamps UTC
+  (`stderr-timestamps.ts` uses `toISOString()`; the shell stamps use `date -u`),
+  so a designator-less line is now normalised to `Z` at the producer. An
+  explicit `+HH:MM` offset is preserved untouched.
+
 - **fleet-health: the ledger's `windowDays` now actually windows the
   findings.** `buildLedger` read `windowDays` but aggregated EVERY finding ever
   recorded into the dedup_key map — `count` and `reach` had no time filter, so

--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -4,6 +4,7 @@ import {
   parseTurns,
   detectTurnFindings,
   detectGatewayFindings,
+  extractTs,
   HANG_MS,
   SILENT_NOOP_FLOOR_TS,
 } from "./detect.js";
@@ -215,6 +216,71 @@ describe("detectGatewayFindings", () => {
         " detection is DISABLED until it exists and is readable.",
     ].join("\n");
     expect(detectGatewayFindings("alpha", quiet).gw_hits["orphaned-db-handle"]).toBe(0);
+  });
+});
+
+/**
+ * `extractTs` feeds `Finding.ts`, which `ledger.recencyFactor` and (since
+ * #4622) `ledger.withinWindow` both read through `Date.parse`. A timestamp with
+ * no zone designator is parsed as LOCAL time there, so it is not enough for the
+ * string to survive the regex — it has to name its zone by the time it leaves
+ * this module.
+ */
+describe("extractTs — a finding's timestamp always names its zone", () => {
+  it("returns the real gateway prefix verbatim (it is already UTC)", () => {
+    // The literal shape `stderr-timestamps.ts` writes: `toISOString()`, i.e.
+    // millisecond precision and a trailing Z. All ~2.5M timestamps in the live
+    // gateway logs look exactly like this.
+    expect(
+      extractTs("[2026-08-12T09:00:00.123Z] telegram gateway: tg-post status=err"),
+    ).toBe("2026-08-12T09:00:00.123Z");
+  });
+
+  it("normalises a designator-less timestamp to UTC instead of silently going local", () => {
+    // THE bug: `Date.parse('2026-08-12T09:00:00')` is LOCAL time, so on the
+    // fleet's +10:00 host this finding was dated 23:00Z the previous day — a
+    // ten-hour error in `recencyFactor`, and enough to move a finding across
+    // `withinWindow`'s boundary.
+    //
+    // The assertion is on the STRING, deliberately: it is host-independent, so
+    // it goes red on the bug on a UTC CI runner too. An assertion on the parsed
+    // INSTANT alone would only fail on a host whose offset is non-zero — a guard
+    // that passes for the wrong reason on half the machines that run it.
+    expect(extractTs("2026-08-12T09:00:00 gateway: represent duplicate-send")).toBe(
+      "2026-08-12T09:00:00Z",
+    );
+    // …and the normalised form is a real UTC instant.
+    expect(Date.parse(extractTs("2026-08-12T09:00:00 gw")!)).toBe(
+      Date.UTC(2026, 7, 12, 9, 0, 0),
+    );
+  });
+
+  it("normalises a designator-less timestamp WITH fractional seconds too", () => {
+    expect(extractTs("2026-08-12T09:00:00.500 gw: x")).toBe("2026-08-12T09:00:00.500Z");
+  });
+
+  it("leaves an EXPLICIT offset alone — appending Z would invent a 10h error", () => {
+    expect(extractTs("2026-08-12T19:00:00+10:00 gw: x")).toBe("2026-08-12T19:00:00+10:00");
+    // Same instant as 09:00Z — the offset is honoured, not overwritten.
+    expect(Date.parse(extractTs("2026-08-12T19:00:00+10:00 gw: x")!)).toBe(
+      Date.UTC(2026, 7, 12, 9, 0, 0),
+    );
+    expect(extractTs("2026-08-12T04:00:00-05:00 gw: x")).toBe("2026-08-12T04:00:00-05:00");
+  });
+
+  it("is still null for a line carrying no timestamp at all", () => {
+    // Undatable stays undatable — `withinWindow` KEEPS those rather than
+    // guessing an age, so inventing one here would be worse than none.
+    expect(extractTs("telegram gateway: tg-post method=getUpdates status=err")).toBeNull();
+  });
+
+  it("dates a gateway FINDING in UTC even when the line's prefix has no Z", () => {
+    // End to end through the real detector, not just the helper.
+    const { findings } = detectGatewayFindings(
+      "alpha",
+      `2026-08-12T09:00:00 gateway: represent duplicate-send tid=${CHAT}:_#42`,
+    );
+    expect(findings[0]?.ts).toBe("2026-08-12T09:00:00Z");
   });
 });
 

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -439,11 +439,42 @@ export function extractTurnId(line: string): string | null {
   return m ? m[0] : null;
 }
 
-/** Best-effort ISO-timestamp extraction from a gateway log line. Gateway lines
- *  are prefixed with an ISO-8601 timestamp; return it if present. */
+/**
+ * ISO-8601 instant, with the zone designator captured separately so a
+ * designator-less match can be told apart from a `Z` or an explicit offset.
+ */
+const ISO_TS_RE =
+  /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(Z|[+-]\d{2}:?\d{2})?/;
+
+/**
+ * Best-effort ISO-timestamp extraction from a gateway log line, ALWAYS returned
+ * as a zoned instant.
+ *
+ * Gateway lines are prefixed with an ISO-8601 timestamp by
+ * `telegram-plugin/stderr-timestamps.ts:29-31`, which stamps
+ * `new Date().toISOString()` — UTC with a literal `Z`, always. Verified against
+ * the 12 live `gateway-supervisor.log` files on the dev host: ~2.5M timestamp
+ * matches, every one `YYYY-MM-DDTHH:MM:SS.mmmZ`, none without. The shell-side
+ * stamps that reach the same log agree — `profiles/_base/start.sh.hbs:2456` and
+ * `docker/hindsight-autoheal.sh:110` both use `date -u …Z`.
+ *
+ * The designator stays OPTIONAL in the match, deliberately: a log-format change
+ * that dropped it must not silently stop dating findings (the same
+ * keep-the-signal posture as `ledger.withinWindow`'s undatable fallback). But a
+ * designator-less string is no longer returned as-is — `Date.parse` reads that
+ * as LOCAL time, so on this fleet's +10:00 host every such finding would be
+ * misdated by ten hours, skewing `recencyFactor` and able to shift a finding
+ * across `buildLedger`'s window boundary (#4622). Every producer in this repo
+ * writes UTC, so a designator-less line is UTC BY CONVENTION, and it is
+ * normalised here at the producer rather than left for each consumer to guess.
+ *
+ * An EXPLICIT offset (`+10:00`) is preserved untouched — it already names its
+ * zone, and appending `Z` to it would invent a ten-hour error.
+ */
 export function extractTs(line: string): string | null {
-  const m = line.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?/);
-  return m ? m[0] : null;
+  const m = line.match(ISO_TS_RE);
+  if (!m) return null;
+  return m[1] ? m[0] : `${m[0]}Z`;
 }
 
 /**

--- a/src/web/blocked-approvals.test.ts
+++ b/src/web/blocked-approvals.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, statSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  chmodSync,
+  statSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import {
   readBlockedApprovals,
   readBlockedApprovalsWithErrors,
@@ -16,6 +24,52 @@ import { deriveAttention, handleGetSummary } from "./api.js";
 // contract (writer picks the path, reader has to scan it); testing either half
 // alone is how it shipped broken.
 import { createBlockedApprovalStore } from "../../telegram-plugin/gateway/approval-hold.js";
+
+/**
+ * Does this process actually get told "no" by a file mode?
+ *
+ * uid 0 does NOT — root reads a 0000 file happily — and neither do some CI
+ * filesystems. A chmod-based guard is therefore VACUOUS for those runs, and the
+ * uid check it replaces was only ever a proxy for this question. Probe the real
+ * capability instead, and say so LOUDLY when it is absent, so a skipped guard
+ * can never be mistaken for a passing one.
+ *
+ * Only the two tests whose SUBJECT is real kernel mode enforcement use this.
+ * Every other unreadable-record case is driven by EISDIR (a directory named
+ * `<agent>.json`), which fails for every uid including root.
+ */
+function fileModesEnforced(): boolean {
+  const probeRoot = mkdtempSync(join(tmpdir(), "sr-mode-probe-"));
+  const probe = join(probeRoot, "probe");
+  try {
+    writeFileSync(probe, "x");
+    chmodSync(probe, 0o000);
+    try {
+      readFileSync(probe);
+      return false; // read succeeded through a 0000 mode — root, or a mode-less fs
+    } catch {
+      return true;
+    }
+  } finally {
+    try {
+      chmodSync(probe, 0o644);
+    } catch {
+      /* best effort */
+    }
+    rmSync(probeRoot, { recursive: true, force: true });
+  }
+}
+
+const MODES_ENFORCED = fileModesEnforced();
+if (!MODES_ENFORCED) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "blocked-approvals.test.ts: file modes are NOT enforced for this process " +
+      `(uid ${process.getuid?.() ?? "?"}) — the two guards that assert on a REAL ` +
+      "0600/0000 record are SKIPPED, not passing. Run the suite as a non-root uid " +
+      "to exercise them.",
+  );
+}
 
 /**
  * The blocked-approvals surface: an agent held on an approval it could not
@@ -162,8 +216,9 @@ describe("readBlockedApprovals (Telegram-independent view of a held agent)", () 
     expect(blocked[0].agent).toBe("overlord");
   });
 
-  it.skipIf(process.getuid?.() === 0)(
-    "degrades honestly on a real 0600/0000 file instead of exploding",
+  it.skipIf(!MODES_ENFORCED)(
+    "degrades honestly on a real 0600/0000 file instead of exploding " +
+      "(skipped when file modes are not enforced — e.g. running as root)",
     () => {
       writeFileSync(join(dir, "locked.json"), JSON.stringify(overlord));
       chmodSync(join(dir, "locked.json"), 0o000);
@@ -226,8 +281,9 @@ describe("readBlockedApprovals (Telegram-independent view of a held agent)", () 
       expect(unreadable).toBe(1);
     });
 
-    it.skipIf(process.getuid?.() === 0)(
-      "a real 0600 root-owned-style record counts as unreadable, not as absent",
+    it.skipIf(!MODES_ENFORCED)(
+      "a real 0600 root-owned-style record counts as unreadable, not as absent " +
+        "(skipped when file modes are not enforced — e.g. running as root)",
       () => {
         writeFileSync(join(dir, "locked.json"), JSON.stringify(overlord));
         chmodSync(join(dir, "locked.json"), 0o000);
@@ -330,39 +386,60 @@ describe("readBlockedApprovals (Telegram-independent view of a held agent)", () 
   // ───────────────────────────────────────────────────────────────────────────
   describe("the FALLBACK record (agent's own state dir) reaches the dashboard", () => {
     /**
-     * The production trigger, faithfully: the SHARED dir cannot be written by
-     * this uid. In prod that is docker auto-creating the bind source root-owned
-     * while the agent runs as uid 10001+. A test can't chown, and it can't just
-     * chmod the shared dir either — `tryWrite` chmods its own parent back to
-     * 1777, and in-test we OWN it, so that would succeed and no fallback fires.
-     * So make the shared dir UNCREATABLE by locking its parent (the pattern from
-     * telegram-plugin/tests/approval-hold-record.test.ts). Same `tryWrite` →
-     * false → fallback branch, no root required.
+     * The production trigger, faithfully: the SHARED dir cannot be WRITTEN by
+     * this uid (docker auto-creates the bind source root-owned while the agent
+     * runs as uid 10001+), while still being readable/enumerable by the web
+     * reader.
+     *
+     * This used to be simulated by `chmod 0500` on the shared dir's parent.
+     * **That guard was vacuous whenever the suite ran as root** — uid 0 ignores
+     * file modes, so the shared write SUCCEEDED and the fallback branch was
+     * never entered. `is written world-readable` and `clears both locations`
+     * then passed while describing the SHARED record, and the two tests that
+     * assert on the fallback PATH went red. Root is not exotic: it is how the
+     * fleet's debug container runs the suite.
+     *
+     * A filesystem artifact cannot replace the chmod either — anything planted
+     * in the shared dir to make the write fail is also seen by the READER and
+     * counted as an unreadable record, which is precisely what
+     * `unreadable === 0` below measures. So the EACCES is INJECTED (see
+     * `BlockedApprovalStoreDeps`): the store's real branch logic runs, the
+     * refusal is deterministic for every uid, and the shared dir stays a clean,
+     * honestly-empty directory from the reader's side.
      */
-    let locked: string; // read-only parent
-    let sharedDir: string; // the (uncreatable) shared dir under it
+    let sharedRoot: string; // stands in for `~/.switchroom`
+    let sharedDir: string; // its `blocked-approvals` — writes here are refused
     let agentsRoot: string; // its `agents` sibling — the fallback root
 
     beforeEach(() => {
-      locked = join(root, "locked");
-      sharedDir = join(locked, "blocked-approvals");
-      agentsRoot = join(locked, "agents");
+      sharedRoot = join(root, "held");
+      sharedDir = join(sharedRoot, "blocked-approvals");
+      agentsRoot = join(sharedRoot, "agents");
       mkdirSync(agentsRoot, { recursive: true });
     });
-    afterEach(() => {
-      try {
-        chmodSync(locked, 0o755);
-      } catch {
-        /* not every case locks it */
-      }
-    });
 
-    /** The real gateway store, pointed at the locked layout. */
+    /** EACCES in the shape the kernel raises it for a root-owned shared dir. */
+    function eacces(path: string): NodeJS.ErrnoException {
+      const e: NodeJS.ErrnoException = new Error(
+        `EACCES: permission denied, open '${path}'`,
+      );
+      e.code = "EACCES";
+      e.errno = -13;
+      e.syscall = "open";
+      e.path = path;
+      return e;
+    }
+
+    /** The real gateway store, with the SHARED write refused (uid-independent). */
     function heldStore(agent: string) {
       const ownDir = join(agentsRoot, agent);
       mkdirSync(ownDir, { recursive: true });
-      const s = createBlockedApprovalStore(sharedDir, agent, ownDir);
-      chmodSync(locked, 0o500); // shared dir now uncreatable — fallback territory
+      const s = createBlockedApprovalStore(sharedDir, agent, ownDir, {
+        writeFileSync: ((file, data, opts) => {
+          if (String(file).startsWith(sharedDir + sep)) throw eacces(String(file));
+          return writeFileSync(file, data, opts);
+        }) as typeof writeFileSync,
+      });
       return { store: s, ownDir };
     }
 
@@ -456,18 +533,18 @@ describe("readBlockedApprovals (Telegram-independent view of a held agent)", () 
     });
 
     it("counts an UNREADABLE fallback record rather than implying all-clear", () => {
+      // The 0600-mode trap, expressed as EISDIR: a DIRECTORY named
+      // `blocked-approval.json` is unreadable by `readFileSync` for EVERY uid,
+      // including root, and lands on the same non-ENOENT branch a real EACCES
+      // does. A `chmod 0000` here was vacuous-then-red under uid 0 — root reads
+      // a 0000 file, so the record surfaced as blocked and `unreadable` was 0.
       const s = store("overlord");
-      const f = join(s.ownDir, "blocked-approval.json");
-      writeFileSync(f, JSON.stringify(rec("overlord")));
-      chmodSync(f, 0o000); // the 0600-mode trap, in its extreme form
-      try {
-        const { blocked, unreadable } = readBlockedApprovalsWithErrors(dir);
-        expect(blocked).toEqual([]);
-        // "I could not look" — NEVER "nothing is blocked".
-        expect(unreadable).toBe(1);
-      } finally {
-        chmodSync(f, 0o644);
-      }
+      mkdirSync(join(s.ownDir, "blocked-approval.json"), { recursive: true });
+
+      const { blocked, unreadable } = readBlockedApprovalsWithErrors(dir);
+      expect(blocked).toEqual([]);
+      // "I could not look" — NEVER "nothing is blocked".
+      expect(unreadable).toBe(1);
     });
   });
 });

--- a/telegram-plugin/gateway/approval-hold.ts
+++ b/telegram-plugin/gateway/approval-hold.ts
@@ -233,6 +233,34 @@ export function safeActionForRecord(
     : naturalAction(toolName, undefined)
 }
 
+/**
+ * The one fs call whose FAILURE selects the fallback branch, injectable.
+ *
+ * The production trigger is "the shared dir is not writable by this uid" — and
+ * that is exactly the condition a test cannot create for itself, because a test
+ * run as **root ignores file modes**. The suite runs as uid 0 in the fleet's
+ * debug container (and in any `docker run` without `--user`), where a
+ * `chmod 0500` on the parent is a no-op: the shared write SUCCEEDS, the fallback
+ * branch is never taken, and every assertion about the fallback record silently
+ * describes the SHARED record instead. Two tests passed that way for real
+ * (`is written world-readable`, `clears both locations`) — vacuous guards that
+ * report coverage they do not provide.
+ *
+ * A filesystem artifact can't fix that either: anything planted in the shared
+ * dir to make the write fail (an `<agent>.json` DIRECTORY → EISDIR, a symlink →
+ * the lstat guard below) is also visible to the READER, which then counts it as
+ * an unreadable record — changing the very thing the test measures. So the
+ * refusal is injected instead: the real `write()` branch logic, the lstat guard,
+ * the fallback selection, the stale-unlink and the stderr log all still run.
+ *
+ * Production callers never pass this.
+ */
+export interface BlockedApprovalStoreDeps {
+  /** Defaults to `node:fs`'s. Tests substitute one that throws EACCES for the
+   *  shared path, reproducing a root-owned bind under a per-agent uid. */
+  writeFileSync?: typeof writeFileSync
+}
+
 export interface BlockedApprovalStore {
   /** Write (or replace) the blocked record for this agent. */
   write(rec: BlockedApprovalRecord): void
@@ -288,7 +316,10 @@ export function createBlockedApprovalStore(
    *      which must stay in sync with the filename below).
    */
   fallbackDir?: string,
+  /** Test-only fs seam — see {@link BlockedApprovalStoreDeps}. */
+  deps: BlockedApprovalStoreDeps = {},
 ): BlockedApprovalStore {
+  const write_ = deps.writeFileSync ?? writeFileSync
   const primary = join(dir, `${agent}.json`)
   // Keep in sync with FALLBACK_RECORD_NAME in src/web/blocked-approvals-read.ts —
   // the reader matches this filename exactly. Pinned by the fallback-contract
@@ -324,7 +355,7 @@ export function createBlockedApprovalStore(
       if (dirMode != null) {
         try { chmodSync(parent, dirMode) } catch { /* not ours to chmod */ }
       }
-      writeFileSync(target, body, { encoding: 'utf-8', mode: BLOCKED_APPROVAL_FILE_MODE })
+      write_(target, body, { encoding: 'utf-8', mode: BLOCKED_APPROVAL_FILE_MODE })
       chmodSync(target, BLOCKED_APPROVAL_FILE_MODE)
       return true
     } catch {

--- a/telegram-plugin/tests/approval-hold-record.test.ts
+++ b/telegram-plugin/tests/approval-hold-record.test.ts
@@ -128,17 +128,30 @@ describe('blocked-approval record — the off-Telegram surface', () => {
   // meant the whole feature was a silent no-op in production.
   it('falls back to the agent\'s own state dir when the shared dir is not writable', () => {
     // Simulate the production failure: Docker auto-created the bind source as
-    // root:root, so this agent's uid can neither create the dir nor chmod it.
-    // Modelled as a read-only PARENT — the store can't mkdir the shared dir
-    // inside it, and can't chmod its way out either.
-    const readOnlyParent = join(root, 'root-owned')
-    mkdirSync(readOnlyParent, { recursive: true })
-    chmodSync(readOnlyParent, 0o555) // r-xr-xr-x
-    const unwritable = join(readOnlyParent, 'blocked-approvals') // cannot be created
+    // root:root, so this agent's uid cannot write inside it.
+    //
+    // This used to be modelled as a read-only PARENT (`chmod 0555`). uid 0
+    // IGNORES file modes, so under root the shared write SUCCEEDED, the fallback
+    // branch was never taken, and this test went red for the wrong reason (the
+    // suite runs as root in the fleet's debug container). Inject the EACCES
+    // instead — deterministic for every uid, and every branch of the real
+    // `write()` still runs.
+    const unwritable = join(root, 'root-owned', 'blocked-approvals')
     const ownDir = join(root, 'agent-state')
     mkdirSync(ownDir, { recursive: true })
 
-    const store = createBlockedApprovalStore(unwritable, 'overlord', ownDir)
+    const store = createBlockedApprovalStore(unwritable, 'overlord', ownDir, {
+      writeFileSync: ((file, data, opts) => {
+        if (String(file).startsWith(unwritable)) {
+          const e: NodeJS.ErrnoException = new Error(
+            `EACCES: permission denied, open '${String(file)}'`,
+          )
+          e.code = 'EACCES'
+          throw e
+        }
+        return writeFileSync(file, data, opts)
+      }) as typeof writeFileSync,
+    })
     store.write(REC)
 
     // The record MUST exist somewhere — never silently lost.


### PR DESCRIPTION
Two small, independent correctness fixes. One branch, two commits — the diffs
touch disjoint files (`src/web` + `telegram-plugin/gateway/approval-hold.ts` vs
`src/fleet-health`), neither is large, and each commit stands alone, so
splitting into two PRs would cost a review round without buying isolation.

## 1. `blocked-approvals.test.ts` — guards that could not fail as root

Four guards on the blocked-approval FALLBACK contract were driven by a `chmod`
that uid 0 ignores. **Two passed vacuously** under root: `is written
world-readable` and `clears both locations` both describe the FALLBACK record,
but with root ignoring the `0500` parent the shared write SUCCEEDED, the
fallback branch was never entered, and both assertions silently described the
SHARED record instead. Deleting the fallback's `0644` chmod, or the fallback leg
of `clear()`, left both GREEN. The other two went RED under root for the wrong
reason. The fleet's debug container runs the suite as root, so this is not an
exotic configuration.

Fixed per guard, not with one blanket approach:

- **Injected refusal** (`BlockedApprovalStoreDeps.writeFileSync`) for the
  "shared dir not writable" trigger. A filesystem artifact cannot do this job:
  anything planted in the shared dir to make the write fail is also seen by the
  READER and counted as an unreadable record — which is exactly what
  `unreadable === 0` measures in the same test. The injected `EACCES` leaves
  every branch of the real `write()` running (lstat guard, fallback selection,
  stale unlink, stderr log), for every uid. Production is unchanged: `deps`
  defaults to `node:fs`'s `writeFileSync` and no production caller passes it.
- **EISDIR** for the unreadable FALLBACK record — a directory named
  `blocked-approval.json` is unreadable for every uid including root, on the
  same non-ENOENT branch a real EACCES takes. The same idiom this file already
  uses for the shared-dir cases.
- **A probed, loud skip** for the two guards whose SUBJECT is real kernel mode
  enforcement: the uid proxy is replaced by an actual capability probe, the
  reason is in the test name, and a warning goes to stderr. A skip that cannot
  be mistaken for a pass.

`telegram-plugin/tests/approval-hold-record.test.ts` carried the same
root-broken `chmod 0555` simulation and is fixed the same way.

**Red-then-green, verified as root**, by breaking each behaviour in turn:

| break | new test | old test (origin/main) |
|---|---|---|
| fallback written `0600` | RED `expected +0 to be 4` | **GREEN — the vacuity** |
| `clear()` drops the fallback | RED `expected [ { agent: 'overlord' … } ] to deeply equal []` | **GREEN — the vacuity** |
| reader stops counting non-ENOENT fallback read errors | RED `expected +0 to be 1` | RED |
| reader drops the fallback scan | RED `expected [] to deeply equal [ 'overlord' ]` | RED |

## 2. `extractTs` accepted a timezone-less timestamp

`src/fleet-health/detect.ts:442` matched the gateway line's ISO prefix with `Z`
OPTIONAL and returned the raw match. `Date.parse` reads a designator-less ISO
string as LOCAL time, so such a finding was misdated by the host's UTC offset —
ten hours here. That skews `recencyFactor`, and since #4622 gave `buildLedger` a
real findings window it can shift a finding across the window boundary.

**What the gateway actually writes** (checked before touching the regex):
`telegram-plugin/stderr-timestamps.ts:29-31` stamps every line with
`new Date().toISOString()` — UTC, trailing `Z`, always. The 12 live
`gateway-supervisor.log` files agree: ~2.5M timestamp matches, every one
`YYYY-MM-DDTHH:MM:SS.mmmZ`, zero without. The shell-side stamps that reach the
same log use `date -u …Z` (`profiles/_base/start.sh.hbs:2456`,
`docker/hindsight-autoheal.sh:110`). So: **UTC by convention**, normalised at
the producer. The designator stays optional in the MATCH on purpose — a format
change must not silently stop dating findings — and an EXPLICIT `+HH:MM` offset
is now captured and preserved, since appending `Z` to one would have invented
the very ten-hour error being removed.

Tests assert the returned STRING rather than the parsed instant: string equality
is host-independent, so the guard goes red on a UTC CI runner too. Verified
red-then-green — restoring `return m[0]` turns three of the new tests red with
`expected '2026-08-12T09:00:00' to be '2026-08-12T09:00:00Z'`.

## Checks

- `npx tsc --noEmit` — clean
- `npm run lint` — clean (all 30 checks, incl. changelog + attribution)
- Scoped: `src/fleet-health src/web telegram-plugin/tests/approval-hold-*` —
  **733 passed | 2 skipped (735)**, the 2 skips being the mode-enforcement
  guards above, now skipping with a stated reason.

## Out of scope, not fixed

Nothing else was found broken in these files. Noted for the record: the two
mode-enforcement guards genuinely cannot run as root, so root runs still have
slightly less coverage than a non-root run — now visibly, rather than silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)