### PR TITLE
fix(hermes): send real strings in GET /api/status, not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,14 @@ now an anomaly worth investigating, not the norm.
   (`stderr-timestamps.ts` uses `toISOString()`; the shell stamps use `date -u`),
   so a designator-less line is now normalised to `Z` at the producer. An
   explicit `+HH:MM` offset is preserved untouched.
+- **hermes: `GET /api/status` no longer renders "null" in the settings pane.**
+  `config_path`, `env_path` and `release_date` are declared as bare `string` in
+  `StatusResponse`, and the adapter sent `null` for all three. They now carry
+  the real resolved `switchroom.yaml` path, `""` for the env file switchroom
+  does not have by construction, and the build's commit date. `version`
+  reports the actual switchroom version instead of the literal string
+  `"switchroom"`.
+
 - **hermes: the cron panel no longer shows every agent's schedule under one
   profile.** `GET /api/cron/jobs` ignored `?profile=`, which the desktop uses
   as endpoint-level scoping rather than a hint. Switchroom has exactly one

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -23,7 +23,8 @@ import { join, resolve } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 import type { SwitchroomConfig } from "../config/schema.js";
 import type { Turn } from "../../telegram-plugin/registry/turns-schema.js";
-import { resolveAgentsDir } from "../config/loader.js";
+import { resolveAgentsDir, findConfigFile } from "../config/loader.js";
+import { VERSION, COMMIT_DATE } from "../build-info.js";
 import { resolveChannelTarget } from "../agent-scheduler/channel-target.js";
 import {
   handleGetAgents,
@@ -920,20 +921,43 @@ export async function handleHermesRest(
 
   // GET /api/status — StatusResponse shape Hermes Desktop expects
   if (method === "GET" && pathname === "/api/status") {
+    // config_path, env_path and release_date are declared as BARE `string` in
+    // StatusResponse (apps/desktop/src/types/hermes.ts:1144-1160), not
+    // `string | null`. Sending null made the settings pane render the literal
+    // "null" — or throw, wherever it calls a string method on one.
+    //
+    // Each value below is the real one, not a placeholder:
+    //   - config_path  the switchroom.yaml this process actually resolved.
+    //                  findConfigFile throws when there is none (a legitimate
+    //                  state for an unconfigured host), and the empty string is
+    //                  the honest "no file", so the throw is caught rather than
+    //                  turned into a fake path.
+    //   - env_path     switchroom has no env file by construction — secrets
+    //                  live in the encrypted vault and config in YAML — so ""
+    //                  is not a stub, it is the answer.
+    //   - release_date the build's commit date (src/build-info.ts, regenerated
+    //                  by scripts/build.mjs), which is the only release
+    //                  timestamp switchroom has.
+    let configPath = "";
+    try {
+      configPath = findConfigFile();
+    } catch {
+      configPath = "";
+    }
     return {
       status: 200,
       body: {
-        version: "switchroom",
+        version: VERSION,
         gateway_running: true,
         gateway_platforms: {},
         gateway_state: "ready",
         config_version: 0,
         latest_config_version: 0,
         hermes_home: "switchroom",
-        release_date: null,
+        release_date: COMMIT_DATE ?? "",
         active_sessions: 0,
-        config_path: null,
-        env_path: null,
+        config_path: configPath,
+        env_path: "",
         gateway_exit_reason: null,
         gateway_health_url: null,
         gateway_pid: null,

--- a/src/web/hermes-rest-parity.test.ts
+++ b/src/web/hermes-rest-parity.test.ts
@@ -976,10 +976,6 @@ const CONTRACT: ContractCase[] = [
     path: "/api/status",
     client: "hermes.ts:785-790 (getStatus); types/hermes.ts:1144-1160",
     server: "hermes_cli/web_server.py",
-    gap:
-      "hermes-adapter.ts:658-661 sends null for release_date, config_path and " +
-      "env_path. StatusResponse declares all three as bare `string`, so the " +
-      "settings pane renders 'null' or throws on a string method.",
     assert: (res) => {
       const b = body200(res);
       for (const field of ["config_path", "env_path", "release_date", "hermes_home", "version"]) {
@@ -1410,8 +1406,8 @@ describe(`Hermes REST response contract (upstream ${UPSTREAM_HERMES_SHA.slice(0,
     // raise `green`) in the same PR that removes a `gap` field.
     expect({ total: CONTRACT.length, green, gaps }).toEqual({
       total: 47,
-      green: 40,
-      gaps: 7,
+      green: 41,
+      gaps: 6,
     });
   });
 });

--- a/src/web/hermes-status-fields.test.ts
+++ b/src/web/hermes-status-fields.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `GET /api/status` — that the string fields carry the REAL values.
+ *
+ * The parity fixture can only assert `typeof === "string"`, which is satisfied
+ * by `""` for every field. That floor is what let `null` be the bug and would
+ * equally let a blanket empty-string stub through. This file pins the values.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleHermesRest } from "./hermes-adapter.js";
+import { VERSION, COMMIT_DATE } from "../build-info.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const CONFIG = { agents: { alpha: {} } } as unknown as SwitchroomConfig;
+
+let configFile = "";
+let previousConfigEnv: string | undefined;
+
+beforeAll(() => {
+  const dir = mkdtempSync(join(tmpdir(), "sr-hermes-status-"));
+  process.env.SWITCHROOM_AGENTS_DIR = dir;
+  configFile = join(dir, "switchroom.yaml");
+  writeFileSync(configFile, "agents:\n  alpha: {}\n");
+  previousConfigEnv = process.env.SWITCHROOM_CONFIG;
+  process.env.SWITCHROOM_CONFIG = configFile;
+});
+
+afterAll(() => {
+  if (previousConfigEnv === undefined) delete process.env.SWITCHROOM_CONFIG;
+  else process.env.SWITCHROOM_CONFIG = previousConfigEnv;
+});
+
+async function status(): Promise<Record<string, unknown>> {
+  const res = await handleHermesRest("GET", "/api/status", CONFIG, "");
+  expect(res!.status).toBe(200);
+  return res!.body as Record<string, unknown>;
+}
+
+describe("GET /api/status string fields", () => {
+  it("config_path is the switchroom.yaml this process actually resolved", async () => {
+    // Not merely a string: the settings pane shows this path to the operator,
+    // so a blank or invented one is worse than useless.
+    expect((await status()).config_path).toBe(configFile);
+  });
+
+  it("config_path falls back to '' rather than throwing when there is no config file", async () => {
+    const saved = process.env.SWITCHROOM_CONFIG;
+    process.env.SWITCHROOM_CONFIG = join(tmpdir(), "sr-hermes-status-absent", "nope.yaml");
+    try {
+      const body = await status();
+      // findConfigFile still walks cwd and ~/.switchroom, so the assertion that
+      // holds on every host is: a string, never null, and the route answers 200.
+      expect(typeof body.config_path).toBe("string");
+    } finally {
+      process.env.SWITCHROOM_CONFIG = saved;
+    }
+  });
+
+  it("version and release_date come from the build, not from a placeholder", async () => {
+    const body = await status();
+    expect(body.version).toBe(VERSION);
+    expect(body.release_date).toBe(COMMIT_DATE ?? "");
+    // The pre-fix values, pinned so a revert is loud.
+    expect(body.version).not.toBe("switchroom");
+    expect(body.release_date).not.toBeNull();
+  });
+
+  it("env_path is an empty string — switchroom has no env file — never null", async () => {
+    const body = await status();
+    expect(body.env_path).toBe("");
+  });
+
+  it("no field StatusResponse declares as a bare string is null", async () => {
+    const body = await status();
+    for (const field of ["config_path", "env_path", "release_date", "hermes_home", "version"]) {
+      expect(body[field], `StatusResponse.${field}`).not.toBeNull();
+      expect(typeof body[field]).toBe("string");
+    }
+  });
+});


### PR DESCRIPTION
**Fifth in a stack:** #4625 → #4627 → #4630 → #4631 → this. Stacked because every one moves the same ratchet line in `hermes-rest-parity.test.ts`.

## The bug

`StatusResponse` (`apps/desktop/src/types/hermes.ts:1144-1160`) declares `config_path`, `env_path` and `release_date` as **bare `string`**, not `string | null`. The adapter sent `null` for all three, so the settings pane rendered the literal `"null"` — or threw wherever it called a string method on one.

## The fix

Each value is the real one, not a placeholder:

| field | value | why it is honest |
|---|---|---|
| `config_path` | the `switchroom.yaml` this process actually resolved | `findConfigFile()`'s throw (a legitimate state on an unconfigured host) is caught down to `""`, rather than invented into a fake path |
| `env_path` | `""` | switchroom has **no env file by construction** — secrets live in the encrypted vault, config in YAML. `""` is the answer, not a stub |
| `release_date` | the build's commit date (`src/build-info.ts`, regenerated by `scripts/build.mjs`) | the only release timestamp switchroom has |

**One adjacent change, called out rather than smuggled:** `version` reported the literal string `"switchroom"`, which is not a version. It now reports the real one from the same generated `build-info` module. It was already type-legal, so no fixture case demanded it — but the About pane shows it to the operator, and it is the same "StatusResponse should be true" concern as the three fields above.

`hermes_home` (`"switchroom"`) is left alone: switchroom has no single home directory that answers that question, and inventing one would be worse than the vague-but-true string.

## The test the fixture cannot be

The parity fixture asserts `typeof === "string"` for these fields — which a blanket `""` stub satisfies for every one of them. That is the exact floor that let `null` through in the first place. `hermes-status-fields.test.ts` pins the **values**: `config_path` equals the file actually resolved (via `SWITCHROOM_CONFIG` pointed at a temp yaml), `version` equals `VERSION` and explicitly **not** `"switchroom"`, `release_date` equals `COMMIT_DATE`, and the no-config-file path still answers 200 with a string rather than throwing.

## Ratchet

`40 green / 7 gaps` → `41 green / 6 gaps`, gap flag deleted in the same commit.

## Verification

```
$ npx vitest run src/web/hermes-rest-parity.test.ts src/web/hermes-ws-parity.test.ts \
    src/web/hermes-status-fields.test.ts src/web/hermes-cron-scope.test.ts \
    src/web/hermes-unsupported-writes.test.ts tests/web/
      Tests  313 passed (313)

$ npm run -s lint    # tsc --noEmit + all guard scripts
check-hostd-template-guard: OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)