### PR TITLE
fix(hindsight): resume the cooccurrence sweep instead of restarting it (#4635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,27 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **hindsight: the cooccurrence sweep now RESUMES instead of restarting when the
+  outer retry re-enters.** `_run_cooccurrence_prune` (Pass 3 of
+  `graph_maintenance`, patched in via `docker/Dockerfile.hindsight`) kept its
+  paging cursor, page size, deleted count and rotating slice index in its own
+  frame, while `retry_with_backoff(..., max_retries=8, retry_timeouts=False)`
+  wraps the whole call. A retryable NON-timeout error (connection reset,
+  deadlock, transient pool failure) that outlives the per-page budget therefore
+  restarted the entire slice from cursor `None` — up to 9 full re-sweeps of
+  pages already committed, on a slice that runs 3–6 s on the largest banks. The
+  state is now hoisted into the enclosing scope and reached through `nonlocal`,
+  so a re-entry picks up at the last committed cursor. Two bugs fell out of the
+  same placement: `stale_cooccurrences_pruned` under-reported (the deleted
+  counter reset on every re-entry, so the job reported only the final attempt's
+  deletions), and the slice index was re-derived from the wall clock on
+  re-entry, so a retry that crossed a 120 s window boundary silently swept a
+  DIFFERENT slice and left the original one unfinished until its next rotation.
+  Sizing the bank (`count_bank_cooccurrences`) now also happens exactly once per
+  job rather than once per attempt. No change to `retry_with_backoff` itself —
+  Passes 1 and 2 are byte-for-byte unaffected, and timeouts still take the inner
+  halve-the-page path from #4604.
+
 - **CI: the `docker-e2e` manual recovery lever now actually runs the pg probe.**
   `hindsight-watch-pg-probe`'s `if:` gate carried `push` and `merge_group` but
   not `workflow_dispatch`, unlike its siblings `e2e-shard` and

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -6423,7 +6423,8 @@ PYEOF
 #     upstream wrote it. The fix is not a cleverer predicate; it is evaluating
 #     the same predicate over a bounded number of rows at a time.
 #
-# THE FIX — two independent mechanisms, each with one job.
+# THE FIX — independent mechanisms, each with one job. B1-B3 shipped in #4624;
+# B4 is the #4635 follow-up that block filed against itself.
 #
 #   B1 BOUNDED PAGES bound the STATEMENT. `prune_stale_cooccurrences` now
 #      sweeps ONE keyset-paginated page of at most `batch_size` cooccurrence
@@ -6546,6 +6547,43 @@ PYEOF
 #      command_timeout. 1,000 is the point that keeps ~135x headroom on the
 #      worst measured page while keeping a slice down to ~25 statements.
 #
+#   B4 THE OUTER RETRY RESUMES INSTEAD OF RESTARTING (#4635). Shipped as a
+#      follow-up to the block above, which documented this as known and
+#      accepted.
+#
+#      There are THREE nested budgets around Pass 3, not two: the slice-level
+#      `retry_with_backoff(_run_cooccurrence_prune, max_retries=8)` below, the
+#      PER-PAGE `retry_with_backoff(lambda: _run_page(...), max_retries=8)`
+#      inside the loop, and the timeout-only shrink ladder (<=4 halvings). A
+#      retryable NON-timeout error — connection reset, deadlock, transient pool
+#      failure — is retried nine times by the per-page budget first; only if all
+#      nine fail does it reach the slice-level one, which used to re-enter
+#      `_run_cooccurrence_prune` with its cursor freshly `None` and re-sweep
+#      every page already committed. Idempotent (delete-if-stale), but up to 9x
+#      a slice, and a slice is 3-6 s on the largest banks.
+#
+#      THE FIX IS A SCOPE, NOT A CONTRACT. The eight progress variables move
+#      from the helper's frame to the enclosing one and the helper declares them
+#      `nonlocal`. `retry_with_backoff` is not touched — Passes 1 and 2 call the
+#      same wrapper with the same semantics, byte for byte — which is what makes
+#      this a narrow change rather than the shared-wrapper refactor #4624
+#      deferred. The slice-level budget is KEPT: its remaining honest job is the
+#      one call it covers that the per-page budget does not, `count_bank_
+#      cooccurrences`, and a failure there is the one place restarting IS free
+#      because no page has been swept yet.
+#
+#      Pinning `slice_count` / `slice_index` on first entry is a CORRECTNESS
+#      requirement, not just an optimisation: `slice_index` is derived from
+#      `time.time()`, so a retry seconds later can compute a different slice,
+#      and carrying the old slice's cursor into it would silently skip every row
+#      below that cursor. `slice_count is None` is the resumption sentinel.
+#
+#      Behavioural proof: the R_ checks in
+#      tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts inject a
+#      non-timeout retryable error mid-slice, exhaust the per-page budget, and
+#      assert the retry's first page carries the LAST COMMITTED cursor (not
+#      None) and that no page is swept twice.
+#
 # PER-BATCH TRANSACTIONS ARE LOAD-BEARING, not incidental. Each page runs in
 # its own transaction, so (a) a page that times out cannot roll back the pages
 # that already succeeded, (b) row locks taken by the `FOR UPDATE OF c` ordered
@@ -6570,14 +6608,6 @@ PYEOF
 #   * The Oracle path. It returns `scanned=0`, which terminates the caller's
 #     loop after one call — i.e. exactly upstream's single-statement behaviour.
 #     Deliberate dialect asymmetry, like the #2529 note already in that file.
-#
-# KNOWN, ACCEPTED, NOT FIXED HERE. The outer `retry_with_backoff(...,
-# max_retries=8)` that wraps `_run_cooccurrence_prune` is upstream's and is
-# untouched, so a retryable NON-timeout error escaping the inner per-page loop
-# restarts the whole slice from cursor `None`. Idempotent (the sweep is a
-# delete-if-stale), but up to 9x wasted work on a slice. Collapsing the two
-# budgets means changing a retry wrapper shared with Passes 1 and 2 — a
-# separate concern with its own blast radius, tracked rather than smuggled in.
 #
 # NO NEW ENV KNOBS. `batch_size` / slice sizing / slice period are module
 # constants rather than `HINDSIGHT_API_*` settings: a knob would have to be
@@ -7288,6 +7318,38 @@ apply("engine/graph_maintenance.py", (
     "            async with conn.transaction():\n"
     "                return await store.prune_stale_cooccurrences(conn=conn, fq_table=fq_table, bank_id=bank_id)\n"
 ), (
+    "    # switchroom (#4635): the sweep's PROGRESS lives in this enclosing scope, not\n"
+    "    # in _run_cooccurrence_prune's own frame, and that placement IS the fix.\n"
+    "    #\n"
+    "    # The helper is wrapped by retry_with_backoff(max_retries=_SWEEP_MAX_RETRIES),\n"
+    "    # so a retryable error that escapes the per-page budget below RE-ENTERS it.\n"
+    "    # With the cursor local to the helper, that re-entry restarted the slice from\n"
+    "    # cursor None and re-swept every page already committed — correct (the sweep\n"
+    "    # is delete-if-stale, so a re-run page deletes nothing the second time) but up\n"
+    "    # to 9x the work of a slice, which is 3-6 s on the largest banks. Hoisting the\n"
+    "    # state ONE scope out turns that restart into a RESUME.\n"
+    "    #\n"
+    "    # NOTHING SHARED CHANGES. retry_with_backoff is untouched — the same wrapper\n"
+    "    # Passes 1 and 2 use, with the same contract for them. The only thing that\n"
+    "    # moved is which frame owns eight local variables.\n"
+    "    #\n"
+    "    # slice_count doubles as the RESUMPTION SENTINEL: None means 'this run has not\n"
+    "    # sized the bank yet'. Re-deriving the slice on a retry would be a CORRECTNESS\n"
+    "    # bug, not merely waste — slice_index is a function of time.time(), so a retry\n"
+    "    # seconds later can land on a DIFFERENT slice, and carrying an old slice's\n"
+    "    # cursor into a new one skips every row below it. Pinning both on first entry\n"
+    "    # makes that impossible, and stops the bank being re-counted per attempt. A\n"
+    "    # failure BEFORE the count still recounts, which is the one place restarting\n"
+    "    # is genuinely free: no page has been swept yet.\n"
+    "    total_rows = 0\n"
+    "    slice_count: int | None = None\n"
+    "    slice_index = 0\n"
+    "    batch_size = _SWEEP_BATCH_SIZE\n"
+    "    after_1: str | None = None\n"
+    "    after_2: str | None = None\n"
+    "    deleted = 0\n"
+    "    pages = 0\n"
+    "\n"
     "    async def _run_cooccurrence_prune() -> int:\n"
     "        # The orphan prune above cascades cooccurrences via FK. This explicit\n"
     "        # pass catches the *stale-count* case: both entities still exist but no\n"
@@ -7332,17 +7394,31 @@ apply("engine/graph_maintenance.py", (
     "        # recently-touched entities: nothing durable records the entities of a\n"
     "        # deleted unit, so a watermark would silently miss every staleness\n"
     "        # source that failed to enqueue, for ever.\n"
-    "        async with acquire_with_retry(backend) as conn:\n"
-    "            total_rows = await store.count_bank_cooccurrences(\n"
-    "                conn=conn, fq_table=fq_table, bank_id=bank_id\n"
+    "        #\n"
+    "        # switchroom (#4635): every one of these is the ENCLOSING scope's, so an\n"
+    "        # outer retry of this helper resumes the slice instead of restarting it.\n"
+    "        # See the block comment above the initialisers for why.\n"
+    "        nonlocal total_rows, slice_count, slice_index, batch_size\n"
+    "        nonlocal after_1, after_2, deleted, pages\n"
+    "\n"
+    "        if slice_count is None:\n"
+    "            async with acquire_with_retry(backend) as conn:\n"
+    "                total_rows = await store.count_bank_cooccurrences(\n"
+    "                    conn=conn, fq_table=fq_table, bank_id=bank_id\n"
+    "                )\n"
+    "            slice_count = _sweep_slice_count(total_rows)\n"
+    "            slice_index = _sweep_slice_index(time.time(), slice_count)\n"
+    "        elif after_1 is not None or pages:\n"
+    "            # Only reachable via the outer retry_with_backoff. Logged at WARNING\n"
+    "            # because reaching it at all means a page exhausted its own 9-attempt\n"
+    "            # budget — rare, and worth seeing — while the RESUME itself is the\n"
+    "            # cheap outcome, not the alarming one.\n"
+    "            logger.warning(\n"
+    "                f\"[GRAPH_MAINT] bank={bank_id} cooccurrence sweep RESUMING slice \"\n"
+    "                f\"{slice_index}/{slice_count} at cursor ({after_1}, {after_2}) after \"\n"
+    "                f\"{pages} page(s) and {deleted} row(s) already committed; batch_size \"\n"
+    "                f\"{batch_size}, operation_id={operation_id}\"\n"
     "            )\n"
-    "        slice_count = _sweep_slice_count(total_rows)\n"
-    "        slice_index = _sweep_slice_index(time.time(), slice_count)\n"
-    "        batch_size = _SWEEP_BATCH_SIZE\n"
-    "        after_1: str | None = None\n"
-    "        after_2: str | None = None\n"
-    "        deleted = 0\n"
-    "        pages = 0\n"
     "\n"
     "        async def _run_page(size: int):\n"
     "            # Each page is its OWN transaction. Load-bearing three times over: a\n"
@@ -7584,6 +7660,70 @@ assert prune.index("continue") < prune.index("after_1 = page.last_entity_id_1"),
     f"{TAG}: shrink-and-retry must re-run the SAME cursor, not advance past the page it failed on"
 )
 
+# ── #4635: the outer retry must RESUME the slice, not restart it ─────────────
+# The helper is wrapped by retry_with_backoff(max_retries=_SWEEP_MAX_RETRIES),
+# so a retryable error that escapes the per-page budget RE-ENTERS it. Whether
+# that re-entry resumes or restarts is decided by ONE thing: which frame owns
+# the cursor. Pin that frame.
+state_head, _, state_tail = gm.partition("    async def _run_cooccurrence_prune")
+assert (
+    "\n    total_rows = 0\n"
+    "    slice_count: int | None = None\n"
+    "    slice_index = 0\n"
+    "    batch_size = _SWEEP_BATCH_SIZE\n"
+    "    after_1: str | None = None\n"
+    "    after_2: str | None = None\n"
+    "    deleted = 0\n"
+    "    pages = 0\n"
+) in state_head, (
+    f"{TAG}: the sweep's progress is not initialised in the scope ENCLOSING "
+    "_run_cooccurrence_prune. Owned by the helper's own frame, every outer retry "
+    "restarts the slice from cursor None and re-sweeps every page already committed "
+    "— up to 9x a slice (#4635)"
+)
+assert (
+    "        nonlocal total_rows, slice_count, slice_index, batch_size\n"
+    "        nonlocal after_1, after_2, deleted, pages\n"
+) in prune, (
+    f"{TAG}: _run_cooccurrence_prune no longer declares the sweep state nonlocal. "
+    "Without it every assignment in the loop rebinds a fresh LOCAL and the enclosing "
+    "cursor never moves — the outer retry would resume from None, i.e. restart (#4635)"
+)
+# The defeat this guards is a one-line re-add: any `after_1 = None` (or a
+# `pages = 0` / `deleted = 0`) back inside the helper silently restores
+# restart-from-the-top while every other assert here stays green.
+_RESET_LITERALS = ("None", "0", "_SWEEP_BATCH_SIZE")
+for _line in prune.split("\n"):
+    # Exactly 8 spaces = _run_cooccurrence_prune's own body. Deeper indents are
+    # inside the `if slice_count is None:` guard or the loop, where assignment
+    # is the point; shallower is a different function.
+    if not (_line.startswith("        ") and _line[8:9] not in (" ", "")):
+        continue
+    _name = _line.strip().split(":")[0].split("=")[0].strip()
+    if _name not in ("after_1", "after_2", "deleted", "pages", "batch_size", "slice_count"):
+        continue
+    assert not _line.rstrip().endswith(_RESET_LITERALS), (
+        f"{TAG}: _run_cooccurrence_prune re-initialises the sweep state at its own "
+        f"body level ({_line.strip()!r}). That resets the cursor on every outer "
+        "retry, which is exactly the restart-from-cursor-None waste #4635 removed"
+    )
+# The slice must be pinned on FIRST entry only. slice_index is a function of
+# time.time(), so re-deriving it on a retry can land on a DIFFERENT slice while
+# the cursor still refers to the old one — every row below that cursor in the
+# new slice would be skipped. That is a correctness bug, not waste.
+assert "        if slice_count is None:\n" in prune, (
+    f"{TAG}: the bank sizing / slice derivation is not guarded by the resumption "
+    "sentinel, so a retry re-derives slice_index from a LATER clock and can carry the "
+    "previous slice's cursor into a different slice (#4635)"
+)
+assert prune.index("if slice_count is None:") < prune.index("slice_count = _sweep_slice_count(total_rows)"), (
+    f"{TAG}: the slice is derived outside the first-entry guard"
+)
+assert "cooccurrence sweep RESUMING slice" in prune, (
+    f"{TAG}: a resumed sweep is silent. Reaching the resume path means a page "
+    "exhausted its own 9-attempt budget; that must be visible in the log"
+)
+
 ops = (BASE / "engine/db/ops.py").read_text()
 assert "class CooccurrenceSweepBatch" in ops, f"{TAG}: the page result type is missing"
 for rel in ("engine/db/ops_postgresql.py", "engine/db/ops_oracle.py", "engine/memories/pg/graph.py", "engine/memories/base.py"):
@@ -7612,7 +7752,8 @@ print(
     f"{TAG}: Pass 3 now sweeps bounded keyset pages (LIMIT-capped, cursor-advancing, "
     "one transaction each) over a hash slice whose COUNT is derived from the size of "
     "the bank (1 slice below _SWEEP_SLICE_TARGET_ROWS, so a bank that sweeps whole is "
-    "never rotated), halving the page on a timeout; the #2473 predicate and the #2529 "
+    "never rotated), halving the page on a timeout and RESUMING from the last committed "
+    "cursor when the outer retry re-enters (#4635); the #2473 predicate and the #2529 "
     "ordered lock are unchanged"
 )
 PYEOF

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -2082,7 +2082,13 @@ describe("Dockerfile.hindsight shape", () => {
       "int(now) // _SWEEP_SLICE_SECONDS % slice_count",
     );
     expect(dockerfile).toContain('"    if total_rows <= _SWEEP_SLICE_TARGET_ROWS:\\n"');
-    expect(dockerfile).toContain('"        slice_count = _sweep_slice_count(total_rows)\\n"');
+    // 12-space indent: since #4635 the derivation sits INSIDE the
+    // `if slice_count is None:` first-entry guard, not at the helper's body
+    // level. Pinning the indent is what stops it drifting back out of the guard
+    // (where a retry would re-derive slice_index from a later clock).
+    expect(dockerfile).toContain(
+      '"            slice_count = _sweep_slice_count(total_rows)\\n"',
+    );
     // …and a fixed count must not come back.
     expect(dockerfile).not.toContain("_SWEEP_SLICE_COUNT = ");
     expect(dockerfile).toMatch(/the paging loop no longer terminates on a short page/);
@@ -2116,6 +2122,48 @@ describe("Dockerfile.hindsight shape", () => {
     // The image build re-checks it as a post-condition on the patched file, so
     // this cannot be satisfied by a comment that says the right thing.
     expect(dockerfile).toMatch(/each page must be its OWN transaction/);
+
+    // ---- B4 (#4635): the slice-level retry must RESUME, not restart. The
+    // helper is wrapped by retry_with_backoff(max_retries=_SWEEP_MAX_RETRIES),
+    // so a retryable NON-timeout error that outlives the per-page budget
+    // RE-ENTERS it. Whether that re-entry resumes or re-sweeps every committed
+    // page comes down to ONE thing a grep can see: which frame owns the cursor.
+    // The initialisers must be at 4-space (enclosing-function) indent…
+    expect(dockerfile).toContain(
+      '"    after_1: str | None = None\\n"\n' +
+        '    "    after_2: str | None = None\\n"',
+    );
+    // …and the helper must declare them nonlocal, or every assignment in the
+    // loop rebinds a fresh local and the enclosing cursor never moves.
+    expect(dockerfile).toContain(
+      '"        nonlocal total_rows, slice_count, slice_index, batch_size\\n"\n' +
+        '    "        nonlocal after_1, after_2, deleted, pages\\n"',
+    );
+    // slice_count doubles as the resumption sentinel: re-deriving the slice on a
+    // retry can land on a DIFFERENT slice (slice_index is a function of
+    // time.time()) while the cursor still refers to the old one — a correctness
+    // bug, not just waste.
+    expect(dockerfile).toContain('"        if slice_count is None:\\n"');
+    // The image build re-checks all of it as a post-condition on the patched
+    // file, including the one-line defeat (re-adding `after_1 = None` inside the
+    // helper), so none of this can be satisfied by a comment.
+    expect(dockerfile).toMatch(
+      /the sweep's progress is not initialised in the scope ENCLOSING/,
+    );
+    expect(dockerfile).toMatch(
+      /no longer declares the sweep state nonlocal/,
+    );
+    expect(dockerfile).toMatch(
+      /re-initialises the sweep state at its own /,
+    );
+    expect(dockerfile).toMatch(
+      /is not guarded by the resumption /,
+    );
+    // The banner must no longer claim this is unfixed.
+    expect(dockerfile).not.toContain("KNOWN, ACCEPTED, NOT FIXED HERE");
+    expect(dockerfile).toContain(
+      "B4 THE OUTER RETRY RESUMES INSTEAD OF RESTARTING (#4635)",
+    );
 
     // Every backend implements the new return shape, including the ones that
     // opt out of paging by reporting scanned=0.

--- a/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
+++ b/tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts
@@ -536,6 +536,130 @@ check("B4_tripwire_returns_not_raises", res.get("stale_cooccurrences_pruned") ==
       f"got {res.get('stale_cooccurrences_pruned')}; the tripwire must return the rows it "
       "did prune, not discard them")
 
+# --- R (#4635): the SLICE-LEVEL retry must RESUME, not restart from the top.
+#
+# There are THREE budgets around Pass 3: the shrink ladder (timeouts only), the
+# PER-PAGE retry_with_backoff(max_retries=8), and the slice-level
+# retry_with_backoff(_run_cooccurrence_prune, max_retries=8). A retryable
+# NON-timeout error is retried nine times by the per-page budget; only when all
+# nine fail does it reach the slice-level one, which RE-ENTERS the helper. If the
+# cursor lives in the helper's own frame, that re-entry restarts the slice from
+# None and re-sweeps every page already committed — up to 9x a slice — and
+# the deleted counter restarts at 0, so the run also UNDER-REPORTS its prune.
+#
+# ConnectionResetError is an OSError, so db_utils._is_retryable accepts it and
+# #4604's retry_timeouts=False does NOT exclude it: exactly the class this check
+# exists for. The backoff DELAY is neutralised (nine real jittered sleeps capped
+# at DEFAULT_MAX_DELAY = 5.0 would add ~20 s to the probe for no signal); the
+# retry COUNTING is untouched, which is the part under test.
+from hindsight_api.engine import db_utils as _db_utils
+
+_real_backoff = getattr(_db_utils, "_backoff_delay", None)
+if _real_backoff is not None:
+    _db_utils._backoff_delay = lambda *a, **k: 0.0
+
+
+class FlakyStore(FakeStore):
+    """Serves pages, then raises a retryable non-timeout error fail_times times.
+
+    10 > the 9 attempts the per-page budget allows, so the 10th failure is served
+    to the re-entry the slice-level budget performs — and that call is the only
+    observation that can distinguish a resume from a restart.
+    """
+
+    def __init__(self, pages, fail_after_pages, fail_times):
+        super().__init__(pages)
+        self.fail_after_pages = fail_after_pages
+        self.fail_times = fail_times
+        self.failed = 0
+        self.served = 0
+
+    async def prune_stale_cooccurrences(self, **kw):
+        self.calls.append(kw)
+        if self.served >= self.fail_after_pages and self.failed < self.fail_times:
+            self.failed += 1
+            raise ConnectionResetError("transient connection reset")
+        idx = self.served
+        self.served += 1
+        if idx >= len(self.pages):
+            return CooccurrenceSweepBatch(0, 0, None, None)
+        return self.pages[idx]
+
+
+# The clock ADVANCES a full _SWEEP_SLICE_SECONDS window on every read. Without
+# that, R_slice_is_pinned_across_re_entry passes vacuously — a re-entry that
+# genuinely re-derives slice_index from a real-but-unmoved clock lands on the
+# same slice, and the check cannot see the bug it exists to guard. A ticking
+# clock makes "derived once" and "derived twice" observably different.
+_r_clock = {"n": 0}
+
+
+def _ticking_clock():
+    _r_clock["n"] += 1
+    return float(_r_clock["n"] * 120)
+
+
+_r_real_time = gm.time
+gm.time = types.SimpleNamespace(time=_ticking_clock)
+
+try:
+    flaky = FlakyStore(
+        [page(2, 1000, "k1a", "k1b"), page(3, 1000, "k2a", "k2b"), page(1, 400, "k3a", "k3b")],
+        fail_after_pages=2,
+        fail_times=10,
+    )
+    res = guard("R_job_runs", lambda: run_job(flaky)) or {}
+    cursors = [(c.get("after_entity_id_1"), c.get("after_entity_id_2")) for c in flaky.calls]
+
+    # Precondition: the error really did exhaust the per-page budget and reach
+    # the slice-level one. Without it the resume check below could pass
+    # vacuously on a run where the outer retry never fired at all.
+    check("R_error_escaped_the_page_budget", flaky.failed == 10,
+          f"the store raised {flaky.failed} time(s), expected 10 — nine to exhaust the "
+          "per-page retry_with_backoff and a tenth served to the slice-level re-entry")
+    check("R_outer_retry_re_entered", len(flaky.calls) == 13,
+          f"made {len(flaky.calls)} Pass 3 call(s), expected 13: 2 pages + 9 failed "
+          f"per-page attempts + 1 failed attempt after re-entry + 1 final page; "
+          f"cursors {cursors}")
+
+    # THE check. Exactly ONE call in the whole run may carry a null cursor: the
+    # very first page. A second one is the slice restarting from the top.
+    check("R_resumes_instead_of_restarting", cursors.count((None, None)) == 1,
+          f"{cursors.count((None, None))} Pass 3 call(s) ran with a null cursor; only "
+          "the first page may. A second means the slice-level retry restarted from the "
+          f"top and re-swept every committed page (#4635). Cursors: {cursors}")
+    if len(cursors) == 13:
+        # Against the LITERAL cursor the last committed page returned, not
+        # against another observation: two None cursors compared to each other
+        # are "equal" and would pass vacuously on the broken shape.
+        check("R_re_entry_uses_the_last_committed_cursor", cursors[11] == ("k2a", "k2b"),
+              f"the first call after the slice-level re-entry ran at {cursors[11]}; it "
+              "must be the literal ('k2a', 'k2b') the last committed page returned")
+    # The count survives the re-entry too: pages 1 and 2 COMMITTED their deletes
+    # before the failure, so a deleted counter that restarts at 0 under-reports
+    # rows that really were pruned.
+    check("R_deleted_count_survives_re_entry", res.get("stale_cooccurrences_pruned") == 6,
+          f"got {res.get('stale_cooccurrences_pruned')}, expected 2+3+1=6 — a reset "
+          "counter drops the rows the committed pages already deleted")
+    # The slice must be PINNED across the re-entry. slice_index is derived from
+    # time.time(), so re-deriving it can select a different slice while the cursor
+    # still refers to the old one, skipping every row below that cursor in the new
+    # slice. Correctness, not efficiency. The clock above ticks a full window per
+    # read, so a second derivation lands on a DIFFERENT index and this check sees
+    # it — with a still clock it would pass on the broken shape too.
+    check("R_slice_is_pinned_across_re_entry",
+          len({c.get("slice_index") for c in flaky.calls}) == 1
+          and len({c.get("slice_count") for c in flaky.calls}) == 1,
+          f"slice_indexes {sorted({c.get('slice_index') for c in flaky.calls}, key=str)}, "
+          f"slice_counts {sorted({c.get('slice_count') for c in flaky.calls}, key=str)}")
+    check("R_bank_sized_once_across_re_entry", flaky.size_calls == 1,
+          f"the bank was sized {flaky.size_calls} time(s); the re-entry must not re-count "
+          "it, because a different count is a different slice_count")
+finally:
+    gm.time = _r_real_time
+    if _real_backoff is not None:
+        _db_utils._backoff_delay = _real_backoff
+
 print("PROBE_EXECUTED")
 for f in failures:
     print("FAILURE:", f)
@@ -1179,6 +1303,11 @@ describe.skipIf(!dockerOk || !imageOk)(
       // A timeout is fatal to the pass — there is no page to shrink.
       expect(stdout).toContain("B3_retried_after_timeout=FAIL");
       expect(stdout).toContain("B3_halving_sequence=FAIL");
+
+      // #4635 — there is no per-page budget to exhaust and no cursor to resume
+      // from, because there is no paging loop at all.
+      expect(stdout).toContain("R_error_escaped_the_page_budget=FAIL");
+      expect(stdout).toContain("R_outer_retry_re_entered=FAIL");
     }, 240_000);
 
     it("patched is GREEN — bounded pages, an advancing cursor, a rotating slice, a shrinking retry", async () => {
@@ -1250,6 +1379,22 @@ describe.skipIf(!dockerOk || !imageOk)(
       // out of pages, and returns rather than raising.
       expect(stdout).toContain("B4_tripwire_stops_the_loop=OK");
       expect(stdout).toContain("B4_tripwire_returns_not_raises=OK");
+
+      // R (#4635) — a retryable NON-timeout error that exhausts the per-page
+      // budget reaches the slice-level retry, which RE-ENTERS the helper. That
+      // re-entry must RESUME from the last committed cursor. Before the fix it
+      // restarted from None: the two committed pages were swept again (up to 9x
+      // a slice) and `deleted` restarted at 0, under-reporting the prune.
+      expect(stdout).toContain("R_error_escaped_the_page_budget=OK");
+      expect(stdout).toContain("R_outer_retry_re_entered=OK");
+      expect(stdout).toContain("R_resumes_instead_of_restarting=OK");
+      expect(stdout).toContain("R_re_entry_uses_the_last_committed_cursor=OK");
+      expect(stdout).toContain("R_deleted_count_survives_re_entry=OK");
+      // slice_index is a function of time.time(): re-deriving it on the re-entry
+      // could carry the old slice's cursor into a DIFFERENT slice and skip every
+      // row below it. Pinned, not recomputed.
+      expect(stdout).toContain("R_slice_is_pinned_across_re_entry=OK");
+      expect(stdout).toContain("R_bank_sized_once_across_re_entry=OK");
 
       // The constants are what this file's hard-coded expectations assume.
       expect(stdout).toContain("C_batch_size=OK");


### PR DESCRIPTION
Closes #4635.

## What the issue got right, and what it got wrong

**Right:** the two budgets really are nested and really are unaware of each other, and a retryable non-timeout error really does restart the slice from cursor `None`.

**Wrong / incomplete, verified against `origin/main`:**

1. **There are THREE nested budgets, not two.** Per-page (halve `batch_size`, retry the same cursor, floor 50, 9 attempts), then the slice-level `retry_with_backoff(..., max_retries=8, retry_timeouts=False)`, and `acquire_with_retry` underneath both.
2. **A non-timeout error does not escape "the inner loop" directly.** It must first exhaust all 9 per-page attempts. The restart is real but rarer than the issue implies — this is a tail-latency fix, not a common-path one.
3. **The clean fix needs NO change to `retry_with_backoff`** — and to be clear, the issue already said as much. Its *Why it was not fixed in #4624* offered "either changing that shared wrapper's contract **or threading cursor state out of the helper**", and its *Shape of a fix* option (1) names this implementation verbatim: "carry the last committed `(after_1, after_2)` in a scope the outer retry can see, so a restart resumes rather than restarting the slice." This PR takes that branch. The point worth adding is only that the branch is cheaper than the issue's framing suggests: the bug is *where the state lives*, not *what the retry contract is*, so hoisting the sweep's state into the enclosing scope and reaching it via `nonlocal` leaves Passes 1 and 2 byte-for-byte unaffected. (An earlier revision of this section claimed the issue had the premise wrong. It did not — that was an overclaim on my part, corrected here.)
4. **Two correctness bugs the issue did not report, falling out of the same placement:**
   - `stale_cooccurrences_pruned` **under-reported**. `deleted` reset on every re-entry, so the job reported only the final attempt's deletions.
   - **Slice drift.** `slice_index` was re-derived from `time.time()` on re-entry. A retry crossing a 120 s window boundary silently swept a *different* slice and left the original unfinished until its next rotation. Pinning the slice is a correctness requirement, not just an efficiency one.

## The change

`docker/Dockerfile.hindsight`, inside the existing `switchroom hindsight graph-maintenance bounded sweep patch` block:

- `total_rows` / `slice_count` / `slice_index` / `batch_size` / `after_1` / `after_2` / `deleted` / `pages` are initialised in the **enclosing** scope, immediately before `async def _run_cooccurrence_prune()`.
- The helper opens with two `nonlocal` lines and guards the sizing block with `if slice_count is None:`, so `count_bank_cooccurrences` runs exactly once per job instead of once per attempt.
- A re-entry that finds committed progress logs `cooccurrence sweep RESUMING slice N/M at cursor (...) after P page(s) and D row(s) already committed`.
- **The paging loop body is unchanged.** That is deliberate: every #4624 build-time assert and every bakes pin over that loop still holds.
- New build-time asserts: the 4-space initialiser block is present; both `nonlocal` lines are present; a line-scan proves nothing at exactly 8-space indent re-initialises the sweep state inside the helper; the sizing block is guarded and the guard precedes the derivation; the RESUMING log exists.
- The design banner's `KNOWN, ACCEPTED, NOT FIXED HERE` paragraph is replaced by a `B4 THE OUTER RETRY RESUMES INSTEAD OF RESTARTING (#4635)` section documenting all three budgets and why the slice-level budget is kept (it still covers `count_bank_cooccurrences`).

## Tests assert the outcome

`tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts` gains an `R (#4635)` probe section that runs inside the real pinned image against the really-patched module:

- A `FlakyStore` raises `ConnectionResetError` **10** times after 2 committed pages. 10 > the 9 per-page attempts, so the 10th is served to the slice-level re-entry — the exact escape path the issue describes.
- A ticking clock advances a full 120 s window per read, so the slice-pinning check cannot pass vacuously.
- `_backoff_delay` is neutralised for delay only; retry *counting* is untouched.

Checks: `R_error_escaped_the_page_budget` (failed == 10), `R_outer_retry_re_entered` (13 calls), **`R_resumes_instead_of_restarting`** (`(None, None)` observed exactly once), **`R_re_entry_uses_the_last_committed_cursor`** (asserted against the literal `("k2a", "k2b")`, not another observation), `R_deleted_count_survives_re_entry`, `R_slice_is_pinned_across_re_entry`, `R_bank_sized_once_across_re_entry`.

**Mutation-tested, three containers, identical probe:**

| build | result |
|---|---|
| this branch | all seven `R_*=OK`, zero `=FAIL`, exit 0 |
| `origin/main`'s patch blocks (i.e. #4635 reverted) | 5 of 7 FAIL — resumes, cursor, deleted count, slice pinning, sizing — exit 1 |
| unpatched upstream (RED arm) | 4 FAIL — `R_error_escaped_the_page_budget`, `R_outer_retry_re_entered`, `R_deleted_count_survives_re_entry`, `R_bank_sized_once_across_re_entry`; exit 1 |

(The RED arm row previously listed only the first two. The extra two were independently measured during review; the test itself is unaffected, since the RED arm uses subset `toContain` assertions per this file's existing convention.)

A test that would not fail on the bug it guards is not a test; this one fails on `origin/main`.

`retry_timeouts=False` from #4604 still works — the timeout arm still takes the inner halve-the-page path, covered by the pre-existing shrink assertions in the same probe, which stay green.

## Local verification

- `tests/docker/dockerfile-hindsight-bakes.test.ts` — 47/47 pass (one existing pin updated: `slice_count = _sweep_slice_count(total_rows)` is now at 12-space indent because it moved inside the guard; plus a new B4 pin group).
- `tests/docker/hindsight-graph-maintenance-bounded-sweep.test.ts` — 9/9 pass, 50.6 s, including both docker arms and the real-Postgres SQL arm.
- `npm run lint` — fully green, including `check-changelog-entry` and `check-agent-attribution-trailers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
