### PR TITLE
fix(gateway): don't fire a false resume_interrupted when only the gateway respawned (#4641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,12 @@ now an anomaly worth investigating, not the norm.
   boot it was written under (PID 1's `/proc` starttime), so a token that
   outlives its generation — `start.sh`'s `rm -f … || true` swallows a per-file
   unlink failure — is self-evidently stale rather than a permanent, silent
-  resume suppressor. (#4641)
+  resume suppressor. The stamp itself is placed to be crash-honest: it happens
+  only after the resume inbound is durably spooled, and only if the boot block
+  did not throw — the block's `catch` swallows and lets init continue, so an
+  ungated stamp could mark the generation done after the reaper had already
+  durably ended a turn that was never spooled. Lose the token, repeat the
+  work; never lose the work. (#4641)
 
 - **CI: the `docker-e2e` manual recovery lever now actually runs the pg probe.**
   `hindsight-watch-pg-probe`'s `if:` gate carried `push` and `merge_group` but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,25 @@ now an anomaly worth investigating, not the norm.
   81 MB table.
   `memory_units` (1.7 GB + HNSW) is deliberately left alone. (#4634)
 
+- **A gateway crash no longer tells the live session it restarted.** The
+  gateway and `claude` are separate supervised processes: when only the gateway
+  crashed and respawned (three Bun 1.3.13 SIGBUS crashes on one agent,
+  2026-08-12), its boot block read its own boot as an agent restart. It stamped
+  the STILL-EXECUTING turn `ended_via='restart'`, injected a
+  `resume_interrupted` synthetic ("You just restarted. Your previous turn was
+  interrupted…") into a session that had never stopped, and listed the
+  still-running sub-agents as "killed by the restart" — so the agent abandoned
+  live work and re-ran finished work on a lie. `start.sh` now publishes the
+  agent process's identity (pid + `/proc` starttime, which survives `exec`)
+  immediately before `exec claude`, and the gateway probes it at boot: if that
+  exact process is still alive and predates this gateway, the orphan-turn
+  reaper, the resume synthetic and `.pending-turn.env` are all skipped. Identity
+  is the (pid, starttime) PAIR, never pid alone, so a recycled PID after a
+  container restart cannot masquerade as the live agent; every uncertainty
+  (no record, torn record, unreadable `/proc`) fails open to the previous
+  behaviour, so genuine restarts, watchdog timeouts and first boots are
+  unchanged. (#4641)
+
 - **CI: the `docker-e2e` manual recovery lever now actually runs the pg probe.**
   `hindsight-watch-pg-probe`'s `if:` gate carried `push` and `merge_group` but
   not `workflow_dispatch`, unlike its siblings `e2e-shard` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,16 +137,23 @@ now an anomaly worth investigating, not the norm.
   `resume_interrupted` synthetic ("You just restarted. Your previous turn was
   interrupted…") into a session that had never stopped, and listed the
   still-running sub-agents as "killed by the restart" — so the agent abandoned
-  live work and re-ran finished work on a lie. `start.sh` now publishes the
-  agent process's identity (pid + `/proc` starttime, which survives `exec`)
-  immediately before `exec claude`, and the gateway probes it at boot: if that
-  exact process is still alive and predates this gateway, the orphan-turn
-  reaper, the resume synthetic and `.pending-turn.env` are all skipped. Identity
-  is the (pid, starttime) PAIR, never pid alone, so a recycled PID after a
-  container restart cannot masquerade as the live agent; every uncertainty
-  (no record, torn record, unreadable `/proc`) fails open to the previous
-  behaviour, so genuine restarts, watchdog timeouts and first boots are
-  unchanged. (#4641)
+  live work and re-ran finished work on a lie. The boot-resume block is a
+  once-per-CONTAINER-boot action, so that is now literal: `start.sh` clears a
+  `.boot-resume-done` generation token once per container boot, before it forks
+  the gateway sidecar; the gateway stamps the token as the last thing its boot
+  block does; a gateway that boots and finds the token knows another gateway in
+  this same container generation already did the work, and skips the
+  orphan-turn reaper, the resume synthetic and `.pending-turn.env`. No clock
+  comparison is involved, so a gateway that crashes during its OWN boot leaves
+  no token and its replacement still resumes the genuinely-interrupted turn.
+  `start.sh` also publishes the agent process's identity (pid + `/proc`
+  starttime, which survives `exec`) before `exec claude`, as a veto: if the
+  token says "done" but that exact process is provably gone, the boot resume
+  runs anyway. Identity is the (pid, starttime) PAIR, never pid alone, so a
+  recycled PID after a container restart cannot masquerade as the live agent;
+  every uncertainty (no token, dead or mismatched record, unreadable `/proc`)
+  fails open to the previous behaviour, so genuine restarts, watchdog timeouts
+  and first boots are unchanged. (#4641)
 
 - **CI: the `docker-e2e` manual recovery lever now actually runs the pg probe.**
   `hindsight-watch-pg-probe`'s `if:` gate carried `push` and `merge_group` but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,8 +140,11 @@ now an anomaly worth investigating, not the norm.
   live work and re-ran finished work on a lie. The boot-resume block is a
   once-per-CONTAINER-boot action, so that is now literal: `start.sh` clears a
   `.boot-resume-done` generation token once per container boot, before it forks
-  the gateway sidecar; the gateway stamps the token as the last thing its boot
-  block does; a gateway that boots and finds the token knows another gateway in
+  the gateway sidecar; the gateway stamps the token the moment the boot resume
+  becomes DURABLE — immediately after the resume inbound reaches the inbound
+  spool, not at the end of the block that merely builds it in memory, so a
+  crash in between loses the token and repeats the work rather than losing the
+  work; a gateway that boots and finds the token knows another gateway in
   this same container generation already did the work, and skips the
   orphan-turn reaper, the resume synthetic and `.pending-turn.env`. No clock
   comparison is involved, so a gateway that crashes during its OWN boot leaves
@@ -153,7 +156,11 @@ now an anomaly worth investigating, not the norm.
   recycled PID after a container restart cannot masquerade as the live agent;
   every uncertainty (no token, dead or mismatched record, unreadable `/proc`)
   fails open to the previous behaviour, so genuine restarts, watchdog timeouts
-  and first boots are unchanged. (#4641)
+  and first boots are unchanged. The token additionally records the container
+  boot it was written under (PID 1's `/proc` starttime), so a token that
+  outlives its generation — `start.sh`'s `rm -f … || true` swallows a per-file
+  unlink failure — is self-evidently stale rather than a permanent, silent
+  resume suppressor. (#4641)
 
 - **CI: the `docker-e2e` manual recovery lever now actually runs the pg probe.**
   `hindsight-watch-pg-probe`'s `if:` gate carried `push` and `merge_group` but

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -2475,6 +2475,60 @@ fi
 rm -f "$_session_model_resolved_tmp"
 unset _session_model_resolved_tmp
 
+# --- Agent-process identity record (switchroom#4641) ---
+#
+# The gateway and the agent are SEPARATE processes: the gateway runs as a
+# supervised sidecar (see `_switchroom_supervise gateway` above) while THIS
+# shell becomes the agent via `exec claude` below. A gateway crash respawns
+# only the gateway — this process, its conversation, its in-flight turn and
+# its sub-agents all keep running. The gateway used to read its own boot as
+# "the agent restarted" and fire a false `resume_interrupted` into the live
+# session ("your previous turn was interrupted", "your sub-agents were killed")
+# while everything it named was demonstrably still alive.
+#
+# So publish this process's identity for the gateway to probe:
+#   pid       — `$$`, and because the `exec` below REPLACES this shell rather
+#               than forking, that pid IS the claude process's pid.
+#   starttime — `/proc/<pid>/stat` field 22, clock ticks since host boot.
+#               Assigned at fork and NOT reset by `exec`, so the value read
+#               here is exactly what claude will carry. PIDs are reused (and a
+#               container restart resets the pid namespace), so identity is the
+#               PAIR — the gateway rejects a pid whose starttime disagrees.
+#
+# Deliberately NOT recorded: `comm`. It is "bash" here and becomes claude's
+# after the exec, so recording it would guarantee a mismatch.
+#
+# Written LAST, immediately before the exec: a record must never name a
+# process that does not exist yet. Best-effort throughout — a missing or torn
+# record makes the gateway fail open to its pre-#4641 behaviour.
+_sr_agent_stat=$(cat "/proc/$$/stat" 2>/dev/null || true)
+if [ -n "$_sr_agent_stat" ]; then
+  # comm is parenthesised and may contain spaces/`)`, so split on the LAST ") ".
+  _sr_agent_rest=${_sr_agent_stat##*') '}
+  # Field 22 (starttime) is the 20th field after comm. Subshell + `set -f` so
+  # the word split neither globs nor clobbers this script's positional params.
+  _sr_agent_start=$( set -f; set -- $_sr_agent_rest; printf '%s' "${20}" )
+  case "$_sr_agent_start" in
+    ''|*[!0-9]*) _sr_agent_start="" ;;
+  esac
+  if [ -n "$_sr_agent_start" ]; then
+    _sr_agent_dir="${TELEGRAM_STATE_DIR:-{{agentDir}}/telegram}"
+    mkdir -p "$_sr_agent_dir" 2>/dev/null || true
+    _sr_agent_tmp="$_sr_agent_dir/agent-process.json.tmp.$$"
+    if printf '{"pid":%s,"starttime":"%s","boot_at":%s}\n' \
+         "$$" "$_sr_agent_start" "$(( $(date +%s) * 1000 ))" > "$_sr_agent_tmp" 2>/dev/null; then
+      mv -f "$_sr_agent_tmp" "$_sr_agent_dir/agent-process.json" 2>/dev/null || true
+    fi
+    rm -f "$_sr_agent_tmp" 2>/dev/null || true
+    # Passive context for the agent process itself (diagnostics only — the
+    # gateway reads the FILE; it was already running when this env was set).
+    export SWITCHROOM_AGENT_PID="$$"
+    export SWITCHROOM_AGENT_STARTTIME="$_sr_agent_start"
+    unset _sr_agent_dir _sr_agent_tmp
+  fi
+fi
+unset _sr_agent_stat _sr_agent_rest _sr_agent_start
+
 {{#if useSwitchroomPlugin}}
 if [ -n "$APPEND_PROMPT" ]; then
   exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG --model "$_EFFECTIVE_MODEL" $_EFFORT_ARG{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -33,6 +33,31 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   # same path the rest of start.sh + the MCP sidecar expects.
   export TELEGRAM_STATE_DIR="{{agentDir}}/telegram"
 
+  # --- Boot-resume generation token: OPEN it (switchroom#4641) -------------
+  #
+  # The gateway's boot-resume block (orphan-turn reaper, `resume_interrupted`
+  # synthetic, bridge-dead marker, `.pending-turn.env`) is a ONCE-PER-CONTAINER-
+  # BOOT action. But the gateway is a SUPERVISED SIDECAR: when it crashes the
+  # supervisor respawns it and its boot block runs again — against a claude
+  # session that never stopped. That is #4641: it stamped the still-executing
+  # turn `ended_via='restart'` and told the live session it had been killed.
+  #
+  # THIS line is the whole generation mechanism. Deleting the token here — in
+  # the outer pass, exactly once per container boot, BEFORE the gateway is
+  # forked below and where the supervisor can never re-run it — is what makes
+  # "the token exists" mean "a gateway in this same container generation
+  # already completed its boot resume". The gateway writes the token at the
+  # END of that block (agent-process-liveness.ts `markBootResumeComplete`) and
+  # skips the block entirely when it finds one. No timing, no clock
+  # comparison: a gateway that dies mid-boot leaves no token, so its
+  # replacement redoes the work and a genuinely interrupted turn is never lost.
+  #
+  # `agent-process.json` (written by the inner pass just before it `exec`s the
+  # agent) goes too: it names a pid from the PREVIOUS generation, and the
+  # pid namespace is reset by a container restart, so leaving it risks a
+  # (pid, starttime) collision against an unrelated live process.
+  rm -f "$TELEGRAM_STATE_DIR/.boot-resume-done" "$TELEGRAM_STATE_DIR/agent-process.json" 2>/dev/null || true
+
   # SWITCHROOM_AGENT_NAME is the canonical "which agent am I" identity. It is
   # normally supplied by the container env (compose.ts) so it is already
   # present here, but the authoritative inner-pass export lives at line ~387,
@@ -2486,6 +2511,13 @@ unset _session_model_resolved_tmp
 # session ("your previous turn was interrupted", "your sub-agents were killed")
 # while everything it named was demonstrably still alive.
 #
+# What DECIDES that is the per-container-boot generation token cleared in the
+# outer pass above (`.boot-resume-done`). This record is the SAFETY VETO on top
+# of it: if the token says "already done" but the recorded agent process is
+# provably gone, the gateway runs the boot resume anyway. It can only ever
+# re-enable a resume, never suppress a legitimate one — which is why nothing
+# here depends on when the gateway was forked relative to this shell.
+#
 # So publish this process's identity for the gateway to probe:
 #   pid       — `$$`, and because the `exec` below REPLACES this shell rather
 #               than forking, that pid IS the claude process's pid.
@@ -2496,7 +2528,10 @@ unset _session_model_resolved_tmp
 #               PAIR — the gateway rejects a pid whose starttime disagrees.
 #
 # Deliberately NOT recorded: `comm`. It is "bash" here and becomes claude's
-# after the exec, so recording it would guarantee a mismatch.
+# after the exec, so recording it would guarantee a mismatch. (An earlier
+# review suggested recording it and requiring the live process to look
+# claude-ish, to close a fresh-boot race cheaply — the generation token closes
+# that race outright, so the extra guard would only add a way to fail.)
 #
 # Written LAST, immediately before the exec: a record must never name a
 # process that does not exist yet. Best-effort throughout — a missing or torn

--- a/telegram-plugin/gateway/agent-process-liveness.ts
+++ b/telegram-plugin/gateway/agent-process-liveness.ts
@@ -23,12 +23,52 @@
  *   1. `start.sh`, in the OUTER docker pass and BEFORE it forks the gateway,
  *      deletes `<stateDir>/.boot-resume-done` (and any stale
  *      `agent-process.json`). That deletion happens exactly once per container
- *      boot, and the gateway supervisor cannot re-run it.
- *   2. The gateway runs its boot-resume block and, on completing it, writes
- *      the sentinel (`markBootResumeComplete`).
- *   3. A gateway that boots and FINDS the sentinel knows some gateway in this
- *      same container generation already did the boot resume — so this boot is
- *      a gateway-only respawn and must skip the whole block.
+ *      boot, and the gateway supervisor cannot re-run it. NOTE: that clear
+ *      lives inside start.sh's `[ "$SWITCHROOM_RUNTIME" = "docker" ]` guard, so
+ *      it is DOCKER-ONLY. Under the legacy systemd runtime nothing clears the
+ *      token, and the guard's fail-open rests entirely on the two vetoes below
+ *      (the boot-identity check and the `/proc` record). The fleet is all
+ *      docker; this is stated so a systemd revival does not inherit it silently.
+ *   2. The gateway runs its boot-resume block and, once the resume inbound is
+ *      DURABLY spooled, writes the sentinel (`markBootResumeComplete`). The
+ *      token embeds the container-boot identity it was written under.
+ *   3. A gateway that boots and FINDS the sentinel — carrying THIS container
+ *      boot's identity — knows some gateway in this same container generation
+ *      already did the boot resume, so this boot is a gateway-only respawn and
+ *      must skip the whole block.
+ *
+ * ## WHERE the token is stamped, and why it is NOT the tail of the block
+ *
+ * The stamp must follow the point at which the resume becomes CRASH-SURVIVABLE,
+ * not the point at which the block stops running. Those are ~8k lines apart in
+ * gateway.ts: the `bootResumeInit` block only builds `bootResumeInbound` in
+ * MEMORY; the inbound becomes durable much later, at
+ * `inboundSpool.put(bootResumeInbound.agent, bootResumeInbound.msg)`. So
+ * `markBootResumeComplete` is called immediately AFTER that put (and after
+ * `markTurnResumed`, which obeys the identical rule — see turns-schema.ts:
+ * "the caller must stamp only AFTER the resume inbound is durably spooled").
+ *
+ * Stamping at the tail of the block instead would create a NEW, silent
+ * work-loss mode, worse than the bug this module fixes. On a genuine restart
+ * the reaper durably stamps the interrupted turn `ended_via='restart'`; if the
+ * gateway then dies before the durable put — the Bun-crash-at-boot pattern
+ * #4641 exists for, and also the `acquireStartupLock` → `process.exit(1)`
+ * path, both of which sit inside that window — the successor would find a
+ * token, find no `agent-process.json` (start.sh has not reached `exec claude`;
+ * its inner pass waits on the LiteLLM probe first), return
+ * `gateway-only-respawn-no-record` and suppress. The turn stays
+ * `ended_via='restart'` with `resumed_at` NULL and is never resumed.
+ *
+ * Stamping after the put moves that window the other way, which is safe BY
+ * CONSTRUCTION: a successor that re-runs the block re-mints the same resume,
+ * `resumed_at` is still NULL so the turn is still findable, and the spool
+ * dedups on `s:resume:<resume_turn_key>` — so the retry is idempotent, not a
+ * double-send. Lose the token, repeat the work; never lose the work.
+ *
+ * The stamp is UNCONDITIONAL: a boot that found nothing to resume still
+ * completed this generation's boot resume, and a later gateway-only respawn
+ * must still be suppressed — that respawn running the reaper against a
+ * meanwhile-started live turn IS bug #4641.
  *
  * This is deliberately NOT timing-derived. An earlier revision of this module
  * compared `/proc` starttimes ("the agent must predate me") and justified it
@@ -66,11 +106,43 @@
  *
  * ## FAIL-OPEN is the invariant
  *
- * No sentinel → run the boot resume (the pre-#4641 behaviour). Recorded
- * process dead or mismatched → run it. Probe throws → run it. Plus a
- * `SWITCHROOM_GATEWAY_RESPAWN_GUARD=0` ops escape hatch. Suppressing a real
- * resume loses work; an extra resume on an already-restarted agent is merely
- * the status quo.
+ * No sentinel → run the boot resume (the pre-#4641 behaviour). Sentinel from a
+ * DIFFERENT container boot → run it. Recorded process dead or mismatched → run
+ * it. Probe throws → run it. Plus a `SWITCHROOM_GATEWAY_RESPAWN_GUARD=0` ops
+ * escape hatch. Suppressing a real resume loses work; an extra resume on an
+ * already-restarted agent is merely the status quo.
+ *
+ * The invariant admits no path-override env vars. An earlier revision let
+ * `SWITCHROOM_BOOT_RESUME_DONE_FILE` / `SWITCHROOM_AGENT_PROCESS_FILE`
+ * redirect the token and record paths from the live process env, while
+ * start.sh hard-codes `"$TELEGRAM_STATE_DIR/.boot-resume-done"`. Setting
+ * either in a container would have made start.sh clear one path and the
+ * gateway read another — the token then never cleared, and EVERY boot
+ * suppressing its resume forever. That is the one fail-CLOSED direction the
+ * module can take, so the overrides are confined to `DetectOpts` (test
+ * injection). Verified: nothing in the repo ever set them.
+ *
+ * ## Why the token carries the container-boot identity
+ *
+ * `gateway-only-respawn-no-record` is the only branch that suppresses on the
+ * token ALONE, with no corroborating `/proc` evidence — and start.sh's clear is
+ * `rm -f … 2>/dev/null || true`, which swallows a per-file failure (EROFS,
+ * EACCES, an immutable attr) while the sibling `agent-process.json` unlink
+ * succeeds. A token surviving into the next container generation would then
+ * suppress a genuine restart's resume, permanently and silently.
+ *
+ * So the token records the container-boot identity it was written under: PID
+ * 1's `/proc` starttime. PID 1 is the container's entry process — it lives for
+ * exactly one container generation and a restart replaces it, which is the
+ * property we need. (`/proc/sys/kernel/random/boot_id` is NOT usable here: it
+ * identifies the HOST kernel boot, which containers share and which survives a
+ * container restart.) A token naming a DIFFERENT boot is self-evidently stale
+ * and is ignored.
+ *
+ * The check is deliberately one-directional — only a MISMATCH is evidence.
+ * A token with no recorded identity, or an unreadable `/proc/1`, keeps the
+ * pre-existing "present ⇒ suppress" behaviour, so the hardening can never
+ * itself re-open #4641.
  *
  * ## What `break bootResumeInit` skips, and why each is safe
  *
@@ -90,6 +162,9 @@
  *     this path at all;
  *   - the bridge-dead IDLE notice — same generation, same marker, already
  *     surfaced (or already declined for want of an allowFrom chat);
+ *   - `bridgeDeadPriorStreak` — the #3038 cross-boot damper seed derived from
+ *     that marker. Left at 0 on a respawn: the streak belongs to the boot that
+ *     consumed the marker, and re-seeding it here would double-count;
  *   - the `pendingRedelivery` capture — a crash-redelivery candidate for the
  *     interrupted turn. Skipped deliberately: on a gateway-only respawn the
  *     turn is STILL RUNNING and will emit its own answer, so re-sending a
@@ -145,6 +220,7 @@ export type RespawnReason =
   | 'gateway-only-respawn-no-record'
   | 'guard-disabled'
   | 'no-boot-resume-sentinel'
+  | 'stale-boot-token'
   | 'agent-process-dead'
   | 'starttime-mismatch'
   | 'comm-mismatch'
@@ -224,32 +300,92 @@ export function bootResumeDonePath(stateDir: string): string {
   return join(stateDir, BOOT_RESUME_DONE_FILE)
 }
 
-/** Is this container generation's boot resume already done? Never throws. */
-export function readBootResumeSentinel(path: string): boolean {
+/** On-disk shape of the generation token. All fields are best-effort. */
+export interface BootResumeToken {
+  /** PID of the gateway that stamped it. Diagnostic. */
+  pid?: number
+  /** Wall-clock ms at stamp time. Diagnostic. */
+  at?: number
+  /** Container-boot identity (PID 1's starttime) at stamp time. */
+  boot?: string
+}
+
+/**
+ * This container generation's identity: PID 1's `/proc` starttime.
+ *
+ * PID 1 is the container's entry process — one per container generation,
+ * replaced on restart. Null when `/proc/1` is unreadable, which callers must
+ * treat as "no evidence", never as a mismatch.
+ */
+export function containerBootIdentity(procRoot = '/proc'): string | null {
+  return readProcIdentity(1, procRoot)?.starttime ?? null
+}
+
+export interface SentinelState {
+  /** The token file exists (whatever its contents). */
+  present: boolean
+  /** Present AND provably written under a DIFFERENT container boot. */
+  stale: boolean
+}
+
+/**
+ * Read the generation token and judge whether it belongs to THIS container
+ * boot. Never throws.
+ *
+ * Only a positive mismatch marks the token stale. An absent/blank/legacy
+ * `boot` field, an unparseable body, or an unreadable `/proc/1` all leave
+ * `stale: false` — so the hardening can only ever ADD a fail-open path, never
+ * suppress where the previous revision would not have.
+ */
+export function readBootResumeSentinel(
+  path: string,
+  opts: { procRoot?: string } = {},
+): SentinelState {
+  let raw: string
   try {
-    return existsSync(path)
+    if (!existsSync(path)) return { present: false, stale: false }
+    raw = readFileSync(path, 'utf8')
   } catch {
-    return false // unreadable → fail open (run the boot resume)
+    return { present: false, stale: false } // unreadable → fail open
   }
+  let stamped: string | null = null
+  try {
+    const parsed = JSON.parse(raw) as BootResumeToken | null
+    if (parsed != null && typeof parsed === 'object' && typeof parsed.boot === 'string' && parsed.boot.length > 0) {
+      stamped = parsed.boot
+    }
+  } catch { /* legacy/foreign body — no identity evidence, treat as present */ }
+  const live = containerBootIdentity(opts.procRoot)
+  if (stamped != null && live != null && stamped !== live) return { present: true, stale: true }
+  return { present: true, stale: false }
 }
 
 /**
  * Stamp the generation token: THIS container generation's boot-resume block
  * ran to completion, so a later gateway respawn must not re-run it.
  *
- * Called from gateway.ts at the END of the boot block (so a gateway that dies
- * mid-boot leaves no token and its successor redoes the work). Atomic
- * tmp+rename, and never throws: failing to stamp only costs a duplicate
- * boot-resume on a respawn, which is the pre-#4641 behaviour.
+ * Called from gateway.ts immediately AFTER the boot-resume inbound is durably
+ * spooled — NOT at the end of the boot block; see "WHERE the token is stamped"
+ * above for why those are different places and why the difference is a
+ * work-loss bug. Atomic tmp+rename, and never throws: failing to stamp only
+ * costs a duplicate boot-resume on a respawn, which is the pre-#4641
+ * behaviour.
+ *
+ * The body records the container-boot identity so a token that outlives its
+ * generation (start.sh's `rm -f … || true` swallowing a per-file failure) is
+ * self-evidently stale rather than a permanent resume suppressor.
  */
 export function markBootResumeComplete(
   stateDir: string,
-  opts: { path?: string; now?: number; log?: (s: string) => void } = {},
+  opts: { path?: string; now?: number; procRoot?: string; log?: (s: string) => void } = {},
 ): void {
-  const path = opts.path ?? process.env.SWITCHROOM_BOOT_RESUME_DONE_FILE ?? bootResumeDonePath(stateDir)
+  const path = opts.path ?? bootResumeDonePath(stateDir)
   const tmp = `${path}.tmp.${process.pid}`
+  const boot = containerBootIdentity(opts.procRoot)
   try {
-    writeFileSync(tmp, JSON.stringify({ pid: process.pid, at: opts.now ?? Date.now() }) + '\n')
+    const token: BootResumeToken = { pid: process.pid, at: opts.now ?? Date.now() }
+    if (boot != null) token.boot = boot
+    writeFileSync(tmp, JSON.stringify(token) + '\n')
     renameSync(tmp, path)
   } catch (err) {
     try { unlinkSync(tmp) } catch { /* best effort */ }
@@ -265,20 +401,27 @@ export function markBootResumeComplete(
  * The decision, pure.
  *
  * `sentinelPresent` is the generation token — the ONLY thing that can say
- * "suppress". `live` is the `/proc` identity read back for `record.pid` (null
- * when that pid is gone) and can only VETO a suppression.
+ * "suppress". `sentinelStale` and `live` (the `/proc` identity read back for
+ * `record.pid`, null when that pid is gone) can only VETO a suppression.
  */
 export function decideGatewayOnlyRespawn(input: {
   sentinelPresent: boolean
+  /** Token exists but names a different container boot. Defaults false. */
+  sentinelStale?: boolean
   record: AgentProcessRecord | null
   live: ProcIdentity | null
 }): RespawnDecision {
-  const { sentinelPresent, record, live } = input
+  const { sentinelPresent, sentinelStale, record, live } = input
   // No token → no gateway in this container generation has completed the boot
   // resume yet. That covers a genuine container restart, a first boot, AND a
   // gateway that crashed during its own boot before finishing the block.
   if (!sentinelPresent) {
     return { gatewayOnly: false, reason: 'no-boot-resume-sentinel', pid: record?.pid ?? null }
+  }
+  // A token start.sh's `rm -f` failed to clear: it names a PREVIOUS container
+  // boot, so it proves nothing about this generation. Run the boot resume.
+  if (sentinelStale === true) {
+    return { gatewayOnly: false, reason: 'stale-boot-token', pid: record?.pid ?? null }
   }
   // Token present but start.sh has not yet published the agent record (the
   // gateway boots long before `exec claude`). The token alone is proof enough:
@@ -300,9 +443,14 @@ export function decideGatewayOnlyRespawn(input: {
 export interface DetectOpts {
   /** Gateway STATE_DIR (`<agentDir>/telegram`). The record + token live here. */
   stateDir: string
-  /** Override the record path outright (tests, ops escape hatch). */
+  /**
+   * Override the record path. TEST INJECTION ONLY — deliberately not readable
+   * from the process env: start.sh hard-codes the production paths, so an env
+   * override could only ever desynchronise the writer from the reader. See
+   * "FAIL-OPEN is the invariant".
+   */
   recordPath?: string
-  /** Override the generation-token path (tests). */
+  /** Override the generation-token path. Test injection only (see above). */
   sentinelPath?: string
   /** `/proc` root; injectable for tests. */
   procRoot?: string
@@ -314,13 +462,19 @@ export interface DetectOpts {
 export function detectGatewayOnlyRespawn(opts: DetectOpts): RespawnDecision {
   if (opts.enabled === false) return { gatewayOnly: false, reason: 'guard-disabled', pid: null }
   const procRoot = opts.procRoot ?? '/proc'
-  const sentinelPresent = readBootResumeSentinel(
+  const sentinel = readBootResumeSentinel(
     opts.sentinelPath ?? bootResumeDonePath(opts.stateDir),
+    { procRoot },
   )
   const recordPath = opts.recordPath ?? join(opts.stateDir, AGENT_PROCESS_RECORD_FILE)
   const record = readAgentProcessRecord(recordPath)
   const live = record == null ? null : readProcIdentity(record.pid, procRoot)
-  return decideGatewayOnlyRespawn({ sentinelPresent, record, live })
+  return decideGatewayOnlyRespawn({
+    sentinelPresent: sentinel.present,
+    sentinelStale: sentinel.stale,
+    record,
+    live,
+  })
 }
 
 /**
@@ -342,8 +496,6 @@ export function shouldSkipBootResumeForGatewayOnlyRespawn(
       ...opts,
       stateDir,
       enabled: opts.enabled ?? process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD !== '0',
-      recordPath: opts.recordPath ?? process.env.SWITCHROOM_AGENT_PROCESS_FILE ?? undefined,
-      sentinelPath: opts.sentinelPath ?? process.env.SWITCHROOM_BOOT_RESUME_DONE_FILE ?? undefined,
     })
   } catch (err) {
     // Fail-open: any surprise keeps the pre-#4641 behaviour.

--- a/telegram-plugin/gateway/agent-process-liveness.ts
+++ b/telegram-plugin/gateway/agent-process-liveness.ts
@@ -1,13 +1,13 @@
 /**
- * Agent-process liveness — "did the AGENT restart, or only the gateway?"
+ * Boot-resume generation guard — "did the AGENT restart, or only the gateway?"
  * (switchroom#4641)
  *
  * The gateway and the `claude` agent session are SEPARATE supervised
  * processes: `profiles/_base/start.sh.hbs` launches the gateway as a
- * supervised sidecar and then `exec claude` in the top-level shell. When the
- * gateway crashes (e.g. the Bun 1.3.13 SIGBUS that motivated #4641) the
- * supervisor respawns ONLY the gateway — the claude session, its context, its
- * in-flight turn, and its sub-agents all keep running, untouched.
+ * supervised sidecar and then `exec claude`. When the gateway crashes (e.g.
+ * the Bun 1.3.13 SIGBUS that motivated #4641) the supervisor respawns ONLY the
+ * gateway — the claude session, its context, its in-flight turn, and its
+ * sub-agents all keep running, untouched.
  *
  * The gateway's boot-resume block reads gateway-local state only, so it read
  * that respawn as "the agent restarted": it stamped the still-executing turn
@@ -15,41 +15,105 @@
  * live session "You just restarted. Your previous turn was interrupted...",
  * and listed the still-running sub-agents as "killed by the restart".
  *
- * This module is the missing liveness predicate. `start.sh` records the agent
- * process's identity (pid + `/proc/<pid>` starttime) immediately before
- * `exec claude`; the gateway reads it at boot and asks: is THAT EXACT process
- * still alive, and did it start before I did?
+ * ## The mechanism: a per-container-boot generation token
  *
- * Identity is (pid, starttime), never pid alone: PIDs are reused, and a
- * container restart resets the PID namespace, so a stale record's pid very
- * plausibly names a live-but-different process. `/proc/<pid>/stat` field 22 is
- * the process start time in clock ticks since HOST boot — it is assigned at
- * fork and is NOT reset by `exec`, so the value start.sh reads for its own
- * shell is the same value the exec'd `claude` carries. That makes it both a
- * stable identity and directly comparable with the gateway's own starttime
- * from `/proc/self/stat` (same clock, same units, no wall-clock skew).
+ * The boot-resume block is a ONCE-PER-CONTAINER-BOOT action. So make that
+ * literal, with a sentinel file whose lifetime IS the container generation:
  *
- * The "started before me" arm closes the fresh-boot race. On a genuine
- * container start the ordering is: start.sh launches the gateway → ... →
- * start.sh writes the record → `exec claude`. If the gateway's boot-resume
- * block were to run LATE enough to observe that freshly-written record, pid
- * and starttime would both match a live process and the aliveness check alone
- * would wrongly suppress a legitimate resume. But that process started AFTER
- * this gateway did, so the ordering check rejects it. A genuine gateway-only
- * respawn is always the other way round: claude was exec'd long before the
- * replacement gateway process was forked.
+ *   1. `start.sh`, in the OUTER docker pass and BEFORE it forks the gateway,
+ *      deletes `<stateDir>/.boot-resume-done` (and any stale
+ *      `agent-process.json`). That deletion happens exactly once per container
+ *      boot, and the gateway supervisor cannot re-run it.
+ *   2. The gateway runs its boot-resume block and, on completing it, writes
+ *      the sentinel (`markBootResumeComplete`).
+ *   3. A gateway that boots and FINDS the sentinel knows some gateway in this
+ *      same container generation already did the boot resume — so this boot is
+ *      a gateway-only respawn and must skip the whole block.
  *
- * FAIL-OPEN is the invariant. Every uncertainty — no record file, torn JSON,
- * unreadable `/proc`, missing gateway starttime — yields `gatewayOnly: false`,
- * i.e. exactly the pre-#4641 behaviour. Suppressing a real resume loses work;
- * an extra resume on an already-restarted agent is merely the status quo.
+ * This is deliberately NOT timing-derived. An earlier revision of this module
+ * compared `/proc` starttimes ("the agent must predate me") and justified it
+ * with the claim that start.sh writes the record after forking the gateway, so
+ * the recorded process necessarily starts later. That reasoning was FALSE: the
+ * recorded pid is `$$`, and the shell that forks the gateway
+ * (`start.sh.hbs`, outer pass) obviously predates it. What actually made the
+ * ordering hold was an incidental, undocumented detail — the docker tmux
+ * re-exec (`start.sh.hbs`: `exec tmux ... bash -l "$0"`), which runs the inner
+ * pass in a FRESH shell forked by the tmux server. Measured on a live
+ * container the margin was one clock tick (gateway starttime 209640551, claude
+ * 209640552 — 10ms). Correct by accident, with nothing pinning the accident.
+ * The sentinel replaces that with a fact the boot sequence establishes.
+ *
+ * It also fixes a hole the starttime comparison could not see: a gateway that
+ * CRASHES DURING ITS OWN BOOT (exactly the Bun-crash-at-boot pattern this fix
+ * exists for) left a genuinely-interrupted turn unreaped forever, because the
+ * respawned gateway saw a live claude that predated it and suppressed. With
+ * the sentinel, gateway #1 never got far enough to write it, so gateway #2
+ * runs the full boot resume — the resume survives the crash.
+ *
+ * ## The `/proc` record is a VETO, not the decision
+ *
+ * `start.sh` still publishes `<stateDir>/agent-process.json` — the agent
+ * process's pid plus `/proc/<pid>/stat` field 22 (starttime) — immediately
+ * before `exec claude` (`exec` replaces the shell without forking, so both
+ * values survive into claude unchanged). It is no longer what decides
+ * suppression; it can only VETO one. If the sentinel says "already done" but
+ * the recorded agent process is provably gone, we run the boot resume anyway.
+ * That can only ever re-enable a resume, never suppress a legitimate one.
+ *
+ * Identity is the (pid, starttime) PAIR, never pid alone: PIDs are reused and
+ * a container restart resets the PID namespace, so a stale record's pid very
+ * plausibly names a live-but-different process. A zombie counts as dead.
+ *
+ * ## FAIL-OPEN is the invariant
+ *
+ * No sentinel → run the boot resume (the pre-#4641 behaviour). Recorded
+ * process dead or mismatched → run it. Probe throws → run it. Plus a
+ * `SWITCHROOM_GATEWAY_RESPAWN_GUARD=0` ops escape hatch. Suppressing a real
+ * resume loses work; an extra resume on an already-restarted agent is merely
+ * the status quo.
+ *
+ * ## What `break bootResumeInit` skips, and why each is safe
+ *
+ * The guard in gateway.ts breaks out of the whole labelled boot block, which
+ * skips MORE than the resume synthetic. Because the sentinel means "a gateway
+ * in THIS container generation already ran this block to completion", every
+ * one of these was already done exactly once this generation:
+ *
+ *   - the orphan-turn reaper (`markOrphanedWithTimeoutClassification`) — the
+ *     thing that stamped the live turn `ended_via='restart'`;
+ *   - `consumeBridgeDeadEscalationMarker` — its comment states the marker is
+ *     "consumed (always cleared) whether or not a turn was in flight", and the
+ *     gateway that wrote the sentinel is the one that consumed it. Re-running
+ *     it here would find nothing; skipping it preserves the #3038 cross-boot
+ *     escalation damper instead of double-counting or resetting it. If that
+ *     gateway died BEFORE consuming, the sentinel is absent and we do not take
+ *     this path at all;
+ *   - the bridge-dead IDLE notice — same generation, same marker, already
+ *     surfaced (or already declined for want of an allowFrom chat);
+ *   - the `pendingRedelivery` capture — a crash-redelivery candidate for the
+ *     interrupted turn. Skipped deliberately: on a gateway-only respawn the
+ *     turn is STILL RUNNING and will emit its own answer, so re-sending a
+ *     "Recovered from an interrupted turn:" draft would double-send;
+ *   - `writePendingTurnEnv` — passive wake-audit context for a restart that
+ *     did not happen.
+ *
+ * (The `.wake-audit-pending` sentinel needs no handling: start.sh drops it
+ * once per CONTAINER boot and start.sh does not re-run on a gateway respawn.)
  */
 
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 
 /** Default basename of the record start.sh writes into the telegram state dir. */
 export const AGENT_PROCESS_RECORD_FILE = 'agent-process.json'
+
+/**
+ * Per-container-boot generation token. Deleted by start.sh in the outer docker
+ * pass BEFORE the gateway is forked; written by the gateway once its
+ * boot-resume block completes. Its presence means "this container generation's
+ * boot resume already happened".
+ */
+export const BOOT_RESUME_DONE_FILE = '.boot-resume-done'
 
 /** The agent-process identity recorded by start.sh before `exec claude`. */
 export interface AgentProcessRecord {
@@ -57,7 +121,12 @@ export interface AgentProcessRecord {
   pid: number
   /** `/proc/<pid>/stat` field 22 (starttime, clock ticks since host boot). */
   starttime: string
-  /** `/proc/<pid>/stat` field 2 (comm) at record time. Optional extra guard. */
+  /**
+   * `/proc/<pid>/stat` field 2 (comm) at record time. Optional extra veto.
+   * start.sh does NOT write it (it is "bash" pre-exec and claude's after), and
+   * with the generation token it buys nothing — but a mismatch, if a future
+   * writer does record it post-exec, still fails open.
+   */
   comm?: string
   /** Wall-clock ms when the record was written. Diagnostic only. */
   boot_at?: number
@@ -73,20 +142,18 @@ export interface ProcIdentity {
 
 export type RespawnReason =
   | 'gateway-only-respawn'
+  | 'gateway-only-respawn-no-record'
   | 'guard-disabled'
-  | 'no-record'
-  | 'unreadable-record'
+  | 'no-boot-resume-sentinel'
   | 'agent-process-dead'
   | 'starttime-mismatch'
   | 'comm-mismatch'
-  | 'agent-started-after-gateway'
-  | 'gateway-starttime-unavailable'
 
 export interface RespawnDecision {
   /**
-   * True ONLY when the recorded agent process is provably still alive and
-   * predates this gateway process — i.e. nothing but the gateway respawned.
-   * The boot-resume block must then do nothing at all.
+   * True ONLY when this container generation's boot resume is already done and
+   * nothing contradicts it — i.e. only the gateway respawned. The boot-resume
+   * block must then do nothing at all.
    */
   gatewayOnly: boolean
   reason: RespawnReason
@@ -152,18 +219,73 @@ export function readAgentProcessRecord(path: string): AgentProcessRecord | null 
   return rec
 }
 
+/** Resolve the generation-token path for a gateway STATE_DIR. */
+export function bootResumeDonePath(stateDir: string): string {
+  return join(stateDir, BOOT_RESUME_DONE_FILE)
+}
+
+/** Is this container generation's boot resume already done? Never throws. */
+export function readBootResumeSentinel(path: string): boolean {
+  try {
+    return existsSync(path)
+  } catch {
+    return false // unreadable → fail open (run the boot resume)
+  }
+}
+
 /**
- * The decision, pure. `live` is the `/proc` identity read back for
- * `record.pid` (null when that pid is gone), `gatewayStarttime` this
- * process's own field-22 value.
+ * Stamp the generation token: THIS container generation's boot-resume block
+ * ran to completion, so a later gateway respawn must not re-run it.
+ *
+ * Called from gateway.ts at the END of the boot block (so a gateway that dies
+ * mid-boot leaves no token and its successor redoes the work). Atomic
+ * tmp+rename, and never throws: failing to stamp only costs a duplicate
+ * boot-resume on a respawn, which is the pre-#4641 behaviour.
+ */
+export function markBootResumeComplete(
+  stateDir: string,
+  opts: { path?: string; now?: number; log?: (s: string) => void } = {},
+): void {
+  const path = opts.path ?? process.env.SWITCHROOM_BOOT_RESUME_DONE_FILE ?? bootResumeDonePath(stateDir)
+  const tmp = `${path}.tmp.${process.pid}`
+  try {
+    writeFileSync(tmp, JSON.stringify({ pid: process.pid, at: opts.now ?? Date.now() }) + '\n')
+    renameSync(tmp, path)
+  } catch (err) {
+    try { unlinkSync(tmp) } catch { /* best effort */ }
+    const log = opts.log ?? ((s: string) => process.stderr.write(s))
+    log(
+      `telegram gateway: boot: could not stamp ${BOOT_RESUME_DONE_FILE} ` +
+      `(${(err as Error).message}) — a gateway respawn may repeat the boot resume (#4641)\n`,
+    )
+  }
+}
+
+/**
+ * The decision, pure.
+ *
+ * `sentinelPresent` is the generation token — the ONLY thing that can say
+ * "suppress". `live` is the `/proc` identity read back for `record.pid` (null
+ * when that pid is gone) and can only VETO a suppression.
  */
 export function decideGatewayOnlyRespawn(input: {
+  sentinelPresent: boolean
   record: AgentProcessRecord | null
   live: ProcIdentity | null
-  gatewayStarttime: string | null
 }): RespawnDecision {
-  const { record, live, gatewayStarttime } = input
-  if (record == null) return { gatewayOnly: false, reason: 'no-record', pid: null }
+  const { sentinelPresent, record, live } = input
+  // No token → no gateway in this container generation has completed the boot
+  // resume yet. That covers a genuine container restart, a first boot, AND a
+  // gateway that crashed during its own boot before finishing the block.
+  if (!sentinelPresent) {
+    return { gatewayOnly: false, reason: 'no-boot-resume-sentinel', pid: record?.pid ?? null }
+  }
+  // Token present but start.sh has not yet published the agent record (the
+  // gateway boots long before `exec claude`). The token alone is proof enough:
+  // re-running the block would duplicate this generation's resume.
+  if (record == null) {
+    return { gatewayOnly: true, reason: 'gateway-only-respawn-no-record', pid: null }
+  }
   if (live == null) return { gatewayOnly: false, reason: 'agent-process-dead', pid: record.pid }
   // PID reuse guard: same pid, different process.
   if (live.starttime !== record.starttime) {
@@ -172,45 +294,33 @@ export function decideGatewayOnlyRespawn(input: {
   if (record.comm != null && record.comm !== live.comm) {
     return { gatewayOnly: false, reason: 'comm-mismatch', pid: record.pid }
   }
-  if (gatewayStarttime == null || !/^\d+$/.test(gatewayStarttime)) {
-    return { gatewayOnly: false, reason: 'gateway-starttime-unavailable', pid: record.pid }
-  }
-  // Fresh-boot race guard: an agent that started AFTER this gateway process
-  // cannot be the one this gateway is a respawn of.
-  if (BigInt(record.starttime) >= BigInt(gatewayStarttime)) {
-    return { gatewayOnly: false, reason: 'agent-started-after-gateway', pid: record.pid }
-  }
   return { gatewayOnly: true, reason: 'gateway-only-respawn', pid: record.pid }
 }
 
 export interface DetectOpts {
-  /** Gateway STATE_DIR (`<agentDir>/telegram`). The record lives here. */
+  /** Gateway STATE_DIR (`<agentDir>/telegram`). The record + token live here. */
   stateDir: string
   /** Override the record path outright (tests, ops escape hatch). */
   recordPath?: string
+  /** Override the generation-token path (tests). */
+  sentinelPath?: string
   /** `/proc` root; injectable for tests. */
   procRoot?: string
-  /** This gateway process's pid. Defaults to `process.pid`. */
-  selfPid?: number
-  /** Explicit gateway starttime; defaults to reading `/proc/<selfPid>/stat`. */
-  gatewayStarttime?: string | null
   /** Set false to force the pre-#4641 behaviour (ops escape hatch). */
   enabled?: boolean
 }
 
-/** Read the record + `/proc` and decide. Never throws. */
+/** Read the token, the record and `/proc`, and decide. Never throws. */
 export function detectGatewayOnlyRespawn(opts: DetectOpts): RespawnDecision {
   if (opts.enabled === false) return { gatewayOnly: false, reason: 'guard-disabled', pid: null }
   const procRoot = opts.procRoot ?? '/proc'
+  const sentinelPresent = readBootResumeSentinel(
+    opts.sentinelPath ?? bootResumeDonePath(opts.stateDir),
+  )
   const recordPath = opts.recordPath ?? join(opts.stateDir, AGENT_PROCESS_RECORD_FILE)
   const record = readAgentProcessRecord(recordPath)
-  if (record == null) return { gatewayOnly: false, reason: 'no-record', pid: null }
-  const live = readProcIdentity(record.pid, procRoot)
-  const gatewayStarttime =
-    opts.gatewayStarttime !== undefined
-      ? opts.gatewayStarttime
-      : readProcIdentity(opts.selfPid ?? process.pid, procRoot)?.starttime ?? null
-  return decideGatewayOnlyRespawn({ record, live, gatewayStarttime })
+  const live = record == null ? null : readProcIdentity(record.pid, procRoot)
+  return decideGatewayOnlyRespawn({ sentinelPresent, record, live })
 }
 
 /**
@@ -218,10 +328,8 @@ export function detectGatewayOnlyRespawn(opts: DetectOpts): RespawnDecision {
  * question the boot block asks — "should I skip the whole boot-resume path?".
  *
  * Called from gateway.ts BEFORE the orphan-turn reaper, so a gateway-only
- * respawn touches nothing: no `ended_via='restart'` stamp on the live turn, no
- * resume synthetic, no `.pending-turn.env`. (The `.wake-audit-pending`
- * sentinel needs no handling here — it is dropped by start.sh once per
- * CONTAINER boot and start.sh does not re-run on a gateway respawn.)
+ * respawn touches nothing. See "What `break bootResumeInit` skips" above for
+ * the full accounting of the skipped side effects.
  */
 export function shouldSkipBootResumeForGatewayOnlyRespawn(
   stateDir: string,
@@ -235,6 +343,7 @@ export function shouldSkipBootResumeForGatewayOnlyRespawn(
       stateDir,
       enabled: opts.enabled ?? process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD !== '0',
       recordPath: opts.recordPath ?? process.env.SWITCHROOM_AGENT_PROCESS_FILE ?? undefined,
+      sentinelPath: opts.sentinelPath ?? process.env.SWITCHROOM_BOOT_RESUME_DONE_FILE ?? undefined,
     })
   } catch (err) {
     // Fail-open: any surprise keeps the pre-#4641 behaviour.
@@ -243,9 +352,10 @@ export function shouldSkipBootResumeForGatewayOnlyRespawn(
   }
   if (decision.gatewayOnly) {
     log(
-      `telegram gateway: boot: GATEWAY-ONLY respawn — agent process pid=${decision.pid} is still alive and ` +
-      `predates this gateway (#4641). Skipping orphan-turn reaper, boot-resume synthetic and .pending-turn.env: ` +
-      `the claude session, its in-flight turn and its sub-agents were never interrupted.\n`,
+      `telegram gateway: boot: GATEWAY-ONLY respawn — this container generation's boot resume is already ` +
+      `done (${BOOT_RESUME_DONE_FILE} present, reason=${decision.reason}, agent pid=${decision.pid ?? 'unrecorded'}). ` +
+      `Skipping the orphan-turn reaper, the bridge-dead marker, the resume synthetic, crash-redelivery capture ` +
+      `and .pending-turn.env (#4641): the claude session, its in-flight turn and its sub-agents were never interrupted.\n`,
     )
     return true
   }

--- a/telegram-plugin/gateway/agent-process-liveness.ts
+++ b/telegram-plugin/gateway/agent-process-liveness.ts
@@ -65,10 +65,29 @@
  * dedups on `s:resume:<resume_turn_key>` — so the retry is idempotent, not a
  * double-send. Lose the token, repeat the work; never lose the work.
  *
- * The stamp is UNCONDITIONAL: a boot that found nothing to resume still
- * completed this generation's boot resume, and a later gateway-only respawn
- * must still be suppressed — that respawn running the reaper against a
- * meanwhile-started live turn IS bug #4641.
+ * The stamp does not depend on there being anything to resume: a boot that
+ * found nothing still completed this generation's boot resume, and a later
+ * gateway-only respawn must still be suppressed — that respawn running the
+ * reaper against a meanwhile-started live turn IS bug #4641.
+ *
+ * It DOES depend on the block not having thrown. gateway.ts's boot block ends
+ * in a `catch` that logs, sets `turnsDb = null` and lets module init continue
+ * — a swallow, not a death. Without a guard that path reaches the stamp with
+ * `bootResumeInbound` still null, and it is reachable from ~156 lines of DB
+ * and fs I/O between the reaper and the first assignment
+ * (`findLatestTurnIfInterrupted`, the clean-shutdown-marker read,
+ * `listNonTerminalSubagentsForTurn`, the synthetic builders). The reaper has
+ * ALREADY durably written `ended_via='restart'` by then, so a token stamped on
+ * that path is exactly the tail-of-block failure above reached through a
+ * different door: gateway respawns, successor sees a this-generation token and
+ * no `agent-process.json`, suppresses, and the turn is never resumed. So
+ * gateway.ts carries a `bootResumeThrew` flag set in that `catch` and the
+ * stamp is gated on it — a swallowed throw leaves NO token, and the next
+ * gateway retries the boot resume. Fail open, as everywhere else here.
+ *
+ * (On `origin/main` a throw in that window also loses the boot's resume; what
+ * the guard preserves is the accidental recovery-on-respawn that the token
+ * would otherwise remove.)
  *
  * This is deliberately NOT timing-derived. An earlier revision of this module
  * compared `/proc` starttimes ("the agent must predate me") and justified it
@@ -176,8 +195,8 @@
  * once per CONTAINER boot and start.sh does not re-run on a gateway respawn.)
  */
 
-import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, readdirSync } from 'node:fs'
+import { join, dirname, basename } from 'node:path'
 
 /** Default basename of the record start.sh writes into the telegram state dir. */
 export const AGENT_PROCESS_RECORD_FILE = 'agent-process.json'
@@ -361,6 +380,28 @@ export function readBootResumeSentinel(
 }
 
 /**
+ * Delete `<file>.tmp.<pid>` siblings left behind by a writer that died between
+ * `writeFileSync` and `renameSync`.
+ *
+ * The tmp name is pid-qualified (two writers must not share one tmp path), so
+ * a crashed write leaves a stray that nothing else removes: start.sh's cleanup
+ * (`start.sh.hbs`) `rm -f`s the two exact filenames with no glob, so strays
+ * would accumulate in STATE_DIR one per crashed generation, forever.
+ *
+ * Called only after our own successful rename, so it never races our own tmp.
+ * Best-effort and never throws — a stray costs bytes, not correctness.
+ */
+function sweepStrayTmps(path: string): void {
+  const prefix = `${basename(path)}.tmp.`
+  try {
+    for (const name of readdirSync(dirname(path))) {
+      if (!name.startsWith(prefix)) continue
+      try { unlinkSync(join(dirname(path), name)) } catch { /* best effort */ }
+    }
+  } catch { /* unreadable dir — nothing to sweep */ }
+}
+
+/**
  * Stamp the generation token: THIS container generation's boot-resume block
  * ran to completion, so a later gateway respawn must not re-run it.
  *
@@ -387,6 +428,7 @@ export function markBootResumeComplete(
     if (boot != null) token.boot = boot
     writeFileSync(tmp, JSON.stringify(token) + '\n')
     renameSync(tmp, path)
+    sweepStrayTmps(path)
   } catch (err) {
     try { unlinkSync(tmp) } catch { /* best effort */ }
     const log = opts.log ?? ((s: string) => process.stderr.write(s))

--- a/telegram-plugin/gateway/agent-process-liveness.ts
+++ b/telegram-plugin/gateway/agent-process-liveness.ts
@@ -1,0 +1,254 @@
+/**
+ * Agent-process liveness — "did the AGENT restart, or only the gateway?"
+ * (switchroom#4641)
+ *
+ * The gateway and the `claude` agent session are SEPARATE supervised
+ * processes: `profiles/_base/start.sh.hbs` launches the gateway as a
+ * supervised sidecar and then `exec claude` in the top-level shell. When the
+ * gateway crashes (e.g. the Bun 1.3.13 SIGBUS that motivated #4641) the
+ * supervisor respawns ONLY the gateway — the claude session, its context, its
+ * in-flight turn, and its sub-agents all keep running, untouched.
+ *
+ * The gateway's boot-resume block reads gateway-local state only, so it read
+ * that respawn as "the agent restarted": it stamped the still-executing turn
+ * `ended_via='restart'`, queued a `resume_interrupted` synthetic telling the
+ * live session "You just restarted. Your previous turn was interrupted...",
+ * and listed the still-running sub-agents as "killed by the restart".
+ *
+ * This module is the missing liveness predicate. `start.sh` records the agent
+ * process's identity (pid + `/proc/<pid>` starttime) immediately before
+ * `exec claude`; the gateway reads it at boot and asks: is THAT EXACT process
+ * still alive, and did it start before I did?
+ *
+ * Identity is (pid, starttime), never pid alone: PIDs are reused, and a
+ * container restart resets the PID namespace, so a stale record's pid very
+ * plausibly names a live-but-different process. `/proc/<pid>/stat` field 22 is
+ * the process start time in clock ticks since HOST boot — it is assigned at
+ * fork and is NOT reset by `exec`, so the value start.sh reads for its own
+ * shell is the same value the exec'd `claude` carries. That makes it both a
+ * stable identity and directly comparable with the gateway's own starttime
+ * from `/proc/self/stat` (same clock, same units, no wall-clock skew).
+ *
+ * The "started before me" arm closes the fresh-boot race. On a genuine
+ * container start the ordering is: start.sh launches the gateway → ... →
+ * start.sh writes the record → `exec claude`. If the gateway's boot-resume
+ * block were to run LATE enough to observe that freshly-written record, pid
+ * and starttime would both match a live process and the aliveness check alone
+ * would wrongly suppress a legitimate resume. But that process started AFTER
+ * this gateway did, so the ordering check rejects it. A genuine gateway-only
+ * respawn is always the other way round: claude was exec'd long before the
+ * replacement gateway process was forked.
+ *
+ * FAIL-OPEN is the invariant. Every uncertainty — no record file, torn JSON,
+ * unreadable `/proc`, missing gateway starttime — yields `gatewayOnly: false`,
+ * i.e. exactly the pre-#4641 behaviour. Suppressing a real resume loses work;
+ * an extra resume on an already-restarted agent is merely the status quo.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** Default basename of the record start.sh writes into the telegram state dir. */
+export const AGENT_PROCESS_RECORD_FILE = 'agent-process.json'
+
+/** The agent-process identity recorded by start.sh before `exec claude`. */
+export interface AgentProcessRecord {
+  /** PID of the shell that `exec`s claude — i.e. the claude process's own pid. */
+  pid: number
+  /** `/proc/<pid>/stat` field 22 (starttime, clock ticks since host boot). */
+  starttime: string
+  /** `/proc/<pid>/stat` field 2 (comm) at record time. Optional extra guard. */
+  comm?: string
+  /** Wall-clock ms when the record was written. Diagnostic only. */
+  boot_at?: number
+}
+
+/** A live process's identity as read back from `/proc`. */
+export interface ProcIdentity {
+  starttime: string
+  comm: string
+  /** `/proc/<pid>/stat` field 3. `Z` is an unreaped corpse, not a live agent. */
+  state: string
+}
+
+export type RespawnReason =
+  | 'gateway-only-respawn'
+  | 'guard-disabled'
+  | 'no-record'
+  | 'unreadable-record'
+  | 'agent-process-dead'
+  | 'starttime-mismatch'
+  | 'comm-mismatch'
+  | 'agent-started-after-gateway'
+  | 'gateway-starttime-unavailable'
+
+export interface RespawnDecision {
+  /**
+   * True ONLY when the recorded agent process is provably still alive and
+   * predates this gateway process — i.e. nothing but the gateway respawned.
+   * The boot-resume block must then do nothing at all.
+   */
+  gatewayOnly: boolean
+  reason: RespawnReason
+  /** Recorded pid, when a record was readable. Diagnostic. */
+  pid: number | null
+}
+
+/**
+ * Parse `/proc/<pid>/stat` for (comm, state, starttime).
+ *
+ * `comm` is parenthesised and may itself contain spaces and `)`, so the field
+ * split is anchored on the LAST `) ` — the documented way to parse this file.
+ * Field 3 (state) is the first field after comm; field 22 (starttime) the 20th.
+ */
+export function parseProcStat(raw: string): ProcIdentity | null {
+  const close = raw.lastIndexOf(') ')
+  const open = raw.indexOf(' (')
+  if (close < 0 || open < 0 || close < open) return null
+  const comm = raw.slice(open + 2, close)
+  const rest = raw.slice(close + 2).trim().split(/\s+/)
+  const state = rest[0]
+  const starttime = rest[19]
+  if (state == null || state.length === 0) return null
+  if (starttime == null || !/^\d+$/.test(starttime)) return null
+  return { comm, state, starttime }
+}
+
+/**
+ * Read a live process's identity, or null when it is gone.
+ *
+ * A zombie (`state === 'Z'`) counts as GONE: the agent has exited and only an
+ * unreaped exit status remains, so its turn really was interrupted.
+ */
+export function readProcIdentity(pid: number, procRoot = '/proc'): ProcIdentity | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null
+  let identity: ProcIdentity | null
+  try {
+    identity = parseProcStat(readFileSync(join(procRoot, String(pid), 'stat'), 'utf8'))
+  } catch {
+    return null // process gone, or /proc unreadable — treat as dead (fail-open)
+  }
+  if (identity != null && identity.state === 'Z') return null
+  return identity
+}
+
+/** Read + validate the record start.sh wrote. Null on absent/torn/invalid. */
+export function readAgentProcessRecord(path: string): AgentProcessRecord | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return null
+  }
+  if (parsed == null || typeof parsed !== 'object') return null
+  const o = parsed as Record<string, unknown>
+  const pid = typeof o.pid === 'number' ? o.pid : Number(o.pid)
+  const starttime = typeof o.starttime === 'string' ? o.starttime : String(o.starttime ?? '')
+  if (!Number.isInteger(pid) || pid <= 0) return null
+  if (!/^\d+$/.test(starttime)) return null
+  const rec: AgentProcessRecord = { pid, starttime }
+  if (typeof o.comm === 'string' && o.comm.length > 0) rec.comm = o.comm
+  if (typeof o.boot_at === 'number' && Number.isFinite(o.boot_at)) rec.boot_at = o.boot_at
+  return rec
+}
+
+/**
+ * The decision, pure. `live` is the `/proc` identity read back for
+ * `record.pid` (null when that pid is gone), `gatewayStarttime` this
+ * process's own field-22 value.
+ */
+export function decideGatewayOnlyRespawn(input: {
+  record: AgentProcessRecord | null
+  live: ProcIdentity | null
+  gatewayStarttime: string | null
+}): RespawnDecision {
+  const { record, live, gatewayStarttime } = input
+  if (record == null) return { gatewayOnly: false, reason: 'no-record', pid: null }
+  if (live == null) return { gatewayOnly: false, reason: 'agent-process-dead', pid: record.pid }
+  // PID reuse guard: same pid, different process.
+  if (live.starttime !== record.starttime) {
+    return { gatewayOnly: false, reason: 'starttime-mismatch', pid: record.pid }
+  }
+  if (record.comm != null && record.comm !== live.comm) {
+    return { gatewayOnly: false, reason: 'comm-mismatch', pid: record.pid }
+  }
+  if (gatewayStarttime == null || !/^\d+$/.test(gatewayStarttime)) {
+    return { gatewayOnly: false, reason: 'gateway-starttime-unavailable', pid: record.pid }
+  }
+  // Fresh-boot race guard: an agent that started AFTER this gateway process
+  // cannot be the one this gateway is a respawn of.
+  if (BigInt(record.starttime) >= BigInt(gatewayStarttime)) {
+    return { gatewayOnly: false, reason: 'agent-started-after-gateway', pid: record.pid }
+  }
+  return { gatewayOnly: true, reason: 'gateway-only-respawn', pid: record.pid }
+}
+
+export interface DetectOpts {
+  /** Gateway STATE_DIR (`<agentDir>/telegram`). The record lives here. */
+  stateDir: string
+  /** Override the record path outright (tests, ops escape hatch). */
+  recordPath?: string
+  /** `/proc` root; injectable for tests. */
+  procRoot?: string
+  /** This gateway process's pid. Defaults to `process.pid`. */
+  selfPid?: number
+  /** Explicit gateway starttime; defaults to reading `/proc/<selfPid>/stat`. */
+  gatewayStarttime?: string | null
+  /** Set false to force the pre-#4641 behaviour (ops escape hatch). */
+  enabled?: boolean
+}
+
+/** Read the record + `/proc` and decide. Never throws. */
+export function detectGatewayOnlyRespawn(opts: DetectOpts): RespawnDecision {
+  if (opts.enabled === false) return { gatewayOnly: false, reason: 'guard-disabled', pid: null }
+  const procRoot = opts.procRoot ?? '/proc'
+  const recordPath = opts.recordPath ?? join(opts.stateDir, AGENT_PROCESS_RECORD_FILE)
+  const record = readAgentProcessRecord(recordPath)
+  if (record == null) return { gatewayOnly: false, reason: 'no-record', pid: null }
+  const live = readProcIdentity(record.pid, procRoot)
+  const gatewayStarttime =
+    opts.gatewayStarttime !== undefined
+      ? opts.gatewayStarttime
+      : readProcIdentity(opts.selfPid ?? process.pid, procRoot)?.starttime ?? null
+  return decideGatewayOnlyRespawn({ record, live, gatewayStarttime })
+}
+
+/**
+ * Gateway boot entry point: decide, log the decision, and answer the one
+ * question the boot block asks — "should I skip the whole boot-resume path?".
+ *
+ * Called from gateway.ts BEFORE the orphan-turn reaper, so a gateway-only
+ * respawn touches nothing: no `ended_via='restart'` stamp on the live turn, no
+ * resume synthetic, no `.pending-turn.env`. (The `.wake-audit-pending`
+ * sentinel needs no handling here — it is dropped by start.sh once per
+ * CONTAINER boot and start.sh does not re-run on a gateway respawn.)
+ */
+export function shouldSkipBootResumeForGatewayOnlyRespawn(
+  stateDir: string,
+  opts: Omit<DetectOpts, 'stateDir'> & { log?: (s: string) => void } = {},
+): boolean {
+  const log = opts.log ?? ((s: string) => process.stderr.write(s))
+  let decision: RespawnDecision
+  try {
+    decision = detectGatewayOnlyRespawn({
+      ...opts,
+      stateDir,
+      enabled: opts.enabled ?? process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD !== '0',
+      recordPath: opts.recordPath ?? process.env.SWITCHROOM_AGENT_PROCESS_FILE ?? undefined,
+    })
+  } catch (err) {
+    // Fail-open: any surprise keeps the pre-#4641 behaviour.
+    log(`telegram gateway: boot: agent-liveness probe failed (${(err as Error).message}) — assuming agent restart\n`)
+    return false
+  }
+  if (decision.gatewayOnly) {
+    log(
+      `telegram gateway: boot: GATEWAY-ONLY respawn — agent process pid=${decision.pid} is still alive and ` +
+      `predates this gateway (#4641). Skipping orphan-turn reaper, boot-resume synthetic and .pending-turn.env: ` +
+      `the claude session, its in-flight turn and its sub-agents were never interrupted.\n`,
+    )
+    return true
+  }
+  log(`telegram gateway: boot: agent-liveness probe → treating as agent restart (reason=${decision.reason})\n`)
+  return false
+}

--- a/telegram-plugin/gateway/bridge-dead-watchdog.ts
+++ b/telegram-plugin/gateway/bridge-dead-watchdog.ts
@@ -228,16 +228,28 @@ export function writeBridgeDeadEscalationMarker(
 /**
  * Read + consume the escalation marker at boot. Returns the marker only
  * when it is fresh (< maxAgeMs); a stale or malformed marker is cleared
- * and ignored. The file is ALWAYS removed — the cause note must surface
- * on exactly the boot that follows the escalation, never a later one.
+ * and ignored. Whenever this function runs the file IS removed — the cause
+ * note must surface on exactly the boot that follows the escalation, never
+ * a later one.
  *
- * Known race window (accepted, documented per review): the marker is
- * written by gateway boot N and consumed by whichever gateway boots NEXT.
- * Normally that is the post-container-restart gateway (the SIGTERM to
- * PID 1 fires ~1.5s after the write and takes the whole container down).
- * But if the escalating gateway PROCESS dies and its supervisor relaunches
- * a new gateway inside the same container before the SIGTERM lands, that
- * interim gateway consumes the marker instead — the cause note is then
+ * Since #4641 the caller does not always run: the gateway's boot-resume
+ * block `break`s before reaching this call when the per-container-boot
+ * generation token says only the GATEWAY respawned. That narrows — and for
+ * the common shape closes — the race documented below, so it is an
+ * improvement rather than a hole; the marker is left on disk for the boot
+ * that genuinely follows the container restart. See "What `break
+ * bootResumeInit` skips" in agent-process-liveness.ts.
+ *
+ * Known race window (accepted, documented per review; largely closed by the
+ * #4641 guard above): the marker is written by gateway boot N and consumed
+ * by whichever gateway boots NEXT and reaches this call. Normally that is
+ * the post-container-restart gateway (the SIGTERM to PID 1 fires ~1.5s
+ * after the write and takes the whole container down). But if the
+ * escalating gateway PROCESS dies and its supervisor relaunches a new
+ * gateway inside the same container before the SIGTERM lands, and that
+ * interim gateway's boot block is NOT suppressed by the generation token
+ * (i.e. no gateway in this generation had completed its boot resume yet),
+ * the interim gateway consumes the marker instead — the cause note is then
  * surfaced (or dropped with the interim process) one boot early, and the
  * post-restart boot sees no marker. Consequences are bounded and safe:
  * the honesty note may be lost for one incident (the loud supervisor-log

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -979,7 +979,7 @@ import {
 } from './resume-inbound-builder.js'
 import { maybeQueueBootBriefing } from './boot-briefing-wiring.js'
 import { writePendingTurnEnv } from './pending-turn-env.js'
-import { shouldSkipBootResumeForGatewayOnlyRespawn } from './agent-process-liveness.js'
+import { shouldSkipBootResumeForGatewayOnlyRespawn, markBootResumeComplete } from './agent-process-liveness.js'
 import {
   createBridgeDeadWatchdog,
   consumeBridgeDeadEscalationMarker,
@@ -1668,7 +1668,7 @@ bootResumeInit: if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqli
   // schema; subagents lives alongside in registry.db. Idempotent — safe on
   // pre-existing DBs (handles the jsonl_agent_id column migration).
   applySubagentsSchema(turnsDb)
-  if (shouldSkipBootResumeForGatewayOnlyRespawn(STATE_DIR)) break bootResumeInit // #4641: agent process still alive — ONLY the gateway respawned; reaper/resume/pending-env would all be lies
+  if (shouldSkipBootResumeForGatewayOnlyRespawn(STATE_DIR)) break bootResumeInit // #4641: this container generation's boot resume is already done — ONLY the gateway respawned. The break skips ALL of: the orphan-turn reaper, consumeBridgeDeadEscalationMarker (already consumed by the gateway that stamped the token), the bridge-dead idle notice, the resume/report synthetic, the pendingRedelivery capture (the turn is still running and will answer itself — redelivering would double-send) and writePendingTurnEnv. Each is safe ONLY because the token proves one gateway already did it this generation; see "What `break bootResumeInit` skips" in agent-process-liveness.ts.
 
   // Read the turn-active marker (the in-flight turn the watchdog tracks)
   // BEFORE classifying — its mtime is "ms since last tool progress" and its
@@ -1954,7 +1954,7 @@ bootResumeInit: if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqli
   // wake-audit context. The injected inbound above is the real wake signal;
   // these vars are passive context only. Extracted to pending-turn-env.ts
   // (atomic tmp+rename writer; never throws).
-  writePendingTurnEnv(agentDir, pending)
+  writePendingTurnEnv(agentDir, pending); markBootResumeComplete(STATE_DIR) // #4641 generation token, LAST statement of the block: this container generation's boot resume completed, so a respawned gateway must skip it. A crash before here leaves no token and the successor redoes the work. (Joined onto one line: gateway.ts sits at its line ratchet — scripts/gateway-line-ratchet.txt.)
 } catch (err) {
   process.stderr.write(`telegram gateway: turn-registry init failed (${(err as Error).message}) — turn tracking disabled\n`)
   turnsDb = null

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1656,7 +1656,7 @@ let pendingRedelivery: { turn: Turn; maxAgeMs: number } | null = null
 // #3038 cross-boot damper: consecutive bridge-dead escalations by PRIOR
 // boots (the consumed marker's `count`; 0 when no fresh marker). Set in
 // the boot block below, consumed by the watchdog constructor further down.
-let bridgeDeadPriorStreak = 0
+let bridgeDeadPriorStreak = 0; let bootResumeThrew = false // #4641: set by the block's catch below. A SWALLOWED throw is not a completed boot resume — the reaper at the top of the block may already have durably stamped the in-flight turn `ended_via='restart'` while `bootResumeInbound` stayed null — so the generation token must not be stamped on that path. See "WHERE the token is stamped" in agent-process-liveness.ts. (Joined: gateway.ts sits at its line ratchet.)
 bootResumeInit: if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqlite + writes .pending-turn.env
   // STATE_DIR is `<agentDir>/telegram` in production. openTurnsDb expects
   // the parent (agent dir) and joins `telegram/registry.db` itself.
@@ -1956,7 +1956,7 @@ bootResumeInit: if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqli
   writePendingTurnEnv(agentDir, pending) // #4641: the generation token is deliberately NOT stamped here. This block only builds `bootResumeInbound` IN MEMORY; the resume becomes crash-survivable ~8k lines below, at the `inboundSpool.put` — and that is where the stamp lives. See the comment at that call site.
 } catch (err) {
   process.stderr.write(`telegram gateway: turn-registry init failed (${(err as Error).message}) — turn tracking disabled\n`)
-  turnsDb = null
+  turnsDb = null; bootResumeThrew = true // #4641: swallow-and-continue must NOT stamp the token — see the declaration above.
 }
 
 /**
@@ -10168,7 +10168,7 @@ if (isGatewayMain && bootResumeInbound != null) {
     }
   }
 }
-if (isGatewayMain) markBootResumeComplete(STATE_DIR) // #4641 generation token, stamped HERE — AFTER the boot-resume inbound is durably spooled above, never at the tail of the `bootResumeInit` block (which only builds it in memory). Same ordering rule, same reason, as `markTurnResumed` directly above: a crash between the block and this line must leave NO token, so the successor re-mints the resume rather than suppressing it. Unconditional by design (a boot with nothing to resume still completed this generation's boot resume). Full argument: "WHERE the token is stamped" in agent-process-liveness.ts. (One line: gateway.ts sits at its line ratchet — scripts/gateway-line-ratchet.txt.)
+if (isGatewayMain && !bootResumeThrew) markBootResumeComplete(STATE_DIR) // #4641 generation token, stamped HERE — AFTER the boot-resume inbound is durably spooled above, never at the tail of the `bootResumeInit` block (which only builds it in memory). Same ordering rule, same reason, as `markTurnResumed` directly above: a crash between the block and this line must leave NO token, so the successor re-mints the resume rather than suppressing it. Unconditional on whether there was anything to resume (a boot that found nothing still completed this generation's boot resume) but NOT on success: a swallowed throw in the block (`bootResumeThrew`) leaves the token unstamped, because the reaper may have durably stamped a turn `ended_via='restart'` that then never got spooled. Full argument: "WHERE the token is stamped" in agent-process-liveness.ts. (One line: gateway.ts sits at its line ratchet — scripts/gateway-line-ratchet.txt.)
 // Boot-replay: re-queue every un-acked spooled inbound into the
 // in-memory buffer so the existing drain triggers (onClientRegistered
 // / silence-poke #1546 / idle-drain #1549) deliver them. push →

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -979,6 +979,7 @@ import {
 } from './resume-inbound-builder.js'
 import { maybeQueueBootBriefing } from './boot-briefing-wiring.js'
 import { writePendingTurnEnv } from './pending-turn-env.js'
+import { shouldSkipBootResumeForGatewayOnlyRespawn } from './agent-process-liveness.js'
 import {
   createBridgeDeadWatchdog,
   consumeBridgeDeadEscalationMarker,
@@ -1656,7 +1657,7 @@ let pendingRedelivery: { turn: Turn; maxAgeMs: number } | null = null
 // boots (the consumed marker's `count`; 0 when no fresh marker). Set in
 // the boot block below, consumed by the watchdog constructor further down.
 let bridgeDeadPriorStreak = 0
-if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqlite + writes .pending-turn.env
+bootResumeInit: if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqlite + writes .pending-turn.env
   // STATE_DIR is `<agentDir>/telegram` in production. openTurnsDb expects
   // the parent (agent dir) and joins `telegram/registry.db` itself.
   const agentDir = STATE_DIR.endsWith('/telegram')
@@ -1667,6 +1668,7 @@ if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqlite + writes .pen
   // schema; subagents lives alongside in registry.db. Idempotent — safe on
   // pre-existing DBs (handles the jsonl_agent_id column migration).
   applySubagentsSchema(turnsDb)
+  if (shouldSkipBootResumeForGatewayOnlyRespawn(STATE_DIR)) break bootResumeInit // #4641: agent process still alive — ONLY the gateway respawned; reaper/resume/pending-env would all be lies
 
   // Read the turn-active marker (the in-flight turn the watchdog tracks)
   // BEFORE classifying — its mtime is "ms since last tool progress" and its

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1668,7 +1668,7 @@ bootResumeInit: if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqli
   // schema; subagents lives alongside in registry.db. Idempotent — safe on
   // pre-existing DBs (handles the jsonl_agent_id column migration).
   applySubagentsSchema(turnsDb)
-  if (shouldSkipBootResumeForGatewayOnlyRespawn(STATE_DIR)) break bootResumeInit // #4641: this container generation's boot resume is already done — ONLY the gateway respawned. The break skips ALL of: the orphan-turn reaper, consumeBridgeDeadEscalationMarker (already consumed by the gateway that stamped the token), the bridge-dead idle notice, the resume/report synthetic, the pendingRedelivery capture (the turn is still running and will answer itself — redelivering would double-send) and writePendingTurnEnv. Each is safe ONLY because the token proves one gateway already did it this generation; see "What `break bootResumeInit` skips" in agent-process-liveness.ts.
+  if (shouldSkipBootResumeForGatewayOnlyRespawn(STATE_DIR)) break bootResumeInit // #4641: this container generation's boot resume is already done — ONLY the gateway respawned. The break skips ALL of: the orphan-turn reaper, consumeBridgeDeadEscalationMarker (already consumed by the gateway that stamped the token), the bridge-dead idle notice, the resume/report synthetic, the pendingRedelivery capture (the turn is still running and will answer itself — redelivering would double-send), the bridgeDeadPriorStreak seed for the #3038 cross-boot damper (left 0: the streak belongs to the gateway that consumed the marker, and re-seeding it here would double-count) and writePendingTurnEnv. Each is safe ONLY because the token proves one gateway already did it this generation; see "What `break bootResumeInit` skips" in agent-process-liveness.ts.
 
   // Read the turn-active marker (the in-flight turn the watchdog tracks)
   // BEFORE classifying — its mtime is "ms since last tool progress" and its
@@ -1950,11 +1950,10 @@ bootResumeInit: if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqli
     }
   }
 
-  // Diagnostic env file (one-shot, sourced by start.sh) — kept for the
-  // wake-audit context. The injected inbound above is the real wake signal;
-  // these vars are passive context only. Extracted to pending-turn-env.ts
-  // (atomic tmp+rename writer; never throws).
-  writePendingTurnEnv(agentDir, pending); markBootResumeComplete(STATE_DIR) // #4641 generation token, LAST statement of the block: this container generation's boot resume completed, so a respawned gateway must skip it. A crash before here leaves no token and the successor redoes the work. (Joined onto one line: gateway.ts sits at its line ratchet — scripts/gateway-line-ratchet.txt.)
+  // Diagnostic env file (one-shot, sourced by start.sh) — kept for wake-audit
+  // context. The injected inbound above is the real wake signal; these vars are
+  // passive context only. pending-turn-env.ts: atomic writer, never throws.
+  writePendingTurnEnv(agentDir, pending) // #4641: the generation token is deliberately NOT stamped here. This block only builds `bootResumeInbound` IN MEMORY; the resume becomes crash-survivable ~8k lines below, at the `inboundSpool.put` — and that is where the stamp lives. See the comment at that call site.
 } catch (err) {
   process.stderr.write(`telegram gateway: turn-registry init failed (${(err as Error).message}) — turn tracking disabled\n`)
   turnsDb = null
@@ -10169,6 +10168,7 @@ if (isGatewayMain && bootResumeInbound != null) {
     }
   }
 }
+if (isGatewayMain) markBootResumeComplete(STATE_DIR) // #4641 generation token, stamped HERE — AFTER the boot-resume inbound is durably spooled above, never at the tail of the `bootResumeInit` block (which only builds it in memory). Same ordering rule, same reason, as `markTurnResumed` directly above: a crash between the block and this line must leave NO token, so the successor re-mints the resume rather than suppressing it. Unconditional by design (a boot with nothing to resume still completed this generation's boot resume). Full argument: "WHERE the token is stamped" in agent-process-liveness.ts. (One line: gateway.ts sits at its line ratchet — scripts/gateway-line-ratchet.txt.)
 // Boot-replay: re-queue every un-acked spooled inbound into the
 // in-memory buffer so the existing drain triggers (onClientRegistered
 // / silence-poke #1546 / idle-drain #1549) deliver them. push →

--- a/telegram-plugin/tests/agent-process-liveness.test.ts
+++ b/telegram-plugin/tests/agent-process-liveness.test.ts
@@ -36,6 +36,8 @@ import {
   shouldSkipBootResumeForGatewayOnlyRespawn,
   markBootResumeComplete,
   bootResumeDonePath,
+  readBootResumeSentinel,
+  containerBootIdentity,
   AGENT_PROCESS_RECORD_FILE,
   BOOT_RESUME_DONE_FILE,
 } from '../gateway/agent-process-liveness.js'
@@ -295,5 +297,110 @@ describe('readAgentProcessRecord', () => {
   it('rejects a nonsense pid', () => {
     expect(readAgentProcessRecord(writeRecord({ pid: 0, starttime: '5' }))).toBeNull()
     expect(readAgentProcessRecord(writeRecord({ pid: -1, starttime: '5' }))).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #4648 LOW-2: the token carries the container-boot identity
+// ---------------------------------------------------------------------------
+
+describe('generation-token boot identity', () => {
+  it('stamps the live container-boot identity (PID 1 starttime) into the token', () => {
+    markBootResumeComplete(dir)
+    const body = JSON.parse(readFileSync(bootResumeDonePath(dir), 'utf8')) as { boot?: string }
+    expect(body.boot).toBe(containerBootIdentity()!)
+  })
+
+  it('treats a token from a DIFFERENT container boot as stale, not as a suppressor', () => {
+    // The failure this closes: start.sh's `rm -f … 2>/dev/null || true` swallows
+    // a per-file unlink failure, so a token can outlive its generation and
+    // suppress EVERY later resume — permanently and silently, since
+    // `gateway-only-respawn-no-record` needs no corroborating evidence.
+    writeFileSync(
+      bootResumeDonePath(dir),
+      JSON.stringify({ pid: 4242, at: Date.now(), boot: '1' }) + '\n',
+    )
+    const decision = detectGatewayOnlyRespawn({ stateDir: dir })
+    expect(decision.gatewayOnly).toBe(false)
+    expect(decision.reason).toBe('stale-boot-token')
+  })
+
+  it('still suppresses for a token stamped in THIS boot, with no record present', () => {
+    // The `gateway-only-respawn-no-record` path must survive the hardening:
+    // the gateway boots long before start.sh `exec`s claude.
+    markBootResumeComplete(dir)
+    expect(existsSync(join(dir, AGENT_PROCESS_RECORD_FILE))).toBe(false)
+    const decision = detectGatewayOnlyRespawn({ stateDir: dir })
+    expect(decision.gatewayOnly).toBe(true)
+    expect(decision.reason).toBe('gateway-only-respawn-no-record')
+  })
+
+  it('keeps the pre-existing behaviour when the token carries NO identity', () => {
+    // One-directional by design: only a positive MISMATCH is evidence. A
+    // legacy/identity-less token must not become a fail-open path, or the
+    // hardening would itself re-open #4641.
+    writeFileSync(bootResumeDonePath(dir), JSON.stringify({ pid: 4242, at: Date.now() }) + '\n')
+    expect(readBootResumeSentinel(bootResumeDonePath(dir))).toEqual({ present: true, stale: false })
+    expect(detectGatewayOnlyRespawn({ stateDir: dir }).gatewayOnly).toBe(true)
+  })
+
+  it('keeps the pre-existing behaviour when the token body is unparseable', () => {
+    writeFileSync(bootResumeDonePath(dir), 'not json at all')
+    expect(readBootResumeSentinel(bootResumeDonePath(dir))).toEqual({ present: true, stale: false })
+  })
+
+  it('keeps the pre-existing behaviour when /proc/1 is unreadable', () => {
+    // No live identity to compare against → no evidence → not stale.
+    writeFileSync(
+      bootResumeDonePath(dir),
+      JSON.stringify({ pid: 4242, at: Date.now(), boot: '1' }) + '\n',
+    )
+    const emptyProc = mkdtempSync(join(tmpdir(), 'noproc-'))
+    try {
+      expect(containerBootIdentity(emptyProc)).toBeNull()
+      expect(readBootResumeSentinel(bootResumeDonePath(dir), { procRoot: emptyProc }))
+        .toEqual({ present: true, stale: false })
+    } finally {
+      rmSync(emptyProc, { recursive: true, force: true })
+    }
+  })
+
+  it('reports absent when there is no token at all', () => {
+    clearToken()
+    expect(readBootResumeSentinel(bootResumeDonePath(dir))).toEqual({ present: false, stale: false })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #4648 LOW-1: no env var may redirect the token/record paths
+// ---------------------------------------------------------------------------
+
+describe('path overrides are test-injection only (fail-open invariant)', () => {
+  it('ignores SWITCHROOM_BOOT_RESUME_DONE_FILE / SWITCHROOM_AGENT_PROCESS_FILE', () => {
+    // If these were honoured, start.sh (which hard-codes
+    // "$TELEGRAM_STATE_DIR/.boot-resume-done") would clear one path while the
+    // gateway read another: the token would never be cleared and EVERY boot
+    // would suppress its resume forever — the module's one fail-CLOSED path.
+    const decoy = mkdtempSync(join(tmpdir(), 'decoy-'))
+    const prevToken = process.env.SWITCHROOM_BOOT_RESUME_DONE_FILE
+    const prevRecord = process.env.SWITCHROOM_AGENT_PROCESS_FILE
+    try {
+      process.env.SWITCHROOM_BOOT_RESUME_DONE_FILE = join(decoy, 'token')
+      process.env.SWITCHROOM_AGENT_PROCESS_FILE = join(decoy, 'record')
+      clearToken()
+      // A token written into the decoy path must NOT be seen…
+      writeFileSync(join(decoy, 'token'), JSON.stringify({ pid: 1, at: Date.now() }) + '\n')
+      expect(shouldSkipBootResumeForGatewayOnlyRespawn(dir, { log: () => {} })).toBe(false)
+      // …and the stamp must land in stateDir, not the decoy.
+      markBootResumeComplete(dir)
+      expect(existsSync(bootResumeDonePath(dir))).toBe(true)
+      expect(shouldSkipBootResumeForGatewayOnlyRespawn(dir, { log: () => {} })).toBe(true)
+    } finally {
+      if (prevToken == null) delete process.env.SWITCHROOM_BOOT_RESUME_DONE_FILE
+      else process.env.SWITCHROOM_BOOT_RESUME_DONE_FILE = prevToken
+      if (prevRecord == null) delete process.env.SWITCHROOM_AGENT_PROCESS_FILE
+      else process.env.SWITCHROOM_AGENT_PROCESS_FILE = prevRecord
+      rmSync(decoy, { recursive: true, force: true })
+    }
   })
 })

--- a/telegram-plugin/tests/agent-process-liveness.test.ts
+++ b/telegram-plugin/tests/agent-process-liveness.test.ts
@@ -1,21 +1,30 @@
 /**
- * switchroom#4641 — agent-process liveness probe.
+ * switchroom#4641 — the boot-resume generation guard.
  *
- * These tests use REAL processes and the REAL `/proc`, not a mocked fs: the
- * whole point of the probe is that it can tell a live agent from a dead one,
- * and a fixture that hand-writes both answers would pass against a probe that
- * always says "alive". Every liveness assertion below is anchored on a process
- * this test actually spawned (and, for the dead case, actually killed).
+ * Two mechanisms, tested for what each is actually responsible for:
  *
- * The two stand-ins are ordinary `sleep` children spawned in a known order:
- * `agentProc` first, `gatewayProc` second — exactly the production ordering of
- * a gateway-only respawn (claude has been running for ages; the replacement
- * gateway was forked seconds ago).
+ *   - the per-container-boot GENERATION TOKEN (`.boot-resume-done`) is the
+ *     only thing that can say "suppress". start.sh deletes it once per
+ *     container boot before forking the gateway; the gateway stamps it after
+ *     completing its boot-resume block.
+ *   - the `/proc` AGENT RECORD is a VETO only: it can re-enable a boot resume
+ *     when the recorded agent is provably gone, never suppress one.
+ *
+ * Liveness assertions use REAL processes and the REAL `/proc`, not a mocked
+ * fs: a fixture that hand-writes both answers would pass against a probe that
+ * always says "alive". Every "alive" claim is anchored on a process this test
+ * spawned; every "dead" claim on one it killed.
+ *
+ * Deliberately NOT tested here, because it no longer exists: any comparison of
+ * the agent's `/proc` starttime against the gateway's. The previous revision
+ * suppressed on "the agent predates me", which was correct only by accident of
+ * the docker tmux re-exec (measured margin on a live container: one clock
+ * tick) and which broke outright when a gateway crashed during its own boot.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { spawn, type ChildProcess } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, unlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -25,7 +34,10 @@ import {
   decideGatewayOnlyRespawn,
   detectGatewayOnlyRespawn,
   shouldSkipBootResumeForGatewayOnlyRespawn,
+  markBootResumeComplete,
+  bootResumeDonePath,
   AGENT_PROCESS_RECORD_FILE,
+  BOOT_RESUME_DONE_FILE,
 } from '../gateway/agent-process-liveness.js'
 
 function starttimeOf(pid: number): string {
@@ -45,23 +57,28 @@ async function waitForExit(child: ChildProcess): Promise<void> {
 
 let dir: string
 let agentProc: ChildProcess
-let gatewayProc: ChildProcess
 
 beforeAll(async () => {
   dir = mkdtempSync(join(tmpdir(), 'agent-liveness-'))
-  // Order is load-bearing: the "agent" must exist BEFORE the "gateway".
   agentProc = spawnSleeper()
-  await new Promise((r) => setTimeout(r, 20))
-  gatewayProc = spawnSleeper()
   await new Promise((r) => setTimeout(r, 20))
 })
 
 afterAll(() => {
-  for (const p of [agentProc, gatewayProc]) {
-    try { p.kill('SIGKILL') } catch { /* already gone */ }
-  }
+  try { agentProc.kill('SIGKILL') } catch { /* already gone */ }
   rmSync(dir, { recursive: true, force: true })
 })
+
+beforeEach(() => {
+  // Every case states its own generation-token state explicitly.
+  try { unlinkSync(bootResumeDonePath(dir)) } catch { /* absent */ }
+  try { unlinkSync(join(dir, AGENT_PROCESS_RECORD_FILE)) } catch { /* absent */ }
+})
+
+/** start.sh's outer-pass "open a new generation" step. */
+function clearToken(): void {
+  try { unlinkSync(bootResumeDonePath(dir)) } catch { /* absent */ }
+}
 
 function writeRecord(rec: unknown, name = AGENT_PROCESS_RECORD_FILE): string {
   const p = join(dir, name)
@@ -96,85 +113,113 @@ describe('parseProcStat', () => {
   })
 })
 
-describe('gateway-only respawn detection (real processes)', () => {
-  it('reports a gateway-only respawn when the agent is alive and older', () => {
+describe('the generation token decides', () => {
+  it('suppresses ONLY after a gateway stamped the token this generation', () => {
     writeRecord({ pid: agentProc.pid, starttime: starttimeOf(agentProc.pid!) })
-    const decision = detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid })
-    expect(decision).toEqual({
+
+    // Fresh container boot: start.sh cleared the token, no gateway has
+    // finished its boot resume yet. The live agent record must NOT suppress.
+    expect(detectGatewayOnlyRespawn({ stateDir: dir })).toEqual({
+      gatewayOnly: false,
+      reason: 'no-boot-resume-sentinel',
+      pid: agentProc.pid,
+    })
+
+    // …the first gateway completes its boot-resume block…
+    markBootResumeComplete(dir)
+    expect(existsSync(bootResumeDonePath(dir))).toBe(true)
+
+    // …and a respawned gateway now sees the generation already handled.
+    expect(detectGatewayOnlyRespawn({ stateDir: dir })).toEqual({
       gatewayOnly: true,
       reason: 'gateway-only-respawn',
       pid: agentProc.pid,
     })
   })
 
-  it('does NOT claim a gateway-only respawn when the agent process is dead', async () => {
+  it('does NOT suppress when the gateway crashed during its own boot', () => {
+    // The #4641-motivating Bun crash-at-boot pattern: gateway #1 died before
+    // finishing the boot-resume block, so it never stamped the token — even
+    // though start.sh had already published a live agent record. Gateway #2
+    // MUST do the boot resume; the previous starttime-ordering guard
+    // suppressed here and lost the interrupted turn permanently.
+    writeRecord({ pid: agentProc.pid, starttime: starttimeOf(agentProc.pid!) })
+    const decision = detectGatewayOnlyRespawn({ stateDir: dir })
+    expect(decision.gatewayOnly).toBe(false)
+    expect(decision.reason).toBe('no-boot-resume-sentinel')
+  })
+
+  it('suppresses on a token with no record yet (gateway respawn pre-exec)', () => {
+    // The gateway boots long before start.sh reaches `exec claude`. A gateway
+    // that crashes in that window must still not repeat this generation's
+    // boot resume — repeating it would spool the resume synthetic twice.
+    markBootResumeComplete(dir)
+    expect(detectGatewayOnlyRespawn({ stateDir: dir })).toEqual({
+      gatewayOnly: true,
+      reason: 'gateway-only-respawn-no-record',
+      pid: null,
+    })
+  })
+
+  it('a container restart re-opens the generation (start.sh clears the token)', () => {
+    writeRecord({ pid: agentProc.pid, starttime: starttimeOf(agentProc.pid!) })
+    markBootResumeComplete(dir)
+    expect(detectGatewayOnlyRespawn({ stateDir: dir }).gatewayOnly).toBe(true)
+    clearToken()
+    expect(detectGatewayOnlyRespawn({ stateDir: dir }).gatewayOnly).toBe(false)
+  })
+})
+
+describe('the /proc record can only VETO a suppression', () => {
+  it('vetoes when the recorded agent process is really dead', async () => {
     const doomed = spawnSleeper()
     await new Promise((r) => setTimeout(r, 20))
     writeRecord({ pid: doomed.pid, starttime: starttimeOf(doomed.pid!) })
     doomed.kill('SIGKILL')
     await waitForExit(doomed)
-    const decision = detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid })
+    markBootResumeComplete(dir)
+
+    const decision = detectGatewayOnlyRespawn({ stateDir: dir })
     expect(decision.gatewayOnly).toBe(false)
     expect(decision.reason).toBe('agent-process-dead')
   })
 
-  it('rejects a recycled PID: same pid, different starttime', () => {
+  it('vetoes a recycled PID: same pid, different starttime', () => {
     const live = starttimeOf(agentProc.pid!)
     writeRecord({ pid: agentProc.pid, starttime: String(BigInt(live) - 1n) })
-    const decision = detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid })
-    expect(decision).toEqual({
+    markBootResumeComplete(dir)
+    expect(detectGatewayOnlyRespawn({ stateDir: dir })).toEqual({
       gatewayOnly: false,
       reason: 'starttime-mismatch',
       pid: agentProc.pid,
     })
   })
 
-  it('rejects an agent that started AFTER this gateway (fresh-boot race)', () => {
-    // Swap the roles: the record names the LATER process, the probe runs as
-    // the EARLIER one. This is the fresh-container ordering (gateway launched,
-    // then `exec claude`), where the resume must still fire.
-    writeRecord({ pid: gatewayProc.pid, starttime: starttimeOf(gatewayProc.pid!) })
-    const decision = detectGatewayOnlyRespawn({ stateDir: dir, selfPid: agentProc.pid })
-    expect(decision).toEqual({
-      gatewayOnly: false,
-      reason: 'agent-started-after-gateway',
-      pid: gatewayProc.pid,
-    })
+  it('cannot manufacture a suppression on its own', () => {
+    // A live, matching, older record with NO token still runs the boot resume.
+    writeRecord({ pid: agentProc.pid, starttime: starttimeOf(agentProc.pid!) })
+    expect(detectGatewayOnlyRespawn({ stateDir: dir }).gatewayOnly).toBe(false)
   })
 
-  it('fails open with no record at all (first boot)', () => {
-    const empty = mkdtempSync(join(tmpdir(), 'agent-liveness-empty-'))
-    try {
-      expect(detectGatewayOnlyRespawn({ stateDir: empty, selfPid: gatewayProc.pid })).toEqual({
-        gatewayOnly: false,
-        reason: 'no-record',
-        pid: null,
-      })
-    } finally {
-      rmSync(empty, { recursive: true, force: true })
-    }
-  })
-
-  it('fails open on a torn record', () => {
+  it('fails open on a torn record even with the token present', () => {
+    markBootResumeComplete(dir)
     writeRecord('{"pid": 12')
-    expect(detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid }).gatewayOnly)
-      .toBe(false)
-    writeRecord({ pid: agentProc.pid, starttime: 'not-a-number' })
-    expect(detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid }).gatewayOnly)
-      .toBe(false)
+    // Torn record is indistinguishable from "no record" — and with the token
+    // present that is a suppression, which is the safe answer here: the block
+    // demonstrably already ran this generation.
+    expect(detectGatewayOnlyRespawn({ stateDir: dir }).reason)
+      .toBe('gateway-only-respawn-no-record')
   })
 
   it('honours the SWITCHROOM_GATEWAY_RESPAWN_GUARD=0 escape hatch', () => {
     writeRecord({ pid: agentProc.pid, starttime: starttimeOf(agentProc.pid!) })
+    markBootResumeComplete(dir)
     const lines: string[] = []
     const prev = process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD
     process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD = '0'
     try {
       expect(
-        shouldSkipBootResumeForGatewayOnlyRespawn(dir, {
-          selfPid: gatewayProc.pid,
-          log: (s) => lines.push(s),
-        }),
+        shouldSkipBootResumeForGatewayOnlyRespawn(dir, { log: (s) => lines.push(s) }),
       ).toBe(false)
     } finally {
       if (prev == null) delete process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD
@@ -183,49 +228,57 @@ describe('gateway-only respawn detection (real processes)', () => {
     expect(lines.join('')).toContain('guard-disabled')
   })
 
-  it('skips the boot-resume path (and says so) for a live older agent', () => {
+  it('skips the boot-resume path (and says so) for a live agent + token', () => {
     writeRecord({ pid: agentProc.pid, starttime: starttimeOf(agentProc.pid!) })
+    markBootResumeComplete(dir)
     const lines: string[] = []
-    const skip = shouldSkipBootResumeForGatewayOnlyRespawn(dir, {
-      selfPid: gatewayProc.pid,
-      log: (s) => lines.push(s),
-    })
-    expect(skip).toBe(true)
-    expect(lines.join('')).toContain('GATEWAY-ONLY respawn')
+    expect(shouldSkipBootResumeForGatewayOnlyRespawn(dir, { log: (s) => lines.push(s) })).toBe(true)
+    const out = lines.join('')
+    expect(out).toContain('GATEWAY-ONLY respawn')
+    // The log must name the side effects the break skips (the MEDIUM finding:
+    // it skips more than the resume synthetic).
+    expect(out).toContain('bridge-dead marker')
+    expect(out).toContain('crash-redelivery')
+  })
+})
+
+describe('markBootResumeComplete', () => {
+  it('writes the token atomically and leaves no tmp file behind', () => {
+    markBootResumeComplete(dir)
+    const p = bootResumeDonePath(dir)
+    expect(p.endsWith(BOOT_RESUME_DONE_FILE)).toBe(true)
+    expect(JSON.parse(readFileSync(p, 'utf8'))).toMatchObject({ pid: process.pid })
+    expect(existsSync(`${p}.tmp.${process.pid}`)).toBe(false)
+  })
+
+  it('never throws when the state dir is unwritable — it logs and continues', () => {
+    const lines: string[] = []
+    expect(() =>
+      markBootResumeComplete(join(dir, 'no', 'such', 'dir'), { log: (s) => lines.push(s) }),
+    ).not.toThrow()
+    expect(lines.join('')).toContain(BOOT_RESUME_DONE_FILE)
   })
 })
 
 describe('decideGatewayOnlyRespawn (pure)', () => {
   const record = { pid: 42, starttime: '1000' }
+  const live = { starttime: '1000', comm: 'claude', state: 'S' }
 
   it('rejects a comm mismatch when the record carries one', () => {
     expect(
       decideGatewayOnlyRespawn({
+        sentinelPresent: true,
         record: { ...record, comm: 'claude' },
-        live: { starttime: '1000', comm: 'imposter', state: 'S' },
-        gatewayStarttime: '2000',
+        live: { ...live, comm: 'imposter' },
       }),
     ).toEqual({ gatewayOnly: false, reason: 'comm-mismatch', pid: 42 })
   })
 
-  it('fails open when this gateway has no readable starttime', () => {
-    expect(
-      decideGatewayOnlyRespawn({
-        record,
-        live: { starttime: '1000', comm: 'claude', state: 'S' },
-        gatewayStarttime: null,
-      }).gatewayOnly,
-    ).toBe(false)
-  })
-
-  it('rejects an exact starttime tie (cannot have forked before itself)', () => {
-    expect(
-      decideGatewayOnlyRespawn({
-        record,
-        live: { starttime: '1000', comm: 'claude', state: 'S' },
-        gatewayStarttime: '1000',
-      }).reason,
-    ).toBe('agent-started-after-gateway')
+  it('never suppresses without the generation token, whatever /proc says', () => {
+    for (const l of [live, null]) {
+      expect(decideGatewayOnlyRespawn({ sentinelPresent: false, record, live: l }).gatewayOnly)
+        .toBe(false)
+    }
   })
 })
 

--- a/telegram-plugin/tests/agent-process-liveness.test.ts
+++ b/telegram-plugin/tests/agent-process-liveness.test.ts
@@ -1,0 +1,246 @@
+/**
+ * switchroom#4641 — agent-process liveness probe.
+ *
+ * These tests use REAL processes and the REAL `/proc`, not a mocked fs: the
+ * whole point of the probe is that it can tell a live agent from a dead one,
+ * and a fixture that hand-writes both answers would pass against a probe that
+ * always says "alive". Every liveness assertion below is anchored on a process
+ * this test actually spawned (and, for the dead case, actually killed).
+ *
+ * The two stand-ins are ordinary `sleep` children spawned in a known order:
+ * `agentProc` first, `gatewayProc` second — exactly the production ordering of
+ * a gateway-only respawn (claude has been running for ages; the replacement
+ * gateway was forked seconds ago).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  parseProcStat,
+  readProcIdentity,
+  readAgentProcessRecord,
+  decideGatewayOnlyRespawn,
+  detectGatewayOnlyRespawn,
+  shouldSkipBootResumeForGatewayOnlyRespawn,
+  AGENT_PROCESS_RECORD_FILE,
+} from '../gateway/agent-process-liveness.js'
+
+function starttimeOf(pid: number): string {
+  const id = readProcIdentity(pid)
+  expect(id, `pid ${pid} should be live`).not.toBeNull()
+  return id!.starttime
+}
+
+function spawnSleeper(): ChildProcess {
+  return spawn('sleep', ['120'], { stdio: 'ignore' })
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode != null || child.signalCode != null) return
+  await new Promise<void>((res) => child.once('exit', () => res()))
+}
+
+let dir: string
+let agentProc: ChildProcess
+let gatewayProc: ChildProcess
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'agent-liveness-'))
+  // Order is load-bearing: the "agent" must exist BEFORE the "gateway".
+  agentProc = spawnSleeper()
+  await new Promise((r) => setTimeout(r, 20))
+  gatewayProc = spawnSleeper()
+  await new Promise((r) => setTimeout(r, 20))
+})
+
+afterAll(() => {
+  for (const p of [agentProc, gatewayProc]) {
+    try { p.kill('SIGKILL') } catch { /* already gone */ }
+  }
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function writeRecord(rec: unknown, name = AGENT_PROCESS_RECORD_FILE): string {
+  const p = join(dir, name)
+  writeFileSync(p, typeof rec === 'string' ? rec : JSON.stringify(rec))
+  return p
+}
+
+describe('parseProcStat', () => {
+  it('reads state + starttime past a comm containing spaces and parens', () => {
+    // A real-shaped line with a hostile comm — the naive `awk $22` split and a
+    // first-`)` split both return the wrong field here.
+    const raw =
+      '4242 (weird ) name) S 1 4242 4242 0 -1 4194304 167 0 0 0 0 0 0 0 20 0 1 0 ' +
+      '987654321 4165632 702 18446744073709551615 0 0 0 0 0 0 2 4 65536 1 0 0 17 0 0 0 0 0 0'
+    expect(parseProcStat(raw)).toEqual({
+      comm: 'weird ) name',
+      state: 'S',
+      starttime: '987654321',
+    })
+  })
+
+  it('agrees with awk on this process\'s own /proc entry', () => {
+    const raw = readFileSync(`/proc/${process.pid}/stat`, 'utf8')
+    const fields = raw.slice(raw.lastIndexOf(') ') + 2).trim().split(/\s+/)
+    expect(parseProcStat(raw)!.starttime).toBe(fields[19])
+  })
+
+  it('treats a zombie as dead', () => {
+    const raw = '4242 (claude) Z 1 4242 4242 0 -1 0 0 0 0 0 0 0 0 20 0 1 0 5 ' +
+      '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+    expect(parseProcStat(raw)!.state).toBe('Z')
+  })
+})
+
+describe('gateway-only respawn detection (real processes)', () => {
+  it('reports a gateway-only respawn when the agent is alive and older', () => {
+    writeRecord({ pid: agentProc.pid, starttime: starttimeOf(agentProc.pid!) })
+    const decision = detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid })
+    expect(decision).toEqual({
+      gatewayOnly: true,
+      reason: 'gateway-only-respawn',
+      pid: agentProc.pid,
+    })
+  })
+
+  it('does NOT claim a gateway-only respawn when the agent process is dead', async () => {
+    const doomed = spawnSleeper()
+    await new Promise((r) => setTimeout(r, 20))
+    writeRecord({ pid: doomed.pid, starttime: starttimeOf(doomed.pid!) })
+    doomed.kill('SIGKILL')
+    await waitForExit(doomed)
+    const decision = detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid })
+    expect(decision.gatewayOnly).toBe(false)
+    expect(decision.reason).toBe('agent-process-dead')
+  })
+
+  it('rejects a recycled PID: same pid, different starttime', () => {
+    const live = starttimeOf(agentProc.pid!)
+    writeRecord({ pid: agentProc.pid, starttime: String(BigInt(live) - 1n) })
+    const decision = detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid })
+    expect(decision).toEqual({
+      gatewayOnly: false,
+      reason: 'starttime-mismatch',
+      pid: agentProc.pid,
+    })
+  })
+
+  it('rejects an agent that started AFTER this gateway (fresh-boot race)', () => {
+    // Swap the roles: the record names the LATER process, the probe runs as
+    // the EARLIER one. This is the fresh-container ordering (gateway launched,
+    // then `exec claude`), where the resume must still fire.
+    writeRecord({ pid: gatewayProc.pid, starttime: starttimeOf(gatewayProc.pid!) })
+    const decision = detectGatewayOnlyRespawn({ stateDir: dir, selfPid: agentProc.pid })
+    expect(decision).toEqual({
+      gatewayOnly: false,
+      reason: 'agent-started-after-gateway',
+      pid: gatewayProc.pid,
+    })
+  })
+
+  it('fails open with no record at all (first boot)', () => {
+    const empty = mkdtempSync(join(tmpdir(), 'agent-liveness-empty-'))
+    try {
+      expect(detectGatewayOnlyRespawn({ stateDir: empty, selfPid: gatewayProc.pid })).toEqual({
+        gatewayOnly: false,
+        reason: 'no-record',
+        pid: null,
+      })
+    } finally {
+      rmSync(empty, { recursive: true, force: true })
+    }
+  })
+
+  it('fails open on a torn record', () => {
+    writeRecord('{"pid": 12')
+    expect(detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid }).gatewayOnly)
+      .toBe(false)
+    writeRecord({ pid: agentProc.pid, starttime: 'not-a-number' })
+    expect(detectGatewayOnlyRespawn({ stateDir: dir, selfPid: gatewayProc.pid }).gatewayOnly)
+      .toBe(false)
+  })
+
+  it('honours the SWITCHROOM_GATEWAY_RESPAWN_GUARD=0 escape hatch', () => {
+    writeRecord({ pid: agentProc.pid, starttime: starttimeOf(agentProc.pid!) })
+    const lines: string[] = []
+    const prev = process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD
+    process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD = '0'
+    try {
+      expect(
+        shouldSkipBootResumeForGatewayOnlyRespawn(dir, {
+          selfPid: gatewayProc.pid,
+          log: (s) => lines.push(s),
+        }),
+      ).toBe(false)
+    } finally {
+      if (prev == null) delete process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD
+      else process.env.SWITCHROOM_GATEWAY_RESPAWN_GUARD = prev
+    }
+    expect(lines.join('')).toContain('guard-disabled')
+  })
+
+  it('skips the boot-resume path (and says so) for a live older agent', () => {
+    writeRecord({ pid: agentProc.pid, starttime: starttimeOf(agentProc.pid!) })
+    const lines: string[] = []
+    const skip = shouldSkipBootResumeForGatewayOnlyRespawn(dir, {
+      selfPid: gatewayProc.pid,
+      log: (s) => lines.push(s),
+    })
+    expect(skip).toBe(true)
+    expect(lines.join('')).toContain('GATEWAY-ONLY respawn')
+  })
+})
+
+describe('decideGatewayOnlyRespawn (pure)', () => {
+  const record = { pid: 42, starttime: '1000' }
+
+  it('rejects a comm mismatch when the record carries one', () => {
+    expect(
+      decideGatewayOnlyRespawn({
+        record: { ...record, comm: 'claude' },
+        live: { starttime: '1000', comm: 'imposter', state: 'S' },
+        gatewayStarttime: '2000',
+      }),
+    ).toEqual({ gatewayOnly: false, reason: 'comm-mismatch', pid: 42 })
+  })
+
+  it('fails open when this gateway has no readable starttime', () => {
+    expect(
+      decideGatewayOnlyRespawn({
+        record,
+        live: { starttime: '1000', comm: 'claude', state: 'S' },
+        gatewayStarttime: null,
+      }).gatewayOnly,
+    ).toBe(false)
+  })
+
+  it('rejects an exact starttime tie (cannot have forked before itself)', () => {
+    expect(
+      decideGatewayOnlyRespawn({
+        record,
+        live: { starttime: '1000', comm: 'claude', state: 'S' },
+        gatewayStarttime: '1000',
+      }).reason,
+    ).toBe('agent-started-after-gateway')
+  })
+})
+
+describe('readAgentProcessRecord', () => {
+  it('accepts the exact shape start.sh writes', () => {
+    const p = writeRecord({ pid: 7, starttime: '213153204', boot_at: 1786572493000 })
+    expect(readAgentProcessRecord(p)).toEqual({
+      pid: 7,
+      starttime: '213153204',
+      boot_at: 1786572493000,
+    })
+  })
+
+  it('rejects a nonsense pid', () => {
+    expect(readAgentProcessRecord(writeRecord({ pid: 0, starttime: '5' }))).toBeNull()
+    expect(readAgentProcessRecord(writeRecord({ pid: -1, starttime: '5' }))).toBeNull()
+  })
+})

--- a/telegram-plugin/tests/boot-resume-gateway-only-respawn.test.ts
+++ b/telegram-plugin/tests/boot-resume-gateway-only-respawn.test.ts
@@ -19,6 +19,15 @@
  *       → ZERO `resume_interrupted` entries in the on-disk spool,
  *         the in-flight turn row is left OPEN (no `ended_via` lie), and
  *         no `.pending-turn.env` is written.
+ *   - a gateway that CRASHES DURING ITS OWN BOOT, before stamping the
+ *     per-container-boot generation token
+ *       → the successor gateway does the full boot resume; the interrupted
+ *         turn is not lost. (This is the case the earlier starttime-ordering
+ *         guard got wrong: it saw a live claude that predated it and
+ *         suppressed forever.)
+ *   - a suppressed respawn and the #3038 bridge-dead escalation marker
+ *       → the marker is NOT re-consumed, because the gateway that stamped
+ *         the token already consumed it this generation.
  *   - genuine agent restart (recorded process really is dead)
  *       → the resume still fires, exactly as before.
  *   - watchdog-timeout classification and first boot (no record file)
@@ -26,7 +35,9 @@
  *
  * Every "alive" claim is anchored on a process this test actually spawned, and
  * every "dead" claim on one it actually killed — so a probe hard-wired to
- * either answer fails here.
+ * either answer fails here. The generation token is never hand-placed for a
+ * suppression case without a boot that legitimately stamped it, or an
+ * explicitly-stated stale-token scenario.
  *
  * Uses bun:sqlite (openTurnsDb) — excluded from vitest.config.ts, run by
  * telegram-plugin/scripts/bun-test-ci.sh (which runs `tests/`).
@@ -65,8 +76,11 @@ import { createInboundSpool } from '../gateway/inbound-spool.js'
 import {
   readProcIdentity,
   shouldSkipBootResumeForGatewayOnlyRespawn,
+  markBootResumeComplete,
+  bootResumeDonePath,
   AGENT_PROCESS_RECORD_FILE,
 } from '../gateway/agent-process-liveness.js'
+import { consumeBridgeDeadEscalationMarker } from '../gateway/bridge-dead-watchdog.js'
 
 // ---------------------------------------------------------------------------
 // Fixture
@@ -74,10 +88,8 @@ import {
 
 let agentDir: string
 let stateDir: string
-/** Long-lived stand-in for the `claude` process. Spawned BEFORE `gatewayPid`. */
+/** Long-lived stand-in for the `claude` process. */
 let agentProc: ReturnType<typeof spawn>
-/** Stand-in for THIS (respawned) gateway process. Spawned after the agent. */
-let gatewayProc: ReturnType<typeof spawn>
 
 function sleepMs(ms: number): void {
   spawnSync('sleep', [String(ms / 1000)])
@@ -115,37 +127,52 @@ interface BootResult {
   spoolRaw: string
   reaped: number
   pendingEnvWritten: boolean
+  /** The #3038 bridge-dead marker this boot consumed, if any. */
+  bridgeDeadStreak: number | null
+  /** Did this boot stamp the per-container-boot generation token? */
+  tokenStamped: boolean
 }
 
 /**
  * The gateway's boot-resume block, in gateway.ts's order, over the real
  * collaborators. `guarded: false` reproduces the pre-#4641 gateway.
+ *
+ * `crashAt` models a gateway that dies during its own boot (the Bun 1.3.13
+ * crash-at-boot pattern that motivated the fix): `'guard'` dies immediately
+ * after the guard, before any side effect; `'stamp'` gets all the way through
+ * the effects but dies before stamping the token. Neither stamps it.
  */
 function runBootSequence(opts: {
-  gatewayPid: number
   guarded?: boolean
   markerTurnKey?: string | null
   markerAgeMs?: number | null
+  crashAt?: 'guard' | 'stamp'
 }): BootResult {
   const spoolPath = join(stateDir, 'inbound-spool.jsonl')
   const db = openTurnsDb(agentDir)
   const spool = createInboundSpool({ path: spoolPath, fs: SPOOL_FS, log: () => {} })
   let reaped = 0
+  let bridgeDeadStreak: number | null = null
+  let tokenStamped = false
   try {
     // ---- the guard (gateway.ts: immediately after applySubagentsSchema) ----
     const skip =
       (opts.guarded ?? true) &&
-      shouldSkipBootResumeForGatewayOnlyRespawn(stateDir, {
-        selfPid: opts.gatewayPid,
-        log: () => {},
-      })
-    if (!skip) {
+      shouldSkipBootResumeForGatewayOnlyRespawn(stateDir, { log: () => {} })
+    if (!skip && opts.crashAt !== 'guard') {
       const res = markOrphanedWithTimeoutClassification(db, {
         markerTurnKey: opts.markerTurnKey ?? null,
         markerAgeMs: opts.markerAgeMs ?? null,
         hangThresholdMs: 300_000,
       })
       reaped = res.reaped
+      // gateway.ts:~1721 — consumed (always cleared) whether or not a turn was
+      // in flight. The `break` skips this too, which is only correct because
+      // the token proves a gateway already consumed it this generation.
+      const marker = consumeBridgeDeadEscalationMarker(
+        join(stateDir, 'bridge-dead-escalation.json'),
+      )
+      if (marker != null) bridgeDeadStreak = marker.count ?? 1
       const pending = findLatestTurnIfInterrupted(db)
       if (pending != null) {
         const kind = decideBootResumeKind({
@@ -164,6 +191,12 @@ function runBootSequence(opts: {
         }
       }
       writePendingTurnEnv(agentDir, pending, () => {})
+      // gateway.ts: LAST statement of the block. A crash before here leaves no
+      // token, so the successor gateway redoes the whole boot resume.
+      if (opts.crashAt !== 'stamp') {
+        markBootResumeComplete(stateDir)
+        tokenStamped = true
+      }
     }
   } finally {
     db.close()
@@ -180,6 +213,8 @@ function runBootSequence(opts: {
     spoolRaw,
     reaped,
     pendingEnvWritten: existsSync(join(agentDir, '.pending-turn.env')),
+    bridgeDeadStreak,
+    tokenStamped,
   }
 }
 
@@ -202,35 +237,55 @@ beforeEach(() => {
   agentDir = mkdtempSync(join(tmpdir(), 'boot-respawn-'))
   stateDir = join(agentDir, 'telegram')
   mkdirSync(stateDir, { recursive: true })
+  // start.sh's outer pass: a fresh container boot clears the generation token.
+  // Every case that wants a gateway-only respawn must first run a boot that
+  // stamps it, exactly as production does.
+  expect(existsSync(bootResumeDonePath(stateDir))).toBe(false)
   agentProc = spawn('sleep', ['120'], { stdio: 'ignore' })
-  sleepMs(20)
-  gatewayProc = spawn('sleep', ['120'], { stdio: 'ignore' })
   sleepMs(20)
 })
 
 afterEach(() => {
-  for (const p of [agentProc, gatewayProc]) {
-    try { p.kill('SIGKILL') } catch { /* already gone */ }
-  }
+  try { agentProc.kill('SIGKILL') } catch { /* already gone */ }
   rmSync(agentDir, { recursive: true, force: true })
 })
+
+/** Write a fresh #3038 bridge-dead escalation marker. */
+function writeBridgeDeadMarker(count = 2): string {
+  const p = join(stateDir, 'bridge-dead-escalation.json')
+  writeFileSync(p, JSON.stringify({ ts: Date.now(), reason: 'mcp-bridge-dead', count }))
+  return p
+}
 
 // ---------------------------------------------------------------------------
 // The bug
 // ---------------------------------------------------------------------------
 
+
+/** A completed first boot of this container generation: stamps the token. */
+function firstBootOfThisContainer(): BootResult {
+  return runBootSequence({})
+}
+
 describe('gateway-only respawn (claude still running)', () => {
   it('spools ZERO resume_interrupted entries and leaves the live turn open', () => {
-    const turnKey = seedInFlightTurn()
+    // Full production sequence. Boot #1 of this container: no turn in flight,
+    // nothing reaped, generation token stamped. start.sh then publishes the
+    // agent record and execs claude, which takes a message…
+    const first = firstBootOfThisContainer()
+    expect(first.tokenStamped).toBe(true)
+    expect(first.spooledSources).toEqual([])
     writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+    const turnKey = seedInFlightTurn()
 
-    const out = runBootSequence({ gatewayPid: gatewayProc.pid! })
+    // …and THEN the gateway alone crashes and respawns.
+    const out = runBootSequence({})
 
     // The outcome the issue names.
     expect(out.spooledSources).toEqual([])
     expect(out.spoolRaw).not.toContain('resume_interrupted')
     // …and no collateral: the live turn keeps its open row (no `restart` lie),
-    // and the one-shot wake-audit env is not written either.
+    // and the one-shot wake-audit env is not written by the respawn either.
     expect(out.reaped).toBe(0)
     expect(out.pendingEnvWritten).toBe(false)
     const db = openTurnsDb(agentDir)
@@ -246,9 +301,10 @@ describe('gateway-only respawn (claude still running)', () => {
   it('WOULD fire the false resume without the guard (bug reproduction)', () => {
     const turnKey = seedInFlightTurn()
     writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+    markBootResumeComplete(stateDir)
 
     // Same fixture, guard bypassed — the pre-#4641 gateway.
-    const out = runBootSequence({ gatewayPid: gatewayProc.pid!, guarded: false })
+    const out = runBootSequence({ guarded: false })
 
     expect(out.spooledSources).toEqual(['resume_interrupted'])
     expect(out.reaped).toBe(1)
@@ -263,9 +319,104 @@ describe('gateway-only respawn (claude still running)', () => {
   it('stays silent across repeated gateway crashes', () => {
     seedInFlightTurn()
     writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+    markBootResumeComplete(stateDir)
     for (let i = 0; i < 3; i++) {
-      expect(runBootSequence({ gatewayPid: gatewayProc.pid! }).spooledSources).toEqual([])
+      expect(runBootSequence({}).spooledSources).toEqual([])
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A gateway that crashes DURING its own boot (reviewer MAJOR 2)
+// ---------------------------------------------------------------------------
+
+describe('gateway crash during its own boot', () => {
+  it('still resumes the interrupted turn — the token was never stamped', () => {
+    // The container restarts with a genuinely interrupted turn. start.sh forks
+    // gateway #1 and (before the exec) publishes a record naming a LIVE agent
+    // process that predates gateway #2. Gateway #1 then dies before reaching
+    // the boot block, so it never stamps the token.
+    //
+    // The replacement gateway MUST do the full boot resume. The previous
+    // starttime-ordering guard suppressed exactly here — it saw a live claude
+    // older than itself — and the interrupted turn was never reaped or
+    // resumed at all.
+    const turnKey = seedInFlightTurn()
+    writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+
+    const crashed = runBootSequence({ crashAt: 'guard' })
+    expect(crashed.tokenStamped).toBe(false)
+    expect(crashed.spooledSources).toEqual([])
+    expect(existsSync(bootResumeDonePath(stateDir))).toBe(false)
+
+    const out = runBootSequence({})
+
+    expect(out.spooledSources).toEqual(['resume_interrupted'])
+    expect(out.reaped).toBe(1)
+    expect(out.pendingEnvWritten).toBe(true)
+    expect(out.tokenStamped).toBe(true)
+    const db = openTurnsDb(agentDir)
+    try {
+      expect(getTurnByKey(db, turnKey)!.ended_via).toBe('restart')
+    } finally {
+      db.close()
+    }
+  })
+
+  it('still consumes the bridge-dead escalation marker', () => {
+    // #3038: the marker is consumed (always cleared) whether or not a turn was
+    // in flight, and its `count` seeds the cross-boot escalation damper. A
+    // gateway that crashed before consuming it must not strand it on disk —
+    // the successor's boot block has to reach it.
+    const markerPath = writeBridgeDeadMarker(3)
+    writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+
+    const crashed = runBootSequence({ crashAt: 'guard' })
+    expect(crashed.bridgeDeadStreak).toBeNull()
+    expect(existsSync(markerPath)).toBe(true)
+
+    const out = runBootSequence({})
+    expect(out.bridgeDeadStreak).toBe(3)
+    expect(existsSync(markerPath)).toBe(false)
+  })
+
+  it('a crash after the effects but before the stamp does not suppress either', () => {
+    // The other half of the window: the block ran, but the token write never
+    // landed. The successor re-runs the block. That is a duplicate resume, not
+    // a lost one — the deliberate fail-open direction.
+    seedInFlightTurn()
+    writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+
+    const crashed = runBootSequence({ crashAt: 'stamp' })
+    expect(crashed.spooledSources).toEqual(['resume_interrupted'])
+    expect(crashed.tokenStamped).toBe(false)
+
+    const out = runBootSequence({})
+    expect(out.tokenStamped).toBe(true) // it did NOT suppress
+  })
+})
+
+// ---------------------------------------------------------------------------
+// What the `break` skips, beyond the resume synthetic (reviewer MEDIUM)
+// ---------------------------------------------------------------------------
+
+describe('a suppressed respawn and the bridge-dead escalation marker', () => {
+  it('leaves an already-consumed generation alone: no marker, no streak reset', () => {
+    // Boot #1 of this container consumes the marker (count=3 → the damper) and
+    // stamps the token. The respawn must NOT re-run that consumption: there is
+    // nothing left to consume, and a fresh marker written later in the SAME
+    // generation belongs to the live watchdog, not to a boot classification.
+    writeBridgeDeadMarker(3)
+    writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+    const first = runBootSequence({})
+    expect(first.bridgeDeadStreak).toBe(3)
+    expect(first.tokenStamped).toBe(true)
+
+    const markerPath = writeBridgeDeadMarker(5)
+    const out = runBootSequence({})
+
+    expect(out.bridgeDeadStreak).toBeNull() // the break skipped the consumption
+    expect(existsSync(markerPath)).toBe(true) // …so the marker survives on disk
   })
 })
 
@@ -281,8 +432,11 @@ describe('genuine agent restart', () => {
     writeAgentProcessRecord(doomed.pid!, starttimeOf(doomed.pid!))
     doomed.kill('SIGKILL')
     sleepMs(200)
+    // Even with a token from the previous generation left behind (a stale
+    // volume, an unclean boot), a dead agent VETOES the suppression.
+    markBootResumeComplete(stateDir)
 
-    const out = runBootSequence({ gatewayPid: gatewayProc.pid! })
+    const out = runBootSequence({})
 
     expect(out.spooledSources).toEqual(['resume_interrupted'])
     expect(out.spoolRaw).toContain('resume_interrupted')
@@ -296,11 +450,25 @@ describe('genuine agent restart', () => {
     }
   })
 
+  it('still fires on a fresh container boot (token cleared by start.sh)', () => {
+    seedInFlightTurn()
+    // The fresh-boot shape the ordering arm used to guard: start.sh has
+    // already published a record for a LIVE agent process. Without the token
+    // there is no suppression, whatever /proc says.
+    writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+    expect(existsSync(bootResumeDonePath(stateDir))).toBe(false)
+
+    const out = runBootSequence({})
+
+    expect(out.spooledSources).toEqual(['resume_interrupted'])
+    expect(out.pendingEnvWritten).toBe(true)
+  })
+
   it('still fires on first boot, when no process record exists at all', () => {
     seedInFlightTurn()
     expect(existsSync(join(stateDir, AGENT_PROCESS_RECORD_FILE))).toBe(false)
 
-    const out = runBootSequence({ gatewayPid: gatewayProc.pid! })
+    const out = runBootSequence({})
 
     expect(out.spooledSources).toEqual(['resume_interrupted'])
     expect(out.pendingEnvWritten).toBe(true)
@@ -314,20 +482,9 @@ describe('genuine agent restart', () => {
       agentProc.pid!,
       String(BigInt(starttimeOf(agentProc.pid!)) - 1n),
     )
+    markBootResumeComplete(stateDir)
 
-    expect(runBootSequence({ gatewayPid: gatewayProc.pid! }).spooledSources)
-      .toEqual(['resume_interrupted'])
-  })
-
-  it('still fires when the agent started AFTER this gateway (fresh boot race)', () => {
-    seedInFlightTurn()
-    // Roles swapped: the record names the process spawned SECOND, and the
-    // probe runs as the one spawned FIRST — i.e. a live claude that this
-    // gateway cannot be a respawn of.
-    writeAgentProcessRecord(gatewayProc.pid!, starttimeOf(gatewayProc.pid!))
-
-    expect(runBootSequence({ gatewayPid: agentProc.pid! }).spooledSources)
-      .toEqual(['resume_interrupted'])
+    expect(runBootSequence({}).spooledSources).toEqual(['resume_interrupted'])
   })
 })
 
@@ -341,7 +498,6 @@ describe('watchdog-timeout classification', () => {
     sleepMs(200)
 
     const out = runBootSequence({
-      gatewayPid: gatewayProc.pid!,
       markerTurnKey: turnKey,
       markerAgeMs: 600_000, // past the 300s hang threshold
     })
@@ -361,9 +517,9 @@ describe('watchdog-timeout classification', () => {
     // a hang and asked the user whether to retry it.
     const turnKey = seedInFlightTurn()
     writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+    markBootResumeComplete(stateDir)
 
     const out = runBootSequence({
-      gatewayPid: gatewayProc.pid!,
       markerTurnKey: turnKey,
       markerAgeMs: 600_000,
     })

--- a/telegram-plugin/tests/boot-resume-gateway-only-respawn.test.ts
+++ b/telegram-plugin/tests/boot-resume-gateway-only-respawn.test.ts
@@ -25,6 +25,12 @@
  * (`boot-resume-guard-wiring.test.ts` pins that gateway.ts really does stamp
  * after the put, since this file cannot import the block.)
  *
+ * The second fidelity trap, same shape: an in-block failure is NOT a process
+ * death. gateway.ts swallows it (`catch { log; turnsDb = null }`) and module
+ * init runs on to the stamp. `throwAt` models that swallow — distinct from
+ * `crashAt`, which kills the sequence — and it is why the stamp is gated on
+ * `bootResumeThrew`, not merely placed late.
+ *
  *   - gateway killed mid-turn while the claude process LIVES
  *       → ZERO `resume_interrupted` entries in the on-disk spool,
  *         the in-flight turn row is left OPEN (no `ended_via` lie), and
@@ -170,6 +176,13 @@ type CrashPoint = 'after-guard' | 'after-block-before-put' | 'after-put-before-s
 
 /** Sentinel used to unwind out of the modelled boot at `crashAt`. */
 const BOOT_CRASH = Symbol('boot-crash')
+/**
+ * A throw INSIDE the boot block — swallowed, not fatal. gateway.ts's block
+ * ends in `catch (err) { log; turnsDb = null }` and module init CONTINUES, so
+ * unlike BOOT_CRASH the later stages still run. Modelling every in-block
+ * failure as a process death is what hid the swallow-then-stamp defect.
+ */
+const BLOCK_THROW = Symbol('block-throw')
 
 /**
  * The gateway's boot sequence in gateway.ts's real order, over the real
@@ -189,6 +202,17 @@ function runBootSequence(opts: {
   crashAt?: CrashPoint
   /** Where the generation token is stamped. Default = production. */
   stampAt?: 'block-end' | 'after-durable-put'
+  /**
+   * Throw inside the block and let gateway.ts's `catch` swallow it. Unlike
+   * `crashAt` the process survives, so stages 2 and 3 still run — which is the
+   * whole point: the reaper has already durably ended the turn.
+   */
+  throwAt?: 'after-reaper'
+  /**
+   * Production (post-fix) gates the stamp on the block not having thrown
+   * (`bootResumeThrew`). Set false to reproduce the ungated defect.
+   */
+  gateStampOnBlockThrow?: boolean
 }): BootResult {
   const spoolPath = join(stateDir, 'inbound-spool.jsonl')
   const db = openTurnsDb(agentDir)
@@ -203,51 +227,65 @@ function runBootSequence(opts: {
   }
   try {
     // ---- stage 1: the bootResumeInit block (IN MEMORY ONLY) ----------------
-    // The guard, gateway.ts: immediately after applySubagentsSchema.
-    const skip =
-      (opts.guarded ?? true) &&
-      shouldSkipBootResumeForGatewayOnlyRespawn(stateDir, { log: () => {} })
+    // gateway.ts's block-level `catch`: it logs, nulls turnsDb and lets module
+    // init CONTINUE. `bootResumeThrew` is the flag that catch sets.
+    let bootResumeThrew = false
     // gateway.ts:1648 — `bootResumeInbound`, stashed and pushed to the spool
     // only much later. Nothing on disk yet.
     let bootResumeInbound: InboundMessage | null = null
-    if (!skip) {
-      if (opts.crashAt === 'after-guard') throw BOOT_CRASH
-      const res = markOrphanedWithTimeoutClassification(db, {
-        markerTurnKey: opts.markerTurnKey ?? null,
-        markerAgeMs: opts.markerAgeMs ?? null,
-        hangThresholdMs: 300_000,
-      })
-      reaped = res.reaped
-      // gateway.ts:~1721 — consumed (always cleared) whether or not a turn was
-      // in flight. The `break` skips this too, which is only correct because
-      // the token proves a gateway already consumed it this generation.
-      const marker = consumeBridgeDeadEscalationMarker(
-        join(stateDir, 'bridge-dead-escalation.json'),
-      )
-      if (marker != null) bridgeDeadStreak = marker.count ?? 1
-      const pending = findLatestTurnIfInterrupted(db)
-      if (pending != null) {
-        const kind = decideBootResumeKind({
-          pending,
-          suppressed: false,
-          ageMs: Math.max(0, Date.now() - pending.started_at),
-          maxAgeMs: 10_800_000,
+    try {
+      // The guard, gateway.ts: immediately after applySubagentsSchema.
+      const skip =
+        (opts.guarded ?? true) &&
+        shouldSkipBootResumeForGatewayOnlyRespawn(stateDir, { log: () => {} })
+      if (!skip) {
+        if (opts.crashAt === 'after-guard') throw BOOT_CRASH
+        const res = markOrphanedWithTimeoutClassification(db, {
+          markerTurnKey: opts.markerTurnKey ?? null,
+          markerAgeMs: opts.markerAgeMs ?? null,
+          hangThresholdMs: 300_000,
         })
-        if (kind === 'resume') {
-          bootResumeInbound = buildResumeInterruptedInbound({ turn: pending, subagents: [] })
-        } else if (kind === 'report') {
-          bootResumeInbound = buildResumeWatchdogReportInbound({
-            turn: pending,
-            idleMs: 600_000,
-            subagents: [],
+        reaped = res.reaped
+        // The turn is NOW durably `ended_via='restart'`. Everything from here to
+        // the first `bootResumeInbound =` — findLatestTurnIfInterrupted, the
+        // clean-shutdown-marker read, listNonTerminalSubagentsForTurn, the
+        // builders — is ~156 lines of DB and fs I/O that can throw.
+        if (opts.throwAt === 'after-reaper') throw BLOCK_THROW
+        // gateway.ts:~1721 — consumed (always cleared) whether or not a turn was
+        // in flight. The `break` skips this too, which is only correct because
+        // the token proves a gateway already consumed it this generation.
+        const marker = consumeBridgeDeadEscalationMarker(
+          join(stateDir, 'bridge-dead-escalation.json'),
+        )
+        if (marker != null) bridgeDeadStreak = marker.count ?? 1
+        const pending = findLatestTurnIfInterrupted(db)
+        if (pending != null) {
+          const kind = decideBootResumeKind({
+            pending,
+            suppressed: false,
+            ageMs: Math.max(0, Date.now() - pending.started_at),
+            maxAgeMs: 10_800_000,
           })
+          if (kind === 'resume') {
+            bootResumeInbound = buildResumeInterruptedInbound({ turn: pending, subagents: [] })
+          } else if (kind === 'report') {
+            bootResumeInbound = buildResumeWatchdogReportInbound({
+              turn: pending,
+              idleMs: 600_000,
+              subagents: [],
+            })
+          }
         }
+        writePendingTurnEnv(agentDir, pending, () => {})
+        // THE DEFECT, reproducible on demand: stamping here marks the generation
+        // done while the resume exists only in this process's heap.
+        if (stampAt === 'block-end') stamp()
+        if (opts.crashAt === 'after-block-before-put') throw BOOT_CRASH
       }
-      writePendingTurnEnv(agentDir, pending, () => {})
-      // THE DEFECT, reproducible on demand: stamping here marks the generation
-      // done while the resume exists only in this process's heap.
-      if (stampAt === 'block-end') stamp()
-      if (opts.crashAt === 'after-block-before-put') throw BOOT_CRASH
+    } catch (err) {
+      if (err === BOOT_CRASH) throw err // process death: nothing below runs
+      if (err !== BLOCK_THROW) throw err
+      bootResumeThrew = true // swallowed — module init continues below
     }
     // ---- stage 2: gateway.ts ~:10148, the DURABLE put ----------------------
     if (bootResumeInbound != null) {
@@ -258,8 +296,11 @@ function runBootSequence(opts: {
       if (typeof rk === 'string' && rk.length > 0) markTurnResumed(db, rk)
     }
     if (opts.crashAt === 'after-put-before-stamp') throw BOOT_CRASH
-    // ---- stage 3: the token, unconditional (gateway.ts, top level) ---------
-    if (stampAt === 'after-durable-put') stamp()
+    // ---- stage 3: the token (gateway.ts, top level) ------------------------
+    // Unconditional on there being anything to resume; NOT unconditional on
+    // the block having completed.
+    const gated = (opts.gateStampOnBlockThrow ?? true) && bootResumeThrew
+    if (stampAt === 'after-durable-put' && !gated) stamp()
   } catch (err) {
     if (err !== BOOT_CRASH) throw err
   } finally {
@@ -510,6 +551,55 @@ describe('gateway crash during its own boot', () => {
 
     const out = runBootSequence({})
 
+    expect(out.spooledSources, 'the resume is dropped, not retried').toEqual([])
+    expect(out.reaped).toBe(0)
+    const db = openTurnsDb(agentDir)
+    try {
+      const turn = getTurnByKey(db, turnKey)!
+      expect(turn.ended_via).toBe('restart') // durably ended…
+      expect(turn.resumed_at).toBeNull() // …and never resumed
+    } finally {
+      db.close()
+    }
+  })
+
+  it('a SWALLOWED throw inside the block leaves no token, so the successor still resumes', () => {
+    // gateway.ts's block ends in `catch { log; turnsDb = null }` — a swallow,
+    // not a death: module init continues and reaches the stamp with
+    // `bootResumeInbound` still null. By then the reaper has ALREADY durably
+    // written `ended_via='restart'`. Gating the stamp on that catch is what
+    // keeps the work recoverable.
+    const turnKey = seedInFlightTurn()
+
+    const threw = runBootSequence({ throwAt: 'after-reaper' })
+    expect(threw.reaped, 'the reaper ran and durably ended the turn').toBe(1)
+    expect(threw.spooledSources, 'nothing was spooled — the block never built it').toEqual([])
+    expect(threw.tokenStamped, 'a swallowed throw must not stamp the generation').toBe(false)
+    expect(existsSync(bootResumeDonePath(stateDir))).toBe(false)
+
+    // The gateway respawns (the Bun-crash pattern #4641 exists for).
+    const out = runBootSequence({})
+    expect(out.spooledSources, 'the successor re-mints the resume').toEqual(['resume_interrupted'])
+    const db = openTurnsDb(agentDir)
+    try {
+      expect(getTurnByKey(db, turnKey)!.resumed_at, 'and stamps it resumed').not.toBeNull()
+    } finally {
+      db.close()
+    }
+  })
+
+  it('WOULD lose the turn forever if a swallowed throw still stamped the token', () => {
+    // Defect reproduction for the ungated stamp: same swallow, stamp not gated
+    // on `bootResumeThrew`. The turn is durably ended, nothing is spooled, and
+    // the successor suppresses on the token alone.
+    const turnKey = seedInFlightTurn()
+
+    const threw = runBootSequence({ throwAt: 'after-reaper', gateStampOnBlockThrow: false })
+    expect(threw.reaped).toBe(1)
+    expect(threw.spooledSources).toEqual([])
+    expect(threw.tokenStamped, 'stamped with nothing spooled anywhere').toBe(true)
+
+    const out = runBootSequence({})
     expect(out.spooledSources, 'the resume is dropped, not retried').toEqual([])
     expect(out.reaped).toBe(0)
     const db = openTurnsDb(agentDir)

--- a/telegram-plugin/tests/boot-resume-gateway-only-respawn.test.ts
+++ b/telegram-plugin/tests/boot-resume-gateway-only-respawn.test.ts
@@ -1,0 +1,379 @@
+/**
+ * switchroom#4641 — OUTCOME test for the gateway-only-respawn guard.
+ *
+ * The bug: the gateway and the `claude` agent are separate supervised
+ * processes. When the gateway alone crashed and respawned (three Bun SIGBUS
+ * crashes on `overlord`, 2026-08-12), its boot block stamped the STILL-RUNNING
+ * turn `ended_via='restart'`, spooled a `resume_interrupted` synthetic telling
+ * the live session "You just restarted. Your previous turn was interrupted…",
+ * and listed its still-running sub-agents as "killed by the restart".
+ *
+ * What this test asserts is the OUTCOME the issue names, end to end over the
+ * REAL collaborators — a real bun:sqlite registry, the real boot reaper, the
+ * real interrupted-turn finder, the real inbound builders and the real durable
+ * inbound spool — with only the ORDERING supplied by `runBootSequence` below,
+ * which mirrors gateway.ts's block 1:1 (and `boot-resume-guard-wiring.test.ts`
+ * pins that gateway.ts still calls the guard in that position):
+ *
+ *   - gateway killed mid-turn while the claude process LIVES
+ *       → ZERO `resume_interrupted` entries in the on-disk spool,
+ *         the in-flight turn row is left OPEN (no `ended_via` lie), and
+ *         no `.pending-turn.env` is written.
+ *   - genuine agent restart (recorded process really is dead)
+ *       → the resume still fires, exactly as before.
+ *   - watchdog-timeout classification and first boot (no record file)
+ *       → unchanged.
+ *
+ * Every "alive" claim is anchored on a process this test actually spawned, and
+ * every "dead" claim on one it actually killed — so a probe hard-wired to
+ * either answer fails here.
+ *
+ * Uses bun:sqlite (openTurnsDb) — excluded from vitest.config.ts, run by
+ * telegram-plugin/scripts/bun-test-ci.sh (which runs `tests/`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { spawn, spawnSync } from 'node:child_process'
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  appendFileSync,
+  renameSync,
+  statSync,
+  mkdirSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  openTurnsDb,
+  recordTurnStart,
+  markOrphanedWithTimeoutClassification,
+  findLatestTurnIfInterrupted,
+  getTurnByKey,
+} from '../registry/turns-schema.js'
+import {
+  decideBootResumeKind,
+  buildResumeInterruptedInbound,
+  buildResumeWatchdogReportInbound,
+} from '../gateway/resume-inbound-builder.js'
+import { writePendingTurnEnv } from '../gateway/pending-turn-env.js'
+import { createInboundSpool } from '../gateway/inbound-spool.js'
+import {
+  readProcIdentity,
+  shouldSkipBootResumeForGatewayOnlyRespawn,
+  AGENT_PROCESS_RECORD_FILE,
+} from '../gateway/agent-process-liveness.js'
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+let agentDir: string
+let stateDir: string
+/** Long-lived stand-in for the `claude` process. Spawned BEFORE `gatewayPid`. */
+let agentProc: ReturnType<typeof spawn>
+/** Stand-in for THIS (respawned) gateway process. Spawned after the agent. */
+let gatewayProc: ReturnType<typeof spawn>
+
+function sleepMs(ms: number): void {
+  spawnSync('sleep', [String(ms / 1000)])
+}
+
+function starttimeOf(pid: number): string {
+  const id = readProcIdentity(pid)
+  if (id == null) throw new Error(`pid ${pid} unexpectedly not live`)
+  return id.starttime
+}
+
+/** Write the record start.sh writes immediately before `exec claude`. */
+function writeAgentProcessRecord(pid: number, starttime: string): void {
+  writeFileSync(
+    join(stateDir, AGENT_PROCESS_RECORD_FILE),
+    JSON.stringify({ pid, starttime, boot_at: Date.now() }),
+  )
+}
+
+const SPOOL_FS = {
+  appendFileSync: (p: string, d: string) => appendFileSync(p, d),
+  readFileSync: (p: string) => readFileSync(p, 'utf8'),
+  writeFileSync: (p: string, d: string) => writeFileSync(p, d),
+  renameSync: (a: string, b: string) => renameSync(a, b),
+  existsSync: (p: string) => existsSync(p),
+  statSizeSync: (p: string) => statSync(p).size,
+  fsyncFileSync: () => {},
+  fsyncDirSync: () => {},
+}
+
+interface BootResult {
+  /** Every `source` value that reached the durable on-disk spool. */
+  spooledSources: string[]
+  /** Raw spool file contents (empty string when never created). */
+  spoolRaw: string
+  reaped: number
+  pendingEnvWritten: boolean
+}
+
+/**
+ * The gateway's boot-resume block, in gateway.ts's order, over the real
+ * collaborators. `guarded: false` reproduces the pre-#4641 gateway.
+ */
+function runBootSequence(opts: {
+  gatewayPid: number
+  guarded?: boolean
+  markerTurnKey?: string | null
+  markerAgeMs?: number | null
+}): BootResult {
+  const spoolPath = join(stateDir, 'inbound-spool.jsonl')
+  const db = openTurnsDb(agentDir)
+  const spool = createInboundSpool({ path: spoolPath, fs: SPOOL_FS, log: () => {} })
+  let reaped = 0
+  try {
+    // ---- the guard (gateway.ts: immediately after applySubagentsSchema) ----
+    const skip =
+      (opts.guarded ?? true) &&
+      shouldSkipBootResumeForGatewayOnlyRespawn(stateDir, {
+        selfPid: opts.gatewayPid,
+        log: () => {},
+      })
+    if (!skip) {
+      const res = markOrphanedWithTimeoutClassification(db, {
+        markerTurnKey: opts.markerTurnKey ?? null,
+        markerAgeMs: opts.markerAgeMs ?? null,
+        hangThresholdMs: 300_000,
+      })
+      reaped = res.reaped
+      const pending = findLatestTurnIfInterrupted(db)
+      if (pending != null) {
+        const kind = decideBootResumeKind({
+          pending,
+          suppressed: false,
+          ageMs: Math.max(0, Date.now() - pending.started_at),
+          maxAgeMs: 10_800_000,
+        })
+        if (kind === 'resume') {
+          spool.put('tester', buildResumeInterruptedInbound({ turn: pending, subagents: [] }))
+        } else if (kind === 'report') {
+          spool.put(
+            'tester',
+            buildResumeWatchdogReportInbound({ turn: pending, idleMs: 600_000, subagents: [] }),
+          )
+        }
+      }
+      writePendingTurnEnv(agentDir, pending, () => {})
+    }
+  } finally {
+    db.close()
+  }
+  const spoolRaw = existsSync(spoolPath) ? readFileSync(spoolPath, 'utf8') : ''
+  const spooledSources = spoolRaw
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as { t: string; msg?: { meta?: { source?: string } } })
+    .filter((r) => r.t === 'put')
+    .map((r) => r.msg?.meta?.source ?? '(none)')
+  return {
+    spooledSources,
+    spoolRaw,
+    reaped,
+    pendingEnvWritten: existsSync(join(agentDir, '.pending-turn.env')),
+  }
+}
+
+/** Seed an in-flight turn: started, never ended — the live turn's row. */
+function seedInFlightTurn(turnKey = 'chat:1786528508921'): string {
+  const db = openTurnsDb(agentDir)
+  try {
+    recordTurnStart(db, {
+      turnKey,
+      chatId: '12345',
+      userPromptPreview: 'dispatch the worker',
+    })
+  } finally {
+    db.close()
+  }
+  return turnKey
+}
+
+beforeEach(() => {
+  agentDir = mkdtempSync(join(tmpdir(), 'boot-respawn-'))
+  stateDir = join(agentDir, 'telegram')
+  mkdirSync(stateDir, { recursive: true })
+  agentProc = spawn('sleep', ['120'], { stdio: 'ignore' })
+  sleepMs(20)
+  gatewayProc = spawn('sleep', ['120'], { stdio: 'ignore' })
+  sleepMs(20)
+})
+
+afterEach(() => {
+  for (const p of [agentProc, gatewayProc]) {
+    try { p.kill('SIGKILL') } catch { /* already gone */ }
+  }
+  rmSync(agentDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// The bug
+// ---------------------------------------------------------------------------
+
+describe('gateway-only respawn (claude still running)', () => {
+  it('spools ZERO resume_interrupted entries and leaves the live turn open', () => {
+    const turnKey = seedInFlightTurn()
+    writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+
+    const out = runBootSequence({ gatewayPid: gatewayProc.pid! })
+
+    // The outcome the issue names.
+    expect(out.spooledSources).toEqual([])
+    expect(out.spoolRaw).not.toContain('resume_interrupted')
+    // …and no collateral: the live turn keeps its open row (no `restart` lie),
+    // and the one-shot wake-audit env is not written either.
+    expect(out.reaped).toBe(0)
+    expect(out.pendingEnvWritten).toBe(false)
+    const db = openTurnsDb(agentDir)
+    try {
+      const turn = getTurnByKey(db, turnKey)!
+      expect(turn.ended_at).toBeNull()
+      expect(turn.ended_via).toBeNull()
+    } finally {
+      db.close()
+    }
+  })
+
+  it('WOULD fire the false resume without the guard (bug reproduction)', () => {
+    const turnKey = seedInFlightTurn()
+    writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+
+    // Same fixture, guard bypassed — the pre-#4641 gateway.
+    const out = runBootSequence({ gatewayPid: gatewayProc.pid!, guarded: false })
+
+    expect(out.spooledSources).toEqual(['resume_interrupted'])
+    expect(out.reaped).toBe(1)
+    const db = openTurnsDb(agentDir)
+    try {
+      expect(getTurnByKey(db, turnKey)!.ended_via).toBe('restart')
+    } finally {
+      db.close()
+    }
+  })
+
+  it('stays silent across repeated gateway crashes', () => {
+    seedInFlightTurn()
+    writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+    for (let i = 0; i < 3; i++) {
+      expect(runBootSequence({ gatewayPid: gatewayProc.pid! }).spooledSources).toEqual([])
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The cases that must NOT change
+// ---------------------------------------------------------------------------
+
+describe('genuine agent restart', () => {
+  it('still fires resume_interrupted when the recorded process is really dead', () => {
+    const turnKey = seedInFlightTurn()
+    const doomed = spawn('sleep', ['120'], { stdio: 'ignore' })
+    sleepMs(20)
+    writeAgentProcessRecord(doomed.pid!, starttimeOf(doomed.pid!))
+    doomed.kill('SIGKILL')
+    sleepMs(200)
+
+    const out = runBootSequence({ gatewayPid: gatewayProc.pid! })
+
+    expect(out.spooledSources).toEqual(['resume_interrupted'])
+    expect(out.spoolRaw).toContain('resume_interrupted')
+    expect(out.reaped).toBe(1)
+    expect(out.pendingEnvWritten).toBe(true)
+    const db = openTurnsDb(agentDir)
+    try {
+      expect(getTurnByKey(db, turnKey)!.ended_via).toBe('restart')
+    } finally {
+      db.close()
+    }
+  })
+
+  it('still fires on first boot, when no process record exists at all', () => {
+    seedInFlightTurn()
+    expect(existsSync(join(stateDir, AGENT_PROCESS_RECORD_FILE))).toBe(false)
+
+    const out = runBootSequence({ gatewayPid: gatewayProc.pid! })
+
+    expect(out.spooledSources).toEqual(['resume_interrupted'])
+    expect(out.pendingEnvWritten).toBe(true)
+  })
+
+  it('still fires when a recycled PID matches but the starttime does not', () => {
+    seedInFlightTurn()
+    // A live pid whose recorded starttime disagrees — the post-container-
+    // restart shape, where the old record's pid names a different process.
+    writeAgentProcessRecord(
+      agentProc.pid!,
+      String(BigInt(starttimeOf(agentProc.pid!)) - 1n),
+    )
+
+    expect(runBootSequence({ gatewayPid: gatewayProc.pid! }).spooledSources)
+      .toEqual(['resume_interrupted'])
+  })
+
+  it('still fires when the agent started AFTER this gateway (fresh boot race)', () => {
+    seedInFlightTurn()
+    // Roles swapped: the record names the process spawned SECOND, and the
+    // probe runs as the one spawned FIRST — i.e. a live claude that this
+    // gateway cannot be a respawn of.
+    writeAgentProcessRecord(gatewayProc.pid!, starttimeOf(gatewayProc.pid!))
+
+    expect(runBootSequence({ gatewayPid: agentProc.pid! }).spooledSources)
+      .toEqual(['resume_interrupted'])
+  })
+})
+
+describe('watchdog-timeout classification', () => {
+  it('still reports resume_watchdog_timeout for a dead agent that stalled', () => {
+    const turnKey = seedInFlightTurn()
+    const doomed = spawn('sleep', ['120'], { stdio: 'ignore' })
+    sleepMs(20)
+    writeAgentProcessRecord(doomed.pid!, starttimeOf(doomed.pid!))
+    doomed.kill('SIGKILL')
+    sleepMs(200)
+
+    const out = runBootSequence({
+      gatewayPid: gatewayProc.pid!,
+      markerTurnKey: turnKey,
+      markerAgeMs: 600_000, // past the 300s hang threshold
+    })
+
+    expect(out.spooledSources).toEqual(['resume_watchdog_timeout'])
+    const db = openTurnsDb(agentDir)
+    try {
+      expect(getTurnByKey(db, turnKey)!.ended_via).toBe('timeout')
+    } finally {
+      db.close()
+    }
+  })
+
+  it('does NOT report a timeout when the agent is alive and only the gateway died', () => {
+    // The nastiest false positive: a long tool call means no marker touch for
+    // >5 min, so the pre-fix gateway classified a HEALTHY long-running turn as
+    // a hang and asked the user whether to retry it.
+    const turnKey = seedInFlightTurn()
+    writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
+
+    const out = runBootSequence({
+      gatewayPid: gatewayProc.pid!,
+      markerTurnKey: turnKey,
+      markerAgeMs: 600_000,
+    })
+
+    expect(out.spooledSources).toEqual([])
+    const db = openTurnsDb(agentDir)
+    try {
+      expect(getTurnByKey(db, turnKey)!.ended_via).toBeNull()
+    } finally {
+      db.close()
+    }
+  })
+})

--- a/telegram-plugin/tests/boot-resume-gateway-only-respawn.test.ts
+++ b/telegram-plugin/tests/boot-resume-gateway-only-respawn.test.ts
@@ -11,20 +11,35 @@
  * What this test asserts is the OUTCOME the issue names, end to end over the
  * REAL collaborators — a real bun:sqlite registry, the real boot reaper, the
  * real interrupted-turn finder, the real inbound builders and the real durable
- * inbound spool — with only the ORDERING supplied by `runBootSequence` below,
- * which mirrors gateway.ts's block 1:1 (and `boot-resume-guard-wiring.test.ts`
- * pins that gateway.ts still calls the guard in that position):
+ * inbound spool — with only the ORDERING supplied by `runBootSequence` below.
+ *
+ * ORDERING FIDELITY (the point an earlier revision of this file got wrong):
+ * gateway.ts's `bootResumeInit` block does NOT spool the resume. It builds
+ * `bootResumeInbound` in MEMORY; the durable `inboundSpool.put` lives ~8k lines
+ * later, and the generation-token stamp lives immediately after THAT. A
+ * harness that puts inside its model of the block collapses the whole window
+ * between "block done" and "resume durable" — the one window a crash can
+ * actually land in — and so cannot see a stamp placed too early. This harness
+ * keeps the three stages distinct and lets `crashAt` land in each of them.
+ * `stampAt: 'block-end'` reproduces the defective placement on purpose.
+ * (`boot-resume-guard-wiring.test.ts` pins that gateway.ts really does stamp
+ * after the put, since this file cannot import the block.)
  *
  *   - gateway killed mid-turn while the claude process LIVES
  *       → ZERO `resume_interrupted` entries in the on-disk spool,
  *         the in-flight turn row is left OPEN (no `ended_via` lie), and
  *         no `.pending-turn.env` is written.
  *   - a gateway that CRASHES DURING ITS OWN BOOT, before stamping the
- *     per-container-boot generation token
+ *     per-container-boot generation token — at each of the three reachable
+ *     points (after the guard, after the block but before the durable spool
+ *     put, after the put but before the stamp)
  *       → the successor gateway does the full boot resume; the interrupted
  *         turn is not lost. (This is the case the earlier starttime-ordering
  *         guard got wrong: it saw a live claude that predated it and
  *         suppressed forever.)
+ *   - the same crash with the token stamped at the END OF THE BLOCK instead
+ *       → the resume is DROPPED forever. Asserted explicitly as a defect
+ *         reproduction, so the correct placement is pinned by outcome.
  *   - a suppressed respawn and the #3038 bridge-dead escalation marker
  *       → the marker is NOT re-consumed, because the gateway that stamped
  *         the token already consumed it this generation.
@@ -65,6 +80,7 @@ import {
   markOrphanedWithTimeoutClassification,
   findLatestTurnIfInterrupted,
   getTurnByKey,
+  markTurnResumed,
 } from '../registry/turns-schema.js'
 import {
   decideBootResumeKind,
@@ -73,6 +89,7 @@ import {
 } from '../gateway/resume-inbound-builder.js'
 import { writePendingTurnEnv } from '../gateway/pending-turn-env.js'
 import { createInboundSpool } from '../gateway/inbound-spool.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
 import {
   readProcIdentity,
   shouldSkipBootResumeForGatewayOnlyRespawn,
@@ -134,32 +151,67 @@ interface BootResult {
 }
 
 /**
- * The gateway's boot-resume block, in gateway.ts's order, over the real
- * collaborators. `guarded: false` reproduces the pre-#4641 gateway.
+ * Where a gateway dies during its own boot (the Bun 1.3.13 crash-at-boot
+ * pattern that motivated the fix). Each value names the point the process
+ * vanishes; everything before it has already happened.
  *
- * `crashAt` models a gateway that dies during its own boot (the Bun 1.3.13
- * crash-at-boot pattern that motivated the fix): `'guard'` dies immediately
- * after the guard, before any side effect; `'stamp'` gets all the way through
- * the effects but dies before stamping the token. Neither stamps it.
+ *   'after-guard'            — before any side effect at all.
+ *   'after-block-before-put' — the WHOLE bootResumeInit block ran (turn reaped
+ *                              and durably stamped `ended_via='restart'`, env
+ *                              written, inbound built IN MEMORY) but the
+ *                              process dies before the durable spool put. This
+ *                              is the window a too-early token stamp loses
+ *                              work in, and the one the pre-fix harness could
+ *                              not express.
+ *   'after-put-before-stamp' — the resume IS durable; only the token is
+ *                              missing. Successor repeats, spool dedups.
+ */
+type CrashPoint = 'after-guard' | 'after-block-before-put' | 'after-put-before-stamp'
+
+/** Sentinel used to unwind out of the modelled boot at `crashAt`. */
+const BOOT_CRASH = Symbol('boot-crash')
+
+/**
+ * The gateway's boot sequence in gateway.ts's real order, over the real
+ * collaborators, in THREE distinct stages:
+ *
+ *   1. `bootResumeInit` — guard, reaper, marker, builders. In-memory only.
+ *   2. the durable `inboundSpool.put` (gateway.ts ~8k lines later).
+ *   3. `markBootResumeComplete` — unconditional, top level.
+ *
+ * `guarded: false` reproduces the pre-#4641 gateway. `stampAt: 'block-end'`
+ * reproduces this PR's first (defective) placement.
  */
 function runBootSequence(opts: {
   guarded?: boolean
   markerTurnKey?: string | null
   markerAgeMs?: number | null
-  crashAt?: 'guard' | 'stamp'
+  crashAt?: CrashPoint
+  /** Where the generation token is stamped. Default = production. */
+  stampAt?: 'block-end' | 'after-durable-put'
 }): BootResult {
   const spoolPath = join(stateDir, 'inbound-spool.jsonl')
   const db = openTurnsDb(agentDir)
   const spool = createInboundSpool({ path: spoolPath, fs: SPOOL_FS, log: () => {} })
+  const stampAt = opts.stampAt ?? 'after-durable-put'
   let reaped = 0
   let bridgeDeadStreak: number | null = null
   let tokenStamped = false
+  const stamp = (): void => {
+    markBootResumeComplete(stateDir)
+    tokenStamped = true
+  }
   try {
-    // ---- the guard (gateway.ts: immediately after applySubagentsSchema) ----
+    // ---- stage 1: the bootResumeInit block (IN MEMORY ONLY) ----------------
+    // The guard, gateway.ts: immediately after applySubagentsSchema.
     const skip =
       (opts.guarded ?? true) &&
       shouldSkipBootResumeForGatewayOnlyRespawn(stateDir, { log: () => {} })
-    if (!skip && opts.crashAt !== 'guard') {
+    // gateway.ts:1648 — `bootResumeInbound`, stashed and pushed to the spool
+    // only much later. Nothing on disk yet.
+    let bootResumeInbound: InboundMessage | null = null
+    if (!skip) {
+      if (opts.crashAt === 'after-guard') throw BOOT_CRASH
       const res = markOrphanedWithTimeoutClassification(db, {
         markerTurnKey: opts.markerTurnKey ?? null,
         markerAgeMs: opts.markerAgeMs ?? null,
@@ -182,22 +234,34 @@ function runBootSequence(opts: {
           maxAgeMs: 10_800_000,
         })
         if (kind === 'resume') {
-          spool.put('tester', buildResumeInterruptedInbound({ turn: pending, subagents: [] }))
+          bootResumeInbound = buildResumeInterruptedInbound({ turn: pending, subagents: [] })
         } else if (kind === 'report') {
-          spool.put(
-            'tester',
-            buildResumeWatchdogReportInbound({ turn: pending, idleMs: 600_000, subagents: [] }),
-          )
+          bootResumeInbound = buildResumeWatchdogReportInbound({
+            turn: pending,
+            idleMs: 600_000,
+            subagents: [],
+          })
         }
       }
       writePendingTurnEnv(agentDir, pending, () => {})
-      // gateway.ts: LAST statement of the block. A crash before here leaves no
-      // token, so the successor gateway redoes the whole boot resume.
-      if (opts.crashAt !== 'stamp') {
-        markBootResumeComplete(stateDir)
-        tokenStamped = true
-      }
+      // THE DEFECT, reproducible on demand: stamping here marks the generation
+      // done while the resume exists only in this process's heap.
+      if (stampAt === 'block-end') stamp()
+      if (opts.crashAt === 'after-block-before-put') throw BOOT_CRASH
     }
+    // ---- stage 2: gateway.ts ~:10148, the DURABLE put ----------------------
+    if (bootResumeInbound != null) {
+      spool.put('tester', bootResumeInbound)
+      // …and the at-most-once ledger, stamped only AFTER the put — the same
+      // ordering rule the generation token now obeys (turns-schema.ts).
+      const rk = bootResumeInbound.meta?.resume_turn_key
+      if (typeof rk === 'string' && rk.length > 0) markTurnResumed(db, rk)
+    }
+    if (opts.crashAt === 'after-put-before-stamp') throw BOOT_CRASH
+    // ---- stage 3: the token, unconditional (gateway.ts, top level) ---------
+    if (stampAt === 'after-durable-put') stamp()
+  } catch (err) {
+    if (err !== BOOT_CRASH) throw err
   } finally {
     db.close()
   }
@@ -344,7 +408,7 @@ describe('gateway crash during its own boot', () => {
     const turnKey = seedInFlightTurn()
     writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
 
-    const crashed = runBootSequence({ crashAt: 'guard' })
+    const crashed = runBootSequence({ crashAt: 'after-guard' })
     expect(crashed.tokenStamped).toBe(false)
     expect(crashed.spooledSources).toEqual([])
     expect(existsSync(bootResumeDonePath(stateDir))).toBe(false)
@@ -371,7 +435,7 @@ describe('gateway crash during its own boot', () => {
     const markerPath = writeBridgeDeadMarker(3)
     writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
 
-    const crashed = runBootSequence({ crashAt: 'guard' })
+    const crashed = runBootSequence({ crashAt: 'after-guard' })
     expect(crashed.bridgeDeadStreak).toBeNull()
     expect(existsSync(markerPath)).toBe(true)
 
@@ -380,19 +444,82 @@ describe('gateway crash during its own boot', () => {
     expect(existsSync(markerPath)).toBe(false)
   })
 
-  it('a crash after the effects but before the stamp does not suppress either', () => {
-    // The other half of the window: the block ran, but the token write never
-    // landed. The successor re-runs the block. That is a duplicate resume, not
-    // a lost one — the deliberate fail-open direction.
+  it('a crash after the DURABLE PUT but before the stamp does not suppress either', () => {
+    // The resume is already on disk; only the token is missing. The successor
+    // re-runs the block, and the spool's `s:resume:<turnKey>` dedup makes the
+    // repeat a no-op rather than a double-send.
     seedInFlightTurn()
     writeAgentProcessRecord(agentProc.pid!, starttimeOf(agentProc.pid!))
 
-    const crashed = runBootSequence({ crashAt: 'stamp' })
+    const crashed = runBootSequence({ crashAt: 'after-put-before-stamp' })
     expect(crashed.spooledSources).toEqual(['resume_interrupted'])
     expect(crashed.tokenStamped).toBe(false)
 
     const out = runBootSequence({})
     expect(out.tokenStamped).toBe(true) // it did NOT suppress
+    // …and exactly ONE resume reached the spool across both boots.
+    expect(out.spooledSources).toEqual(['resume_interrupted'])
+  })
+
+  it('a crash AFTER the block but BEFORE the durable put still resumes (the reachable window)', () => {
+    // THE regression this placement fix exists for. The block ran to
+    // completion: the reaper has DURABLY stamped the turn `ended_via='restart'`
+    // and the resume inbound exists only in the dying process's heap. Nothing
+    // about the resume is on disk.
+    //
+    // With the token stamped after the durable put (production), the successor
+    // finds no token and re-mints the resume — the work survives.
+    const turnKey = seedInFlightTurn()
+    // Note: start.sh has NOT yet published agent-process.json at this point —
+    // the gateway is forked long before `exec claude`. That is precisely why a
+    // premature token is fatal here: the successor's only corroborating
+    // evidence is absent, so it returns `gateway-only-respawn-no-record`.
+    expect(existsSync(join(stateDir, AGENT_PROCESS_RECORD_FILE))).toBe(false)
+
+    const crashed = runBootSequence({ crashAt: 'after-block-before-put' })
+    expect(crashed.spooledSources).toEqual([]) // nothing durable yet
+    expect(crashed.reaped).toBe(1) // …but the turn IS durably stamped
+    expect(crashed.tokenStamped).toBe(false)
+    expect(existsSync(bootResumeDonePath(stateDir))).toBe(false)
+
+    const out = runBootSequence({})
+
+    expect(out.spooledSources).toEqual(['resume_interrupted'])
+    expect(out.tokenStamped).toBe(true)
+    const db = openTurnsDb(agentDir)
+    try {
+      expect(getTurnByKey(db, turnKey)!.ended_via).toBe('restart')
+    } finally {
+      db.close()
+    }
+  })
+
+  it('WOULD lose the turn forever if the token were stamped at the end of the block', () => {
+    // Defect reproduction for the placement, mirroring the `guarded: false`
+    // bug-reproduction above. Same crash point as the test directly above;
+    // only the stamp moves. The turn is durably `ended_via='restart'`, no
+    // resume ever reaches the spool, and the successor suppresses on the token
+    // alone — silent, permanent work loss, and a NEW failure mode versus the
+    // pre-#4641 gateway, which simply re-ran the block.
+    const turnKey = seedInFlightTurn()
+
+    const crashed = runBootSequence({ crashAt: 'after-block-before-put', stampAt: 'block-end' })
+    expect(crashed.tokenStamped).toBe(true) // stamped while the resume is in RAM
+    expect(crashed.spooledSources).toEqual([])
+    expect(existsSync(bootResumeDonePath(stateDir))).toBe(true)
+
+    const out = runBootSequence({})
+
+    expect(out.spooledSources, 'the resume is dropped, not retried').toEqual([])
+    expect(out.reaped).toBe(0)
+    const db = openTurnsDb(agentDir)
+    try {
+      const turn = getTurnByKey(db, turnKey)!
+      expect(turn.ended_via).toBe('restart') // durably ended…
+      expect(turn.resumed_at).toBeNull() // …and never resumed
+    } finally {
+      db.close()
+    }
   })
 })
 

--- a/telegram-plugin/tests/boot-resume-guard-wiring.test.ts
+++ b/telegram-plugin/tests/boot-resume-guard-wiring.test.ts
@@ -128,12 +128,18 @@ describe('#4641 boot-resume guard wiring in gateway.ts', () => {
     expect(durablePut, 'the durable spool put must precede the token stamp').toBeLessThan(stamp)
     expect(idx('markTurnResumed(turnsDb, resumeTurnKey)')).toBeLessThan(stamp)
 
-    // 3. It is UNCONDITIONAL — top-level (zero indentation, so not nested
-    //    inside `if (isGatewayMain && bootResumeInbound != null)`), gated only
-    //    on isGatewayMain. A boot with nothing to resume must still stamp, or
-    //    a later gateway-only respawn reaps a meanwhile-started live turn.
+    // 3. It is top-level (zero indentation, so not nested inside
+    //    `if (isGatewayMain && bootResumeInbound != null)`) and independent of
+    //    whether there was anything to resume — a boot that found nothing must
+    //    still stamp, or a later gateway-only respawn reaps a
+    //    meanwhile-started live turn — but it IS gated on the block not having
+    //    thrown. gateway.ts's block-level `catch` swallows and lets init
+    //    continue, so an ungated stamp marks the generation done after the
+    //    reaper has already durably ended a turn that was never spooled.
     const stampLine = SRC.split('\n').find((l) => l.includes('markBootResumeComplete(STATE_DIR)'))!
-    expect(stampLine).toMatch(/^if \(isGatewayMain\) markBootResumeComplete\(STATE_DIR\)/)
+    expect(stampLine).toMatch(
+      /^if \(isGatewayMain && !bootResumeThrew\) markBootResumeComplete\(STATE_DIR\)/,
+    )
 
     // 4. Nothing durable-resume-related may sneak between the put and the
     //    stamp except the resumed_at ledger — i.e. the stamp closes that
@@ -156,6 +162,32 @@ describe('#4641 boot-resume guard wiring in gateway.ts', () => {
       envLine,
       'the generation token must not be stamped alongside writePendingTurnEnv (still in-memory-only territory)',
     ).not.toContain('markBootResumeComplete')
+  })
+
+  it("sets bootResumeThrew in the block's own catch, and nowhere else", () => {
+    // The catch is a SWALLOW: it logs, nulls turnsDb and lets module init run
+    // on to the stamp. By then the reaper may already have durably written
+    // `ended_via='restart'` with nothing spooled, so the catch must record the
+    // failure and the stamp must honour it. Pinned by source text because the
+    // block is module-init code this suite cannot import.
+    const blockStart = idx('bootResumeInit: if (isGatewayMain) try {')
+    const catchAt = SRC.indexOf('} catch (err) {', blockStart)
+    const stamp = idx('markBootResumeComplete(STATE_DIR)')
+
+    const sets = [...SRC.matchAll(/bootResumeThrew = true/g)].map((m) => m.index!)
+    expect(sets.length, 'exactly one assignment site').toBe(1)
+    expect(sets[0]!, "the assignment must be in the block's catch").toBeGreaterThan(catchAt)
+    expect(sets[0]!, 'and before the stamp reads it').toBeLessThan(stamp)
+
+    // The catch must not early-return/exit instead: init continues, which is
+    // precisely why the flag is needed.
+    const catchBody = SRC.slice(catchAt, SRC.indexOf('\n}\n', catchAt) + 2)
+    expect(catchBody).toContain('turnsDb = null')
+    expect(catchBody).not.toContain('process.exit')
+
+    const decl = SRC.indexOf('let bootResumeThrew = false')
+    expect(decl, 'declared before the block so the stamp can read it').toBeGreaterThan(-1)
+    expect(decl).toBeLessThan(blockStart)
   })
 
   it('keeps the guard AFTER the registry is opened, so turn tracking still works', () => {

--- a/telegram-plugin/tests/boot-resume-guard-wiring.test.ts
+++ b/telegram-plugin/tests/boot-resume-guard-wiring.test.ts
@@ -7,10 +7,10 @@
  * supplies the ORDERING itself: gateway.ts is a 24k-line module whose boot
  * block cannot be imported without booting a gateway. This file closes that gap
  * by pinning gateway.ts's own wiring, so a refactor cannot move the guard below
- * the reaper, drop it, or move the token stamp out of the block's tail while
+ * the reaper, drop it, or move the token stamp back inside the block while
  * the outcome suite stays green against its own copy of the sequence.
  *
- * Pinned, in source order inside the labelled `bootResumeInit` block:
+ * Pinned:
  *   1. the label exists and is on the `isGatewayMain` boot-registry block,
  *   2. the guard runs and `break`s out of that label,
  *   3. it precedes the orphan-turn reaper, the bridge-dead marker consumption,
@@ -18,8 +18,18 @@
  *      capture and `writePendingTurnEnv` — i.e. `break` skips ALL of them,
  *   4. the break carries a comment naming those skipped effects (the reviewer
  *      MEDIUM: the skip is wider than the resume path and was undocumented),
- *   5. the generation token is stamped as the LAST thing the block does, so a
- *      gateway that dies mid-boot leaves no token behind.
+ *   5. THE STAMP FOLLOWS THE DURABLE PUT. The `bootResumeInit` block only
+ *      builds `bootResumeInbound` in MEMORY; the resume becomes crash-
+ *      survivable ~8k lines later at `inboundSpool.put(...)`. Stamping at the
+ *      tail of the block (the shape this PR's first revision shipped) means a
+ *      crash in between leaves a token, no `agent-process.json`, and a
+ *      successor that suppresses a turn already stamped `ended_via='restart'`
+ *      — silent, permanent work loss. So: the stamp must NOT appear inside the
+ *      block at all, must come after the put and after `markTurnResumed`, and
+ *      must be UNCONDITIONAL (top-level, gated only on `isGatewayMain`) so a
+ *      boot with nothing to resume still writes a token. Same rule
+ *      `markTurnResumed` already obeys — see turns-schema.ts's "the caller
+ *      must stamp only AFTER the resume inbound is durably spooled".
  */
 
 import { describe, it, expect } from 'vitest'
@@ -91,32 +101,61 @@ describe('#4641 boot-resume guard wiring in gateway.ts', () => {
     }
   })
 
-  it('stamps the generation token as the LAST statement of the block', () => {
-    // A gateway that crashes mid-boot must leave NO token, so its successor
-    // redoes the boot resume (reviewer MAJOR 2). That property is exactly
-    // "the stamp is last": everything the block does precedes it.
-    const stamp = idx('markBootResumeComplete(STATE_DIR)')
-    for (const effect of [
-      'markOrphanedWithTimeoutClassification(turnsDb',
-      'consumeBridgeDeadEscalationMarker(',
-      'findLatestTurnIfInterrupted(turnsDb)',
-      'buildResumeInterruptedInbound({',
-      'buildBridgeDeadIdleNoticeInbound({',
-      'writePendingTurnEnv(agentDir, pending)',
-    ]) {
-      expect(idx(effect), `${effect} must run before the token stamp`).toBeLessThan(stamp)
-    }
-    // …and it is inside the block, i.e. before the block's catch clause.
+  it('stamps the generation token AFTER the durable spool put, never inside the block', () => {
+    // The invariant this pins, and why it is NOT "the stamp is last in the
+    // block": the block builds `bootResumeInbound` in memory only. Stamping at
+    // its tail marks the generation done while the resume is still nowhere on
+    // disk, so a crash before the put leaves a token + no `agent-process.json`
+    // + a turn stamped `ended_via='restart'` and `resumed_at` NULL — and the
+    // successor returns `gateway-only-respawn-no-record` and drops it forever.
+    const durablePut = idx('inboundSpool.put(bootResumeInbound.agent, bootResumeInbound.msg)')
+    const stamps = [...SRC.matchAll(/markBootResumeComplete\(STATE_DIR\)/g)].map((m) => m.index!)
+    expect(stamps.length, 'exactly one token stamp site in gateway.ts').toBe(1)
+    const stamp = stamps[0]!
+
+    // 1. It is OUTSIDE the bootResumeInit block: the block's `} catch (err) {`
+    //    closes long before the stamp.
     const blockStart = idx('bootResumeInit: if (isGatewayMain) try {')
-    const catchAt = SRC.indexOf('} catch (err) {', stamp)
-    expect(blockStart).toBeLessThan(stamp)
-    expect(catchAt).toBeGreaterThan(stamp)
-    // Nothing else may run between the stamp and the end of the block.
-    const afterStamp = SRC.slice(stamp, catchAt)
-      .replace('markBootResumeComplete(STATE_DIR)', '')
-      .replace(/\/\/[^\n]*/g, '')
-      .trim()
-    expect(afterStamp, 'no statement may follow the generation-token stamp').toBe('')
+    const blockEnd = SRC.indexOf('} catch (err) {', blockStart)
+    expect(blockEnd).toBeGreaterThan(blockStart)
+    expect(
+      stamp,
+      'the token stamp must NOT live inside the bootResumeInit block — the block only builds the resume in memory',
+    ).toBeGreaterThan(blockEnd)
+
+    // 2. It follows the durable put, and the at-most-once `markTurnResumed`
+    //    ledger that obeys the identical ordering rule.
+    expect(durablePut, 'the durable spool put must precede the token stamp').toBeLessThan(stamp)
+    expect(idx('markTurnResumed(turnsDb, resumeTurnKey)')).toBeLessThan(stamp)
+
+    // 3. It is UNCONDITIONAL — top-level (zero indentation, so not nested
+    //    inside `if (isGatewayMain && bootResumeInbound != null)`), gated only
+    //    on isGatewayMain. A boot with nothing to resume must still stamp, or
+    //    a later gateway-only respawn reaps a meanwhile-started live turn.
+    const stampLine = SRC.split('\n').find((l) => l.includes('markBootResumeComplete(STATE_DIR)'))!
+    expect(stampLine).toMatch(/^if \(isGatewayMain\) markBootResumeComplete\(STATE_DIR\)/)
+
+    // 4. Nothing durable-resume-related may sneak between the put and the
+    //    stamp except the resumed_at ledger — i.e. the stamp closes that
+    //    sequence rather than floating somewhere later in module init.
+    const between = SRC.slice(durablePut + 1, stamp)
+    expect(between, 'no second spool put may separate the durable put from the stamp')
+      .not.toContain('inboundSpool.put(bootResumeInbound')
+    expect(
+      between.split('\n').length,
+      'the stamp must sit immediately after the resume-commit block, not drift away from it',
+    ).toBeLessThan(40)
+  })
+
+  it('does not re-join the stamp onto writePendingTurnEnv inside the block', () => {
+    // The exact regression shape: `writePendingTurnEnv(agentDir, pending); markBootResumeComplete(STATE_DIR)`
+    // — joined onto one line to satisfy the gateway line ratchet. The ratchet
+    // is not a licence to stamp early.
+    const envLine = SRC.split('\n').find((l) => l.includes('writePendingTurnEnv(agentDir, pending)'))!
+    expect(
+      envLine,
+      'the generation token must not be stamped alongside writePendingTurnEnv (still in-memory-only territory)',
+    ).not.toContain('markBootResumeComplete')
   })
 
   it('keeps the guard AFTER the registry is opened, so turn tracking still works', () => {

--- a/telegram-plugin/tests/boot-resume-guard-wiring.test.ts
+++ b/telegram-plugin/tests/boot-resume-guard-wiring.test.ts
@@ -1,20 +1,25 @@
 /**
- * switchroom#4641 — wiring pin for the gateway-only-respawn guard.
+ * switchroom#4641 — wiring pin for the boot-resume generation guard.
  *
- * `boot-resume-gateway-only-respawn.test.ts` proves the OUTCOME (a live agent
- * process yields zero `resume_interrupted` spool entries) over the real
- * registry, builders and spool, but it supplies the ORDERING itself: gateway.ts
- * is a 24k-line module whose boot block cannot be imported without booting a
- * gateway. This file closes that gap by pinning gateway.ts's own wiring, so a
- * refactor cannot move the guard below the reaper — or drop it — while the
- * outcome suite stays green against its own copy of the sequence.
+ * `boot-resume-gateway-only-respawn.test.ts` proves the OUTCOME (a stamped
+ * generation token yields zero `resume_interrupted` spool entries, an unstamped
+ * one still resumes) over the real registry, builders and spool, but it
+ * supplies the ORDERING itself: gateway.ts is a 24k-line module whose boot
+ * block cannot be imported without booting a gateway. This file closes that gap
+ * by pinning gateway.ts's own wiring, so a refactor cannot move the guard below
+ * the reaper, drop it, or move the token stamp out of the block's tail while
+ * the outcome suite stays green against its own copy of the sequence.
  *
  * Pinned, in source order inside the labelled `bootResumeInit` block:
  *   1. the label exists and is on the `isGatewayMain` boot-registry block,
  *   2. the guard runs and `break`s out of that label,
- *   3. it precedes the orphan-turn reaper, the interrupted-turn finder, the
- *      resume builders and `writePendingTurnEnv` — i.e. `break` skips ALL of
- *      them, which is exactly what "the agent was never interrupted" means.
+ *   3. it precedes the orphan-turn reaper, the bridge-dead marker consumption,
+ *      the interrupted-turn finder, the resume builders, the crash-redelivery
+ *      capture and `writePendingTurnEnv` — i.e. `break` skips ALL of them,
+ *   4. the break carries a comment naming those skipped effects (the reviewer
+ *      MEDIUM: the skip is wider than the resume path and was undocumented),
+ *   5. the generation token is stamped as the LAST thing the block does, so a
+ *      gateway that dies mid-boot leaves no token behind.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -45,7 +50,7 @@ describe('#4641 boot-resume guard wiring in gateway.ts', () => {
       /if \(shouldSkipBootResumeForGatewayOnlyRespawn\(STATE_DIR\)\) break bootResumeInit/,
     )
     expect(SRC).toContain(
-      "import { shouldSkipBootResumeForGatewayOnlyRespawn } from './agent-process-liveness.js'",
+      "import { shouldSkipBootResumeForGatewayOnlyRespawn, markBootResumeComplete } from './agent-process-liveness.js'",
     )
   })
 
@@ -53,13 +58,65 @@ describe('#4641 boot-resume guard wiring in gateway.ts', () => {
     const guard = idx('shouldSkipBootResumeForGatewayOnlyRespawn(STATE_DIR)')
     // The orphan-turn reaper — what stamped the live turn `ended_via='restart'`.
     expect(guard).toBeLessThan(idx('markOrphanedWithTimeoutClassification(turnsDb'))
+    // #3038 bridge-dead escalation marker consumption.
+    expect(guard).toBeLessThan(idx('consumeBridgeDeadEscalationMarker('))
     // The interrupted-turn finder + the synthetic that lied to the session.
     expect(guard).toBeLessThan(idx('findLatestTurnIfInterrupted(turnsDb)'))
     expect(guard).toBeLessThan(idx('buildResumeInterruptedInbound({'))
     // The sub-agent "killed by the restart" list.
     expect(guard).toBeLessThan(idx('listNonTerminalSubagentsForTurn(turnsDb'))
+    // The crash-redelivery candidate capture.
+    expect(guard).toBeLessThan(idx('pendingRedelivery = { turn: pending'))
+    // The bridge-dead idle notice.
+    expect(guard).toBeLessThan(idx('buildBridgeDeadIdleNoticeInbound({'))
     // The one-shot wake-audit env file.
     expect(guard).toBeLessThan(idx('writePendingTurnEnv(agentDir, pending)'))
+  })
+
+  it('documents at the break every effect it skips beyond the resume path', () => {
+    // The reviewer MEDIUM: `break bootResumeInit` silently skipped the
+    // bridge-dead marker (whose own comment claims it is ALWAYS cleared), the
+    // idle notice and the redelivery capture. The break must name them, so the
+    // next reader of gateway.ts:1721 is not misled by that stale invariant.
+    const line = SRC.split('\n').find((l) => l.includes('break bootResumeInit'))
+    expect(line, 'gateway.ts should contain the guarded break').toBeDefined()
+    for (const named of [
+      'reaper',
+      'consumeBridgeDeadEscalationMarker',
+      'idle notice',
+      'pendingRedelivery',
+      'writePendingTurnEnv',
+    ]) {
+      expect(line!, `the break comment must name ${named}`).toContain(named)
+    }
+  })
+
+  it('stamps the generation token as the LAST statement of the block', () => {
+    // A gateway that crashes mid-boot must leave NO token, so its successor
+    // redoes the boot resume (reviewer MAJOR 2). That property is exactly
+    // "the stamp is last": everything the block does precedes it.
+    const stamp = idx('markBootResumeComplete(STATE_DIR)')
+    for (const effect of [
+      'markOrphanedWithTimeoutClassification(turnsDb',
+      'consumeBridgeDeadEscalationMarker(',
+      'findLatestTurnIfInterrupted(turnsDb)',
+      'buildResumeInterruptedInbound({',
+      'buildBridgeDeadIdleNoticeInbound({',
+      'writePendingTurnEnv(agentDir, pending)',
+    ]) {
+      expect(idx(effect), `${effect} must run before the token stamp`).toBeLessThan(stamp)
+    }
+    // …and it is inside the block, i.e. before the block's catch clause.
+    const blockStart = idx('bootResumeInit: if (isGatewayMain) try {')
+    const catchAt = SRC.indexOf('} catch (err) {', stamp)
+    expect(blockStart).toBeLessThan(stamp)
+    expect(catchAt).toBeGreaterThan(stamp)
+    // Nothing else may run between the stamp and the end of the block.
+    const afterStamp = SRC.slice(stamp, catchAt)
+      .replace('markBootResumeComplete(STATE_DIR)', '')
+      .replace(/\/\/[^\n]*/g, '')
+      .trim()
+    expect(afterStamp, 'no statement may follow the generation-token stamp').toBe('')
   })
 
   it('keeps the guard AFTER the registry is opened, so turn tracking still works', () => {

--- a/telegram-plugin/tests/boot-resume-guard-wiring.test.ts
+++ b/telegram-plugin/tests/boot-resume-guard-wiring.test.ts
@@ -1,0 +1,75 @@
+/**
+ * switchroom#4641 — wiring pin for the gateway-only-respawn guard.
+ *
+ * `boot-resume-gateway-only-respawn.test.ts` proves the OUTCOME (a live agent
+ * process yields zero `resume_interrupted` spool entries) over the real
+ * registry, builders and spool, but it supplies the ORDERING itself: gateway.ts
+ * is a 24k-line module whose boot block cannot be imported without booting a
+ * gateway. This file closes that gap by pinning gateway.ts's own wiring, so a
+ * refactor cannot move the guard below the reaper — or drop it — while the
+ * outcome suite stays green against its own copy of the sequence.
+ *
+ * Pinned, in source order inside the labelled `bootResumeInit` block:
+ *   1. the label exists and is on the `isGatewayMain` boot-registry block,
+ *   2. the guard runs and `break`s out of that label,
+ *   3. it precedes the orphan-turn reaper, the interrupted-turn finder, the
+ *      resume builders and `writePendingTurnEnv` — i.e. `break` skips ALL of
+ *      them, which is exactly what "the agent was never interrupted" means.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SRC = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf8',
+)
+
+/** First index of `needle`, asserted present. */
+function idx(needle: string): number {
+  const i = SRC.indexOf(needle)
+  expect(i, `gateway.ts should contain ${JSON.stringify(needle)}`).toBeGreaterThan(-1)
+  return i
+}
+
+describe('#4641 boot-resume guard wiring in gateway.ts', () => {
+  it('labels the boot-registry block so the guard can exit it', () => {
+    expect(SRC).toContain('bootResumeInit: if (isGatewayMain) try {')
+  })
+
+  it('calls the guard and breaks out of the whole block', () => {
+    expect(SRC).toMatch(
+      /if \(shouldSkipBootResumeForGatewayOnlyRespawn\(STATE_DIR\)\) break bootResumeInit/,
+    )
+    expect(SRC).toContain(
+      "import { shouldSkipBootResumeForGatewayOnlyRespawn } from './agent-process-liveness.js'",
+    )
+  })
+
+  it('runs the guard BEFORE every side effect a gateway-only respawn must skip', () => {
+    const guard = idx('shouldSkipBootResumeForGatewayOnlyRespawn(STATE_DIR)')
+    // The orphan-turn reaper — what stamped the live turn `ended_via='restart'`.
+    expect(guard).toBeLessThan(idx('markOrphanedWithTimeoutClassification(turnsDb'))
+    // The interrupted-turn finder + the synthetic that lied to the session.
+    expect(guard).toBeLessThan(idx('findLatestTurnIfInterrupted(turnsDb)'))
+    expect(guard).toBeLessThan(idx('buildResumeInterruptedInbound({'))
+    // The sub-agent "killed by the restart" list.
+    expect(guard).toBeLessThan(idx('listNonTerminalSubagentsForTurn(turnsDb'))
+    // The one-shot wake-audit env file.
+    expect(guard).toBeLessThan(idx('writePendingTurnEnv(agentDir, pending)'))
+  })
+
+  it('keeps the guard AFTER the registry is opened, so turn tracking still works', () => {
+    // A gateway-only respawn still needs a live turnsDb for the rest of the
+    // gateway; the guard skips the boot-resume side effects, not the DB.
+    expect(idx('turnsDb = openTurnsDb(agentDir)')).toBeLessThan(
+      idx('shouldSkipBootResumeForGatewayOnlyRespawn(STATE_DIR)'),
+    )
+    expect(idx('applySubagentsSchema(turnsDb)')).toBeLessThan(
+      idx('shouldSkipBootResumeForGatewayOnlyRespawn(STATE_DIR)'),
+    )
+  })
+})

--- a/tests/agent-process-record.test.ts
+++ b/tests/agent-process-record.test.ts
@@ -145,6 +145,54 @@ describe('start.sh agent-process record (#4641)', () => {
     }
   })
 
+  it('opens a fresh boot-resume generation before the gateway is forked', () => {
+    // The generation token is the whole #4641 mechanism, and its meaning
+    // ("a gateway in THIS container generation already finished its boot
+    // resume") rests entirely on WHERE start.sh clears it: once per container
+    // boot, in the outer docker pass, BEFORE the supervised gateway sidecar is
+    // forked. Clear it after the fork and a respawned gateway could wipe its
+    // own generation; clear it in the inner pass and the token would never
+    // outlive a boot at all.
+    const src = readFileSync(TEMPLATE, 'utf-8')
+    const outerPass = src.indexOf(
+      'if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" ]; then',
+    )
+    expect(outerPass, 'outer docker pass guard not found').toBeGreaterThan(-1)
+    const clear = src.indexOf('rm -f "$TELEGRAM_STATE_DIR/.boot-resume-done"')
+    const fork = src.indexOf('_switchroom_supervise gateway')
+    const tmuxReexec = src.indexOf('exec tmux -L')
+    expect(clear, '.boot-resume-done is never cleared').toBeGreaterThan(-1)
+    expect(fork, 'gateway sidecar fork not found').toBeGreaterThan(-1)
+    expect(clear).toBeGreaterThan(outerPass)
+    expect(clear).toBeLessThan(fork)
+    expect(fork).toBeLessThan(tmuxReexec) // …and the whole thing is the outer pass
+    // The stale agent record from the previous container generation goes with
+    // it: a container restart resets the pid namespace, so its (pid,
+    // starttime) pair could collide with an unrelated live process.
+    expect(src.slice(clear, src.indexOf('\n', clear))).toContain('agent-process.json')
+    // Exactly one clear, so no second site can re-open a generation mid-boot.
+    expect(src.split('rm -f "$TELEGRAM_STATE_DIR/.boot-resume-done"').length - 1).toBe(1)
+  })
+
+  it('actually deletes both files when that outer-pass line runs', () => {
+    // Executed, not pattern-matched: `rm -f` on a path that does not exist
+    // must also be a no-op that cannot fail the boot.
+    const stateDir = join(dir, 'telegram-clear')
+    execFileSync('mkdir', ['-p', stateDir])
+    const token = join(stateDir, '.boot-resume-done')
+    const record = join(stateDir, 'agent-process.json')
+    writeFileSync(token, '{"pid":1}')
+    writeFileSync(record, '{"pid":1,"starttime":"5"}')
+    const src = readFileSync(TEMPLATE, 'utf-8')
+    const clear = src.indexOf('rm -f "$TELEGRAM_STATE_DIR/.boot-resume-done"')
+    const line = src.slice(clear, src.indexOf('\n', clear))
+    const p = join(dir, 'clear.sh')
+    writeFileSync(p, `#!/bin/bash\nset -e\n${line}\n${line}\n`)
+    execFileSync('bash', [p], { env: { ...process.env, TELEGRAM_STATE_DIR: stateDir } })
+    expect(existsSync(token)).toBe(false)
+    expect(existsSync(record)).toBe(false)
+  })
+
   it('is written immediately before the exec, never after it', () => {
     const src = readFileSync(TEMPLATE, 'utf-8')
     const marker = src.indexOf(START_MARKER)

--- a/tests/agent-process-record.test.ts
+++ b/tests/agent-process-record.test.ts
@@ -1,0 +1,164 @@
+/**
+ * switchroom#4641 — the agent-process identity record start.sh publishes
+ * immediately before `exec claude`.
+ *
+ * The gateway's whole ability to tell "the agent restarted" from "only I
+ * restarted" rests on this record being (a) correct for the process that
+ * becomes claude and (b) written before the exec. Both are properties of
+ * SHELL, so this test EXECUTES the block extracted from the template rather
+ * than pattern-matching it, and then checks the emitted JSON against the real
+ * `/proc` entry of the shell that ran it.
+ *
+ * The load-bearing subtlety it guards: `exec` REPLACES the shell without
+ * forking, so the pid AND `/proc/<pid>/stat` field 22 (starttime, assigned at
+ * fork) survive into claude unchanged — which is why start.sh can record them
+ * before the exec at all. `comm` does NOT survive, which is why the record
+ * deliberately omits it. The final case proves both halves against a real
+ * `exec`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync, spawn } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const TEMPLATE = join(__dirname, '..', 'profiles', '_base', 'start.sh.hbs')
+const START_MARKER = '# --- Agent-process identity record (switchroom#4641) ---'
+
+/** The record block, with the one handlebars token resolved. */
+function extractBlock(agentDir: string): string {
+  const src = readFileSync(TEMPLATE, 'utf-8')
+  const start = src.indexOf(START_MARKER)
+  expect(start, 'agent-process record block not found in start.sh.hbs')
+    .toBeGreaterThanOrEqual(0)
+  const end = src.indexOf('{{#if useSwitchroomPlugin}}', start)
+  expect(end, 'exec block not found after the record block').toBeGreaterThan(start)
+  const block = src.slice(start, end)
+  // The only handlebars token in the block is the agent dir fallback.
+  expect(block.match(/\{\{[^}]+\}\}/g)).toEqual(['{{agentDir}}'])
+  return block.replaceAll('{{agentDir}}', agentDir)
+}
+
+let dir: string
+let block: string
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'agent-record-'))
+  block = extractBlock(dir)
+})
+
+function runBlock(script: string, env: NodeJS.ProcessEnv = {}): string {
+  const p = join(dir, 'run.sh')
+  writeFileSync(p, `#!/bin/bash\n${block}\n${script}\n`)
+  return execFileSync('bash', [p], {
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  })
+}
+
+function recordPath(stateDir: string): string {
+  return join(stateDir, 'agent-process.json')
+}
+
+describe('start.sh agent-process record (#4641)', () => {
+  it('records the running shell\'s real pid and /proc starttime', () => {
+    const stateDir = join(dir, 'telegram-a')
+    const out = runBlock('echo "$$ $(awk \'{print $22}\' /proc/$$/stat)"', {
+      TELEGRAM_STATE_DIR: stateDir,
+    })
+    const [pid, starttime] = out.trim().split(/\s+/)
+
+    const rec = JSON.parse(readFileSync(recordPath(stateDir), 'utf-8'))
+    expect(rec.pid).toBe(Number(pid))
+    // Independently derived (awk field 22) — not a re-read of what we wrote.
+    expect(rec.starttime).toBe(starttime)
+    expect(typeof rec.boot_at).toBe('number')
+    // comm is deliberately absent: it is "bash" here and becomes claude's
+    // after the exec, so recording it would guarantee a mismatch.
+    expect(rec).not.toHaveProperty('comm')
+  })
+
+  it('parses starttime correctly even when comm contains a space and a paren', () => {
+    // Rename the shell's own comm via /proc/self/comm-adjacent trick: run the
+    // block from a bash whose argv0 makes comm hostile. `exec -a` sets argv[0];
+    // the kernel derives comm from it for the exec'd binary.
+    const stateDir = join(dir, 'telegram-paren')
+    const p = join(dir, 'inner.sh')
+    writeFileSync(p, `#!/bin/bash\n${block}\necho "$(awk '{print $22}' /proc/$$/stat)"\n`)
+    const out = execFileSync(
+      'bash',
+      ['-c', `exec -a 'we ) ird' bash ${JSON.stringify(p)}`],
+      { encoding: 'utf-8', env: { ...process.env, TELEGRAM_STATE_DIR: stateDir } },
+    )
+    const rec = JSON.parse(readFileSync(recordPath(stateDir), 'utf-8'))
+    expect(rec.starttime).toBe(out.trim())
+  })
+
+  it('exports the pid/starttime into the environment claude inherits', () => {
+    const stateDir = join(dir, 'telegram-env')
+    const out = runBlock('echo "$SWITCHROOM_AGENT_PID/$SWITCHROOM_AGENT_STARTTIME"; echo "$$"', {
+      TELEGRAM_STATE_DIR: stateDir,
+    })
+    const [exported, pid] = out.trim().split('\n')
+    const rec = JSON.parse(readFileSync(recordPath(stateDir), 'utf-8'))
+    expect(exported).toBe(`${pid}/${rec.starttime}`)
+  })
+
+  it('falls back to {{agentDir}}/telegram when TELEGRAM_STATE_DIR is unset', () => {
+    const script = 'true'
+    const p = join(dir, 'run-nofallback.sh')
+    writeFileSync(p, `#!/bin/bash\n${block}\n${script}\n`)
+    const env = { ...process.env }
+    delete env.TELEGRAM_STATE_DIR
+    execFileSync('bash', [p], { encoding: 'utf-8', env })
+    expect(existsSync(recordPath(join(dir, 'telegram')))).toBe(true)
+  })
+
+  it('records identity that SURVIVES the exec into another program', () => {
+    // The property the whole fix depends on: the record is written pre-exec,
+    // and after `exec` the SAME pid carries the SAME starttime (only comm
+    // changes). Recorded by the shell, verified against the exec'd process.
+    const stateDir = join(dir, 'telegram-exec')
+    const p = join(dir, 'exec.sh')
+    writeFileSync(p, `#!/bin/bash\n${block}\nexec sleep 5\n`)
+    const child = spawn('bash', [p], {
+      stdio: 'ignore',
+      env: { ...process.env, TELEGRAM_STATE_DIR: stateDir },
+    })
+    try {
+      // Wait for the record, then read the post-exec /proc entry.
+      const deadline = Date.now() + 5000
+      while (!existsSync(recordPath(stateDir)) && Date.now() < deadline) {
+        execFileSync('sleep', ['0.05'])
+      }
+      const rec = JSON.parse(readFileSync(recordPath(stateDir), 'utf-8'))
+      // Give the exec a moment to land.
+      execFileSync('sleep', ['0.3'])
+      const stat = readFileSync(`/proc/${rec.pid}/stat`, 'utf-8')
+      const fields = stat.slice(stat.lastIndexOf(') ') + 2).trim().split(/\s+/)
+      expect(rec.pid).toBe(child.pid)
+      expect(fields[19]).toBe(rec.starttime) // starttime survived the exec
+      expect(stat).toContain('(sleep)') // …and comm did NOT
+    } finally {
+      child.kill('SIGKILL')
+    }
+  })
+
+  it('is written immediately before the exec, never after it', () => {
+    const src = readFileSync(TEMPLATE, 'utf-8')
+    const marker = src.indexOf(START_MARKER)
+    expect(marker).toBeGreaterThan(-1)
+    // The first EXECUTABLE `exec claude` (the earlier hits are prose in
+    // comments), and every executable one, must follow the record block.
+    const execLines = [...src.matchAll(/^[ \t]*exec claude /gm)].map((m) => m.index!)
+    expect(execLines.length).toBeGreaterThan(0)
+    for (const at of execLines) expect(at).toBeGreaterThan(marker)
+    // Nothing else may sneak an `exec` in between the record and the first one.
+    expect(src.slice(marker, execLines[0])).not.toMatch(/^[ \t]*exec\s/m)
+  })
+})
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -299,6 +299,9 @@ export default defineConfig({
       "**/telegram-plugin/tests/setup-state.test.ts",
       // registry-turns.test.ts uses bun:sqlite — excluded here, run via test:bun.
       "**/telegram-plugin/tests/registry-turns.test.ts",
+      // #4641 gateway-only-respawn OUTCOME suite drives a real turns registry
+      // (bun:sqlite openTurnsDb) — excluded here, run via bun (`tests/`).
+      "**/telegram-plugin/tests/boot-resume-gateway-only-respawn.test.ts",
       // subagents.test.ts uses bun:sqlite + bun:test — excluded here, run via test:bun.
       "**/telegram-plugin/registry/subagents.test.ts",
       // turns-writer.test.ts uses bun:sqlite — excluded here, run via test:bun.


### PR DESCRIPTION
Fixes #4641.

## The bug

The gateway and `claude` are **separate supervised processes**: `profiles/_base/start.sh.hbs` launches the gateway as a supervised sidecar, and the top-level shell then becomes the agent via `exec claude`. A gateway crash respawns *only* the gateway — the claude session, its context, its in-flight turn and its sub-agents all keep running.

The boot-resume block (`gateway.ts`) read gateway-local state only, so it read its own boot as an agent restart. On the three Bun 1.3.13 SIGBUS crashes on `overlord` (2026-08-12) it:

- stamped the **still-executing** turn `ended_via='restart'` (registry shows `resumed_at` 57 s after `started_at`, while the turn was live),
- queued a `resume_interrupted` synthetic — "You just restarted. Your previous turn was interrupted…" — into a session that had never stopped,
- listed 44 still-running sub-agent rows as "were killed by the restart and did NOT complete".

The agent then abandoned live work and re-ran finished work on the strength of that.

## The fix — a per-container-boot generation token

The boot-resume block is a **once-per-CONTAINER-boot** action. The fix makes that literal rather than inferring it from process timing.

1. **`start.sh.hbs`**, in the OUTER docker pass and **before it forks the gateway sidecar**, deletes `<stateDir>/.boot-resume-done`. That is the whole mechanism: it runs exactly once per container boot, somewhere the gateway supervisor can never re-run.
2. **`gateway.ts`** stamps the token the moment the boot resume becomes **durable** — immediately after `inboundSpool.put(bootResumeInbound…)`, *not* at the end of the `bootResumeInit` block, which only builds the inbound in memory. A gateway that dies anywhere before that leaves no token. (See "What changed after re-review" below; this is the placement fix.)
3. A gateway that boots and **finds** the token knows another gateway in this same container generation already did the work, and `break`s out of the whole block — no reaper stamp, no resume synthetic, no `.pending-turn.env`.

No clock comparison anywhere.

**The `/proc` record is a veto, not the decision.** `start.sh` still publishes `agent-process.json` (pid + `/proc` starttime, which survives `exec`) immediately before `exec claude`, and `agent-process-liveness.ts` still reads it — but only to *overrule* a suppression: token present, recorded agent provably dead or PID-recycled → run the boot resume anyway. It can only ever re-enable a resume, never suppress a legitimate one. Identity stays the **(pid, starttime) pair**, never pid alone; a zombie counts as dead.

Every uncertainty — no token, a token from a **different container boot**, dead/mismatched record, unreadable `/proc`, probe throws — **fails open** to the pre-#4641 behaviour, plus a `SWITCHROOM_GATEWAY_RESPAWN_GUARD=0` ops escape hatch.

## What changed after the THIRD review (commit `63a92337`, head)

**MAJOR — the block's own `catch` bypassed the placement fix.** `bootResumeInit` ends in `catch (err) { log; turnsDb = null }`: a **swallow**, not a death. Module init continues and reached the (then unconditional) stamp with `bootResumeInbound` still `null`. The reaper at the top of the block has already **durably** written `ended_via='restart'` by then, and ~156 lines of DB and fs I/O sit between it and the first `bootResumeInbound =` (`findLatestTurnIfInterrupted`, the clean-shutdown-marker read, `listNonTerminalSubagentsForTurn`, the synthetic builders). Any throw in there stamped the generation with nothing spooled anywhere; the next respawn saw a this-generation token and no `agent-process.json`, returned `gateway-only-respawn-no-record`, and the turn stayed `ended_via='restart'` / `resumed_at` NULL forever. The same silent work-loss mode as an early stamp, through a different door.

Fixed with a `bootResumeThrew` flag set in that `catch` and gating the stamp: a swallowed throw leaves **no** token, so the successor retries the boot resume. Honest narrowing: on `origin/main` a throw here also loses that boot's resume — what the gate preserves is the accidental recover-on-respawn that the token would otherwise remove.

**Harness fidelity (the reason the suite could not see it).** It modelled *every* in-block failure as a process death that skips the stamp. Production swallows and stamps anyway. It now distinguishes `BLOCK_THROW` (swallowed — stages 2 and 3 still run) from `BOOT_CRASH` (process dies), with `throwAt: 'after-reaper'` and a `gateStampOnBlockThrow` knob, carrying both the correct-outcome test and the ungated-stamp **defect reproduction**. `boot-resume-guard-wiring.test.ts` pins the gate in gateway.ts's source (one assignment site, inside the catch, before the stamp; the catch continues rather than exiting), since module-init code cannot be imported.

**LOW — tmp strays.** `markBootResumeComplete` now sweeps `<file>.tmp.<pid>` siblings after its own successful rename: the tmp name is pid-qualified, and `start.sh` removes only the two exact filenames with no glob, so a writer that died between `writeFileSync` and `renameSync` leaked one stray per generation, forever.

**Line ratchet — a correction to the review's instruction.** The review said to bump `scripts/gateway-line-ratchet.txt`. That would fail CI: rule 3 of `check-gateway-line-ratchet.mjs` is NEVER-RAISE (`ratchet > mainRatchet` ⇒ FAIL), so the ceiling can only be lowered. The fix is therefore **line-neutral** in `gateway.ts` (still exactly 24855): the flag is joined onto the `bridgeDeadPriorStreak` declaration and onto the catch's `turnsDb = null`.

**Not touched, by request:** `gateway.ts`'s STATIC-mode path, where the "durable" put is an in-memory `pendingInboundBuffer.push` while the stamp still runs. Pre-existing, and `markTurnResumed` two lines above has identical exposure.

**Mutation proof, both arms:**

| mutation | result |
|---|---|
| gate removed from gateway.ts (stamp unconditional, catch no longer sets the flag) | wiring **6 passed / 2 failed** — the stamp-line regex and `"exactly one assignment site"` |
| harness `gateStampOnBlockThrow` defaulted to `false` | outcome **16 passed / 1 failed** — `"a swallowed throw must not stamp the generation"` |

Clean after rebase onto `5e6dfdf9`: **17/17** outcome (bun), **8/8** wiring, **27/27** liveness, **44/44** bridge-dead-watchdog, **8/8** agent-process-record; `npm run lint` green, ratchet clean at 24855.

## What changed after re-review (commit `579ff1be`, head)

Two independent reviewers, neither seeing the other's report, reached the same blocker.

### MAJOR 1 (blocker) — the token was stamped ~8,200 lines before the resume became durable

`bootResumeInit` (`gateway.ts:1660`) only builds `bootResumeInbound` **in memory** (declared `:1648`, assigned at `:1857`/`:1877`/`:1890`/`:1936`). The inbound becomes crash-survivable much later, at `inboundSpool.put(bootResumeInbound.agent, bootResumeInbound.msg)`. Between the two sit `createInboundSpool`, `loadAccess()`, socket setup, a top-level `await maybeQueueBootBriefing({…})` — and `acquireStartupLock`'s `process.exit(1)` on a blocked lock, a **non-crash** exit inside the same window.

The regression the first revision shipped: on a genuine restart the reaper **durably** stamps the interrupted turn `ended_via='restart'`; the inbound is built in memory; the token is stamped durably. If the gateway then died before the put — the Bun 1.3.13 crash-at-boot pattern this PR exists for — the successor found the token, found **no** `agent-process.json` (start.sh has not reached `exec claude`; its inner pass waits on the LiteLLM probe first, up to 120 s), returned `gateway-only-respawn-no-record` (`agent-process-liveness.ts`) and broke out. The turn stayed `ended_via='restart'` with `resumed_at` NULL and was **never resumed**. Silent, permanent work loss — and a **new** failure mode, since pre-#4648 the successor simply re-ran the block and re-minted the resume.

The correct rule was already stated twice in the codebase, and the token now obeys it:

- `gateway.ts`, 12 lines below the durable put: *"Stamping AFTER the durable put (never before) means a crash in between leaves the turn un-stamped and the resume is retried, not silently dropped."*
- `registry/turns-schema.ts`, `markTurnResumed`'s docstring: *"the caller must stamp only AFTER the resume inbound is durably spooled … so a crash between 'decide to resume' and 'persist the resume' can never mark a turn resumed that was never actually spooled."*

**The fix:** `markBootResumeComplete(STATE_DIR)` moved out of the block to top level, directly after the `if (isGatewayMain && bootResumeInbound != null) { … }` block — i.e. after the durable put *and* after `markTurnResumed`, which obeys the identical rule — and made **unconditional** (gated only on `isGatewayMain`).

**Why moving it later is safe by construction.** It enlarges the fail-open window, but in that window `resumed_at` is still NULL so `findLatestTurnIfInterrupted` still returns the turn, and the spool dedups on `s:resume:<resume_turn_key>` (`inbound-spool.ts:94-97`, verified). A successor re-running the block therefore re-mints the **same** resume idempotently — a repeat, not a double-send. Lose the token, repeat the work; never lose the work.

**Why unconditional.** A boot that found nothing to resume still *completed* this generation's boot resume. Without a token, a later gateway-only respawn runs the reaper against a turn that started in the meantime — which is bug #4641 itself.

**Free side-benefit:** the `acquireStartupLock` → `process.exit(1)` path also sat between the block and the put. Under the old placement it stamped and exited, dropping the resume. Under the new placement the exit happens before the stamp, so the successor re-mints.

**Line ratchet.** `gateway.ts` = 24855, ratchet 24805 + slack 50 — zero headroom. Net zero achieved by moving the full argument into `agent-process-liveness.ts`'s docblock ("WHERE the token is stamped"), leaving a single line in `gateway.ts`, paid for by tightening the `writePendingTurnEnv` comment by one line. `npm run lint:gateway-line-ratchet` clean at exactly 24855.

### MAJOR 2 — two tests structurally could not see MAJOR 1, and one pinned the defect

- **`boot-resume-gateway-only-respawn.test.ts`** — its `runBootSequence` harness called `spool.put(...)` **inside** its model of the block, immediately before the stamp. Production does not. That collapsed the only window a crash can actually land in, so its `crashAt` enum could express only `'guard'` and `'stamp'`. The harness now runs three distinct stages in gateway.ts's real order — block (in-memory only) → durable `spool.put` + `markTurnResumed` → token — and `crashAt` is `'after-guard' | 'after-block-before-put' | 'after-put-before-stamp'`. A `stampAt: 'block-end'` knob reproduces the defective placement, so the suite now carries an explicit **defect reproduction** ("WOULD lose the turn forever if the token were stamped at the end of the block": turn durably `ended_via='restart'`, `resumed_at` NULL, zero spooled resumes, successor suppresses) sitting next to the correct-outcome assertion for the *same* crash point.
- **`boot-resume-guard-wiring.test.ts`** — asserted `'no statement may follow the generation-token stamp'` inside the block. The correct fix makes that red, so it was rewritten (not deleted) to pin the real invariant: exactly **one** stamp site; **outside** the `bootResumeInit` block; **after** the durable put and after `markTurnResumed`; **unconditional** (matched at zero indentation, so it cannot be nested inside the `bootResumeInbound != null` guard); plus a dedicated test forbidding re-joining it onto the `writePendingTurnEnv` line for ratchet reasons.

### LOW 1 — the only fail-CLOSED path in a fail-open module

`SWITCHROOM_BOOT_RESUME_DONE_FILE` / `SWITCHROOM_AGENT_PROCESS_FILE` were read from the live process env, while `start.sh.hbs` hard-codes `"$TELEGRAM_STATE_DIR/.boot-resume-done"`. Either var set in a container would have desynchronised writer from reader: start.sh clears one path, the gateway reads another, the token is never cleared, and **every** boot suppresses its resume forever — the one fail-closed direction the module can take, against a stated invariant of "fail-open is the invariant". A repo-wide grep found **no** producer or consumer of either var, so the overrides are now confined to `DetectOpts` (test injection only), documented as such.

### LOW 2 — `gateway-only-respawn-no-record` suppressed on the token alone: **taken, not declined**

It is the only branch returning `gatewayOnly: true` with zero corroboration, and `start.sh`'s `rm -f … 2>/dev/null || true` swallows a per-file unlink failure (EROFS, EACCES, an immutable attr) while the sibling `agent-process.json` unlink succeeds. Rare, but the consequence is the same severity class as MAJOR 1: permanent, silent suppression of every future resume.

The token now embeds the container-boot identity it was written under, and a mismatch is treated as stale (`reason: 'stale-boot-token'`).

**On the mechanism choice:** `/proc/sys/kernel/random/boot_id` — the reviewer's first suggestion — is **not usable here**. It identifies the *host kernel* boot, which containers share and which survives a container restart, so it would never differ between generations. The second suggestion, PID 1's `/proc` starttime, is correct: PID 1 is the container's entry process, it lives for exactly one container generation, and a restart replaces it.

**Deliberately one-directional:** only a positive *mismatch* is evidence. An identity-less token, an unparseable body, or an unreadable `/proc/1` all keep the pre-existing "present ⇒ suppress" behaviour, so the hardening can only ever add a fail-open path and can never itself re-open #4641.

### Docs corrected (no behaviour change)

- `agent-process-liveness.ts` now states out loud that start.sh's token clear is **docker-only** — it sits inside the `[ "$SWITCHROOM_RUNTIME" = "docker" ]` guard, so under the legacy systemd runtime nothing clears the token and fail-open rests entirely on the two vetoes. The fleet is all docker; this is written down so a systemd revival does not inherit it silently.
- `bridge-dead-watchdog.ts`'s *"the file is ALWAYS removed"* claim is now conditionally false, since the #4641 break can skip the consume. The behaviour change is an **improvement** to the race documented directly below it (the interim gateway no longer steals the marker), so the docstring says that rather than the behaviour changing.
- the `break bootResumeInit` comment now also names `bridgeDeadPriorStreak`, an output of the block that its "complete accounting" omitted.

### Not a finding

Reviewer 1 read `gateway.ts:1719-1721`'s *"consumed (always cleared) whether or not a turn was in flight"* as falsified by the wider skip. Reviewer 2 disagreed, and on reading it that comment's literal claim is still true **within the block**; the wider skip is already reconciled in `agent-process-liveness.ts`'s "What `break bootResumeInit` skips". Left as-is.

### Mutation proof (this round)

| mutation | result |
|---|---|
| stamp moved back inside the block (joined onto `writePendingTurnEnv`, exactly the shipped shape) | wiring suite **2 failed / 5 passed** — `"the durable spool put must precede the token stamp"` and `"must not be stamped alongside writePendingTurnEnv"` |
| harness `stampAt` defaulted to `'block-end'` | outcome suite **13 passed / 2 failed** — exactly the two new placement cases, and *only* those, which is MAJOR 2's point restated |
| env path overrides restored + boot identity dropped from the token | liveness suite **25 passed / 2 failed** |

Clean: **15/15** outcome (bun), **7/7** wiring, **27/27** liveness, **8/8** `agent-process-record`, **44/44** bridge-dead-watchdog; `npm run lint` green including the gateway line ratchet at exactly 24855.

## What changed in the previous round (folded into `f0a918f4` by the rebase onto `421ab2a8`)

The first revision decided suppression from `/proc` alone: *alive, matching, and started before me*. Review found two defects, both re-verified against the source and a live container.

**MAJOR 1 — the ordering arm's documented reason was false.** It claimed start.sh writes the record after forking the gateway, so the recorded process necessarily starts later. The recorded pid is `$$`, and the shell that forks the gateway (`start.sh.hbs`, outer pass) predates it. What actually held the ordering was the **docker tmux re-exec** (`exec tmux -L … bash -l "$0"`), which runs the inner pass in a fresh shell forked by the tmux server. Measured live on `switchroom-carrie`: gateway pid 32 starttime `209640551`, claude pid 83 starttime `209640552` — **one clock tick**. Correct, but for an undocumented, unpinned reason. (`>=` was correctly pinned and failed safe on a tie; the point is that nothing guaranteed the tie-break direction.) The token removes the dependency entirely.

**MAJOR 2 — a gateway that crashed during its own boot lost the resume permanently.** Container restarts with a genuinely interrupted turn. start.sh forks gateway #1, publishes the record, execs claude. Gateway #1 dies before reaching the boot block — exactly the Bun crash-at-boot pattern this PR cites as motivation. Gateway #2 sees a live claude that predates it, concludes `gatewayOnly`, and the turn is never reaped or resumed. The pre-#4641 gateway handled this correctly. With the token, gateway #1 never stamped it, so gateway #2 does the full boot resume.

**MEDIUM — `break bootResumeInit` skips more than the resume path.** It also skips `consumeBridgeDeadEscalationMarker` (whose own comment states the marker is "consumed (always cleared) whether or not a turn was in flight" — silently false under the first revision, stranding the marker and resetting the #3038 cross-boot damper), the bridge-dead idle notice, and the `pendingRedelivery` capture. The break now carries a comment naming all of them, and the module docstring says why each is safe: the token means one gateway already did each of them this generation. If the gateway that would have consumed the marker died first, there is no token and we never take the skip path.

**LOW 1 — stale `agent-process.json`** is now removed alongside the token in the same outer-pass line (a container restart resets the pid namespace, so an old record's pair could collide with an unrelated live process).

**LOW 3 — record `comm` and require the live process to look claude-ish: declined.** It was a cheap way to close the fresh-boot race; the token closes that race outright, so the extra guard would only add a failure mode. The optional `comm` field and its fail-open mismatch check are kept for a future writer.

**LOW 2 (previous round) — deferred and filed: #4655.** `gateway.ts` is at `24855` lines against ratchet `24805` + slack `50` — **zero headroom**, and the ratchet may only be lowered. This PR therefore leaves the file at exactly 24855 (net zero), which is why the stamp is a single line carrying its rationale by reference. (The previous round joined it onto the `writePendingTurnEnv(...)` line; see MAJOR 1 above for why that was wrong, and note that #4655's "Constraints" section has been amended accordingly.) Extracting the ~290-line boot block is out of scope here and tracked in #4655, which also unlocks driving the real function from the outcome test instead of re-implementing its ordering.

## Tests — outcomes, over real collaborators

Real bun:sqlite registry, real boot reaper, real interrupted-turn finder, real bridge-dead marker consumer, real inbound builders, real durable spool; "alive" is a process the test spawned, "dead" one it killed. The generation token is never hand-placed for a suppression case without a boot that legitimately stamped it (or an explicitly-stated stale-token scenario).

- gateway respawn while the agent lives → **zero `resume_interrupted` spool entries**, turn row left OPEN (no `ended_via` lie), no `.pending-turn.env`
- **the same fixture with the guard bypassed → the false resume DOES fire** — the bug reproduced, so the suite cannot pass vacuously
- **gateway crash before the boot block → the successor reaps, resumes, and consumes the bridge-dead marker** (MAJOR 2)
- **crash after the block but before the durable put → the successor re-mints the resume** (the one reachable window; new)
- **the same crash with the token stamped at the end of the block → the resume is DROPPED forever** (defect reproduction; new)
- crash after the durable put but before the stamp → the successor does not suppress, and exactly one resume reaches the spool across both boots
- **suppressed respawn → the bridge-dead marker is NOT re-consumed and survives on disk** (MEDIUM)
- fresh container boot with a LIVE agent record and no token → the resume still fires
- genuine restart (recorded process really killed), recycled PID, first boot (no record), watchdog timeout, alive-plus-stale-marker → unchanged
- the `start.sh` clear is pinned to the outer pass, before the gateway fork, exactly once — and **executed**, proving it deletes both files and is a safe no-op when they are absent
- the record block is still **executed** and its JSON checked against real `/proc`, including across a real `exec`
- source pins so a refactor cannot move the guard below the reaper, drop the break comment, or move the stamp off the block's tail

Mutation-checked: stripping the token from the decision — leaving exactly the `/proc` liveness rule the first revision shipped — fails **5 of the 13** outcome cases, including all three crash-during-boot cases and the bridge-dead one. The re-review round's own mutation table is above.

## Not attempted (issue item 3)

`sessionId` on the `register` IPC message, dropping a queued resume whose turn shares the reconnecting bridge's session id. `sendRegister()` runs at connect time with only `agentName`/`topicId` in scope, and the session id is learned later by the session tailer in a different process — real cross-process plumbing. Worse, `--continue` can carry a session id across a *genuine* restart, in which case that rule would suppress a legitimate resume: a regression traded for belt-and-braces on a case item 2 already closes.

## Note on the diagnosis

One item in the issue's proposed fix was moot: the `.wake-audit-pending` sentinel is dropped by `start.sh` once per **container** boot, and `start.sh` does not re-run on a gateway respawn — so there was nothing to skip there. Documented in the module rather than coded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


