### PR TITLE
test(compose): pin the service emit shape servicesByFleetLabel parses

### DIFF
--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -144,6 +144,33 @@ function findCollidingPair(): [string, string] {
  * Parsing is intentionally structural: service keys are the 2-space-indented
  * mapping keys under the top-level `services:` block, and a label line binds
  * to the service key that most recently opened.
+ *
+ * EMIT SHAPE THIS HELPER PINS. It pattern-matches generated text, so it is
+ * coupled to how `src/agents/compose.ts` emits a service block. The contract,
+ * and why each clause is load-bearing:
+ *
+ *   1. A top-level block opens at column 0 (`name:`, `services:`, `volumes:`,
+ *      `networks:` — compose.ts:1515, :1517, :2075, :2134). Only lines after
+ *      `services:` and before the next column-0 line count. That gate is what
+ *      keeps the volume and network keys (compose.ts:2077-2136) — also
+ *      2-space-indented and colon-terminated — out of `all`.
+ *   2. A service key is EXACTLY 2 spaces of indent, the name, a colon, then
+ *      nothing but optional trailing whitespace: the shape
+ *      `lines.push(`  <name>:`)` produces. Emit sites are compose.ts:642
+ *      (voice-sidecar), :1520 (vault-broker), :1769 (approval-kernel),
+ *      :1862 (switchroom-auth-broker) and :2178 (agent-<name>).
+ *   3. Indentation ALONE separates a service key from a nested mapping key of
+ *      the same textual form. The 6-space `vault-broker:` under `depends_on:`
+ *      (compose.ts:2274-2282) is byte-identical but for its indent; the
+ *      `^ {2}` anchor is the only thing excluding it.
+ *
+ * Change any of those emit sites and this helper must change with them. A
+ * clause-2 break yields an empty `all`, which would make callers assert over
+ * an empty set instead of failing (`expect(labelled).toEqual(all)` is
+ * trivially true when both are empty) — so the helper hard-fails on a
+ * zero-service parse. generateCompose emits the vault-broker singleton
+ * unconditionally (compose.ts:1520), so zero services always means the PARSER
+ * broke, never the input.
  */
 function servicesByFleetLabel(
   yaml: string,
@@ -171,6 +198,17 @@ function servicesByFleetLabel(
     if (current && line.trim() === `switchroom.fleet: "${fleet}"`) {
       labelled.push(current);
     }
+  }
+  // Fail loudly on a vacuous parse. See clause 2/3 above: the only way a
+  // generated compose has no services is that the emit shape moved out from
+  // under this matcher.
+  if (all.length === 0) {
+    throw new Error(
+      "servicesByFleetLabel parsed 0 services — generateCompose always emits " +
+        "at least `  vault-broker:` (src/agents/compose.ts:1520), so the " +
+        "service emit shape this helper pins has changed. Update the matcher " +
+        "and the docblock above it.",
+    );
   }
   return { all: all.sort(), labelled: labelled.sort() };
 }

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -165,12 +165,16 @@ function findCollidingPair(): [string, string] {
  *      `^ {2}` anchor is the only thing excluding it.
  *
  * Change any of those emit sites and this helper must change with them. A
- * clause-2 break yields an empty `all`, which would make callers assert over
- * an empty set instead of failing (`expect(labelled).toEqual(all)` is
- * trivially true when both are empty) — so the helper hard-fails on a
- * zero-service parse. generateCompose emits the vault-broker singleton
- * unconditionally (compose.ts:1520), so zero services always means the PARSER
- * broke, never the input.
+ * GLOBAL clause-2 break (every emit site moving at once) empties `all`, which
+ * would make callers assert over an empty set instead of failing
+ * (`expect(labelled).toEqual(all)` is trivially true when both are empty) — so
+ * the helper hard-fails on a zero-service parse. A SINGLE-SITE break leaves
+ * `all` non-empty and slips past that guard silently; it is caught only by the
+ * call sites' explicit `expect(all).toEqual([...])` name lists, which is why
+ * those lists must stay explicit rather than degrade into a length or set
+ * check. generateCompose emits the vault-broker singleton unconditionally
+ * (compose.ts:1520), so zero services always means the PARSER broke, never the
+ * input.
  */
 function servicesByFleetLabel(
   yaml: string,


### PR DESCRIPTION
Deferred LOW from the #4645 review (887dbf1a), split out into its own PR because #4645 had already merged.

## The finding

`servicesByFleetLabel` (`tests/docker/compose-generator.test.ts`) is a pattern-matcher over `generateCompose`'s **text** output, so it is coupled to an emit shape it never wrote down. If `src/agents/compose.ts` changes how it emits a service block, the matcher stops matching and returns an empty set — and `expect(labelled).toEqual(all)` is trivially true when both are empty. The assertion goes quietly vacuous instead of failing.

## What changed

Two changes, both scoped to the helper. No `src/` change.

**1. Document the contract.** The docblock now names the three clauses the matcher depends on and the emit sites that must move with it:

- the top-level-block gate (`compose.ts:1515`, `:1517`, `:2075`, `:2134`) — what keeps the volume and network keys (`:2077-2136`), which are *also* 2-space-indented and colon-terminated, out of `all`;
- the service-key shape `` lines.push(`  <name>:`) `` — `compose.ts:642`, `:1520`, `:1769`, `:1862`, `:2178`;
- indentation as the **only** thing separating a service key from a nested mapping key of identical text: the 6-space `vault-broker:` under `depends_on:` (`compose.ts:2274-2282`) differs from the real service key at `:1520` by indent alone, and the `^ {2}` anchor is what excludes it.

All five emit sites and the `depends_on` entry were verified against `origin/main` at ec679b2e, not taken from the review notes.

**2. Make the failure loud, not silent.** A docblock is only a comment; the actual failure mode is a vacuous pass. The helper now throws when it parses zero services. That is never a legitimate input — `generateCompose` emits the vault-broker singleton unconditionally (`compose.ts:1517-1520`) — so a zero-service parse always means the matcher broke, never the input. The message names the expected line and points back at the docblock.

## Verification

Mutation-proven rather than asserted. Re-indenting the five service emit sites from 2 to 3 spaces in `compose.ts` turns the two fleet-label tests red with:

```
servicesByFleetLabel parsed 0 services — generateCompose always emits at least
`  vault-broker:` (src/agents/compose.ts:1520), so the service emit shape this
helper pins has changed. Update the matcher and the docblock above it.
```

Before this change those two tests would have compared two empty arrays and passed. Mutation reverted; **224/224 pass** on the committed tree. `tsc --noEmit` clean. `check-changelog-entry` reports "no shippable code changed", so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)