### PR TITLE
fix(hermes): scope GET /api/cron/jobs by ?profile=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ now an anomaly worth investigating, not the norm.
   (`stderr-timestamps.ts` uses `toISOString()`; the shell stamps use `date -u`),
   so a designator-less line is now normalised to `Z` at the producer. An
   explicit `+HH:MM` offset is preserved untouched.
+- **hermes: the cron panel no longer shows every agent's schedule under one
+  profile.** `GET /api/cron/jobs` ignored `?profile=`, which the desktop uses
+  as endpoint-level scoping rather than a hint. Switchroom has exactly one
+  profile (`default`, the name `/api/profiles/active` reports), so that profile
+  gets the fleet's schedule and any other profile correctly gets none.
+
 - **hermes: the desktop's session search box works instead of throwing.**
   `GET /api/sessions/search` was caught by the `/api/sessions/:id` regex, which
   read `search` as a session id and answered `404 {error:'Unknown session'}`;

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -986,6 +986,20 @@ export async function handleHermesRest(
   // the UI — the same constraint as the Telegram /schedule command).
   if (pathname.startsWith("/api/cron")) {
     if (method === "GET" && pathname === "/api/cron/jobs") {
+      // `?profile=` is endpoint-level scoping, not a client-side hint: the
+      // desktop asks for "just that profile's jobs, or all"
+      // (apps/desktop/src/hermes.ts:1381-1389) and renders whatever comes back,
+      // pinned upstream at apps/desktop/src/hermes-cron-scope.test.ts:60-73.
+      // Ignoring it leaked every agent's schedule into a single profile's panel.
+      //
+      // Switchroom has exactly one profile, and `default` is the name it
+      // reports for it (see the /api/profiles/active branch below). So the
+      // fleet's schedule IS that profile's schedule, and any other profile owns
+      // nothing — an empty list is the true answer here, not a fabricated one.
+      const profile = new URLSearchParams(search).get("profile");
+      if (profile !== null && profile !== "" && profile !== "default") {
+        return { status: 200, body: [] };
+      }
       const schedule = await handleGetSchedule(config);
       const jobs = scheduleToCronJobs(schedule);
       return { status: 200, body: jobs };

--- a/src/web/hermes-cron-scope.test.ts
+++ b/src/web/hermes-cron-scope.test.ts
@@ -1,0 +1,53 @@
+/**
+ * `GET /api/cron/jobs?profile=` — the scoping, in both directions.
+ *
+ * The parity fixture pins the miss (an unknown profile must return `[]`) and
+ * the unfiltered read (the whole fleet's schedule). Neither catches the
+ * over-correction that a naive "any ?profile= means filter" implementation
+ * makes: the desktop's cron panel passes the ACTIVE profile
+ * (apps/desktop/src/hermes.ts:1381-1389), which for switchroom is `default` —
+ * so filtering that one out would empty the panel in normal use while both
+ * fixture cases stayed green.
+ */
+
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleHermesRest } from "./hermes-adapter.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const CONFIG = {
+  agents: {
+    alpha: { schedule: [{ cron: "0 9 * * *", prompt: "alpha morning digest" }] },
+    beta: { schedule: [{ cron: "0 17 * * 5", prompt: "beta weekly roundup" }] },
+  },
+} as unknown as SwitchroomConfig;
+
+beforeAll(() => {
+  process.env.SWITCHROOM_AGENTS_DIR = mkdtempSync(join(tmpdir(), "sr-hermes-cron-"));
+});
+
+async function jobs(search: string): Promise<unknown[]> {
+  const res = await handleHermesRest("GET", "/api/cron/jobs", CONFIG, search);
+  expect(res!.status).toBe(200);
+  return res!.body as unknown[];
+}
+
+describe("GET /api/cron/jobs profile scoping", () => {
+  it("returns the fleet's schedule when no profile is given", async () => {
+    expect((await jobs("")).length).toBe(2);
+  });
+
+  it("returns the fleet's schedule for the profile switchroom actually reports", async () => {
+    // /api/profiles/active answers {active: 'default'}. That profile owns
+    // everything; filtering it out would blank the panel in the ONLY
+    // configuration a real desktop ever sends.
+    expect((await jobs("?profile=default")).length).toBe(2);
+    expect((await jobs("?profile=")).length).toBe(2);
+  });
+
+  it("returns nothing for a profile switchroom does not have", async () => {
+    expect(await jobs("?profile=__no_such_profile__")).toEqual([]);
+  });
+});

--- a/src/web/hermes-rest-parity.test.ts
+++ b/src/web/hermes-rest-parity.test.ts
@@ -1045,11 +1045,6 @@ const CONTRACT: ContractCase[] = [
     search: "?profile=__no_such_profile__",
     client: "hermes.ts:1381-1389 — 'list just that profile's jobs, or all'",
     server: "hermes_cli/web_server.py",
-    gap:
-      "hermes-adapter.ts:713-717 ignores ?profile= and returns the whole " +
-      "fleet's schedule. The desktop expects endpoint-level filtering — pinned " +
-      "upstream at apps/desktop/src/hermes-cron-scope.test.ts:60-73 — so cron " +
-      "jobs from every agent leak into a single profile's panel.",
     assert: (res) => {
       expect(res!.status).toBe(200);
       // The fixture fleet has 2 jobs (asserted above), none of them owned by
@@ -1415,8 +1410,8 @@ describe(`Hermes REST response contract (upstream ${UPSTREAM_HERMES_SHA.slice(0,
     // raise `green`) in the same PR that removes a `gap` field.
     expect({ total: CONTRACT.length, green, gaps }).toEqual({
       total: 47,
-      green: 39,
-      gaps: 8,
+      green: 40,
+      gaps: 7,
     });
   });
 });


### PR DESCRIPTION
**Fourth in a stack:** #4625 → #4627 → #4630 → this. Stacked because every one moves the same ratchet line in `hermes-rest-parity.test.ts`; rebase down as each merges.

## The bug

`GET /api/cron/jobs` ignored `?profile=` and returned the whole fleet's schedule. That parameter is **endpoint-level scoping, not a client-side hint** — the desktop asks for *"just that profile's jobs, or all"* (`apps/desktop/src/hermes.ts:1381-1389`) and renders whatever comes back. The contract is pinned upstream in `apps/desktop/src/hermes-cron-scope.test.ts:60-73`. So every agent's cron jobs leaked into a single profile's panel.

## The fix

Switchroom has exactly one profile, and `default` is the name it reports for it (`/api/profiles/active` answers `{active: 'default', current: 'default'}`). So:

- no `?profile=`, or `?profile=default` → the fleet's schedule;
- any other profile → `[]`.

Both directions are the *true* answer. The empty list here is not the "fabricate a 200" anti-pattern: that profile genuinely owns no jobs.

## The test the fixture cannot be

The parity fixture pins the miss (`?profile=__no_such_profile__` → `[]`) and the unfiltered read (2 jobs). A naive *"any `?profile=` means filter"* implementation passes **both** — while blanking the panel for `?profile=default`, which is the only value a real desktop ever sends. `hermes-cron-scope.test.ts` asserts that third case explicitly.

## Ratchet

`39 green / 8 gaps` → `40 green / 7 gaps`, gap flag deleted in the same commit.

## Verification

```
$ npx vitest run src/web/hermes-cron-scope.test.ts src/web/hermes-rest-parity.test.ts
      Tests  186 passed (186)

$ npm run -s lint    # tsc --noEmit + all guard scripts
check-hostd-template-guard: OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)