### PR TITLE
fix(ci): run hindsight-watch-pg-probe on workflow_dispatch

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -776,10 +776,15 @@ jobs:
   #
   # merge_group and push run it unconditionally, same reasoning as
   # hindsight-probe: a job that exists so a probe cannot silently skip
-  # must not silently skip on candidate-main.
+  # must not silently skip on candidate-main. workflow_dispatch is here
+  # for the same reason it is on e2e-shard and hindsight-probe: `changes`
+  # has no diff base on a dispatch, so `hindsightwatch` comes back false
+  # and the advertised recovery lever would exercise no pg probe at all
+  # (#4638). The job needs nothing the dispatch path lacks — no service
+  # container, no secret, no input; it pulls postgres:16-alpine itself.
   hindsight-watch-pg-probe:
     needs: changes
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.hindsightwatch == 'true'
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.hindsightwatch == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -871,17 +876,15 @@ jobs:
 
           # Events where the work jobs are unconditional (their `if:` has
           # no filter term). A skip on one of these is a broken gate.
-          # Derived PER JOB from that job's own `if:`, not globally:
-          # e2e-shard and hindsight-probe carry a workflow_dispatch term,
-          # hindsight-watch-pg-probe does not, so a dispatch skip is
-          # legitimate for it and a broken gate for the other two.
+          # One set for all three: since #4638 every work job's `if:`
+          # carries the same push / merge_group / workflow_dispatch terms
+          # (hindsight-watch-pg-probe used to omit workflow_dispatch and
+          # needed a separate, weaker `must_run_pg` to excuse the skip).
+          # If a job's `if:` ever diverges again, split this back out —
+          # the set must be derived from the gate it is judging.
           must_run=0
           case "$EVENT" in
             push|merge_group|workflow_dispatch) must_run=1 ;;
-          esac
-          must_run_pg=0
-          case "$EVENT" in
-            push|merge_group) must_run_pg=1 ;;
           esac
 
           fail=0
@@ -923,7 +926,7 @@ jobs:
           verdict e2e-shard "$E2E_SHARD" "$WANT_E2E_SHARD" "$must_run"
           verdict hindsight-probe "$HINDSIGHT_PROBE" "$WANT_HINDSIGHT_PROBE" "$must_run"
           verdict hindsight-watch-pg-probe "$HINDSIGHT_WATCH_PG_PROBE" \
-            "$WANT_HINDSIGHT_WATCH_PG_PROBE" "$must_run_pg"
+            "$WANT_HINDSIGHT_WATCH_PG_PROBE" "$must_run"
 
           if [ "$fail" -ne 0 ]; then
             headline="❌ FAILED"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **CI: the `docker-e2e` manual recovery lever now actually runs the pg probe.**
+  `hindsight-watch-pg-probe`'s `if:` gate carried `push` and `merge_group` but
+  not `workflow_dispatch`, unlike its siblings `e2e-shard` and
+  `hindsight-probe`. `changes` has no diff base on a dispatch, so
+  `hindsightwatch` came back false and a manual `gh workflow run
+  docker-e2e.yml` never exercised the streak-retention-floor probe against a
+  real PostgreSQL at all — the same "recovered nothing and said it had" shape
+  run 31131064381 surfaced for the other two jobs. The gate now carries the
+  `workflow_dispatch` term, and `e2e-ok`'s verdict drops the separate
+  `must_run_pg` must-run set #4628 had added purely to excuse that skip: all
+  three work jobs share one `must_run`, so a pg-probe skip on any must-run
+  event is a broken gate again rather than a tolerated one. The job needs
+  nothing the dispatch path lacks — no service container, no secret, no
+  workflow input; it pulls `postgres:16-alpine` in its own step. (#4638)
+
 - **CI: `e2e-ok` no longer reports a path-skipped run as a verified pass.** The
   sentinel collapsed "the e2e shards ran and passed" and "nothing ran at all"
   into the same silent green, so a reviewer could not tell them apart. PR #4619
@@ -54,9 +69,8 @@ now an anomaly worth investigating, not the norm.
   `relevant=false`, every job skipped, and the run went green in 3 seconds
   (run 31131064381) without testing anything. `hindsight-watch-pg-probe`
   (added to the sentinel's `needs:` by #4623) is aggregated by the same
-  three-state verdict, with its must-run set derived from its own `if:` —
-  it carries no `workflow_dispatch` term, so a dispatch skip warns there
-  rather than failing the gate.
+  three-state verdict; its `if:` gained the matching `workflow_dispatch`
+  term in #4638, above.
 - **CI: the `hindsight-probe` `Timeout calling "onTaskUpdate"` flake is
   fixed at the cause.** All five tests passed and vitest still exited 1. The
   docker probes drove `docker run` / `docker exec` through `execFileSync`,

--- a/tests/ci-e2e-ok-verdict.test.ts
+++ b/tests/ci-e2e-ok-verdict.test.ts
@@ -205,15 +205,14 @@ describe('e2e-ok verdict — a skip that should not have happened is a failure',
       expect(r.stdout).toContain('::error title=e2e gate broken::e2e-shard was SKIPPED')
       expect(r.stdout).toContain('::error title=e2e gate broken::hindsight-probe was SKIPPED')
 
-      // must-run is derived PER JOB from that job's own `if:`.
-      // hindsight-watch-pg-probe carries no workflow_dispatch term, so a
-      // dispatch skip is legitimate for it and a broken gate elsewhere.
-      const pgBroken = r.stdout.includes(
-        '::error title=e2e gate broken::hindsight-watch-pg-probe was SKIPPED',
-      )
-      expect(pgBroken, `hindsight-watch-pg-probe skip on ${event}`).toBe(
-        event !== 'workflow_dispatch',
-      )
+      // Since #4638 all three work jobs carry the same must-run terms, so
+      // a skip on ANY of these events — workflow_dispatch included — is a
+      // broken gate for the pg probe too. Before #4638 it was excused on
+      // dispatch by a separate, weaker `must_run_pg`.
+      expect(
+        r.stdout,
+        `hindsight-watch-pg-probe skip on ${event} must fail the gate`,
+      ).toContain('::error title=e2e gate broken::hindsight-watch-pg-probe was SKIPPED')
     })
   }
 
@@ -244,9 +243,13 @@ describe('docker-e2e — the workflow_dispatch recovery lever actually runs the 
   // hindsight-probe both `skipped` — `changes` has no diff base on a
   // dispatch, so `relevant` came back false. The advertised recovery
   // lever recovered nothing and said it had.
+  //
+  // hindsight-watch-pg-probe kept that exact gap after #4628 (#4638): its
+  // `if:` carried push and merge_group only, so a manual dispatch never
+  // exercised the streak-retention-floor probe against a real PostgreSQL.
   const jobs = (workflow.jobs ?? {}) as Record<string, { if?: string }>
 
-  for (const name of ['e2e-shard', 'hindsight-probe']) {
+  for (const name of ['e2e-shard', 'hindsight-probe', 'hindsight-watch-pg-probe']) {
     it(`${name} runs on workflow_dispatch`, () => {
       const cond = jobs[name]?.if ?? ''
       expect(cond, `${name} must have a gating if:`).toBeTruthy()


### PR DESCRIPTION
## The gap

`.github/workflows/docker-e2e.yml`'s `hindsight-watch-pg-probe` gated on:

```yaml
if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.hindsightwatch == 'true'
```

No `workflow_dispatch` term, unlike its two siblings (`e2e-shard` L209,
`hindsight-probe` L369). `changes` has no diff base on a dispatch, so
`hindsightwatch` comes back `false` and every term is false — the job skips.
A manual `gh workflow run docker-e2e.yml`, which the workflow header
advertises as the recovery lever, therefore gave **zero** coverage of the
streak-retention-floor probe against a real PostgreSQL. Exactly the
"recovered nothing and said it had" shape run 31131064381 surfaced for the
other two jobs, still live for the third.

## Why `must_run_pg` existed — and why it goes

Verified against the `e2e-ok` job before touching it: `must_run_pg` is not
load-bearing for any other reason. Its own comment said so —

```
# Derived PER JOB from that job's own `if:`, not globally:
# e2e-shard and hindsight-probe carry a workflow_dispatch term,
# hindsight-watch-pg-probe does not, so a dispatch skip is
# legitimate for it and a broken gate for the other two.
```

It is passed to `verdict()` in exactly one place (the pg-probe call) and is
otherwise unreferenced in the repo. It is a `must` flag only — it does not
touch the `want` path-filter term, the failure/cancel branches, or the
headline arithmetic. With the `if:` fixed, `must_run_pg` and `must_run` are
the same set, so the split is dead weight that only weakens the gate.
Collapsed, with a comment saying to split it back out if a job's `if:` ever
diverges again.

## Is the dispatch path safe to run the pg probe on?

Yes — checked the job's own steps rather than assuming:

- **No `services:` block.** The test boots its own throwaway
  `postgres:16-alpine` via `docker run --network none` and tears it down.
- **No secrets.** The only `env:` is `SWITCHROOM_REQUIRE_PG_PROBE: "1"`.
- **No workflow inputs.** `workflow_dispatch:` declares none, and no step
  reads `github.event.inputs`.
- **Nothing event-conditional** in the job or in `./.github/actions/setup-switchroom`.
- The image is pulled in-job (`docker pull postgres:16-alpine`) precisely so
  `SWITCHROOM_REQUIRE_PG_PROBE=1` never hard-fails on a cache miss, and
  `hindsight-probe` — which already runs on dispatch — does heavier docker
  work on the same `ubuntu-latest` runner.

A manual run will now **run** the probe, not fail it.

## Test

`tests/ci-e2e-ok-verdict.test.ts` extracts and executes the real verdict
script, so it asserts outcomes rather than shape. Updated for the new
contract: the pg probe joins the `runs on workflow_dispatch` loop, and a
dispatch skip must now emit `::error title=e2e gate broken::` instead of
being excused. Both fail against the pre-fix workflow (2 failed / 15
passed, verified by reverting only the YAML); 17/17 pass with it.

`npm run -s lint` exits 0. `actionlint` on the workflow reports only three
pre-existing SC2086 infos in untouched `docker rm -f $ids` lines.

Closes #4638