### PR TITLE
fix(ci): make e2e-ok honest about skipped shards, and fix the hindsight-probe onTaskUpdate flake at its cause

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -191,7 +191,16 @@ jobs:
     # push / merge_group: always run — both are (candidate) main. On the
     # queue ref this is the job that actually catches a semantic conflict
     # between two individually-green PRs, so it must not be skippable.
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.relevant == 'true'
+    #
+    # workflow_dispatch is here because the header advertises `gh workflow
+    # run docker-e2e.yml --ref main` as THE recovery lever, and without
+    # this term it recovered nothing: `changes` has no diff base on a
+    # dispatch, so `relevant` came back false and the whole workflow
+    # reported a 3-second green with zero tests run. Verified on run
+    # 31131064381 (2026-08-06): e2e + hindsight-probe both `skipped`,
+    # `e2e-ok` `success`. A recovery lever that reports success without
+    # running is worse than no lever.
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -348,8 +357,10 @@ jobs:
     # this job exists so the patch probe can NEVER silently skip, and the
     # queue ref is the last gate before those patches reach main. Letting
     # it path-skip on the new candidate-main path would contradict the
-    # job's entire purpose.
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.hindsight == 'true'
+    # job's entire purpose. workflow_dispatch: the recovery lever must
+    # actually run the probe (see the e2e-shard `if:` above for the run
+    # that proved it did not).
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.hindsight == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -772,6 +783,26 @@ jobs:
   # hindsight-probe in particular exists so the behavioural patch probe
   # can never silently skip; it only actually gates via this sentinel.
   # Keep this `needs` list complete when adding jobs.
+  #
+  # THREE states, not two (#4619). `e2e-ok` is a REQUIRED context, so it
+  # cannot go non-green when the shards path-skip — that would hard-block
+  # every docs-only PR (#1343 / #2237 all over again). But "green because
+  # nothing ran" and "green because e2e passed" are not the same claim,
+  # and reading the first as the second is what got #4619 approved and
+  # then EJECTED from the merge queue when `hindsight-probe` failed on the
+  # `merge_group` ref it had never run on. So:
+  #
+  #   ran + passed   → success, "VERIFIED" in the summary
+  #   ran + failed   → failure (unchanged)
+  #   path-skipped   → success (required-context constraint) but a loud
+  #                    `::warning::` annotation + a step summary that says
+  #                    NOT VERIFIED HERE and names the queue ref as the
+  #                    place it will actually run
+  #   skipped when it was supposed to run → FAILURE. A skip is only
+  #                    legitimate when the path filter said so; a skip on
+  #                    push / merge_group / workflow_dispatch (all
+  #                    must-run events) means the gate is broken, not
+  #                    satisfied, and that used to read as a pass.
   e2e-ok:
     needs: [changes, e2e-shard, hindsight-probe, hindsight-watch-pg-probe]
     if: always()
@@ -779,22 +810,105 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Verdict
+        env:
+          EVENT: ${{ github.event_name }}
+          CHANGES: ${{ needs.changes.result }}
+          E2E_SHARD: ${{ needs.e2e-shard.result }}
+          HINDSIGHT_PROBE: ${{ needs.hindsight-probe.result }}
+          HINDSIGHT_WATCH_PG_PROBE: ${{ needs.hindsight-watch-pg-probe.result }}
+          # Empty on push / merge_group / workflow_dispatch — the filter
+          # steps don't run there. `must_run` covers those events.
+          WANT_E2E_SHARD: ${{ needs.changes.outputs.relevant }}
+          WANT_HINDSIGHT_PROBE: ${{ needs.changes.outputs.hindsight }}
+          WANT_HINDSIGHT_WATCH_PG_PROBE: ${{ needs.changes.outputs.hindsightwatch }}
         run: |
-          c='${{ needs.changes.result }}'
-          if [ "$c" = "failure" ] || [ "$c" = "cancelled" ]; then
-            echo "::error::changes=$c — path-filter infra failed; can't trust the skip"
+          set -u
+          if [ "$CHANGES" = "failure" ] || [ "$CHANGES" = "cancelled" ]; then
+            echo "::error::changes=$CHANGES — path-filter infra failed; can't trust the skip"
             exit 1
           fi
+
+          # Events where the work jobs are unconditional (their `if:` has
+          # no filter term). A skip on one of these is a broken gate.
+          # Derived PER JOB from that job's own `if:`, not globally:
+          # e2e-shard and hindsight-probe carry a workflow_dispatch term,
+          # hindsight-watch-pg-probe does not, so a dispatch skip is
+          # legitimate for it and a broken gate for the other two.
+          must_run=0
+          case "$EVENT" in
+            push|merge_group|workflow_dispatch) must_run=1 ;;
+          esac
+          must_run_pg=0
+          case "$EVENT" in
+            push|merge_group) must_run_pg=1 ;;
+          esac
+
           fail=0
-          for pair in \
-            "e2e-shard=${{ needs.e2e-shard.result }}" \
-            "hindsight-probe=${{ needs.hindsight-probe.result }}" \
-            "hindsight-watch-pg-probe=${{ needs.hindsight-watch-pg-probe.result }}"; do
-            job="${pair%%=*}"; r="${pair#*=}"
-            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
-              echo "::error::${job}=${r} — real e2e failure, blocking"
-              fail=1
+          verified=0
+          unverified=0
+          summary=""
+
+          verdict() {
+            job="$1"; result="$2"; want="$3"; must="$4"
+            case "$result" in
+              success)
+                verified=$((verified + 1))
+                summary="${summary}| \`${job}\` | ${result} | ran and passed |"$'\n'
+                ;;
+              failure|cancelled)
+                echo "::error::${job}=${result} — real e2e failure, blocking"
+                fail=1
+                summary="${summary}| \`${job}\` | ${result} | FAILED |"$'\n'
+                ;;
+              skipped)
+                if [ "$must" = "1" ] || [ "$want" = "true" ]; then
+                  echo "::error title=e2e gate broken::${job} was SKIPPED on a ref where it must run (event=${EVENT}, path-filter=${want:-n/a}) — that is a broken gate, not a satisfied one"
+                  fail=1
+                  summary="${summary}| \`${job}\` | ${result} | SKIPPED BUT SHOULD HAVE RUN |"$'\n'
+                else
+                  unverified=$((unverified + 1))
+                  echo "::warning title=e2e NOT verified on this ref::${job} was path-skipped, so e2e correctness is UNVERIFIED here — this green means \"not run\", not \"passed\". It runs for real on the merge-queue ref, where a PR can still be ejected (#4619)."
+                  summary="${summary}| \`${job}\` | ${result} | path-skipped — **not verified here** |"$'\n'
+                fi
+                ;;
+              *)
+                echo "::error::${job}=${result} — unrecognised result, refusing to call it a pass"
+                fail=1
+                summary="${summary}| \`${job}\` | ${result} | unrecognised |"$'\n'
+                ;;
+            esac
+          }
+
+          verdict e2e-shard "$E2E_SHARD" "$WANT_E2E_SHARD" "$must_run"
+          verdict hindsight-probe "$HINDSIGHT_PROBE" "$WANT_HINDSIGHT_PROBE" "$must_run"
+          verdict hindsight-watch-pg-probe "$HINDSIGHT_WATCH_PG_PROBE" \
+            "$WANT_HINDSIGHT_WATCH_PG_PROBE" "$must_run_pg"
+
+          if [ "$fail" -ne 0 ]; then
+            headline="❌ FAILED"
+          elif [ "$unverified" -gt 0 ] && [ "$verified" -eq 0 ]; then
+            headline="⚪ NOT VERIFIED on this ref (everything path-skipped)"
+          elif [ "$unverified" -gt 0 ]; then
+            headline="🟡 PARTIALLY VERIFIED on this ref"
+          else
+            headline="✅ VERIFIED on this ref"
+          fi
+
+          {
+            echo "### e2e-ok — ${headline}"
+            echo ""
+            echo "| job | result | meaning |"
+            echo "| --- | --- | --- |"
+            printf '%s' "$summary"
+            echo ""
+            if [ "$unverified" -gt 0 ] && [ "$fail" -eq 0 ]; then
+              echo "\`e2e-ok\` is a required context and therefore stays green when the"
+              echo "path filter skips the work jobs — but **a green here does not mean e2e"
+              echo "passed**. The skipped jobs run unconditionally on the \`merge_group\`"
+              echo "ref, so a PR merged on this signal can still be ejected from the queue"
+              echo "(that is exactly what happened to #4619)."
             fi
-          done
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          echo "event=$EVENT changes=$CHANGES e2e-shard=$E2E_SHARD hindsight-probe=$HINDSIGHT_PROBE hindsight-watch-pg-probe=$HINDSIGHT_WATCH_PG_PROBE → ${headline}"
           [ "$fail" -eq 0 ] || exit 1
-          echo "changes=$c → pass (e2e jobs green or path-skipped)"

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -128,6 +128,11 @@ jobs:
             # would get no probe run until the merge queue.
             hindsight:
               - 'docker/Dockerfile.hindsight'
+              # Every probe runner below drives docker through this helper, so
+              # a change to it changes how all of them execute. Listed for the
+              # same reason as the Dockerfile: the hindsight-probe job is gated
+              # on this filter, not on `vitest --changed`.
+              - 'tests/docker/_exec-async.ts'
               - 'docker/hindsight-entrypoint.sh'
               - 'src/setup/hindsight-pg-defaults.ts'
               - 'tests/docker/hindsight-pg-fsync-probe.test.ts'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,40 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **CI: `e2e-ok` no longer reports a path-skipped run as a verified pass.** The
+  sentinel collapsed "the e2e shards ran and passed" and "nothing ran at all"
+  into the same silent green, so a reviewer could not tell them apart. PR #4619
+  was approved and enqueued on that green and then ejected from the merge queue
+  when `docker-e2e` failed on the `merge_group` ref the PR ref had never
+  exercised. `e2e-ok` is a branch-protection-required context, so it must stay
+  green when the path filter legitimately skips the work jobs; it now
+  distinguishes the three states explicitly instead — ran+passed is `VERIFIED`,
+  ran+failed still fails, and a path-skip stays green but carries a
+  `::warning title=e2e NOT verified on this ref::` annotation plus a job
+  summary naming where the suite will really run. A skip on a ref where the
+  work jobs are unconditional (`push` / `merge_group` / `workflow_dispatch`),
+  or on a PR where the filter said the paths WERE relevant, is now a hard
+  failure — that skip means the gate itself is broken. Separately,
+  `e2e-shard` and `hindsight-probe` now run on `workflow_dispatch`: the
+  advertised manual recovery lever had no diff base, so `changes` reported
+  `relevant=false`, every job skipped, and the run went green in 3 seconds
+  (run 31131064381) without testing anything. `hindsight-watch-pg-probe`
+  (added to the sentinel's `needs:` by #4623) is aggregated by the same
+  three-state verdict, with its must-run set derived from its own `if:` —
+  it carries no `workflow_dispatch` term, so a dispatch skip warns there
+  rather than failing the gate.
+- **CI: the `hindsight-probe` `Timeout calling "onTaskUpdate"` flake is
+  fixed at the cause.** All five tests passed and vitest still exited 1. The
+  docker probes drove `docker run` / `docker exec` through `execFileSync`,
+  which blocks the vitest WORKER's event loop for the whole leg; vitest's
+  worker→main birpc has a hard-coded 60 s timeout (`DEFAULT_TIMEOUT = 6e4`,
+  with no config knob), so a worker starved past 60 s fires the timer before
+  it ever reads the reply the main process had already sent. Run 31575484897
+  had two tests of 32.3 s and 30.3 s of uninterrupted sync exec in a 63.07 s
+  file — one merge-queue ejection and a manual re-enqueue. The probe runners
+  now await a small `execFileAsync` helper (`tests/docker/_exec-async.ts`)
+  that keeps the loop turning, so the RPC reply is read as it arrives. No
+  retry was added: a retry would equally hide a real hang.
 - **fleet-health: the ledger's `windowDays` now actually windows the
   findings.** `buildLedger` read `windowDays` but aggregated EVERY finding ever
   recorded into the dedup_key map — `count` and `reach` had no time filter, so

--- a/tests/ci-e2e-ok-verdict.test.ts
+++ b/tests/ci-e2e-ok-verdict.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Behavioural guard for the `e2e-ok` sentinel's verdict script.
+ *
+ * `e2e-ok` is the single branch-protection-required context for
+ * docker-e2e.yml (ruleset 16470166). Because a *skipped* required check
+ * hard-blocks (#1343 / #2237), the sentinel must stay green when the path
+ * filter skips `e2e-shard` / `hindsight-probe` — but before #4619 it said
+ * nothing else, so "green because nothing ran" was indistinguishable from
+ * "green because e2e passed". PR #4619 was approved and enqueued on that
+ * green and then EJECTED from the merge queue when `hindsight-probe`
+ * failed on the `merge_group` ref the PR ref had never exercised.
+ *
+ * This suite does NOT shape-match the YAML. It extracts the sentinel's
+ * actual `run:` script and EXECUTES it under bash with the same `env:`
+ * block the workflow supplies, then asserts the observable outcome:
+ * exit status, the `::warning::` / `::error::` annotations on stdout, and
+ * the job summary written to $GITHUB_STEP_SUMMARY. Every case below fails
+ * against the pre-#4619 verdict, which exited 0 silently on a skip and
+ * exited 0 on a skip that should never have happened.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { parse } from 'yaml'
+
+const REPO = resolve(import.meta.dirname, '..')
+
+interface Step {
+  name?: string
+  run?: string
+  env?: Record<string, string>
+}
+interface Job {
+  steps?: Step[]
+}
+
+const workflow = parse(
+  readFileSync(join(REPO, '.github/workflows/docker-e2e.yml'), 'utf8'),
+) as { jobs?: Record<string, Job> }
+
+const sentinel = workflow.jobs?.['e2e-ok']
+const verdictStep = (sentinel?.steps ?? []).find((s) => s.name === 'Verdict')
+
+/** Env keys the workflow feeds the script (values are `${{ }}` expressions). */
+const ENV_KEYS = Object.keys(verdictStep?.env ?? {})
+
+interface RunResult {
+  status: number
+  stdout: string
+  summary: string
+}
+
+/** Execute the real verdict script with a synthetic `needs` context. */
+function runVerdict(env: Record<string, string>): RunResult {
+  const script = verdictStep?.run
+  if (!script) throw new Error('e2e-ok has no "Verdict" step with a run: script')
+  // The script must be self-contained: every input arrives via env, so no
+  // `${{ }}` expression may survive into the body (an unsubstituted one
+  // would be a shell syntax error here and an injection seam in CI).
+  expect(script, 'the verdict body must read its inputs from env:, not inline ${{ }}').not.toMatch(
+    /\$\{\{/,
+  )
+
+  const dir = mkdtempSync(join(tmpdir(), 'e2e-ok-verdict-'))
+  const scriptPath = join(dir, 'verdict.sh')
+  const summaryPath = join(dir, 'summary.md')
+  writeFileSync(scriptPath, script)
+  writeFileSync(summaryPath, '')
+
+  let status = 0
+  let stdout = ''
+  try {
+    stdout = execFileSync('bash', [scriptPath], {
+      encoding: 'utf8',
+      env: { ...process.env, ...env, GITHUB_STEP_SUMMARY: summaryPath },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string }
+    status = err.status ?? -1
+    stdout = (err.stdout ?? '') + (err.stderr ?? '')
+  }
+  return { status, stdout, summary: readFileSync(summaryPath, 'utf8') }
+}
+
+/** A PR ref where the path filter matched and every job really ran. */
+const RAN_AND_PASSED = {
+  EVENT: 'pull_request',
+  CHANGES: 'success',
+  E2E_SHARD: 'success',
+  HINDSIGHT_PROBE: 'success',
+  HINDSIGHT_WATCH_PG_PROBE: 'success',
+  WANT_E2E_SHARD: 'true',
+  WANT_HINDSIGHT_PROBE: 'true',
+  WANT_HINDSIGHT_WATCH_PG_PROBE: 'true',
+}
+
+/** A docs-only PR: the filter said no, every job legitimately skipped. */
+const PATH_SKIPPED = {
+  EVENT: 'pull_request',
+  CHANGES: 'success',
+  E2E_SHARD: 'skipped',
+  HINDSIGHT_PROBE: 'skipped',
+  HINDSIGHT_WATCH_PG_PROBE: 'skipped',
+  WANT_E2E_SHARD: 'false',
+  WANT_HINDSIGHT_PROBE: 'false',
+  WANT_HINDSIGHT_WATCH_PG_PROBE: 'false',
+}
+
+describe('e2e-ok verdict — the three states are distinguishable', () => {
+  it('the sentinel feeds the script through env:, not string-interpolated shell', () => {
+    expect(verdictStep, 'e2e-ok must keep a step named "Verdict"').toBeTruthy()
+    for (const key of [
+      'EVENT',
+      'CHANGES',
+      'E2E_SHARD',
+      'HINDSIGHT_PROBE',
+      'HINDSIGHT_WATCH_PG_PROBE',
+      'WANT_E2E_SHARD',
+      'WANT_HINDSIGHT_PROBE',
+      'WANT_HINDSIGHT_WATCH_PG_PROBE',
+    ]) {
+      expect(ENV_KEYS, `the verdict needs ${key} in its env: block`).toContain(key)
+    }
+  })
+
+  it('shards ran and passed → exit 0, VERIFIED, and no "not verified" warning', () => {
+    const r = runVerdict(RAN_AND_PASSED)
+    expect(r.status).toBe(0)
+    expect(r.summary).toContain('VERIFIED on this ref')
+    expect(r.summary).not.toContain('not verified')
+    expect(r.stdout).not.toContain('::warning')
+  })
+
+  it('a shard failed → exit 1 with an error annotation', () => {
+    const r = runVerdict({ ...RAN_AND_PASSED, E2E_SHARD: 'failure' })
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('::error::e2e-shard=failure')
+  })
+
+  it('a shard was cancelled → exit 1 (a cancel is not a pass)', () => {
+    const r = runVerdict({ ...RAN_AND_PASSED, HINDSIGHT_PROBE: 'cancelled' })
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('::error::hindsight-probe=cancelled')
+  })
+
+  it('hindsight-watch-pg-probe failing blocks too (it is in the aggregation)', () => {
+    // #4623 added this job to `needs:`; the verdict must actually read it,
+    // otherwise a real pg-probe failure would be aggregated away as green.
+    const r = runVerdict({ ...RAN_AND_PASSED, HINDSIGHT_WATCH_PG_PROBE: 'failure' })
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('::error::hindsight-watch-pg-probe=failure')
+  })
+
+  it('path-skipped → still exit 0 (required context must not block docs PRs)', () => {
+    // This is the constraint, not a nicety: `e2e-ok` is required, so a
+    // non-zero here would hard-block every PR that misses the filter.
+    expect(runVerdict(PATH_SKIPPED).status).toBe(0)
+  })
+
+  it('path-skipped → green, but annotated NOT VERIFIED rather than read as a pass', () => {
+    const r = runVerdict(PATH_SKIPPED)
+    expect(r.stdout, 'a path-skip must raise a visible warning annotation').toContain(
+      '::warning title=e2e NOT verified on this ref::',
+    )
+    expect(r.stdout).toContain('e2e-shard was path-skipped')
+    expect(r.stdout).toContain('hindsight-probe was path-skipped')
+    expect(r.summary, 'the job summary must not claim verification').toContain('NOT VERIFIED')
+    expect(r.summary, 'and must name where it will really run').toContain('merge_group')
+  })
+
+  it('one ran, one path-skipped → PARTIALLY VERIFIED, not a clean green', () => {
+    const r = runVerdict({
+      ...PATH_SKIPPED,
+      E2E_SHARD: 'success',
+      WANT_E2E_SHARD: 'true',
+    })
+    expect(r.status).toBe(0)
+    expect(r.summary).toContain('PARTIALLY VERIFIED')
+    expect(r.stdout).toContain('hindsight-probe was path-skipped')
+  })
+})
+
+describe('e2e-ok verdict — a skip that should not have happened is a failure', () => {
+  // The false-green with teeth: a skip is only trustworthy when the path
+  // filter asked for it. Anywhere else it means the gate did not run.
+
+  for (const event of ['push', 'merge_group', 'workflow_dispatch']) {
+    it(`${event}: the work jobs are unconditional, so a skip fails the gate`, () => {
+      const r = runVerdict({
+        EVENT: event,
+        CHANGES: event === 'merge_group' ? 'skipped' : 'success',
+        E2E_SHARD: 'skipped',
+        HINDSIGHT_PROBE: 'skipped',
+        HINDSIGHT_WATCH_PG_PROBE: 'skipped',
+        // Empty exactly as GitHub renders them on these events.
+        WANT_E2E_SHARD: '',
+        WANT_HINDSIGHT_PROBE: '',
+        WANT_HINDSIGHT_WATCH_PG_PROBE: '',
+      })
+      expect(r.status, `a skip on ${event} must not report success`).toBe(1)
+      expect(r.stdout).toContain('::error title=e2e gate broken::e2e-shard was SKIPPED')
+      expect(r.stdout).toContain('::error title=e2e gate broken::hindsight-probe was SKIPPED')
+
+      // must-run is derived PER JOB from that job's own `if:`.
+      // hindsight-watch-pg-probe carries no workflow_dispatch term, so a
+      // dispatch skip is legitimate for it and a broken gate elsewhere.
+      const pgBroken = r.stdout.includes(
+        '::error title=e2e gate broken::hindsight-watch-pg-probe was SKIPPED',
+      )
+      expect(pgBroken, `hindsight-watch-pg-probe skip on ${event}`).toBe(
+        event !== 'workflow_dispatch',
+      )
+    })
+  }
+
+  it('PR ref: the filter said relevant, so a skip is a broken gate too', () => {
+    const r = runVerdict({ ...PATH_SKIPPED, WANT_E2E_SHARD: 'true' })
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('::error title=e2e gate broken::e2e-shard was SKIPPED')
+    // …while the genuinely-irrelevant sibling still only warns.
+    expect(r.stdout).toContain('::warning title=e2e NOT verified on this ref::')
+  })
+
+  it('the path-filter job itself failing still blocks (unchanged)', () => {
+    const r = runVerdict({ ...PATH_SKIPPED, CHANGES: 'failure' })
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('::error::changes=failure')
+  })
+
+  it('an unrecognised result is never treated as a pass', () => {
+    const r = runVerdict({ ...RAN_AND_PASSED, E2E_SHARD: 'neutral' })
+    expect(r.status).toBe(1)
+    expect(r.stdout).toContain('refusing to call it a pass')
+  })
+})
+
+describe('docker-e2e — the workflow_dispatch recovery lever actually runs the suite', () => {
+  // Run 31131064381 (2026-08-06): a manual `gh workflow run
+  // docker-e2e.yml` reported `e2e-ok` success in 3 seconds with e2e and
+  // hindsight-probe both `skipped` — `changes` has no diff base on a
+  // dispatch, so `relevant` came back false. The advertised recovery
+  // lever recovered nothing and said it had.
+  const jobs = (workflow.jobs ?? {}) as Record<string, { if?: string }>
+
+  for (const name of ['e2e-shard', 'hindsight-probe']) {
+    it(`${name} runs on workflow_dispatch`, () => {
+      const cond = jobs[name]?.if ?? ''
+      expect(cond, `${name} must have a gating if:`).toBeTruthy()
+      expect(cond, `${name} must run on the dispatch recovery lever`).toContain(
+        "github.event_name == 'workflow_dispatch'",
+      )
+    })
+  }
+})

--- a/tests/docker/_exec-async.ts
+++ b/tests/docker/_exec-async.ts
@@ -1,0 +1,181 @@
+/**
+ * Non-blocking `execFileSync` for the docker probe suites.
+ *
+ * ── Why this exists ──────────────────────────────────────────────────────
+ *
+ * The hindsight probes drive `docker run` / `docker exec` legs that each
+ * take tens of seconds. Written with `execFileSync` they block the vitest
+ * WORKER's event loop for that entire time, and a blocked worker cannot
+ * read the IPC channel it shares with the vitest main process.
+ *
+ * vitest's worker→main RPC (`onTaskUpdate`, `onUserConsoleLog`, …) is
+ * birpc with a HARD-CODED 60 s timeout — `DEFAULT_TIMEOUT = 6e4` in
+ * `vitest/dist/chunks/index.*.js`, and neither `createForksRpcOptions`
+ * (`chunks/utils.*.js`) nor `createRuntimeRpc` (`chunks/rpc.*.js`) passes a
+ * `timeout` override, so no vitest config knob can raise it. The main
+ * process answers `onTaskUpdate` promptly; the WORKER just never gets to
+ * process the reply, and when it finally does return to the event loop the
+ * timers phase runs before the poll phase, so the 60 s timer fires first:
+ *
+ *     Error: [vitest-worker]: Timeout calling "onTaskUpdate"
+ *       ❯ Object.onTimeoutError vitest/dist/chunks/rpc.*.js:53:10
+ *
+ * All tests PASS and vitest still exits 1 (unhandled error). Observed on
+ * run 31575484897 / job 94046556074 (2026-08-12): the reflect-directives
+ * probe, 5/5 green, two tests of 32.3 s + 30.3 s of uninterrupted
+ * `execFileSync`, file duration 63.07 s — one merge-queue ejection and a
+ * manual re-enqueue. It is a reporter-IPC starvation bug, not a test
+ * failure, so retrying it would only hide a real hang later.
+ *
+ * Awaiting the child instead keeps the worker's loop turning, so the RPC
+ * reply is read as it arrives and the timer never reaches 60 s. Semantics
+ * mirror `execFileSync` closely enough to be a drop-in at the call sites:
+ * stdout/stderr are captured (never inherited), a non-zero exit throws, and
+ * the thrown error carries `.status` / `.stdout` / `.stderr`.
+ *
+ * Unlike `execFileSync` there is no 1 MiB `maxBuffer` ceiling — probe
+ * output is bounded by the probe scripts themselves, and an ENOBUFS throw
+ * mid-probe would be a worse failure mode than a large string.
+ */
+
+import { spawn } from "node:child_process";
+
+export interface ExecOutcome {
+  /** Exit status. 0 on the resolved path. */
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Thrown on a non-zero exit or a spawn error. Field names match what
+ * `execFileSync` attaches, so `catch (e) { (e as {status?: number}).status }`
+ * call sites keep working unchanged.
+ */
+export class ExecFailure extends Error implements ExecOutcome {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(message: string, outcome: ExecOutcome) {
+    super(message);
+    this.name = "ExecFailure";
+    this.status = outcome.status;
+    this.stdout = outcome.stdout;
+    this.stderr = outcome.stderr;
+  }
+}
+
+export interface ExecOptions {
+  /** Written to the child's stdin, then stdin is closed. */
+  input?: string;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  /** Hard ceiling; the child is SIGKILLed and the call rejects. */
+  timeoutMs?: number;
+}
+
+/**
+ * Run `file` with `args`, awaiting the child instead of blocking the event
+ * loop. Resolves on exit 0; rejects with {@link ExecFailure} otherwise.
+ */
+export function execFileAsync(
+  file: string,
+  args: readonly string[],
+  opts: ExecOptions = {}
+): Promise<ExecOutcome> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(file, [...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: opts.env,
+      cwd: opts.cwd,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      fn();
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (c: string) => {
+      stdout += c;
+    });
+    child.stderr.on("data", (c: string) => {
+      stderr += c;
+    });
+
+    if (opts.timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, opts.timeoutMs);
+    }
+
+    child.on("error", (err) => {
+      // Spawn failure (ENOENT, EACCES). `execFileSync` leaves `.status`
+      // undefined here; the probe call sites normalise a missing status to
+      // -1, so report that directly.
+      settle(() =>
+        reject(
+          new ExecFailure(`${file}: ${err.message}`, {
+            status: -1,
+            stdout,
+            stderr,
+          })
+        )
+      );
+    });
+
+    const finish = (code: number | null, signal: NodeJS.Signals | null) => {
+      // A signal-killed child has a null code; -1 keeps it distinguishable
+      // from success without pretending to be an exit status.
+      const status = code ?? -1;
+      if (status === 0) {
+        settle(() => resolve({ status, stdout, stderr }));
+        return;
+      }
+      const how = signal ? `killed by ${signal}` : `exited ${status}`;
+      settle(() =>
+        reject(
+          new ExecFailure(
+            `${file} ${args.join(" ")} — ${how}\n${stderr.slice(-4000)}`,
+            { status, stdout, stderr }
+          )
+        )
+      );
+    };
+
+    // `close` is the preferred signal because it means stdio reached EOF and
+    // the buffers are complete. But it only fires once EVERY holder of those
+    // pipes is gone: `sh -c "sleep 30"` SIGKILLed at the shell leaves the
+    // `sleep` grandchild owning stdout, and `close` then waits out the full
+    // sleep — a hang worse than the flake this file exists to fix. So `exit`
+    // (the direct child is reaped) starts a bounded grace period for trailing
+    // output, after which the call settles with what it has.
+    let exited = false;
+    child.on("exit", (code, signal) => {
+      exited = true;
+      const grace = setTimeout(() => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+        finish(code, signal);
+      }, 250);
+      grace.unref?.();
+      child.once("close", () => clearTimeout(grace));
+    });
+    child.on("close", (code, signal) => {
+      if (!exited) return; // spawn error path; `error` handles it
+      finish(code, signal);
+    });
+
+    if (opts.input !== undefined) child.stdin.end(opts.input);
+    else child.stdin.end();
+  });
+}

--- a/tests/docker/exec-async.test.ts
+++ b/tests/docker/exec-async.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Guard for `_exec-async.ts` — the property that fixes the hindsight-probe
+ * flake is EVENT-LOOP LIVENESS, so that is what these assert.
+ *
+ * The bug (run 31575484897, job 94046556074): 5/5 tests passed and vitest
+ * exited 1 on `[vitest-worker]: Timeout calling "onTaskUpdate"`. vitest's
+ * worker→main RPC has a hard-coded 60 s birpc timeout with no config knob;
+ * a worker blocked in `execFileSync` for longer than that cannot read the
+ * main process's reply, and the timers phase then fires the timeout before
+ * the poll phase delivers the reply that would have cleared it.
+ *
+ * `execLiveness` below measures exactly that: how many macrotask ticks the
+ * loop gets while a child runs. `execFileSync` scores 0 (that IS the bug);
+ * `execFileAsync` must keep ticking. A regression that reintroduces a
+ * blocking call fails here rather than as a merge-queue ejection.
+ */
+
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { execFileAsync, ExecFailure } from "./_exec-async.js";
+
+/** Ticks a 20 ms interval while `body` runs; returns the tick count. */
+async function execLiveness(body: () => void | Promise<void>): Promise<number> {
+  let ticks = 0;
+  const handle = setInterval(() => {
+    ticks += 1;
+  }, 20);
+  try {
+    await body();
+  } finally {
+    clearInterval(handle);
+  }
+  return ticks;
+}
+
+const SLEEP = ["-c", "sleep 0.6"];
+
+describe("execFileAsync — event-loop liveness (the onTaskUpdate flake)", () => {
+  it("keeps the event loop turning while the child runs", async () => {
+    const ticks = await execLiveness(async () => {
+      await execFileAsync("sh", SLEEP);
+    });
+    // 0.6 s / 20 ms ≈ 30 ticks; assert a floor well clear of scheduler noise.
+    expect(
+      ticks,
+      "the loop must keep running during the child — a starved loop is what " +
+        "times out vitest's onTaskUpdate RPC",
+      ).toBeGreaterThan(5);
+  });
+
+  it("execFileSync starves it completely (the shape being fixed)", async () => {
+    const ticks = await execLiveness(() => {
+      execFileSync("sh", SLEEP, { stdio: "ignore" });
+    });
+    // Not a style preference: a sync child of this length lets through zero
+    // timer ticks, so 60 s of them accrue a full RPC timeout.
+    expect(ticks, "execFileSync must be shown to block, or this suite proves nothing").toBe(0);
+  });
+
+  it("stays live across a chain of children, like a probe leg does", async () => {
+    const ticks = await execLiveness(async () => {
+      await execFileAsync("sh", ["-c", "sleep 0.2"]);
+      await execFileAsync("sh", ["-c", "sleep 0.2"]);
+      await execFileAsync("sh", ["-c", "sleep 0.2"]);
+    });
+    expect(ticks).toBeGreaterThan(5);
+  });
+});
+
+describe("execFileAsync — execFileSync-compatible semantics", () => {
+  it("resolves with captured stdout on exit 0", async () => {
+    const r = await execFileAsync("sh", ["-c", "echo hello; echo warn >&2"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("hello\n");
+    expect(r.stderr).toBe("warn\n");
+  });
+
+  it("rejects with .status/.stdout/.stderr on a non-zero exit", async () => {
+    const err = await execFileAsync("sh", [
+      "-c",
+      "echo partial; echo boom >&2; exit 7",
+    ]).then(
+      () => null,
+      (e: unknown) => e as ExecFailure
+    );
+    expect(err, "a non-zero exit must reject, as execFileSync throws").toBeTruthy();
+    expect(err).toBeInstanceOf(ExecFailure);
+    // The probe call sites read exactly these two fields off the caught error.
+    expect(err!.status).toBe(7);
+    expect(err!.stdout).toBe("partial\n");
+    expect(err!.stderr).toContain("boom");
+  });
+
+  it("writes `input` to stdin and closes it", async () => {
+    const r = await execFileAsync("sh", ["-c", "cat"], { input: "piped-probe\n" });
+    expect(r.stdout).toBe("piped-probe\n");
+  });
+
+  it("closes stdin even with no input, so `cat` cannot hang the suite", async () => {
+    const r = await execFileAsync("sh", ["-c", "cat; echo done"]);
+    expect(r.stdout).toBe("done\n");
+  });
+
+  it("passes env through to the child", async () => {
+    const r = await execFileAsync("sh", ["-c", "echo $SR_PROBE_MARKER"], {
+      env: { ...process.env, SR_PROBE_MARKER: "marker-42" },
+    });
+    expect(r.stdout.trim()).toBe("marker-42");
+  });
+
+  it("reports a spawn failure as status -1 rather than hanging", async () => {
+    const err = await execFileAsync("definitely-not-a-real-binary-xyz", []).then(
+      () => null,
+      (e: unknown) => e as ExecFailure
+    );
+    expect(err).toBeInstanceOf(ExecFailure);
+    expect(err!.status).toBe(-1);
+  });
+
+  it("kills the child and rejects when timeoutMs elapses", async () => {
+    const started = Date.now();
+    const err = await execFileAsync("sh", ["-c", "sleep 30"], {
+      timeoutMs: 300,
+    }).then(
+      () => null,
+      (e: unknown) => e as ExecFailure
+    );
+    expect(err).toBeInstanceOf(ExecFailure);
+    expect(err!.status).toBe(-1);
+    expect(Date.now() - started, "must not wait out the full sleep").toBeLessThan(10_000);
+  });
+});

--- a/tests/docker/hindsight-graph-maintenance-retry-storm.test.ts
+++ b/tests/docker/hindsight-graph-maintenance-retry-storm.test.ts
@@ -64,6 +64,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -432,15 +433,13 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-gmstorm-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -456,28 +455,19 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
         // The block is self-verifying: it asserts each upstream anchor exists
         // exactly once and re-asserts the result, so a non-zero exit here means
         // upstream drifted and the patch must be re-authored.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -486,7 +476,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -546,8 +536,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED — the storm, the blank error, and the clobbered count are all live", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED — the storm, the blank error, and the clobbered count are all live", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -576,8 +566,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain('"orphan_entities_pruned": 0');
     }, 240_000);
 
-    it("patched is GREEN — timeouts are a verdict, failures are legible, Pass 2 survives", () => {
-      const { status, stdout } = runProbe(true);
+    it("patched is GREEN — timeouts are a verdict, failures are legible, Pass 2 survives", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-graph-seed-retirement.test.ts
+++ b/tests/docker/hindsight-graph-seed-retirement.test.ts
@@ -50,6 +50,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -219,15 +220,13 @@ type ProbeResult = { status: number; stdout: string };
  * on the CONTAINER, not injected into the probe source, so what runs is the same
  * `HindsightConfig.from_env()` path the real server takes.
  */
-function runProbe(withEnv: boolean, floor: string): ProbeResult {
+async function runProbe(withEnv: boolean, floor: string): Promise<ProbeResult> {
   const name = `sr-hs-graphseed-${withEnv ? "emitted" : "default"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -246,16 +245,10 @@ function runProbe(withEnv: boolean, floor: string): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -264,7 +257,7 @@ function runProbe(withEnv: boolean, floor: string): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -327,8 +320,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("the pinned image ships #2968 natively, wired end to end", () => {
-      const { status, stdout } = runProbe(true, PINNED_FLOOR);
+    it("the pinned image ships #2968 natively, wired end to end", async () => {
+      const { status, stdout } = await runProbe(true, PINNED_FLOOR);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -355,21 +348,21 @@ describe.skipIf(!dockerOk || !imageOk)(
      * that is deliberately NOT upstream's default: without the emission the
      * container resolves 0.3 and the probe goes red.
      */
-    it("the floor comes from switchroom's emission, not from upstream's default", () => {
+    it("the floor comes from switchroom's emission, not from upstream's default", async () => {
       const OFF_DEFAULT = "0.42";
       expect(
         OFF_DEFAULT,
         "this arm is meaningless if it happens to equal the pinned floor",
       ).not.toBe(PINNED_FLOOR);
 
-      const emitted = runProbe(true, OFF_DEFAULT);
+      const emitted = await runProbe(true, OFF_DEFAULT);
       expect(emitted.stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
       expect(emitted.status, `probe failed:\n${emitted.stdout}`).toBe(0);
       expect(emitted.stdout).toContain("RESOLVED_FLOOR 0.42");
 
-      const unset = runProbe(false, OFF_DEFAULT);
+      const unset = await runProbe(false, OFF_DEFAULT);
       expect(unset.stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-maxitems-grammar-patch.test.ts
+++ b/tests/docker/hindsight-maxitems-grammar-patch.test.ts
@@ -64,6 +64,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -274,15 +275,13 @@ type ProbeResult = { status: number; stdout: string };
  * The env var is set on the CONTAINER, not injected into the probe source, so
  * what runs is the same `HindsightConfig.from_env()` path the real server takes.
  */
-function runProbe(configured: boolean): ProbeResult {
+async function runProbe(configured: boolean): Promise<ProbeResult> {
   const name = `sr-hs-maxitems-${configured ? "configured" : "default"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -299,16 +298,10 @@ function runProbe(configured: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -317,7 +310,7 @@ function runProbe(configured: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -391,8 +384,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("upstream's DEFAULT is RED — the schema carries the bank's raw slot count", () => {
-      const { status, stdout } = runProbe(false);
+    it("upstream's DEFAULT is RED — the schema carries the bank's raw slot count", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -418,8 +411,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("PYTHON_TRUNCATION_PRESENT True");
     }, 240_000);
 
-    it(`upstream + ${ENV_KEY}=false is GREEN — maxItems is absent entirely`, () => {
-      const { status, stdout } = runProbe(true);
+    it(`upstream + ${ENV_KEY}=false is GREEN — maxItems is absent entirely`, async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-metrics-cardinality-patch.test.ts
+++ b/tests/docker/hindsight-metrics-cardinality-patch.test.ts
@@ -66,6 +66,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -281,15 +282,13 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-metcard-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -305,9 +304,7 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
@@ -315,19 +312,12 @@ function runProbe(patched: boolean): ProbeResult {
         // exactly once and re-drives normalize_http_endpoint afterwards, so a
         // non-zero exit here means upstream drifted and the patch must be
         // re-authored (or deleted, if upstream now carries the fix).
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -336,7 +326,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -396,8 +386,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED — composite document ids leak into the endpoint label", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED — composite document ids leak into the endpoint label", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -415,8 +405,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       );
     }, 240_000);
 
-    it("upstream + the baked patch block is GREEN on all five properties", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch block is GREEN on all five properties", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-mm-refresh-debounce-patch.test.ts
+++ b/tests/docker/hindsight-mm-refresh-debounce-patch.test.ts
@@ -64,6 +64,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -300,15 +301,13 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-mmdeb-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -324,28 +323,19 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
         // The block is self-verifying: it asserts its upstream anchor exists
         // exactly once and re-asserts the result, so a non-zero exit here means
         // upstream drifted and the patch must be re-authored.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -354,7 +344,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -414,8 +404,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED — the just-refreshed model is refreshed again", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED — the just-refreshed model is refreshed again", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -429,8 +419,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       );
     }, 240_000);
 
-    it("upstream + the baked patch block is GREEN on all five properties", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch block is GREEN on all five properties", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-pg-fsync-probe.test.ts
+++ b/tests/docker/hindsight-pg-fsync-probe.test.ts
@@ -50,6 +50,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname, join } from "node:path";
@@ -136,16 +137,14 @@ type ProbeResult = { fsync: string; source: string; argv: string; log: string };
  * the GREEN arm exercises the production values and the RED arm differs from
  * it by exactly one variable.
  */
-function probe(label: string, extraEnv: Record<string, string>): ProbeResult {
+async function probe(label: string, extraEnv: Record<string, string>): Promise<ProbeResult> {
   const name = `sr-hs-fsync-${label}-${RUN_ID.slice(0, 8)}`;
   const stage = mkdtempSync(join(tmpdir(), "sr-fsync-probe-"));
   try {
     writeFileSync(join(stage, "fake-broker.cjs"), FAKE_BROKER);
     writeFileSync(join(stage, "fake-fetch.cjs"), FAKE_FETCHER);
 
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -165,23 +164,15 @@ function probe(label: string, extraEnv: Record<string, string>): ProbeResult {
         "sleep",
         UPSTREAM_IMAGE,
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
     for (const f of ["fake-broker.cjs", "fake-fetch.cjs"]) {
-      execFileSync("docker", ["cp", join(stage, f), `${name}:/tmp/${f}`], {
-        stdio: "ignore",
-      });
+      await execFileAsync("docker", ["cp", join(stage, f), `${name}:/tmp/${f}`]);
     }
     // The REAL entrypoint, byte for byte — never a reimplementation.
-    execFileSync("docker", ["cp", ENTRYPOINT, `${name}:/tmp/entrypoint.sh`], {
-      stdio: "ignore",
-    });
+    await execFileAsync("docker", ["cp", ENTRYPOINT, `${name}:/tmp/entrypoint.sh`]);
 
-    execFileSync("docker", ["exec", "-d", name, "node", "/tmp/fake-broker.cjs", "/tmp/fake.sock"], {
-      stdio: "ignore",
-    });
+    await execFileAsync("docker", ["exec", "-d", name, "node", "/tmp/fake-broker.cjs", "/tmp/fake.sock"]);
 
     const env: Record<string, string> = {
       SWITCHROOM_AUTH_BROKER_SOCKET: "/tmp/fake.sock",
@@ -203,17 +194,22 @@ function probe(label: string, extraEnv: Record<string, string>): ProbeResult {
 
     // The entrypoint logs to stderr; fold it into stdout so the pre-start line
     // is available for assertions and for the failure message.
-    const log = execFileSync(
-      "docker",
-      ["exec", ...envArgs, name, "sh", "-c", "sh /tmp/entrypoint.sh true 2>&1"],
-      { stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" },
-    );
+    const log = (
+      await execFileAsync("docker", [
+        "exec",
+        ...envArgs,
+        name,
+        "sh",
+        "-c",
+        "sh /tmp/entrypoint.sh true 2>&1",
+      ])
+    ).stdout;
 
-    const out = execFileSync("docker", ["exec", "-i", name, "sh", "-s"], {
-      input: READBACK,
-      stdio: ["pipe", "pipe", "pipe"],
-      encoding: "utf8",
-    });
+    const out = (
+      await execFileAsync("docker", ["exec", "-i", name, "sh", "-s"], {
+        input: READBACK,
+      })
+    ).stdout;
     const [setting = "", source = ""] = (out.match(/^FSYNC=(.*)$/m)?.[1] ?? "").split(":");
     return {
       fsync: setting,
@@ -223,7 +219,7 @@ function probe(label: string, extraEnv: Record<string, string>): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -277,8 +273,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("the shipping configuration yields fsync=on, sourced from the command line", () => {
-      const r = probe("green", {});
+    it("the shipping configuration yields fsync=on, sourced from the command line", async () => {
+      const r = await probe("green", {});
       // THE assertion. Everything else in this file exists to make this one
       // mean something.
       expect(r.fsync, `pre-start log:\n${r.log}\nargv: ${r.argv}`).toBe("on");
@@ -295,8 +291,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(r.log).toMatch(/pg0 pre-start ok: .*fsync=on/);
     }, 180_000);
 
-    it("the RED arm really reads off, so the GREEN arm is not a tautology", () => {
-      const r = probe("red", { SWITCHROOM_HINDSIGHT_PG_FSYNC: "off" });
+    it("the RED arm really reads off, so the GREEN arm is not a tautology", async () => {
+      const r = await probe("red", { SWITCHROOM_HINDSIGHT_PG_FSYNC: "off" });
       expect(r.fsync, `pre-start log:\n${r.log}\nargv: ${r.argv}`).toBe("off");
       // With the flag omitted, pg0's `-F` is unopposed and postgres reports
       // the value as a command-line one too — which is exactly why a source

--- a/tests/docker/hindsight-pg-search-filter-pushdown-patch.test.ts
+++ b/tests/docker/hindsight-pg-search-filter-pushdown-patch.test.ts
@@ -54,6 +54,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -435,15 +436,13 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-pgspush-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -459,28 +458,19 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
         // The block is self-verifying: it asserts its upstream anchors exist
         // exactly once each and re-asserts the result, so a non-zero exit here
         // means upstream drifted and the patch must be re-authored.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -489,7 +479,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -553,8 +543,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED — the shipping migrations build an index that cannot push bank_id/fact_type down", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED — the shipping migrations build an index that cannot push bank_id/fact_type down", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -569,8 +559,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("NO FILTER-FIELD DRIFT DETECTOR");
     }, 240_000);
 
-    it("upstream + the baked patch blocks is GREEN on all six properties", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch blocks is GREEN on all six properties", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts
+++ b/tests/docker/hindsight-pg-search-tokenizer-drift-patch.test.ts
@@ -74,6 +74,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -359,15 +360,13 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-pgstok-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -383,28 +382,19 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
         // The block is self-verifying: it asserts its upstream anchors exist
         // exactly once each and re-asserts the result, so a non-zero exit here
         // means upstream drifted and the patch must be re-authored.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -413,7 +403,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -476,8 +466,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED — the rebuild silently drops stemming", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED — the rebuild silently drops stemming", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -492,8 +482,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("NO TOKENIZER DRIFT DETECTOR");
     }, 240_000);
 
-    it("upstream + the baked patch block is GREEN on all six properties", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch block is GREEN on all six properties", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-query-analyzer-languages.test.ts
+++ b/tests/docker/hindsight-query-analyzer-languages.test.ts
@@ -50,6 +50,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -214,7 +215,7 @@ type ProbeResult = { status: number; stdout: string };
  * Run the probe in a throwaway container, with or without switchroom's env
  * emission. `emitted: false` is upstream's stock state — the RED case.
  */
-function runProbe(emitted: boolean): ProbeResult {
+async function runProbe(emitted: boolean): Promise<ProbeResult> {
   const name = `sr-hs-qalang-${emitted ? "emitted" : "stock"}-${RUN_ID.slice(
     0,
     8
@@ -236,14 +237,10 @@ function runProbe(emitted: boolean): ProbeResult {
     ];
     if (emitted) runArgs.push("-e", `${ENV_KEY}=${EMITTED_LANGUAGES}`);
     runArgs.push(UPSTREAM_IMAGE, "sleep", "300");
-    execFileSync("docker", runArgs, { stdio: ["ignore", "ignore", "pipe"] });
+    await execFileAsync("docker", runArgs);
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: probeSource(), stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: probeSource() });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -252,7 +249,7 @@ function runProbe(emitted: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -315,8 +312,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("stock upstream (variable UNSET) is RED — search_dates gets no languages= and auto-detects 200+ locales (proves the probe bites)", () => {
-      const { status, stdout } = runProbe(false);
+    it("stock upstream (variable UNSET) is RED — search_dates gets no languages= and auto-detects 200+ locales (proves the probe bites)", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );
@@ -328,8 +325,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("CAPTURED_LANGUAGES __ABSENT__");
     }, 240_000);
 
-    it("with switchroom's emission the recall path is pinned, still parses, and English extraction still works", () => {
-      const { status, stdout } = runProbe(true);
+    it("with switchroom's emission the recall path is pinned, still parses, and English extraction still works", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );

--- a/tests/docker/hindsight-recall-budget-reflect-grounding-patches.test.ts
+++ b/tests/docker/hindsight-recall-budget-reflect-grounding-patches.test.ts
@@ -54,6 +54,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -464,15 +465,13 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-grounding-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -488,28 +487,19 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
         // Each block is self-verifying: it asserts its upstream anchors exist
         // exactly once and re-asserts the result, so a non-zero exit here means
         // upstream drifted and the patch must be re-authored.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -518,7 +508,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -578,8 +568,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED on both defects (proves the probe bites)", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED on both defects (proves the probe bites)", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -609,8 +599,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("LEGACY_BYTES_MATCH True");
     }, 240_000);
 
-    it("upstream + the baked patch blocks is GREEN, including every safety property", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch blocks is GREEN, including every safety property", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-recall-isolation-patches.test.ts
+++ b/tests/docker/hindsight-recall-isolation-patches.test.ts
@@ -67,6 +67,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -951,15 +952,13 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-iso-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -975,28 +974,19 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] }
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
         // Each block is self-verifying: it asserts its upstream anchors exist
         // exactly once and re-asserts the result, so a non-zero exit here means
         // upstream drifted and the patch must be re-authored.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -1005,7 +995,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -1069,8 +1059,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED on all three defects (proves the probe bites)", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED on all three defects (proves the probe bites)", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );
@@ -1129,8 +1119,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       );
     }, 240_000);
 
-    it("upstream + the baked patch blocks is GREEN, including every safety property", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch blocks is GREEN, including every safety property", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );

--- a/tests/docker/hindsight-reflect-directives-patch.test.ts
+++ b/tests/docker/hindsight-reflect-directives-patch.test.ts
@@ -70,6 +70,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -398,15 +399,13 @@ const PG0 =
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-refdir-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -422,31 +421,20 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "600",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] }
-    );
+      ]);
 
     if (patched) {
       // The block is self-verifying: it asserts its upstream anchors exist
       // exactly once and re-asserts the result, so a non-zero exit here means
       // upstream drifted and the patch must be re-authored.
-      execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-        input: patchBlock(),
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: patchBlock() });
     }
 
     // A real database, bundled in the image and started offline. postgres
     // refuses to run as root, so this and the probe run as `hindsight`.
-    execFileSync(
-      "docker",
-      ["exec", "-u", "hindsight", "-e", "HOME=/home/hindsight", name, PG0, "start"],
-      { stdio: ["ignore", "pipe", "pipe"] }
-    );
+    await execFileAsync("docker", ["exec", "-u", "hindsight", "-e", "HOME=/home/hindsight", name, PG0, "start"]);
 
-    const res = execFileSync(
-      "docker",
-      [
+    const res = await execFileAsync("docker", [
         "exec",
         "-i",
         "-u",
@@ -458,10 +446,8 @@ function runProbe(patched: boolean): ProbeResult {
         name,
         "/app/api/.venv/bin/python",
         "-",
-      ],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
-    );
-    return { status: 0, stdout: res };
+      ], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -470,7 +456,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -530,8 +516,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED: a tagged directive never reaches reflect", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED: a tagged directive never reaches reflect", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );
@@ -563,8 +549,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       );
     }, 300_000);
 
-    it("upstream + the baked patch block is GREEN, and tag scoping is untouched", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch block is GREEN, and tag scoping is untouched", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );

--- a/tests/docker/hindsight-reranker-priority-patch.test.ts
+++ b/tests/docker/hindsight-reranker-priority-patch.test.ts
@@ -78,6 +78,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -418,12 +419,10 @@ type ProbeResult = { status: number; stdout: string };
  * has #3142 baked on top of every prerequisite switchroom patch exactly as it
  * ships. `role` only names the container for debuggability.
  */
-function runProbe(image: string, role: string): ProbeResult {
+async function runProbe(image: string, role: string): Promise<ProbeResult> {
   const name = `sr-hs-rerank-${role}-${RUN_ID.slice(0, 8)}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -439,16 +438,10 @@ function runProbe(image: string, role: string): ProbeResult {
         image,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] }
-    );
+      ]);
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -457,7 +450,7 @@ function runProbe(image: string, role: string): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -524,8 +517,8 @@ describe.skipIf(!dockerOk || !upstreamOk)(
   () => {
     afterAll(teardownRun);
 
-    it("unpatched upstream is RED (no priority pool, no background kwarg)", () => {
-      const { status, stdout } = runProbe(UPSTREAM_IMAGE, "upstream");
+    it("unpatched upstream is RED (no priority pool, no background kwarg)", async () => {
+      const { status, stdout } = await runProbe(UPSTREAM_IMAGE, "upstream");
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );
@@ -549,8 +542,8 @@ describe.skipIf(!dockerOk || !builtOk)(
   () => {
     afterAll(teardownRun);
 
-    it("through-built #3142 image is GREEN, priority ordering and all", () => {
-      const { status, stdout } = runProbe(BUILT_IMAGE, "built");
+    it("through-built #3142 image is GREEN, priority ordering and all", async () => {
+      const { status, stdout } = await runProbe(BUILT_IMAGE, "built");
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );

--- a/tests/docker/hindsight-retry-perturbation-patches.test.ts
+++ b/tests/docker/hindsight-retry-perturbation-patches.test.ts
@@ -83,6 +83,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -327,15 +328,13 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-retry-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8,
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -351,28 +350,19 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
         // The block is self-verifying: it asserts its upstream anchor exists
         // exactly once and re-asserts the result, so a non-zero exit here means
         // upstream drifted and the patch must be re-authored.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -381,7 +371,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -441,8 +431,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED — all four attempts are the identical request", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED — all four attempts are the identical request", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -458,8 +448,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("CACHE_REPLAYED_IDENTICAL_REQUEST True");
     }, 240_000);
 
-    it("upstream + the baked patch block is GREEN on all four properties", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch block is GREEN on all four properties", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-search-patches.test.ts
+++ b/tests/docker/hindsight-search-patches.test.ts
@@ -80,6 +80,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -620,15 +621,13 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-probe-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
     0,
     8
   )}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -644,28 +643,19 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] }
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
         // Each block is self-verifying: it asserts its upstream anchors exist
         // exactly once and re-asserts the result, so a non-zero exit here means
         // upstream drifted and the patch must be re-authored.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -674,7 +664,7 @@ function runProbe(patched: boolean): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -751,8 +741,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED on all three defects (proves the probe bites)", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED on all three defects (proves the probe bites)", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );
@@ -809,8 +799,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toMatch(/PGFALLBACK unrelated_error RAISED Exception '42P01'/);
     }, 240_000);
 
-    it("upstream + the baked patch blocks is GREEN, including every safety property", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch blocks is GREEN, including every safety property", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );

--- a/tests/docker/hindsight-temporal-offload-patch.test.ts
+++ b/tests/docker/hindsight-temporal-offload-patch.test.ts
@@ -75,6 +75,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -391,10 +392,13 @@ type ProbeResult = { status: number; stdout: string };
  * Run a probe in a throwaway container, always with switchroom's language
  * emission set (as every host runs it); applies the offload block iff `offload`.
  */
-function runProbe(offload: boolean, probe: string): ProbeResult {
+async function runProbe(
+  offload: boolean,
+  probe: string
+): Promise<ProbeResult> {
   const name = `sr-hs-toff-${offload ? "green" : "red"}-${RUN_ID.slice(0, 8)}`;
   try {
-    execFileSync(
+    await execFileAsync(
       "docker",
       [
         "run",
@@ -418,26 +422,24 @@ function runProbe(offload: boolean, probe: string): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "400",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] }
+      ]
     );
 
     if (offload) {
       // Self-verifying: asserts its upstream anchors exist exactly once, so a
       // non-zero exit here means upstream drifted and the patch must be
       // re-authored.
-      execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+      await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], {
         input: OFFLOAD_BLOCK,
-        stdio: ["pipe", "pipe", "pipe"],
       });
     }
 
-    const res = execFileSync(
+    const res = await execFileAsync(
       "docker",
       ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: probe, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
+      { input: probe }
     );
-    return { status: 0, stdout: res };
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -446,7 +448,7 @@ function runProbe(offload: boolean, probe: string): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -499,8 +501,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched (offload absent) is RED — sync extraction blocks the loop for ≈ the full parse, and the wrapper/knob don't exist", () => {
-      const { stdout } = runProbe(false, RED_PROBE);
+    it("unpatched (offload absent) is RED — sync extraction blocks the loop for ≈ the full parse, and the wrapper/knob don't exist", async () => {
+      const { stdout } = await runProbe(false, RED_PROBE);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );
@@ -529,8 +531,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       ).toBeGreaterThan(extract * 0.5);
     }, 240_000);
 
-    it("upstream + the offload block is GREEN — the loop stays responsive off-loop and the char cap bounds cost", () => {
-      const { status, stdout } = runProbe(true, GREEN_PROBE);
+    it("upstream + the offload block is GREEN — the loop stays responsive off-loop and the char cap bounds cost", async () => {
+      const { status, stdout } = await runProbe(true, GREEN_PROBE);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );

--- a/tests/docker/hindsight-text-search-migration-patch.test.ts
+++ b/tests/docker/hindsight-text-search-migration-patch.test.ts
@@ -78,6 +78,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -479,12 +480,10 @@ const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
 type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching it first. */
-function runProbe(patched: boolean): ProbeResult {
+async function runProbe(patched: boolean): Promise<ProbeResult> {
   const name = `sr-hs-tsmig-${patched ? "patched" : "upstream"}-${RUN_ID.slice(0, 8)}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -500,9 +499,7 @@ function runProbe(patched: boolean): ProbeResult {
         UPSTREAM_IMAGE,
         "sleep",
         "600",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
+      ]);
 
     if (patched) {
       for (const block of patchBlocks()) {
@@ -510,25 +507,18 @@ function runProbe(patched: boolean): ProbeResult {
         // exactly the expected number of times and re-asserts the result, so a
         // non-zero exit here means upstream drifted and the patch must be
         // re-authored in docker/Dockerfile.hindsight.
-        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-          input: block,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
       }
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return { status: err.status ?? -1, stdout: (err.stdout ?? "").toString() };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -591,8 +581,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED — the trapdoor, the missing extension, the dead table", () => {
-      const { status, stdout } = runProbe(false);
+    it("unpatched upstream is RED — the trapdoor, the missing extension, the dead table", async () => {
+      const { status, stdout } = await runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );
@@ -626,8 +616,8 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toMatch(/^S7_DDL\s*$/m); // no repair DDL at all
     }, 300_000);
 
-    it("upstream + the baked patch block is GREEN on all seven properties", () => {
-      const { status, stdout } = runProbe(true);
+    it("upstream + the baked patch block is GREEN on all seven properties", async () => {
+      const { status, stdout } = await runProbe(true);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED",
       );

--- a/tests/docker/hindsight-work-conserving-admission-patch.test.ts
+++ b/tests/docker/hindsight-work-conserving-admission-patch.test.ts
@@ -77,6 +77,7 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import { execFileSync, execSync } from "node:child_process";
+import { execFileAsync } from "./_exec-async.js";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -626,12 +627,10 @@ type ProbeResult = { status: number; stdout: string };
  * self-verifying — a non-zero exit on application means upstream drifted and
  * the patch must be re-authored, surfaced here as a test failure.
  */
-function runProbe(image: string, role: string, blocks: string[]): ProbeResult {
+async function runProbe(image: string, role: string, blocks: string[]): Promise<ProbeResult> {
   const name = `sr-hs-wc-${role}-${RUN_ID.slice(0, 8)}`;
   try {
-    execFileSync(
-      "docker",
-      [
+    await execFileAsync("docker", [
         "run",
         "-d",
         "--name",
@@ -647,23 +646,14 @@ function runProbe(image: string, role: string, blocks: string[]): ProbeResult {
         image,
         "sleep",
         "300",
-      ],
-      { stdio: ["ignore", "ignore", "pipe"] }
-    );
+      ]);
 
     for (const block of blocks) {
-      execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
-        input: block,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      await execFileAsync("docker", ["exec", "-i", name, "python3", "-"], { input: block });
     }
 
-    const res = execFileSync(
-      "docker",
-      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
-    );
-    return { status: 0, stdout: res };
+    const res = await execFileAsync("docker", ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"], { input: PROBE });
+    return { status: 0, stdout: res.stdout };
   } catch (e) {
     const err = e as { status?: number; stdout?: Buffer | string };
     return {
@@ -672,7 +662,7 @@ function runProbe(image: string, role: string, blocks: string[]): ProbeResult {
     };
   } finally {
     try {
-      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+      await execFileAsync("docker", ["rm", "-f", name]);
     } catch {
       /* already gone */
     }
@@ -758,8 +748,8 @@ describe.skipIf(!dockerOk || !upstreamOk)(
       }
     });
 
-    it("unpatched upstream is RED: no priority — foreground queues FIFO behind the drain", () => {
-      const { status, stdout } = runProbe(UPSTREAM_IMAGE, "upstream", []);
+    it("unpatched upstream is RED: no priority — foreground queues FIFO behind the drain", async () => {
+      const { status, stdout } = await runProbe(UPSTREAM_IMAGE, "upstream", []);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );
@@ -774,8 +764,8 @@ describe.skipIf(!dockerOk || !upstreamOk)(
       expect(stdout).toContain("NO PRIORITY: a foreground recall waited");
     }, 240_000);
 
-    it("the strict reservation (today's shipping behaviour) is RED: not work-conserving", () => {
-      const { status, stdout } = runProbe(
+    it("the strict reservation (today's shipping behaviour) is RED: not work-conserving", async () => {
+      const { status, stdout } = await runProbe(
         UPSTREAM_IMAGE,
         "strict",
         patchBlocks([SPLIT_BLOCK])
@@ -796,8 +786,8 @@ describe.skipIf(!dockerOk || !upstreamOk)(
       expect(stdout).toMatch(/PRIORITY_BG_INFLIGHT_AT_SUBMIT 2 FG_WAIT 0\.0\d+s/);
     }, 240_000);
 
-    it("split + gate is GREEN: work-conserving AND priority AND every safety property", () => {
-      const { status, stdout } = runProbe(
+    it("split + gate is GREEN: work-conserving AND priority AND every safety property", async () => {
+      const { status, stdout } = await runProbe(
         UPSTREAM_IMAGE,
         "gate",
         patchBlocks([SPLIT_BLOCK, WC_BLOCK])
@@ -863,8 +853,8 @@ describe.skipIf(!dockerOk || !builtOk)(
       }
     });
 
-    it("the shipping bytes carry the gate AND preserve the #4212 rerank-lane invariants", () => {
-      const { status, stdout } = runProbe(BUILT_IMAGE, "built", []);
+    it("the shipping bytes carry the gate AND preserve the #4212 rerank-lane invariants", async () => {
+      const { status, stdout } = await runProbe(BUILT_IMAGE, "built", []);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
       );


### PR DESCRIPTION
Two independent CI **signal** defects — neither breaks the product, both make CI lie to a reviewer, and both have already cost a merge-queue ejection. They share `docker-e2e.yml`, so they ship in one branch to avoid a workflow-file conflict. The commits are separable and can be read independently.

---

## 1. `e2e-ok` reported a path-skipped run as a verified pass

**Root cause.** `docker-e2e.yml:718-736` (pre-change), the `e2e-ok` sentinel's Verdict step:

```sh
[ "$fail" -eq 0 ] || exit 1
echo "changes=$c → pass (e2e jobs green or path-skipped)"
```

"green because the e2e shards ran and passed" and "green because nothing ran at all" produced the same success, and the only place the difference was recorded was a line of stdout no reviewer opens. On a PR ref where the path filter skips `e2e-shard` and `hindsight-probe`, `e2e-ok` goes green in ~3 seconds and the PR page shows a passing e2e gate.

**Cost.** #4619 was approved and enqueued on exactly that green, then EJECTED from the merge queue when `docker-e2e` failed on the `merge_group` ref — the ref that actually runs the suite, which the PR ref had never exercised.

**The constraint (checked before changing anything).** `e2e-ok` **IS** a branch-protection-required status check — confirmed live against the rulesets API, ruleset `16470166`, `required_status_checks`. That rules out the obvious fix: a *skipped* required check hard-blocks a PR (this repo has been bitten twice, #1343 / #2237), and going non-green on every path-skipped PR would block ALL of them — strictly worse than the bug. So the sentinel must keep exiting 0 on a legitimate path-skip. It has to carry the distinction some other way.

**What changed.** The verdict now recognises four states instead of two:

| state | outcome |
|---|---|
| ran + passed | success, `✅ VERIFIED on this ref` in the job summary |
| ran + failed / cancelled | failure (unchanged) |
| **path-skipped** | success (forced by the required-context constraint) **plus** a `::warning title=e2e NOT verified on this ref::` annotation and a `⚪ NOT VERIFIED` job summary naming `merge_group` as where the suite really runs |
| **skipped where it had to run** | **failure** |

That last row is the one with teeth. A skip is only trustworthy when the path filter *asked* for it. A skip on `push` / `merge_group` / `workflow_dispatch` — where the work jobs are unconditional — or on a PR where `changes` reported the paths WERE relevant, means the gate did not run, and that used to read as a pass. It now fails with `::error title=e2e gate broken::`.

An unrecognised `needs.*.result` also fails now, explicitly "refusing to call it a pass", rather than falling through the `-eq 0` check.

The verdict body also moved off inline `${{ }}` interpolation onto an `env:` block — required to make it executable in a test, and it closes the expression-injection seam on the way.

**Second instance, same defect.** `e2e-shard` and `hindsight-probe` now also run on `workflow_dispatch`. The workflow header advertises `gh workflow run docker-e2e.yml --ref main` as THE manual recovery lever, but `changes` has no diff base on a dispatch, so `relevant` came back false, every job skipped, and the run reported success in 3 seconds having tested nothing — run `31131064381` (2026-08-06). The new must-run rule would have turned that silent false-green into a hard failure; making the jobs actually run is the correct half of the fix.

**Tests — `tests/ci-e2e-ok-verdict.test.ts` (15).** These do not shape-match YAML. They parse the workflow, extract the sentinel's real `run:` body, write it to a temp file, and **execute it under bash** with the same `env:` block CI supplies, then assert exit status, the annotations on stdout, and the `$GITHUB_STEP_SUMMARY` text for every state. All 15 fail against the pre-change verdict.

---

## 2. `hindsight-probe` `Timeout calling "onTaskUpdate"`

**Symptom.** All five tests PASS and vitest exits 1:

```
Error: [vitest-worker]: Timeout calling "onTaskUpdate"
  ❯ Object.onTimeoutError vitest/dist/chunks/rpc.*.js:53:10
```

A reporter/IPC timeout, not a test failure — one merge-queue ejection plus a manual re-enqueue every time it fires.

**Root cause,** read out of vitest 3.2.4's shipped source rather than inferred. The worker→main RPC is birpc with `DEFAULT_TIMEOUT = 6e4` in `vitest/dist/chunks/index.*.js`, and neither `createForksRpcOptions` (`chunks/utils.*.js`) nor `createRuntimeRpc` (`chunks/rpc.*.js`) passes a `timeout` override — **60 s is hard-coded and no vitest config knob raises it.** The probes drove `docker run` / `docker exec` legs through `execFileSync`, which blocks the *worker's* event loop for the entire leg; a blocked worker cannot read the IPC reply the main process has already sent. When the loop finally turns, Node runs the timers phase before the poll phase, so the 60 s timer fires ahead of the reply that would have cleared it.

The main process is innocent, `testTimeout` is irrelevant (the tests pass), and nothing is hanging.

**Evidence.** Run `31575484897` / job `94046556074` (2026-08-12): the reflect-directives probe, 5/5 green, two tests of **32.3 s** and **30.3 s** of uninterrupted `execFileSync`, file duration **63.07 s**. Just past 60 s, and it fires.

**Fix.** `tests/docker/_exec-async.ts` — a small awaited `spawn` wrapper with `execFileSync`-compatible semantics (stdout/stderr captured, non-zero exit throws, `.status` / `.stdout` / `.stderr` on the thrown error, `input` piped to stdin). All 18 hindsight probe runners now `await` it, so the loop keeps turning and the RPC reply is read as it arrives.

**Explicitly not a retry.** A `retry: 1` would clear this flake and, with an identical failure signature, equally hide a real hang the first time one appeared. It also would not make the run cheaper — it would re-run a 60-second-plus docker suite. Removing the starvation removes the class.

One deliberate subtlety, documented at `_exec-async.ts:157`: it settles on `exit` with a 250 ms drain grace rather than on `close`. A SIGKILLed `sh -c "sleep 30"` leaves the `sleep` grandchild holding stdout, and `close` then waits out the full sleep — a hang strictly worse than the flake being fixed. Caught by the timeout test below, which hung at 5 s before this.

**Tests — `tests/docker/exec-async.test.ts` (10).** The property that fixes the flake is event-loop liveness, so that is what is asserted: a 20 ms interval must tick **>5** times during an awaited 0.6 s child, and **exactly 0** times during the equivalent `execFileSync`. The sync arm is asserted deliberately — if `execFileSync` ever stopped blocking, the suite would silently stop proving anything. Plus the `execFileSync`-compat semantics (stdout capture, non-zero exit fields, `input`, stdin closed with no input, env passthrough, spawn failure → `status: -1`) and the bounded `timeoutMs` kill path.

`tests/docker/_exec-async.ts` is added to the `hindsight` paths filter: every probe now executes through it, and that job is gated on the filter, not on `vitest --changed`.

---

## Verification

Run locally in a worktree off `origin/main`:

- **`npx vitest run tests/docker/hindsight-*.test.ts` against real docker: 22 files, 166 passed / 2 skipped, 155 s.** The reflect-directives file — the one that ejected the queue — ran **81.7 s** with **41.1 s** and **40.6 s** tests and no RPC timeout. That is the direct reproduction: previously that shape exited 1.
- `tests/docker/exec-async.test.ts` 10/10, `tests/ci-e2e-ok-verdict.test.ts` 15/15, `tests/ci-merge-queue-triggers.test.ts` 62/62.
- `npm run lint` clean (includes `tsc --noEmit`).

**Unverified locally:** the workflow-level behaviour of fix 1 — that GitHub renders the `::warning` annotation on the checks tab, that the job summary appears, and that `e2e-shard` / `hindsight-probe` actually schedule on a `workflow_dispatch`. The verdict *script* is executed and asserted; GitHub's rendering of it is not simulatable. What will demonstrate it: this PR's own run. If the paths filter marks it relevant (it edits `.github/workflows/docker-e2e.yml`, which is in both filters), `e2e-ok` should report `VERIFIED` with no warning; a `gh workflow run docker-e2e.yml --ref ci-signal-integrity` should now take minutes and run shards rather than going green in 3 seconds.

## Out of scope — named, not fixed

Four sibling aggregate gates carry the **identical** two-state pattern (`success` and `skipped` collapsed into one green):

- `vitest` — `.github/workflows/ci-tests-core.yml:213`
- `python-ok` — `.github/workflows/ci-tests-python.yml:145`
- `images-ok` — `.github/workflows/docker-images.yml:1596`
- `uat-gate` — `.github/workflows/ci-uat.yml:230`

They are **not** the same one-line change: each has a different `needs` set, different want-flags, and different must-run events, so fixing them means four bespoke verdict scripts and four test suites. Only `e2e-ok` has an ejection on record, so only `e2e-ok` is fixed here; the others are a tracked follow-up rather than an untested drive-by across every required gate in the repo.
