### PR TITLE
fix(hermes): refuse unsupported writes with a reason instead of a 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,19 @@ now an anomaly worth investigating, not the norm.
   (`stderr-timestamps.ts` uses `toISOString()`; the shell stamps use `date -u`),
   so a designator-less line is now normalised to `Z` at the producer. An
   explicit `+HH:MM` offset is preserved untouched.
+- **hermes: session delete, env writes and memory-provider config answer an
+  explicit refusal instead of a 404 the desktop misreads.** `DELETE
+  /api/sessions/:id`, `PUT /api/env` and `PUT /api/memory/providers/:p/config`
+  fell through to a 404, and the desktop's `isEndpointMissingError` only
+  matches 404s — so a route switchroom deliberately does not support was
+  indistinguishable from a dead gateway, and the action either threw or
+  silently took a fallback path. All three now return 422 with a reason
+  naming where the real control lives (switchroom.yaml / the vault), the same
+  answer the schedule-write branch already gives. `GET
+  /api/memory/providers/:p/config` now serves the real `MemoryProviderConfig`
+  shape with an empty declared surface, which is the desktop's own signal to
+  collapse the pane rather than render a form that cannot save.
+
 - **hermes: transcripts past the first page are no longer silently dropped,
   and no longer arrive backwards.** `GET /api/sessions/:id/messages` emitted no
   `pagination` block, and the desktop's `getAllSessionMessages` reads a missing

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -771,6 +771,29 @@ export async function handleHermesRest(
     return { status: 200, body: { session: toHermesSession(id, agent, agentLiveness(config, agentName), config) } };
   }
 
+  // DELETE /api/sessions/:id — `deleteSession` (apps/desktop/src/hermes.ts:755-761)
+  // has no catch, so whatever comes back is what the sidebar's delete action
+  // does. A switchroom session IS an agent, and an agent is created and removed
+  // by editing `switchroom.yaml` and applying — there is no per-session row to
+  // drop. That makes this route genuinely unsupported, but a bare 404 is the
+  // wrong way to say so: `isEndpointMissingError` reads 404 as "old backend,
+  // fall back", so the desktop cannot tell a refused delete from a dead
+  // gateway. 422 with a reason is the same answer the schedule-write branch
+  // above already gives, and the desktop surfaces the body.
+  //
+  // Unknown ids are refused identically rather than 404-ing: deletion is
+  // unsupported for every id, so branching on existence would leak a
+  // distinction that has no bearing on the outcome.
+  if (method === "DELETE" && sessionMatch) {
+    return {
+      status: 422,
+      body: {
+        error:
+          "Sessions are switchroom agents — remove the agent from switchroom.yaml and apply, rather than deleting a session here.",
+      },
+    };
+  }
+
   // GET /api/sessions/:id/messages — conversation history (SessionMessagesResponse shape)
   //
   // The `pagination` object is load-bearing, not decoration. `getAllSessionMessages`
@@ -1047,6 +1070,53 @@ export async function handleHermesRest(
   // GET /api/env — API keys / env-var panel; no agent env vars to surface
   if (method === "GET" && pathname === "/api/env") {
     return { status: 200, body: {} };
+  }
+
+  // PUT /api/env — `setEnvVar` (apps/desktop/src/hermes.ts:891-898) has no
+  // catch. Switchroom agent environments are composed from `switchroom.yaml`
+  // plus the encrypted vault and are re-materialised on apply, so a value
+  // written here would be silently discarded at the next reconcile. Refuse it
+  // in the shape the desktop can render, not with a 404 that
+  // `isEndpointMissingError` mistakes for an old backend.
+  if (method === "PUT" && pathname === "/api/env") {
+    return {
+      status: 422,
+      body: {
+        error:
+          "Agent environment is owned by switchroom.yaml and the encrypted vault — set the value there and apply; edits made here would be discarded on the next reconcile.",
+      },
+    };
+  }
+
+  // GET|PUT /api/memory/providers/:provider/config — the memory settings pane
+  // (`getMemoryProviderConfig` / `saveMemoryProviderConfig`,
+  // apps/desktop/src/hermes.ts:868-882; both always append `?surface=declared`).
+  //
+  // `fields: []` is not a stub: `MemoryProviderConfig` is
+  // `{docs_url, fields, label, name}` (apps/desktop/src/types/hermes.ts:151-156)
+  // and the panel that consumes it returns null on an empty field list —
+  // "Providers without a declared config surface (e.g. builtin) render nothing"
+  // (apps/desktop/src/app/settings/memory/provider-config-panel.tsx:80-82).
+  // That is precisely switchroom's situation: memory is Hindsight over MCP,
+  // declared in `switchroom.yaml` and credentialed through the vault, with no
+  // key the console may edit. Upstream answers an undeclared provider with this
+  // same shape (`hermes_cli/web_server.py:6125`), so the pane collapses cleanly
+  // instead of rendering an empty form that cannot save.
+  const memoryConfigMatch = pathname.match(/^\/api\/memory\/providers\/([^/]+)\/config$/);
+  if (memoryConfigMatch) {
+    const provider = decodeURIComponent(memoryConfigMatch[1]);
+    if (method === "GET") {
+      return { status: 200, body: { name: provider, label: provider, docs_url: "", fields: [] } };
+    }
+    if (method === "PUT") {
+      return {
+        status: 422,
+        body: {
+          error:
+            "Memory providers are declared in switchroom.yaml and credentialed through the vault — there is no console-writable configuration to save.",
+        },
+      };
+    }
   }
 
   // POST /api/providers/validate — credential check; switchroom has no API keys

--- a/src/web/hermes-rest-parity.test.ts
+++ b/src/web/hermes-rest-parity.test.ts
@@ -261,7 +261,7 @@ const CENSUS: CensusRow[] = [
   { line: 637, method: "PATCH", path: `/api/sessions/${AGENT}`, served: false, note: "setSessionArchived" },
   { line: 650, method: "PATCH", path: `/api/sessions/${AGENT}`, served: false, note: "setSessionPinnedRemote" },
   { line: 770, method: "PATCH", path: `/api/sessions/${AGENT}`, served: false, note: "renameSession" },
-  { line: 758, method: "DELETE", path: `/api/sessions/${AGENT}`, served: false, note: "deleteSession" },
+  { line: 758, method: "DELETE", path: `/api/sessions/${AGENT}`, served: true, note: "deleteSession — refused 422, see the route comment" },
 
   // ── status / config / model ───────────────────────────────────────────────
   { line: 787, method: "GET", path: "/api/status", served: true },
@@ -280,7 +280,7 @@ const CENSUS: CensusRow[] = [
 
   // ── env / providers ───────────────────────────────────────────────────────
   { line: 887, method: "GET", path: "/api/env", served: true },
-  { line: 894, method: "PUT", path: "/api/env", served: false },
+  { line: 894, method: "PUT", path: "/api/env", served: true, note: "refused 422 — env is YAML+vault owned" },
   { line: 956, method: "DELETE", path: "/api/env", served: false },
   { line: 965, method: "POST", path: "/api/env/reveal", served: false },
   { line: 907, method: "POST", path: "/api/providers/validate", served: true },
@@ -315,14 +315,15 @@ const CENSUS: CensusRow[] = [
     line: 871,
     method: "GET",
     path: "/api/memory/providers/hindsight/config",
-    served: false,
+    served: true,
     note:
-      "Still unimplemented. The adapter used to serve the bare " +
-      "/api/memory/providers instead — a path with no upstream route " +
-      "(hermes_cli/memory_oauth.py:18 mounts the prefix but registers no bare " +
-      "handler) and no call site; that dead stub has been deleted.",
+      "Served with an empty declared surface ({name, label, docs_url, fields: []}). " +
+      "The adapter used to serve the bare /api/memory/providers instead — a " +
+      "path with no upstream route (hermes_cli/memory_oauth.py:18 mounts the " +
+      "prefix but registers no bare handler) and no call site; that dead stub " +
+      "has been deleted.",
   },
-  { line: 878, method: "PUT", path: "/api/memory/providers/hindsight/config", served: false },
+  { line: 878, method: "PUT", path: "/api/memory/providers/hindsight/config", served: true, note: "refused 422 — no console-writable memory config" },
   { line: 1024, method: "POST", path: "/api/memory/providers/hindsight/oauth/start", served: false },
   { line: 1032, method: "GET", path: "/api/memory/providers/hindsight/oauth/status", served: false },
   { line: 1865, method: "GET", path: "/api/memory", served: false },
@@ -880,11 +881,6 @@ const CONTRACT: ContractCase[] = [
     path: `/api/sessions/${AGENT}`,
     client: "hermes.ts:755-761 (deleteSession) — no catch",
     server: "hermes_cli/web_routers/sessions.py:655",
-    gap:
-      "Unimplemented. Switchroom sessions ARE agents, so a real delete is not " +
-      "meaningful — but a bare 404 makes the desktop throw. The contract " +
-      "answer is an explicit refusal the client can render (the 422 the cron " +
-      "branch already uses at hermes-adapter.ts:739-741), not silence.",
     assert: (res) => {
       expect(res).not.toBeNull();
       // Either honoured, or refused in a way the desktop can surface.
@@ -1298,10 +1294,6 @@ const CONTRACT: ContractCase[] = [
     path: "/api/env",
     client: "hermes.ts:891-898 (setEnv)",
     server: "hermes_cli/web_server.py:7209",
-    gap:
-      "Unimplemented. Switchroom has no desktop-writable env — but the honest " +
-      "answer is the 422 refusal the cron branch already models, not a 404 " +
-      "the client cannot distinguish from a dead backend.",
     assert: (res) => {
       expect(res).not.toBeNull();
       expect([200, 422]).toContain(res!.status);
@@ -1314,9 +1306,6 @@ const CONTRACT: ContractCase[] = [
     search: "?surface=declared",
     client: "hermes.ts:868-873 (getMemoryProviderConfig)",
     server: "hermes_cli/web_server.py:6125",
-    gap:
-      "Unimplemented. The adapter serves the bare /api/memory/providers " +
-      "(hermes-adapter.ts:767) instead — a path no desktop call site emits.",
     assert: (res) => {
       expect(res).not.toBeNull();
       expect(res!.status).toBe(200);
@@ -1329,10 +1318,6 @@ const CONTRACT: ContractCase[] = [
     search: "?surface=declared",
     client: "hermes.ts:875-882 (setMemoryProviderConfig)",
     server: "hermes_cli/web_server.py:6170",
-    gap:
-      "Unimplemented — same root cause as the GET above: the adapter's only " +
-      "memory route is the bare /api/memory/providers, which the desktop " +
-      "never calls. The memory settings pane cannot save.",
     assert: (res) => {
       expect(res).not.toBeNull();
       expect([200, 422]).toContain(res!.status);
@@ -1435,8 +1420,8 @@ describe(`Hermes REST response contract (upstream ${UPSTREAM_HERMES_SHA.slice(0,
     // raise `green`) in the same PR that removes a `gap` field.
     expect({ total: CONTRACT.length, green, gaps }).toEqual({
       total: 47,
-      green: 34,
-      gaps: 13,
+      green: 38,
+      gaps: 9,
     });
   });
 });

--- a/src/web/hermes-unsupported-writes.test.ts
+++ b/src/web/hermes-unsupported-writes.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The four routes the desktop calls with no client-side tolerance, and which
+ * switchroom cannot honour.
+ *
+ * `hermes-rest-parity.test.ts` asserts the CONTRACT floor for these — status in
+ * `[200, 422]`, or `200` for the memory GET. That floor is deliberately loose,
+ * so it cannot tell an honest refusal from a fabricated one: a `422` with an
+ * empty body, or a memory GET answering `{}`, both satisfy it while leaving the
+ * desktop with nothing to render. This file pins what is actually IN the answer.
+ *
+ * Why not just 404 and be done: `isEndpointMissingError`
+ * (apps/desktop/src/hermes.ts) only matches 404-shaped responses, and the
+ * desktop reads that as "old backend, take the fallback path". A refusal that
+ * 404s is therefore indistinguishable from a dead gateway, and the user is told
+ * nothing. A 422 with a reason is the same answer the schedule-write branch
+ * already gives.
+ */
+
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleHermesRest, type HermesRestResult } from "./hermes-adapter.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const AGENT = "alpha";
+const CONFIG = { agents: { [AGENT]: { model: "sonnet" } } } as unknown as SwitchroomConfig;
+
+beforeAll(() => {
+  process.env.SWITCHROOM_AGENTS_DIR = mkdtempSync(join(tmpdir(), "sr-hermes-writes-"));
+});
+
+function call(method: string, path: string, search = ""): Promise<HermesRestResult | null> {
+  return handleHermesRest(method, path, CONFIG, search);
+}
+
+/** A refusal the desktop can put in front of a human, not a bare status code. */
+async function expectRenderableRefusal(method: string, path: string, search = "") {
+  const res = await call(method, path, search);
+  expect(res, `${method} ${path} must be answered, not fall through to 404`).not.toBeNull();
+  expect(res!.status).toBe(422);
+  const error = (res!.body as { error?: unknown }).error;
+  expect(typeof error, `${method} ${path} must carry a string reason`).toBe("string");
+  // Not merely present — long enough to be a sentence a user can act on, and
+  // naming where the real control lives. An empty or one-word `error` renders
+  // as a blank toast.
+  expect((error as string).length).toBeGreaterThan(40);
+  expect(error as string).toMatch(/switchroom\.yaml|vault/i);
+}
+
+describe("writes switchroom cannot honour are refused, not 404'd", () => {
+  it("DELETE /api/sessions/:id refuses with a reason", async () => {
+    await expectRenderableRefusal("DELETE", `/api/sessions/${AGENT}`);
+  });
+
+  it("DELETE /api/sessions/:id refuses unknown ids identically (no existence leak)", async () => {
+    const known = await call("DELETE", `/api/sessions/${AGENT}`);
+    const unknown = await call("DELETE", "/api/sessions/does-not-exist");
+    expect(unknown!.status).toBe(known!.status);
+    expect(unknown!.body).toEqual(known!.body);
+  });
+
+  it("DELETE /api/sessions/:id does not swallow the messages sub-route", async () => {
+    // The refusal is anchored on /api/sessions/:id with no trailing segment;
+    // a greedy match here would start refusing transcript reads.
+    const res = await call("GET", `/api/sessions/${AGENT}/messages`);
+    expect(res!.status).toBe(200);
+  });
+
+  it("PUT /api/env refuses with a reason", async () => {
+    await expectRenderableRefusal("PUT", "/api/env");
+  });
+
+  it("PUT /api/env does not disturb the GET the env panel reads", async () => {
+    const res = await call("GET", "/api/env");
+    expect(res!.status).toBe(200);
+  });
+
+  it("PUT /api/memory/providers/:provider/config refuses with a reason", async () => {
+    await expectRenderableRefusal(
+      "PUT",
+      "/api/memory/providers/hindsight/config",
+      "?surface=declared",
+    );
+  });
+});
+
+describe("GET /api/memory/providers/:provider/config serves the real declared shape", () => {
+  it("answers every field of MemoryProviderConfig, echoing the requested provider", async () => {
+    const res = await call(
+      "GET",
+      "/api/memory/providers/hindsight/config",
+      "?surface=declared",
+    );
+    expect(res!.status).toBe(200);
+    // apps/desktop/src/types/hermes.ts:151-156 — {docs_url, fields, label, name}.
+    // A fabricated `{}` passes the parity fixture's status-only floor and then
+    // crashes provider-config-panel.tsx:81 on `config.fields.length`.
+    expect(res!.body).toEqual({
+      name: "hindsight",
+      label: "hindsight",
+      docs_url: "",
+      fields: [],
+    });
+  });
+
+  it("an empty `fields` is the panel's own 'no config surface' signal", async () => {
+    // provider-config-panel.tsx:80-82 returns null when fields.length === 0
+    // ("Providers without a declared config surface (e.g. builtin) render
+    // nothing"). So the pane collapses rather than showing a form that cannot
+    // save — which is why a non-empty placeholder field would be a regression.
+    const res = await call("GET", "/api/memory/providers/anything/config", "?surface=declared");
+    expect((res!.body as { fields: unknown[] }).fields).toEqual([]);
+  });
+
+  it("percent-encoded provider names round-trip", async () => {
+    const res = await call("GET", "/api/memory/providers/my%20provider/config");
+    expect((res!.body as { name: string }).name).toBe("my provider");
+  });
+});


### PR DESCRIPTION
**Stacked on #4625** (base is `fix/hermes-adapter-gaps`, not `main`) — both PRs move the same ratchet line in `hermes-rest-parity.test.ts`, and stacking keeps that a fast-forward instead of a conflict. Rebase onto `main` once #4625 merges.

## The bug

Three routes the desktop calls with **no client-side catch** fell through to a 404:

| route | desktop call site |
|---|---|
| `DELETE /api/sessions/:id` | `hermes.ts:755-761` `deleteSession` |
| `PUT /api/env` | `hermes.ts:891-898` `setEnvVar` |
| `PUT /api/memory/providers/:p/config` | `hermes.ts:875-882` `saveMemoryProviderConfig` |

Switchroom genuinely cannot honour any of them — a session **is** an agent, and env and memory config are owned by `switchroom.yaml` plus the encrypted vault. The problem is not the refusal, it is *how it was expressed*: `isEndpointMissingError` only matches 404-shaped responses, so the desktop reads a deliberate refusal as "old backend, take the fallback path". A refused delete and a dead gateway are indistinguishable, and the user is told nothing either way.

All three now return **422 with a reason naming where the real control lives** — the same answer the schedule-write branch at `hermes-adapter.ts:961` already gives for YAML-owned schedules.

## `GET /api/memory/providers/:p/config`

Now serves the real `MemoryProviderConfig` — `{docs_url, fields, label, name}` (`apps/desktop/src/types/hermes.ts:151-156`) — with an empty `fields`.

That is **not** a fabricated 200. `provider-config-panel.tsx:80-82` returns `null` when `fields.length === 0`, commented *"Providers without a declared config surface (e.g. builtin) render nothing"*. Switchroom's memory is Hindsight over MCP, declared in YAML and credentialed through the vault, with no key the console may edit — so an empty declared surface is the literal truth, and it is the same shape upstream returns for an undeclared provider (`hermes_cli/web_server.py:6125`). The pane collapses cleanly rather than rendering a form that cannot save.

## Why a new test file rather than leaning on the parity fixture

`hermes-rest-parity.test.ts` asserts the contract *floor* for these — `[200, 422]`, or `200` for the memory GET. That floor deliberately cannot tell an honest refusal from a fabricated one. `hermes-unsupported-writes.test.ts` pins what is actually in the answer:

- the 422 body carries a sentence long enough to render, naming `switchroom.yaml`/vault;
- unknown session ids are refused **identically** to known ones (no existence leak);
- the `DELETE /api/sessions/:id` match does not swallow the `/messages` sub-route;
- the memory GET returns **every** field of the interface, and `fields` stays empty.

**Verified by mutation, not by inspection:** stubbing the env refusal to `200` and the memory GET to `{}` leaves the parity fixture **fully green** (183/183) while reddening **4** cases here. The new file is guarding something the old one structurally could not.

## Ratchet

Closes 4 REST gaps. `34 green / 13 gaps` → `38 green / 9 gaps`, with the four `gap` flags deleted and the four CENSUS rows flipped to `served: true` in the same commit.

## Verification

```
$ npx vitest run src/web/hermes-unsupported-writes.test.ts src/web/hermes-rest-parity.test.ts \
    src/web/hermes-ws-parity.test.ts src/web/hermes-adapter.test.ts tests/web/
 Test Files  6 passed (6)
      Tests  313 passed (313)

$ npm run -s lint     # tsc --noEmit + all 30 guard scripts
check-changelog-entry: OK — ## Unreleased grew (origin/main...HEAD).
check-agent-attribution-trailers: OK — 2 commit(s), 2 machine-authored and attributed.
check-test-runner-coverage: OK — 1574 test file(s), every one has a runner
check-hostd-template-guard: OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)