### PR TITLE
docs(hindsight-watch): drop the R7 backstop overclaim; widen the pg-probe path filter

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -165,11 +165,16 @@ jobs:
             # semantics regression through on the hermetic string pins alone.
             # It gets a job here — the only workflow that already treats a
             # docker-dependent probe as a gate.
+            #
+            # The whole directory, not a file list: the enumeration already
+            # omitted `types.ts`, which the probe imports and the gated test
+            # pulls in transitively, so a change there would not have run the
+            # gate. A list has to be maintained by whoever next adds a file to
+            # the module and silently loses coverage when they don't; the glob
+            # cannot drift. It costs at most one extra 34s job on a change to
+            # a file the gated test does not read.
             hindsightwatch:
-              - 'src/hindsight-watch/probe.ts'
-              - 'src/hindsight-watch/evaluate.ts'
-              - 'src/hindsight-watch/thresholds.ts'
-              - 'src/hindsight-watch/streak-retention-floor.pg.test.ts'
+              - 'src/hindsight-watch/**'
               - '.github/workflows/docker-e2e.yml'
 
   # ─── Sharded docker e2e run ───────────────────────────────────────

--- a/src/hindsight-watch/evaluate.ts
+++ b/src/hindsight-watch/evaluate.ts
@@ -953,7 +953,16 @@ export function evaluateConsolidationQueueAge(ring: Sample[]): Verdict {
  *    to be consecutive with the ones after it, because the completion that
  *    would have broken the streak is exactly what the prune deletes. Do NOT
  *    "fix" it by widening the scan; that is #4620. `pending-consolidation-
- *    depth` (R7) covers the same pair from the depth side. Pinned in
+ *    depth` (R7) covers the same pair from the depth side ONLY when the pair
+ *    is `consolidation`: R7 counts `consolidated_at IS NULL` rows, and
+ *    `graph_maintenance` never writes that column. This arm is about TERMINAL
+ *    (`status = 'failed'`) attempts — fixture 5 and both real #4618 pairs are
+ *    that shape — and for a terminal `graph_maintenance` streak there is no
+ *    second signal. A `graph_maintenance` op wedged in the OTHER shape, stuck
+ *    `pending`/`processing`, still raises `consolidation-queue-age` (R5),
+ *    which filters on status alone and not on `operation_type`. See
+ *    `bankConsolidationQuery` and `CONSOLIDATION_QUEUE_SH` in `probe.ts` for
+ *    the evidence, and #4644 for the residual hole. Pinned in
  *    `streak-retention-floor.pg.test.ts` (fixture 5, `sparsebank`).
  */
 function lastSuccessPhrase(lastCompletedAgeS: number | null | undefined): string {

--- a/src/hindsight-watch/probe.ts
+++ b/src/hindsight-watch/probe.ts
@@ -532,8 +532,21 @@ PGPASSWORD="$PW" "$PSQL" -U "$U" -h /tmp -p "$P" -d "$DB" -tAc \\
  * pair failing more slowly than the retention window can accumulate three
  * attempts — for a 30-day horizon, slower than roughly one attempt per 10
  * days. That pair is still caught the moment a third attempt lands inside the
- * window, and `pending-consolidation-depth` (R7) covers it from the other
- * side, on rising unconsolidated depth rather than on failure counting.
+ * window. Do NOT read `pending-consolidation-depth` (R7) as a general backstop
+ * for it: R7 counts `memory_units` rows with `consolidated_at IS NULL AND
+ * fact_type IN ('experience','world')`, keyed by bank alone, so it moves on
+ * the CONSOLIDATION BACKLOG — which a wedged `consolidation` pair raises, but
+ * so does retain volume outrunning consolidation, consolidation never being
+ * scheduled, or a bulk re-consolidation reset. What it cannot do is move for a
+ * `graph_maintenance` pair: that path never writes the column — verified
+ * against `ghcr.io/switchroom/switchroom-hindsight:v0.21.7`, where
+ * `engine/graph_maintenance.py` contains zero references to `consolidated_at`
+ * (it drains `graph_maintenance_queue`, i.e. entity relinking) and dispatches
+ * as its own `task_type` branch alongside `consolidation`, not beneath it.
+ * Fixture 5 and both real #4618 pairs (`overlord/graph_maintenance`,
+ * `klanker/graph_maintenance`) are exactly that op type, so for them the
+ * third-attempt-inside-the-window path is the whole of the coverage. The
+ * residual hole that leaves is tracked as #4644.
  */
 export function bankConsolidationQuery(retentionDaysSql: string): string {
   return `SELECT 'S|'||a.bank_id||'|'||a.operation_type||'|'||count(*)||'|'||extract(epoch from (now()-max(a.created_at)))::bigint


### PR DESCRIPTION
Two non-blocking follow-ups from review round 3 on #4623. The merge queue landed that PR early (`87c2180d`) before these two one-liners made it onto the branch, so they ship here. No behaviour change: one doc-comment correction, one CI path filter.

## 1. The R7 backstop claim was false for the op type it mattered for

`probe.ts` and `evaluate.ts` justified the streak-scan truncation by saying `pending-consolidation-depth` (R7) covers the affected pair "from the other side".

Verified against the actual code path, it does not:

- R7 is the `'P|'` arm of `bankConsolidationQuery` (`src/hindsight-watch/probe.ts:560`): `count(*) FILTER (WHERE m.consolidated_at IS NULL AND m.fact_type IN ('experience','world'))`, `GROUP BY m.bank_id`. It is keyed by **bank alone** and measures the **consolidation backlog** — a quantity a wedged `consolidation` pair raises, but so does retain volume outrunning consolidation, consolidation never being scheduled, or a bulk re-consolidation reset (`memory_engine.py:7606` sets `consolidated_at = NULL` for a whole bank).
- The streak arm is keyed by `(bank_id, operation_type)`.
- In `ghcr.io/switchroom/switchroom-hindsight:v0.21.7`, `hindsight_api/engine/graph_maintenance.py` contains **zero** references to `consolidated_at` (`grep -c` → `0`); it drains `graph_maintenance_queue`, i.e. entity relinking. There is no indirect path either: `consolidation` and `graph_maintenance` dispatch as sibling `task_type` branches at `memory_engine.py:2464-2472`, so draining one cannot enqueue the other.

So a wedged `graph_maintenance` pair cannot move R7 — and that is precisely the case the claim was covering for: fixture 5 (`sparsebank`, `streak-retention-floor.pg.test.ts:219-223`) and both real #4618 pairs (`overlord/graph_maintenance`, `klanker/graph_maintenance`) are all `graph_maintenance`.

**Scoped to the terminal shape.** The corrected comments do not claim a `graph_maintenance` pair has *no* coverage at all: one wedged `pending`/`processing` still raises R5 `consolidation-queue-age`, whose query filters on status alone with no `operation_type` filter (`probe.ts:381`). What has no second signal is a **terminal** (`status = 'failed'`) `graph_maintenance` streak truncated below the warn floor — the shape fixture 5 and both #4618 pairs actually are. That residual hole is now tracked as **#4644**, referenced from both comment sites so the in-tree comment points at tracking rather than being the tracking.

**Comment-only**: the truncation behaviour itself is deliberate (#4620 soundness) and is untouched here.

## 2. `hindsightwatch` CI path filter had a gap

The enumerated filter in `.github/workflows/docker-e2e.yml` omitted `src/hindsight-watch/types.ts`, which `probe.ts` imports (`probe.ts:45`) and the gated test pulls in transitively — so a change there would not have triggered the gate the same PR added.

Replaced the list with `src/hindsight-watch/**` rather than appending `types.ts`: a strict superset that cannot drift the next time the module graph grows a file nobody remembers to add here. Cost is bounded — `hindsightwatch` feeds only `hindsight-watch-pg-probe` and the `e2e-ok` WANT_ var, so the worst case is one extra 34s job on a change to a file the gated test does not read.

## Verification

- `npx vitest run src/hindsight-watch/` — 10 files / 277 tests green.
- The pg probe re-run with `SWITCHROOM_REQUIRE_PG_PROBE=1` against a real `postgres:16-alpine` — 5/5 pass, **not** skipped.
- `npm run lint` — exit 0.

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
