### PR TITLE
fix(hindsight): vacuum unit_entities/entities often enough to keep the visibility map fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ now an anomaly worth investigating, not the norm.
   halve-the-page path from #4604.
 
 - **hindsight pg0: `unit_entities` / `entities` now get vacuumed often enough
-  to keep their visibility maps fresh, so index-only scans stay index-only.**
+  to bound visibility-map staleness to hours, so index-only scans stay mostly
+  index-only.**
   Measured read-only on the live fleet DB (2026-08-13): `unit_entities` at
   62.8 % `relallvisible/relpages` and `entities` at 31.4 %, with
   `last_autovacuum` NULL and `autovacuum_count` 0 on both. `EXPLAIN (ANALYZE,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,27 @@ now an anomaly worth investigating, not the norm.
   Passes 1 and 2 are byte-for-byte unaffected, and timeouts still take the inner
   halve-the-page path from #4604.
 
+- **hindsight pg0: `unit_entities` / `entities` now get vacuumed often enough
+  to keep their visibility maps fresh, so index-only scans stay index-only.**
+  Measured read-only on the live fleet DB (2026-08-13): `unit_entities` at
+  62.8 % `relallvisible/relpages` and `entities` at 31.4 %, with
+  `last_autovacuum` NULL and `autovacuum_count` 0 on both. `EXPLAIN (ANALYZE,
+  BUFFERS)` over 200 k index tuples paid 64,177 heap fetches on
+  `idx_unit_entities_entity_unit` and 138,465 on `pk_entities` — 69 % of the
+  "index-only" rows on `entities` touching the heap anyway, on indexes the
+  graph queries drive 6.2 M / 73.8 M scans through. `entities` was never in
+  the maintenance script's autovacuum tuning at all, and the
+  `scale_factor=0.05` `unit_entities` already had is the DEAD-tuple trigger —
+  useless on a table that took 25,583 inserts and 0 updates over the measured
+  window. Its INSERT trigger was still stock: 1000 + 0.2 × 1.7 M = 340,735
+  inserts, about two weeks of ingest, so nothing ever refreshed the map. Both
+  tables now pin the insert / dead-tuple / analyze triggers plus a cost budget
+  so a pass lands roughly every 8 h at the measured churn (~9.5 k inserts for
+  `unit_entities`, ~1.7 k dead tuples for `entities`). More frequent vacuum is
+  more background I/O; these two are small enough (108 MB + 261 MB of index,
+  and 25 MB + 56 MB) that a pass is a few hundred MB of mostly-cached reads.
+  `memory_units` (1.7 GB + HNSW) is deliberately left alone. (#4634)
+
 - **CI: the `docker-e2e` manual recovery lever now actually runs the pg probe.**
   `hindsight-watch-pg-probe`'s `if:` gate carried `push` and `merge_group` but
   not `workflow_dispatch`, unlike its siblings `e2e-shard` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,7 @@ now an anomaly worth investigating, not the norm.
   ~23 h of accumulated churn, which took its VM straight back to 100 %. That
   is the problem rather than the refutation: a container recreate inside that
   day-long window resets the dead-tuple counter and the map just stays stale.
-  `EXPLAIN (ANALYZE,
-  BUFFERS)` over 200 k index tuples paid 64,177 heap fetches on
+  `EXPLAIN (ANALYZE, BUFFERS)` over 200 k index tuples paid 64,177 heap fetches on
   `idx_unit_entities_entity_unit` and 138,465 on `pk_entities` — 69 % of the
   "index-only" rows on `entities` touching the heap anyway, on indexes the
   graph queries drive 6.2 M / 73.8 M scans through. `entities` was never in
@@ -83,11 +82,11 @@ now an anomaly worth investigating, not the norm.
   floor (the 22.5 h average that reached the old 4,849 trigger, ~5.2 k
   dead/day), while the rate measured live in the 38.5 min after the 22:19Z
   pass — 948 dead tuples, 21-25/min ≈ 30-35 k/day, consistent across six
-  samples — puts it closer to hourly, ~18-21 passes/day. More frequent
-  vacuum is more background
-  I/O, and the upper end is the number to budget against; these two are small
-  enough (108 MB + 261 MB of index, and 25 MB + 56 MB) that a pass is a few
-  hundred MB of mostly-cached reads, and the ~hourly one is the 81 MB table.
+  samples — puts it closer to hourly, ~18-21 passes/day. More frequent vacuum
+  is more background I/O, and the upper end is the number to budget against;
+  these two are small enough (108 MB + 261 MB of index, and 25 MB + 56 MB) that
+  a pass is a few hundred MB of mostly-cached reads, and the ~hourly one is the
+  81 MB table.
   `memory_units` (1.7 GB + HNSW) is deliberately left alone. (#4634)
 
 - **CI: the `docker-e2e` manual recovery lever now actually runs the pg probe.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,14 @@ now an anomaly worth investigating, not the norm.
 - **hindsight pg0: `unit_entities` / `entities` now get vacuumed often enough
   to bound visibility-map staleness to hours, so index-only scans stay mostly
   index-only.**
-  Measured read-only on the live fleet DB (2026-08-13): `unit_entities` at
+  Measured read-only on the live fleet DB (2026-08-12 UTC): `unit_entities` at
   62.8 % `relallvisible/relpages` and `entities` at 31.4 %, with
-  `last_autovacuum` NULL and `autovacuum_count` 0 on both. `EXPLAIN (ANALYZE,
+  `last_autovacuum` NULL and `autovacuum_count` 0 on both *at the time of
+  measurement* — `entities` subsequently autovacuumed once, at 22:19:13Z after
+  ~23 h of accumulated churn, which took its VM straight back to 100 %. That
+  is the problem rather than the refutation: a container recreate inside that
+  day-long window resets the dead-tuple counter and the map just stays stale.
+  `EXPLAIN (ANALYZE,
   BUFFERS)` over 200 k index tuples paid 64,177 heap fetches on
   `idx_unit_entities_entity_unit` and 138,465 on `pk_entities` — 69 % of the
   "index-only" rows on `entities` touching the heap anyway, on indexes the
@@ -71,11 +76,18 @@ now an anomaly worth investigating, not the norm.
   useless on a table that took 25,583 inserts and 0 updates over the measured
   window. Its INSERT trigger was still stock: 1000 + 0.2 × 1.7 M = 340,735
   inserts, about two weeks of ingest, so nothing ever refreshed the map. Both
-  tables now pin the insert / dead-tuple / analyze triggers plus a cost budget
-  so a pass lands roughly every 8 h at the measured churn (~9.5 k inserts for
-  `unit_entities`, ~1.7 k dead tuples for `entities`). More frequent vacuum is
-  more background I/O; these two are small enough (108 MB + 261 MB of index,
-  and 25 MB + 56 MB) that a pass is a few hundred MB of mostly-cached reads.
+  tables now pin the insert / dead-tuple / analyze triggers plus a cost budget:
+  ~9.5 k inserts for `unit_entities` (~7.6 h at the measured ~1,255 inserts/h,
+  so ~3 passes/day) and ~1.7 k dead tuples for `entities`. Churn on `entities`
+  is bursty, so that one is a **range, not a point**: ~3 passes/day is the
+  floor (the 22.5 h average that reached the old 4,849 trigger, ~5.2 k
+  dead/day), while the rate measured live in the 38.5 min after the 22:19Z
+  pass — 948 dead tuples, 21-25/min ≈ 30-35 k/day, consistent across six
+  samples — puts it closer to hourly, ~18-21 passes/day. More frequent
+  vacuum is more background
+  I/O, and the upper end is the number to budget against; these two are small
+  enough (108 MB + 261 MB of index, and 25 MB + 56 MB) that a pass is a few
+  hundred MB of mostly-cached reads, and the ~hourly one is the 81 MB table.
   `memory_units` (1.7 GB + HNSW) is deliberately left alone. (#4634)
 
 - **CI: the `docker-e2e` manual recovery lever now actually runs the pg probe.**

--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -9,13 +9,16 @@
 #                   SEPARATE from the data volume, so a data-volume loss
 #                   or corruption is recoverable. Runs at most once per
 #                   BACKUP_INTERVAL_MIN. Keeps the newest BACKUP_KEEP.
-#   2. Autovacuum — pins per-table autovacuum scale factors on the large
-#                   / high-churn tables. Upstream ships pg defaults (0.2),
-#                   which on a multi-million-row table means autovacuum
+#   2. Autovacuum — pins per-table autovacuum scale factors / thresholds on
+#                   the large / high-churn tables. Upstream ships pg defaults
+#                   (0.2), which on a multi-million-row table means autovacuum
 #                   never fires until >1M dead tuples — so memory_links /
 #                   async_operations bloat unbounded and their planner
 #                   stats go stale (mis-estimating the worker's queue
-#                   table by ~80x). Idempotent `ALTER TABLE ... SET`.
+#                   table by ~80x). On unit_entities / entities the same
+#                   under-vacuuming leaves the VISIBILITY MAP stale, which
+#                   silently un-does index-only scans (#4634). Idempotent
+#                   `ALTER TABLE ... SET`.
 #   3. Retention  — prune COMPLETED async_operations older than
 #                   RETENTION_DAYS. Terminal queue records the worker
 #                   never reads again; left unbounded they accumulate
@@ -127,10 +130,53 @@ _sql() {
 }
 
 # --- 2. Autovacuum tuning (idempotent; ALTER is a no-op if unchanged) ---
+#
+# `ALTER TABLE ... SET (...)` MERGES into reloptions — options not named on a
+# line are left standing — so each line states only what it means to pin.
 _sql "ALTER TABLE IF EXISTS memory_links SET (autovacuum_vacuum_scale_factor=0.02, autovacuum_analyze_scale_factor=0.02)" >/dev/null
 _sql "ALTER TABLE IF EXISTS async_operations SET (autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.02)" >/dev/null
 _sql "ALTER TABLE IF EXISTS entity_cooccurrences SET (autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.05)" >/dev/null
-_sql "ALTER TABLE IF EXISTS unit_entities SET (autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.05)" >/dev/null
+#
+# unit_entities / entities: VISIBILITY-MAP freshness, not bloat (#4634).
+#
+# Only VACUUM sets all-visible bits, so how often a table is vacuumed IS how
+# fresh its visibility map is, and a stale VM turns an index-only scan into an
+# index scan plus a heap access per row. Measured read-only on the live fleet
+# DB, 2026-08-13, over 22h of uptime since the last crash-recovery stats reset:
+#
+#   relation       relpages  relallvisible    VM%       rows
+#   unit_entities    13,454          8,445  62.8%  1,739,740
+#   entities          3,210          1,009  31.4%    239,939
+#
+#   EXPLAIN (ANALYZE, BUFFERS) over the first 200k index tuples:
+#     idx_unit_entities_entity_unit -> Heap Fetches:  64,177  (63,492 buffers)
+#     pk_entities                   -> Heap Fetches: 138,465 (139,325 buffers)
+#
+#   i.e. 69% of the "index-only" rows on `entities` hit the heap anyway, on
+#   indexes the graph queries drive 6.2M / 73.8M scans through.
+#
+# Why the previous unit_entities line (scale_factor=0.05 alone) did not fix it:
+# autovacuum computes its triggers from pg_class.reltuples, and it has THREE
+# independent triggers. The dead-tuple one is the only one 0.05 touched, and
+# unit_entities is append-only — 25,583 inserts vs 0 updates and 560 deletes
+# over those 22h — so dead tuples never approach 50 + 0.05 * 1.7M = 84,984.
+# What governs an insert-only table is the INSERT trigger, and that was still
+# at the stock 1000 + 0.2 * 1.7M = 340,735 inserts (~2 weeks of ingest at the
+# measured rate). Hence `last_autovacuum` NULL and `autovacuum_count` 0 on
+# BOTH tables, while `entities` was not listed here at all.
+#
+# The values below put a vacuum on each table roughly every 8h at the measured
+# churn, bounding VM staleness to hours instead of leaving it unbounded:
+#   unit_entities insert trigger: 1000 + 0.005 * 1.7M    =  9,493 ins  (was 340,735)
+#   entities      dead   trigger:  500 + 0.005 * 239,629 =  1,698 dead (was 4,843)
+# Cost is the tradeoff — more frequent vacuum is more background I/O — but
+# these two are small: 108MB heap + 261MB index (unit_entities) and 25MB + 56MB
+# (entities), so a pass is a few hundred MB of mostly-cached reads, unlike
+# memory_units (1.7GB + HNSW) which is deliberately left alone. cost_delay /
+# cost_limit match the memory_links precedent so the pass finishes promptly
+# instead of being throttled across the ingest window.
+_sql "ALTER TABLE IF EXISTS unit_entities SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_threshold=1000, autovacuum_vacuum_insert_scale_factor=0.005, autovacuum_vacuum_insert_threshold=1000, autovacuum_analyze_scale_factor=0.02, autovacuum_analyze_threshold=1000, autovacuum_vacuum_cost_delay=2, autovacuum_vacuum_cost_limit=3000)" >/dev/null
+_sql "ALTER TABLE IF EXISTS entities SET (autovacuum_vacuum_scale_factor=0.005, autovacuum_vacuum_threshold=500, autovacuum_vacuum_insert_scale_factor=0.01, autovacuum_vacuum_insert_threshold=1000, autovacuum_analyze_scale_factor=0.01, autovacuum_analyze_threshold=500, autovacuum_vacuum_cost_delay=2, autovacuum_vacuum_cost_limit=3000)" >/dev/null
 
 # --- 3. Retention: prune terminal completed ops (never failed/pending/processing) ---
 _pruned="$(_sql "WITH d AS (DELETE FROM async_operations WHERE status='completed' AND created_at < now() - make_interval(days => ${RETENTION_DAYS}) RETURNING 1) SELECT count(*) FROM d")"

--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -133,6 +133,41 @@ _sql() {
 #
 # `ALTER TABLE ... SET (...)` MERGES into reloptions — options not named on a
 # line are left standing — so each line states only what it means to pin.
+#
+# COROLLARY: DELETING A LINE HERE DOES NOT UNDO IT. reloptions live in the
+# catalog, on the data volume; nothing in this script ever RESETs them. So a
+# `git revert` of the change that added a line leaves every option it set
+# standing on the live database forever, invisibly — which is precisely the
+# hand-applied drift #4650 exists to document. Backing a tuning out means
+# running the matching RESET by hand, once, against the live DB. For the
+# unit_entities / entities block below (#4634) that is:
+#
+#   -- unit_entities: reverting restores the old line, which re-pins
+#   -- autovacuum_vacuum_scale_factor / autovacuum_analyze_scale_factor to
+#   -- 0.05 on the next tick, but leaves these six standing:
+#   ALTER TABLE unit_entities RESET (
+#     autovacuum_vacuum_threshold,
+#     autovacuum_vacuum_insert_scale_factor,
+#     autovacuum_vacuum_insert_threshold,
+#     autovacuum_analyze_threshold,
+#     autovacuum_vacuum_cost_delay,
+#     autovacuum_vacuum_cost_limit);
+#
+#   -- entities: main has NO line for this table, so a revert restores
+#   -- nothing at all here and all eight must be reset explicitly.
+#   ALTER TABLE entities RESET (
+#     autovacuum_vacuum_scale_factor,
+#     autovacuum_vacuum_threshold,
+#     autovacuum_vacuum_insert_scale_factor,
+#     autovacuum_vacuum_insert_threshold,
+#     autovacuum_analyze_scale_factor,
+#     autovacuum_analyze_threshold,
+#     autovacuum_vacuum_cost_delay,
+#     autovacuum_vacuum_cost_limit);
+#
+# (RESET drops the per-table override so the global GUC applies again. It does
+# NOT restore any hand-applied value that predated the line — on `entities`
+# that was scale_factor=0.02 / cost_limit=2000, per #4650.)
 _sql "ALTER TABLE IF EXISTS memory_links SET (autovacuum_vacuum_scale_factor=0.02, autovacuum_analyze_scale_factor=0.02)" >/dev/null
 _sql "ALTER TABLE IF EXISTS async_operations SET (autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.02)" >/dev/null
 _sql "ALTER TABLE IF EXISTS entity_cooccurrences SET (autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.05)" >/dev/null
@@ -142,7 +177,8 @@ _sql "ALTER TABLE IF EXISTS entity_cooccurrences SET (autovacuum_vacuum_scale_fa
 # Only VACUUM sets all-visible bits, so how often a table is vacuumed IS how
 # fresh its visibility map is, and a stale VM turns an index-only scan into an
 # index scan plus a heap access per row. Measured read-only on the live fleet
-# DB, 2026-08-13, over 22h of uptime since the last crash-recovery stats reset:
+# DB, 2026-08-12 UTC (all timestamps in this block are UTC), over 22h of uptime
+# since the last crash-recovery stats reset:
 #
 #   relation       relpages  relallvisible    VM%       rows
 #   unit_entities    13,454          8,445  62.8%  1,739,740
@@ -166,23 +202,38 @@ _sql "ALTER TABLE IF EXISTS entity_cooccurrences SET (autovacuum_vacuum_scale_fa
 # BOTH tables at the time of measurement, while `entities` was not listed here
 # at all.
 #
-# The values below put a vacuum on each table roughly every 8h at the measured
-# churn, bounding VM staleness to hours instead of leaving it unbounded:
-#   unit_entities insert trigger: 1000 + 0.005 * 1.7M    =  9,493 ins  (was 340,735)
-#   entities      dead   trigger:  500 + 0.005 * 239,629 =  1,698 dead (was 4,843)
-# 4,843 IS reachable — `entities` did hit it once, autovacuuming at 2026-08-12
-# 22:19Z and taking its VM from 31.4% straight back to 100% — but only after
-# roughly 23h of accumulated churn (~5.2k dead tuples/day). That is the
-# problem, not the refutation: any container recreate inside that day-long
-# window resets the dead-tuple counter, the trigger is never reached, and the
-# visibility map just stays stale. 1,698 puts a pass ~3x/day, well inside the
-# restart window.
+# The values below bound VM staleness to hours instead of leaving it unbounded:
+#   unit_entities insert trigger: 1000 + 0.005 * 1,698,677 =  9,493 ins  (was 340,735)
+#   entities      dead   trigger:  500 + 0.005 *   239,964 =  1,700 dead (was 4,849)
+#
+# unit_entities: 29,014 inserts over 23.1h of pg uptime (~1,255/h) puts 9,493
+# about 7.6h out — call it ~3 passes/day, up from ~0.
+#
+# entities: AT LEAST ~3 passes/day, and in practice a good deal more. Churn is
+# bursty, so quote a range, not a point:
+#   - 22.5h-average: it took that long to reach the old 4,849 trigger, i.e.
+#     ~5.2k dead/day => 1,700 every ~8h => ~3 passes/day. This is the FLOOR.
+#   - measured live in the 38.5 min after the 2026-08-12 22:19:13Z pass: 948
+#     dead tuples accumulated, i.e. 21-25/min ≈ 30-35k/day, consistent across
+#     six samples spanning 22:52-22:58Z (arrival is bursty minute to minute,
+#     but the trend is flat, so this is not one spike) => 1,700 every ~70-80
+#     min => ~18-21 passes/day.
+# Size the I/O expectation off the upper end (roughly hourly), not the floor.
+#
+# 4,849 IS reachable — `entities` did hit it once, autovacuuming at 2026-08-12
+# 22:19:13Z and taking its VM from 31.4% straight back to 100% — but only after
+# roughly 23h of accumulated churn. That is the problem, not the refutation:
+# any container recreate inside that day-long window resets the dead-tuple
+# counter, the trigger is never reached, and the visibility map just stays
+# stale. 1,700 puts a pass well inside the restart window.
 # Cost is the tradeoff — more frequent vacuum is more background I/O — but
 # these two are small: 108MB heap + 261MB index (unit_entities) and 25MB + 56MB
-# (entities), so a pass is a few hundred MB of mostly-cached reads, unlike
-# memory_units (1.7GB + HNSW) which is deliberately left alone. cost_delay /
-# cost_limit match the memory_links precedent so the pass finishes promptly
-# instead of being throttled across the ingest window.
+# (entities), so a pass is a few hundred MB of mostly-cached reads. That holds
+# even at the ~20x/day upper end above, because the frequent table is the 81MB
+# one; the 369MB one stays at ~3x/day on its insert trigger. memory_units
+# (1.7GB + HNSW) is a genuinely expensive pass and is deliberately left alone.
+# cost_delay / cost_limit match the memory_links precedent so the pass finishes
+# promptly instead of being throttled across the ingest window.
 _sql "ALTER TABLE IF EXISTS unit_entities SET (autovacuum_vacuum_scale_factor=0.01, autovacuum_vacuum_threshold=1000, autovacuum_vacuum_insert_scale_factor=0.005, autovacuum_vacuum_insert_threshold=1000, autovacuum_analyze_scale_factor=0.02, autovacuum_analyze_threshold=1000, autovacuum_vacuum_cost_delay=2, autovacuum_vacuum_cost_limit=3000)" >/dev/null
 _sql "ALTER TABLE IF EXISTS entities SET (autovacuum_vacuum_scale_factor=0.005, autovacuum_vacuum_threshold=500, autovacuum_vacuum_insert_scale_factor=0.01, autovacuum_vacuum_insert_threshold=1000, autovacuum_analyze_scale_factor=0.01, autovacuum_analyze_threshold=500, autovacuum_vacuum_cost_delay=2, autovacuum_vacuum_cost_limit=3000)" >/dev/null
 

--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -163,12 +163,20 @@ _sql "ALTER TABLE IF EXISTS entity_cooccurrences SET (autovacuum_vacuum_scale_fa
 # What governs an insert-only table is the INSERT trigger, and that was still
 # at the stock 1000 + 0.2 * 1.7M = 340,735 inserts (~2 weeks of ingest at the
 # measured rate). Hence `last_autovacuum` NULL and `autovacuum_count` 0 on
-# BOTH tables, while `entities` was not listed here at all.
+# BOTH tables at the time of measurement, while `entities` was not listed here
+# at all.
 #
 # The values below put a vacuum on each table roughly every 8h at the measured
 # churn, bounding VM staleness to hours instead of leaving it unbounded:
 #   unit_entities insert trigger: 1000 + 0.005 * 1.7M    =  9,493 ins  (was 340,735)
 #   entities      dead   trigger:  500 + 0.005 * 239,629 =  1,698 dead (was 4,843)
+# 4,843 IS reachable — `entities` did hit it once, autovacuuming at 2026-08-12
+# 22:19Z and taking its VM from 31.4% straight back to 100% — but only after
+# roughly 23h of accumulated churn (~5.2k dead tuples/day). That is the
+# problem, not the refutation: any container recreate inside that day-long
+# window resets the dead-tuple counter, the trigger is never reached, and the
+# visibility map just stays stale. 1,698 puts a pass ~3x/day, well inside the
+# restart window.
 # Cost is the tradeoff — more frequent vacuum is more background I/O — but
 # these two are small: 108MB heap + 261MB index (unit_entities) and 25MB + 56MB
 # (entities), so a pass is a few hundred MB of mostly-cached reads, unlike

--- a/tests/docker/hindsight-maintenance.test.ts
+++ b/tests/docker/hindsight-maintenance.test.ts
@@ -210,7 +210,10 @@ describe("hindsight-maintenance.sh", () => {
       expect(ue.autovacuum_analyze_scale_factor).toBeLessThanOrEqual(0.02);
 
       // entities is update-heavy (18,043 updates / 22h): the dead-tuple
-      // trigger governs. 500 + 0.005 * 239,939 ≈ 1.7k dead ≈ every ~8h.
+      // trigger governs. 500 + 0.005 * 239,939 ≈ 1.7k dead — a pass somewhere
+      // between ~3x/day (the 22.5h average) and roughly hourly (the 21-25
+      // dead-tuples/min rate sampled live); churn is bursty, so the low end
+      // is a floor. Derivation in docker/hindsight-maintenance.sh.
       const en = optsFor("entities");
       const enDeadTrigger =
         en.autovacuum_vacuum_threshold + en.autovacuum_vacuum_scale_factor * 239_939;

--- a/tests/docker/hindsight-maintenance.test.ts
+++ b/tests/docker/hindsight-maintenance.test.ts
@@ -179,13 +179,32 @@ describe("hindsight-maintenance.sh", () => {
       expect(r.status).toBe(0);
       const sql = readFileSync(sqlLog, "utf-8");
 
-      /** Parse the reloptions the script actually SET on `table`. */
+      /**
+       * Parse the reloptions the script actually SET on `table`.
+       *
+       * `ALTER TABLE ... SET (...)` MERGES reloptions and is last-write-wins,
+       * so a second ALTER appended below the first silently overrides those
+       * keys in live postgres. Reading only the FIRST match would let exactly
+       * that regression through green — the very merge semantic this file
+       * exists to pin — so require there be exactly ONE ALTER per table.
+       */
       const optsFor = (table: string): Record<string, number> => {
-        const line = sql
+        const prefix = `ALTER TABLE IF EXISTS ${table} SET (`;
+        const hits = sql
           .split("\n")
-          .find((l) => l.startsWith(`ALTER TABLE IF EXISTS ${table} SET (`));
-        expect(line, `no autovacuum ALTER issued for ${table}`).toBeTruthy();
-        const body = line!.slice(line!.indexOf("(") + 1, line!.lastIndexOf(")"));
+          .map((l, i) => ({ line: l, lineNo: i + 1 }))
+          .filter((h) => h.line.startsWith(prefix));
+        expect(hits.length, `no autovacuum ALTER issued for ${table}`).toBeGreaterThan(0);
+        expect(
+          hits.length,
+          `${hits.length} autovacuum ALTERs issued for ${table} (SQL-log lines ` +
+            `${hits.map((h) => h.lineNo).join(", ")}) — ALTER TABLE ... SET MERGES ` +
+            `reloptions last-write-wins, so the LAST one silently overrides the ` +
+            `earlier ones. Fold them into a single ALTER in ` +
+            `docker/hindsight-maintenance.sh.`,
+        ).toBe(1);
+        const line = hits[0].line;
+        const body = line.slice(line.indexOf("(") + 1, line.lastIndexOf(")"));
         return Object.fromEntries(
           body.split(",").map((kv) => {
             const [k, v] = kv.split("=");

--- a/tests/docker/hindsight-maintenance.test.ts
+++ b/tests/docker/hindsight-maintenance.test.ts
@@ -147,6 +147,92 @@ describe("hindsight-maintenance.sh", () => {
     expect(raw).toMatch(/ALTER TABLE IF EXISTS async_operations SET \(autovacuum_vacuum_scale_factor=/);
   });
 
+  // ── Visibility-map freshness on unit_entities / entities (#4634) ─────────
+  //
+  // A stale visibility map silently un-does index-only scans: measured on the
+  // live fleet DB (2026-08-13) 200k index tuples cost 64,177 heap fetches on
+  // `idx_unit_entities_entity_unit` and 138,465 on `pk_entities`. Only VACUUM
+  // sets all-visible bits, so the fix is a vacuum that actually fires.
+  //
+  // This drives the script with a FAKE psql and asserts the OUTCOME — the
+  // reloptions actually SENT to postgres, parsed and bounds-checked. It fails
+  // if either table is dropped from the tuning, if the INSERT trigger (the one
+  // that governs an append-only table like unit_entities) is left at the stock
+  // 0.2, or if a scale factor is loosened past what the measurement supports.
+  it("tunes unit_entities + entities so autovacuum actually fires (VM freshness)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "swr-hsi-maint-"));
+    const binDir = installFakePsql();
+    try {
+      const pgInstance = join(dir, "instance.json");
+      const sqlLog = join(dir, "psql-sql.log");
+      writePgInstance(pgInstance);
+      const r = spawnSync("sh", [SCRIPT], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+          FAKE_PSQL_LOG: sqlLog,
+        },
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+      expect(r.status).toBe(0);
+      const sql = readFileSync(sqlLog, "utf-8");
+
+      /** Parse the reloptions the script actually SET on `table`. */
+      const optsFor = (table: string): Record<string, number> => {
+        const line = sql
+          .split("\n")
+          .find((l) => l.startsWith(`ALTER TABLE IF EXISTS ${table} SET (`));
+        expect(line, `no autovacuum ALTER issued for ${table}`).toBeTruthy();
+        const body = line!.slice(line!.indexOf("(") + 1, line!.lastIndexOf(")"));
+        return Object.fromEntries(
+          body.split(",").map((kv) => {
+            const [k, v] = kv.split("=");
+            return [k.trim(), Number(v)];
+          }),
+        );
+      };
+
+      // unit_entities is append-only (25,583 inserts / 0 updates over the
+      // measured 22h), so the INSERT trigger is the one that governs it. The
+      // stock 0.2 needs 340,735 inserts (~2 weeks of ingest); pin it small.
+      const ue = optsFor("unit_entities");
+      expect(ue.autovacuum_vacuum_insert_scale_factor).toBeLessThanOrEqual(0.005);
+      expect(ue.autovacuum_vacuum_insert_threshold).toBeLessThanOrEqual(1000);
+      // 1000 + 0.005 * 1.74M rows ≈ 9.5k inserts — well under a day of ingest.
+      const ueInsertTrigger =
+        ue.autovacuum_vacuum_insert_threshold +
+        ue.autovacuum_vacuum_insert_scale_factor * 1_739_740;
+      expect(ueInsertTrigger).toBeLessThan(20_000);
+      // ...and the dead-tuple / analyze triggers stay tightened too.
+      expect(ue.autovacuum_vacuum_scale_factor).toBeLessThanOrEqual(0.01);
+      expect(ue.autovacuum_analyze_scale_factor).toBeLessThanOrEqual(0.02);
+
+      // entities is update-heavy (18,043 updates / 22h): the dead-tuple
+      // trigger governs. 500 + 0.005 * 239,939 ≈ 1.7k dead ≈ every ~8h.
+      const en = optsFor("entities");
+      const enDeadTrigger =
+        en.autovacuum_vacuum_threshold + en.autovacuum_vacuum_scale_factor * 239_939;
+      expect(enDeadTrigger).toBeLessThan(2_500);
+      expect(en.autovacuum_vacuum_insert_scale_factor).toBeLessThanOrEqual(0.01);
+
+      // Both get a cost budget that lets the pass finish rather than being
+      // throttled across the ingest window (the memory_links precedent).
+      for (const o of [ue, en]) {
+        expect(o.autovacuum_vacuum_cost_limit).toBeGreaterThanOrEqual(2000);
+        expect(o.autovacuum_vacuum_cost_delay).toBeLessThanOrEqual(2);
+      }
+
+      // Tuning only — job #2 must never VACUUM/ANALYZE inline (that would run a
+      // blocking full pass inside the 30-min maintenance tick).
+      expect(sql).not.toMatch(/^\s*(VACUUM|ANALYZE)\b/im);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
   it("writes backups to a separate dir + rotates, and is gated on an interval + pg readiness", () => {
     const raw = readFileSync(SCRIPT, "utf-8");
     // Rotated pg_dump in custom format to the backup dir.


### PR DESCRIPTION
Closes #4634.

## What I measured (independently, 2026-08-13, read-only)

22h of uptime since the last crash-recovery stats reset on `switchroom-hindsight`:

| relation | relpages | relallvisible | VM % | rows | dead | last_autovacuum | autovacuum_count |
|---|---|---|---|---|---|---|---|
| `unit_entities` | 13,454 | 8,445 | **62.8 %** | 1,739,740 | 560 | NULL | 0 |
| `entities` | 3,210 | 1,009 | **31.4 %** | 239,939 | 4,782 | NULL | 0 |

`last_autovacuum` / `autovacuum_count` are as of the time of measurement:
`entities` autovacuumed once shortly after, at 22:19:13Z, and is now at
`autovacuum_count=1` with a 100 % visibility map (see below — that pass is the
evidence for the trigger arithmetic, not a refutation of the finding).

`EXPLAIN (ANALYZE, BUFFERS)` over the first 200k index tuples:

```
Index Only Scan using idx_unit_entities_entity_unit  Heap Fetches:  64,177  (63,492 buffers, 101 ms)
Index Only Scan using pk_entities                    Heap Fetches: 138,465 (139,325 buffers, 74 ms)
```

69 % of the "index-only" rows on `entities` touch the heap anyway — on indexes the
graph queries drive 6.2M (`pk_entities`) / 73.8M (`idx_unit_entities_entity_unit`)
scans through. The issue's headline finding reproduces; `unit_entities` is
unchanged at 62.8 %, `entities` is if anything worse than the 36.3 % filed (31.4 %).

## Where the issue's diagnosis was wrong

The issue says pg0 "runs stock autovacuum settings — `autovacuum_vacuum_scale_factor = 0.2`".
That is the *global* default, but it is **not** what applies to these tables:
`docker/hindsight-maintenance.sh` has been pinning `unit_entities` at
`autovacuum_vacuum_scale_factor=0.05` on every 30-minute tick since it shipped,
and the live `reloptions` confirm it. Simply lowering that scale factor further
— the issue's proposed fix — would have changed nothing measurable.

Two things are actually wrong:

1. **`entities` was never in the tuning at all.** (Its live `reloptions` carry a
   hand-applied 0.02 that exists nowhere in the repo — see the follow-up note below.)
2. **`unit_entities` was tuned on the wrong trigger.** Autovacuum has three
   independent triggers, all computed from `pg_class.reltuples`. `scale_factor`
   drives only the **dead-tuple** one, and `unit_entities` is append-only:
   25,583 inserts, **0** updates and 560 deletes over the measured 22h. Dead
   tuples never approach `50 + 0.05 × 1.7M = 84,984`. What governs an
   append-only table is the **INSERT** trigger, which was still stock at
   `1000 + 0.2 × 1.7M = 340,735` inserts — about two weeks of ingest at the
   measured rate. Hence `autovacuum_count = 0`.

## The fix, and the chosen values

Per-table storage parameters committed to `docker/hindsight-maintenance.sh`, which
the entrypoint loop re-applies every 30 minutes and which is baked into the image
(the `COPY --chmod=0755 docker/hindsight-maintenance.sh …` line in
`docker/Dockerfile.hindsight` — 7910 as of this branch's base c4eb8b86; it was
miscited as 6048 in an earlier revision of this body) — so this survives a rebuild and a
fresh data volume, unlike a hand-run `ALTER TABLE`.

```
unit_entities: vacuum_scale_factor=0.01  vacuum_threshold=1000
               vacuum_insert_scale_factor=0.005  vacuum_insert_threshold=1000
               analyze_scale_factor=0.02  analyze_threshold=1000
               vacuum_cost_delay=2  vacuum_cost_limit=3000

entities:      vacuum_scale_factor=0.005  vacuum_threshold=500
               vacuum_insert_scale_factor=0.01  vacuum_insert_threshold=1000
               analyze_scale_factor=0.01  analyze_threshold=500
               vacuum_cost_delay=2  vacuum_cost_limit=3000
```

Derived from the measured churn, not copied from the issue:

- `unit_entities` — insert-driven. `1000 + 0.005 × 1,698,677 = 9,493` inserts
  vs 29,014 over 23.1h of pg uptime (~1,255/h) ⇒ a pass every ~7.6h, i.e.
  ~3/day (was 340,735 ⇒ ~0). The dead-tuple and analyze triggers are tightened
  too so a future change in the update mix doesn't re-open the same hole.
- `entities` — update-driven (18,043 updates, 16,107 of them HOT, per 22h; HOT
  updates still clear all-visible bits). `500 + 0.005 × 239,964 = 1,700` dead.
  **How often that fires is a range, not a point** — churn here is bursty, and
  the two rates I can measure disagree by ~6x, so quoting only the low one
  understates the I/O this PR buys:

  | basis | dead-tuple rate | pass every | passes/day |
  |---|---|---|---|
  | 22.5h average (what it took to reach the old 4,849 trigger) | ~3.6/min, ~5.2k/day | ~8h | ~3 — **floor** |
  | live, 38.5 min after the 22:19:13Z pass (948 dead, six samples 22:52–22:58Z) | 21–25/min, 30–35k/day | ~70–80 min | ~18–21 |

  Budget against the upper end (roughly hourly), not the floor. The previous
  trigger, 4,849, IS reachable — `entities` hit it and autovacuumed at
  2026-08-12 22:19:13Z, at 23h of container uptime with zero restarts, taking
  its VM from 31.4 % back to 100 % — but only after roughly 23h of accumulated
  churn. Any container recreate inside that day-long window resets the
  dead-tuple counter, the trigger is never reached, and the visibility map just
  stays stale; 1,700 puts the pass well inside the restart window.

**Tradeoff:** more frequent vacuum is more background I/O. It is affordable
*here specifically* because these two tables are small: 108 MB heap + 261 MB of
index (`unit_entities`) and 25 MB + 56 MB (`entities`), so a pass is a few
hundred MB of mostly-cached reads. That holds at the ~18–21x/day upper end
too, because the frequently-vacuumed table is the 81 MB one — `unit_entities`,
the 369 MB one, stays at ~3x/day on its insert trigger. `cost_delay=2` /
`cost_limit=3000` match the existing `memory_links` precedent so the pass
finishes promptly rather than being throttled across the ingest window.
`memory_units` (1.7 GB + HNSW indexes) is a genuinely expensive vacuum and is
deliberately left untouched.

## Test

`tests/docker/hindsight-maintenance.test.ts` drives the script with the existing
fake `psql`, **parses the reloptions actually sent to postgres**, and asserts the
derived trigger arithmetic (`insert_threshold + insert_scale_factor × 1.74M <
20,000`, etc.) plus that job #2 still issues no inline `VACUUM`/`ANALYZE`.
Verified it FAILS against the pre-fix script, not just that it matches a string.

## Reverting this

`ALTER TABLE ... SET (...)` merges into `reloptions`, and nothing in the script
ever `RESET`s them — so **deleting these lines does not undo them.** A
`git revert` of this PR goes green in CI and leaves every option standing on
the live catalog, invisibly, which is exactly the drift #4650 documents. Backing
the tuning out means running the matching `RESET` by hand, once. Documented in
the script itself alongside the merge note; reproduced here:

```sql
-- unit_entities: the revert restores the old line, which re-pins
-- vacuum/analyze_scale_factor to 0.05 on the next tick, but leaves these six.
ALTER TABLE unit_entities RESET (
  autovacuum_vacuum_threshold, autovacuum_vacuum_insert_scale_factor,
  autovacuum_vacuum_insert_threshold, autovacuum_analyze_threshold,
  autovacuum_vacuum_cost_delay, autovacuum_vacuum_cost_limit);

-- entities: main has NO line for this table, so a revert restores nothing
-- here and all eight must be reset explicitly.
ALTER TABLE entities RESET (
  autovacuum_vacuum_scale_factor, autovacuum_vacuum_threshold,
  autovacuum_vacuum_insert_scale_factor, autovacuum_vacuum_insert_threshold,
  autovacuum_analyze_scale_factor, autovacuum_analyze_threshold,
  autovacuum_vacuum_cost_delay, autovacuum_vacuum_cost_limit);
```

(`RESET` drops the per-table override so the global GUC applies again; it does
not restore the hand-applied values that predated these lines — on `entities`
that was `scale_factor=0.02` / `cost_limit=2000`, per #4650.)

## Follow-up, not in this PR

The live DB carries autovacuum reloptions on `memory_links` (`vacuum_threshold=5000`,
`cost_limit=3000`, …) and on `memory_units` (which the script does not mention at
all) that exist nowhere in the repo — hand-applied and lost on any fresh data
volume. Filed as #4650, with the live reloptions re-verified read-only on
2026-08-12 22:25 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

