### PR TITLE
fix(hermes): emit the optional SessionInfo fields the sidebar groups on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,14 @@ now an anomaly worth investigating, not the norm.
   (`stderr-timestamps.ts` uses `toISOString()`; the shell stamps use `date -u`),
   so a designator-less line is now normalised to `Z` at the producer. An
   explicit `+HH:MM` offset is preserved untouched.
+
+- **hermes: the desktop sidebar gets the `SessionInfo` fields it groups and
+  sorts on.** Session rows omitted `pinned`, `archived`, `profile`,
+  `is_default_profile`, the `git_*`, lineage, handoff and cost fields. They are
+  all optional, so nothing threw — the cost was silent feature loss (no Pinned
+  section, no profile badge, no cost sort). Costs are `null` rather than `0`:
+  switchroom has no token metering, and `0` would sort every session to the top
+  of a cost-ordered list as if it were measured.
 - **hermes: `GET /api/status` no longer renders "null" in the settings pane.**
   `config_path`, `env_path` and `release_date` are declared as bare `string` in
   `StatusResponse`, and the adapter sent `null` for all three. They now carry

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -150,6 +150,50 @@ function toHermesSession(sessionId: string, agent: AgentInfo, liveness: AgentLiv
     quota: agent.primaryAccount
       ? { used_pct: null, slot: agent.primaryAccount }
       : null,
+
+    // ─── Optional SessionInfo fields the sidebar groups and sorts on ────────
+    //
+    // All optional in SessionInfo (apps/desktop/src/types/hermes.ts:464-523),
+    // so omitting them threw nothing — the cost was silent feature loss: no
+    // Pinned section, no profile badge, no cost sort. Every value below is a
+    // true statement about switchroom, and the ones that are `false`/`null`
+    // are that way because the concept does not exist here, not as a stub:
+    //
+    //   pinned / archived  no per-session pin or archive store, and the PATCH
+    //                      that would set one is refused (see the DELETE
+    //                      /api/sessions/:id comment) — so these are
+    //                      permanently false, which is what the sidebar needs
+    //                      to know to render the sections at all.
+    //   profile            switchroom has exactly one profile and reports it
+    //                      as `default` (/api/profiles/active). The field's
+    //                      own docstring says the UI treats a missing profile
+    //                      as the default — stating it explicitly is the same
+    //                      answer, minus the inference.
+    //   git_*              a session is an agent, not a repo working tree;
+    //                      there is no branch or checkout to group by.
+    //   parent_session_id  no forking and no auto-compression, so no lineage:
+    //   _lineage_root_id   every session is its own root.
+    //   handoff_*          no cross-platform session handoff concept.
+    //   *_cost_usd         no token metering. Sending 0 would be a LIE that
+    //                      sorts to the top of a cost-ordered list; null is
+    //                      "unknown", which is the truth.
+    //
+    // Nullable per the type: only `archived`, `pinned`, `profile` and
+    // `is_default_profile` are declared without `| null`, and those four are
+    // the four non-null values here.
+    pinned: false,
+    archived: false,
+    profile: "default",
+    is_default_profile: true,
+    git_branch: null,
+    git_repo_root: null,
+    parent_session_id: null,
+    _lineage_root_id: null,
+    handoff_platform: null,
+    handoff_state: null,
+    handoff_error: null,
+    actual_cost_usd: null,
+    estimated_cost_usd: null,
   };
 }
 

--- a/src/web/hermes-rest-parity.test.ts
+++ b/src/web/hermes-rest-parity.test.ts
@@ -908,15 +908,6 @@ const CONTRACT: ContractCase[] = [
     search: "?limit=40&offset=0&min_messages=0&archived=exclude&order=recent",
     client: "types/hermes.ts:464-523 (SessionInfo)",
     server: "hermes_cli/web_routers/sessions.py:54",
-    gap:
-      "toHermesSession (hermes-adapter.ts:128-153) emits none of these. They " +
-      "are all optional in SessionInfo so nothing throws — the cost is silent " +
-      "feature loss: no Pinned section (`pinned`), no archive state " +
-      "(`archived`), no profile badge (`profile`/`is_default_profile`), no " +
-      "branch/repo grouping (`git_branch`/`git_repo_root`), no fork lineage " +
-      "(`parent_session_id`/`_lineage_root_id`), no handoff badge " +
-      "(`handoff_platform`/`handoff_state`/`handoff_error`), and no cost sort " +
-      "(`actual_cost_usd`/`estimated_cost_usd`).",
     assert: (res) => {
       const b = body200(res);
       const s = (b.sessions as Record<string, unknown>[])[0];
@@ -1406,8 +1397,8 @@ describe(`Hermes REST response contract (upstream ${UPSTREAM_HERMES_SHA.slice(0,
     // raise `green`) in the same PR that removes a `gap` field.
     expect({ total: CONTRACT.length, green, gaps }).toEqual({
       total: 47,
-      green: 41,
-      gaps: 6,
+      green: 42,
+      gaps: 5,
     });
   });
 });

--- a/src/web/hermes-sessioninfo-fields.test.ts
+++ b/src/web/hermes-sessioninfo-fields.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The optional `SessionInfo` fields — that the VALUES are true, not just present.
+ *
+ * The parity fixture asserts `toHaveProperty` for each field, which any value
+ * satisfies. That distinction matters most for cost: `actual_cost_usd: 0` would
+ * satisfy the fixture and then sort every switchroom session to the top of a
+ * cost-ordered list as if it were free-and-measured, rather than unmeasured.
+ * `null` is the truthful "unknown".
+ *
+ * It also pins the type contract: `archived`, `pinned`, `profile` and
+ * `is_default_profile` are the only four of these declared WITHOUT `| null`
+ * (apps/desktop/src/types/hermes.ts:464-523), so those four must never be null
+ * — the same class of bug as the `GET /api/status` nulls.
+ */
+
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleHermesRest } from "./hermes-adapter.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const AGENT = "alpha";
+const CONFIG = { agents: { [AGENT]: { model: "sonnet" } } } as unknown as SwitchroomConfig;
+
+beforeAll(() => {
+  process.env.SWITCHROOM_AGENTS_DIR = mkdtempSync(join(tmpdir(), "sr-hermes-sessioninfo-"));
+});
+
+/** Fields the type declares without `| null`. */
+const NON_NULLABLE = ["pinned", "archived", "profile", "is_default_profile"] as const;
+
+/** Fields that are `null | T` and have no switchroom concept behind them. */
+const NULL_VALUED = [
+  "git_branch",
+  "git_repo_root",
+  "parent_session_id",
+  "_lineage_root_id",
+  "handoff_platform",
+  "handoff_state",
+  "handoff_error",
+  "actual_cost_usd",
+  "estimated_cost_usd",
+] as const;
+
+async function firstSession(): Promise<Record<string, unknown>> {
+  const res = await handleHermesRest("GET", "/api/sessions", CONFIG, "");
+  expect(res!.status).toBe(200);
+  const rows = (res!.body as { sessions: Record<string, unknown>[] }).sessions;
+  expect(rows.length).toBeGreaterThan(0);
+  return rows[0];
+}
+
+describe("SessionInfo optional fields", () => {
+  it("the four non-nullable fields carry real values, never null", async () => {
+    const s = await firstSession();
+    for (const field of NON_NULLABLE) {
+      expect(s[field], `SessionInfo.${field} is declared without | null`).not.toBeNull();
+    }
+    expect(s.pinned).toBe(false);
+    expect(s.archived).toBe(false);
+    expect(s.profile).toBe("default");
+    expect(s.is_default_profile).toBe(true);
+  });
+
+  it("profile matches the one /api/profiles/active reports", async () => {
+    const active = await handleHermesRest("GET", "/api/profiles/active", CONFIG, "");
+    const s = await firstSession();
+    expect(s.profile).toBe((active!.body as { active: string }).active);
+  });
+
+  it("fields with no switchroom concept are null, not zero-valued", async () => {
+    const s = await firstSession();
+    for (const field of NULL_VALUED) {
+      expect(s[field], `SessionInfo.${field}`).toBeNull();
+    }
+    // Stated separately because this is the one that changes UI behaviour:
+    // 0 would sort as "measured and free" in a cost-ordered list.
+    expect(s.actual_cost_usd).not.toBe(0);
+    expect(s.estimated_cost_usd).not.toBe(0);
+  });
+
+  it("the single-session route carries the same fields as the list route", async () => {
+    const res = await handleHermesRest("GET", `/api/sessions/${AGENT}`, CONFIG, "");
+    const s = (res!.body as { session: Record<string, unknown> }).session;
+    for (const field of [...NON_NULLABLE, ...NULL_VALUED]) {
+      expect(s, `SessionInfo.${field} missing on /api/sessions/:id`).toHaveProperty(field);
+    }
+  });
+});


### PR DESCRIPTION
**Sixth in a stack:** #4625 → #4627 → #4630 → #4631 → #4632 → this.

## The bug

`toHermesSession` emitted **none** of the optional `SessionInfo` fields. They are all optional (`apps/desktop/src/types/hermes.ts:464-523`), so nothing threw — the cost was silent feature loss: no Pinned section, no archive state, no profile badge, no branch/repo grouping, no fork lineage, no handoff badge, no cost sort.

## Every value is a true statement, not a stub

| field(s) | value | why |
|---|---|---|
| `pinned`, `archived` | `false` | no per-session pin or archive store, and the PATCH that would set one is refused. Permanently false — which is what the sidebar needs in order to render the sections at all |
| `profile`, `is_default_profile` | `"default"`, `true` | exactly one profile, reported as `default` by `/api/profiles/active`. The field's own docstring says the UI infers exactly this when it is absent — stating it explicitly is the same answer minus the inference |
| `git_branch`, `git_repo_root` | `null` | a session is an agent, not a repo working tree |
| `parent_session_id`, `_lineage_root_id` | `null` | no forking, no auto-compression: every session is its own root |
| `handoff_*` | `null` | no cross-platform handoff concept |
| `actual_cost_usd`, `estimated_cost_usd` | `null` | no token metering |

The cost fields are the one place where the choice is load-bearing: **`0` would be a lie that sorts every switchroom session to the top of a cost-ordered list** as if it were measured and free. `null` is "unknown", which is the truth.

Type contract: only `archived`, `pinned`, `profile` and `is_default_profile` are declared **without** `| null`, and those four are exactly the four non-null values here — the same class of bug #4632 fixed on `StatusResponse`.

## The test the fixture cannot be

The parity fixture asserts `toHaveProperty` for each field, which **any** value satisfies — including `actual_cost_usd: 0`. `hermes-sessioninfo-fields.test.ts` pins the values, asserts the four non-nullable fields are never null, cross-checks `profile` against what `/api/profiles/active` actually reports (rather than hardcoding `"default"` twice), and checks the single-session route carries the same fields as the list route.

## Ratchet

`41 green / 6 gaps` → `42 green / 5 gaps`.

## Verification

```
$ npx vitest run src/web/hermes-rest-parity.test.ts src/web/hermes-ws-parity.test.ts \
    src/web/hermes-sessioninfo-fields.test.ts src/web/hermes-status-fields.test.ts \
    src/web/hermes-cron-scope.test.ts src/web/hermes-unsupported-writes.test.ts tests/web/
      Tests  317 passed (317)

$ npm run -s lint    # tsc --noEmit + all guard scripts
check-hostd-template-guard: OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)