### PR TITLE
test(compose): make the fleet-label test hermetic and name the services

### DIFF
--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -131,6 +131,50 @@ function findCollidingPair(): [string, string] {
   throw new Error("no collision found in 20000 candidates (impossible for 999 buckets)");
 }
 
+/**
+ * Split a generated compose file into the services it emits and the subset
+ * of those that carry `switchroom.fleet: "<fleet>"`.
+ *
+ * Both arrays come back sorted so callers assert a SET, not emit order.
+ * Counting label lines (the pre-#4637 shape) reports drift as
+ * `expected 5 to be 4`, which names nothing and cannot tell "a new service
+ * arrived" from "a service lost its label"; comparing the two arrays does
+ * both, and vitest prints the offending name in the diff.
+ *
+ * Parsing is intentionally structural: service keys are the 2-space-indented
+ * mapping keys under the top-level `services:` block, and a label line binds
+ * to the service key that most recently opened.
+ */
+function servicesByFleetLabel(
+  yaml: string,
+  fleet: string,
+): { all: string[]; labelled: string[] } {
+  const all: string[] = [];
+  const labelled: string[] = [];
+  let inServices = false;
+  let current: string | null = null;
+  for (const line of yaml.split("\n")) {
+    // A non-indented, non-comment line opens a new top-level block
+    // (`services:`, `volumes:`, ...).
+    if (/^[^\s#]/.test(line)) {
+      inServices = line.startsWith("services:");
+      current = null;
+      continue;
+    }
+    if (!inServices) continue;
+    const key = /^ {2}([A-Za-z0-9._-]+):\s*$/.exec(line);
+    if (key) {
+      current = key[1];
+      all.push(current);
+      continue;
+    }
+    if (current && line.trim() === `switchroom.fleet: "${fleet}"`) {
+      labelled.push(current);
+    }
+  }
+  return { all: all.sort(), labelled: labelled.sort() };
+}
+
 describe("assertNoAgentUidCollision — sec WS6-F4 (#1419)", () => {
   it("passes for a distinct-UID fleet", () => {
     expect(() =>
@@ -334,16 +378,50 @@ describe("generateCompose", () => {
     expect(out).not.toContain('switchroom.fleet: "switchroom"');
   });
 
-  it("default containerNamePrefix preserves the production fleet label", () => {
-    // Critical for productionFleetIsLive() to keep working: the
-    // default-emit path MUST still stamp `switchroom.fleet=switchroom`
-    // on every service so `docker ps --filter
-    // label=switchroom.fleet=switchroom` finds them.
-    const out = generateCompose({ config: makeConfig({ coach: {} }) });
-    // One label line per service: vault-broker + approval-kernel +
-    // switchroom-auth-broker + 1 agent = 4.
-    const matches = out.match(/switchroom\.fleet: "switchroom"/g) ?? [];
-    expect(matches.length).toBe(4);
+  // Critical for productionFleetIsLive() to keep working: the default-emit
+  // path MUST stamp `switchroom.fleet=switchroom` on EVERY service so
+  // `docker ps --filter label=switchroom.fleet=switchroom` finds them.
+  //
+  // Both cases pin `voiceEngine` explicitly. Omitting it sends the generator
+  // down `opts.voiceEngine ?? loadHostCapabilities()?.voice.engine ??
+  // "cloud"` (src/agents/compose.ts), which reads the DEVELOPER'S
+  // ~/.switchroom/host-capabilities.json — so on a GPU box the extra
+  // `voice-sidecar` service appeared and the old count assertion failed with
+  // `expected 5 to be 4` (#4637). Pinning the option is what the option is
+  // for, and asserting the service SET (not a magic count) means the next
+  // drift fails with a diff that NAMES the service that arrived or lost its
+  // label.
+  it("default containerNamePrefix labels every service — cloud verdict", () => {
+    const out = generateCompose({
+      config: makeConfig({ coach: {} }),
+      voiceEngine: "cloud",
+    });
+    const { all, labelled } = servicesByFleetLabel(out, "switchroom");
+    expect(all).toEqual([
+      "agent-coach",
+      "approval-kernel",
+      "switchroom-auth-broker",
+      "vault-broker",
+    ]);
+    expect(labelled).toEqual(all);
+  });
+
+  // The `local` companion: nothing else covers that the OPTIONAL service is
+  // labelled at all, and productionFleetIsLive() depends on it being found.
+  it("default containerNamePrefix labels the voice-sidecar too — local verdict", () => {
+    const out = generateCompose({
+      config: makeConfig({ coach: {} }),
+      voiceEngine: "local",
+    });
+    const { all, labelled } = servicesByFleetLabel(out, "switchroom");
+    expect(all).toEqual([
+      "agent-coach",
+      "approval-kernel",
+      "switchroom-auth-broker",
+      "vault-broker",
+      "voice-sidecar",
+    ]);
+    expect(labelled).toEqual(all);
   });
 
   it("emits agents in sorted order", () => {


### PR DESCRIPTION
Fixes #4637.

## The bug

`tests/docker/compose-generator.test.ts` ("default containerNamePrefix preserves the production fleet label") called `generateCompose` with **no `voiceEngine`** and asserted a fixed count of `switchroom.fleet: "switchroom"` label lines.

`voiceEngine` falls back to `loadHostCapabilities()?.voice.engine ?? "cloud"` (`src/agents/compose.ts`), which reads the developer's `~/.switchroom/host-capabilities.json`. A persisted `local` verdict emits the extra singleton `voice-sidecar` service — so the assertion was a function of the machine and went red on any GPU host with `expected 5 to be 4`, a message that names nothing.

Reproduced live at `origin/main`: with `HOME` pointed at a home carrying `"engine": "local"`, the file fails **1/223** on exactly that test; with a `cloud`/absent verdict it passes 223/223.

## The fix (test-only)

- **Pin `voiceEngine` explicitly.** That is what the option is documented to exist for — "INJECTABLE so the compose-generator stays pure ... without shelling out to real hardware". Adds the `local` companion case too: nothing previously covered that the *optional* `voice-sidecar` carries the fleet label at all, which is what `productionFleetIsLive()` depends on.
- **Assert the service SET, not a count.** A structural `servicesByFleetLabel()` helper returns every service emitted under `services:` and the labelled subset; the tests assert the named set and that the two are equal.

This is strictly stronger than the count it replaces: the old assertion counted label lines, so a **new service that never had the label** kept the count at 4 and passed. Comparing `labelled` to `all` catches both directions, and vitest prints the offending service name.

## Non-vacuity, proved by mutation

Against a deliberately broken generator (each mutation reverted after):

| mutation | result |
|---|---|
| delete the `switchroom.fleet` line from the auth-broker emitter | FAIL, diff names `- "switchroom-auth-broker"` |
| `if (voiceEngine === "local" \|\| true)` (the #4637 shape) | FAIL on the cloud case, `voice-sidecar` in the diff |
| push an extra unlabelled `telemetry-shim:` service | FAIL both cases (the old count assertion passed here) |

Clean tree: 224/224 under **both** a `local` and a `cloud` persisted verdict.

## Sweep

Ran all 13 test files that call `generateCompose` (326 tests) under a `local` verdict: the one test in this issue was the *only* host-dependent assertion. The other whole-file counters in this file (`stop_grace_period: 45s` ×2, `Dockerfile.agent` ×1, the `~`-path scan) are unaffected — the sidecar block emits `stop_grace_period: 10s`, `Dockerfile.voice`, and no `~` paths.

`tsc --noEmit`, `check-test-runner-coverage`, `check-changelog-entry`, `check-agent-attribution-trailers` all clean locally.

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)