### PR TITLE
feat(agents): a local-time prompt rule for every agent — 432 chars, funded by cutting 477 chars of duplicated prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ now an anomaly worth investigating, not the norm.
 
 ### Features
 
+- **every agent inherits a local-time rule, and it pays for its own bytes** —
+  a new unconditional shared prompt fragment
+  (`profiles/_shared/local-time.md.hbs`) appended at both scaffold sites, so no
+  profile can opt out. Fixing the container's tzdata (#4647) stops the machine
+  lying about UTC; it does not stop an agent showing a human a technically
+  correct UTC timestamp, hardcoding `+10:00` or `"AEST"` (both move with DST),
+  or calling `.astimezone()` on a naive value and silently assuming the process
+  clock. 432 chars, zone-agnostic, pinned by a `< 500` fragment ratchet. The
+  worst-case CLAUDE.md byte ratchet was NOT raised: the bytes come from cutting
+  four duplicated rules out of the default profile — the contentless `## Tools`
+  section (the Core Behavior tool bullet already says it), "save important
+  facts … to memory" (the whole Memory section says it), the auto-retain
+  restatement under "What to retain" (verbatim the `retain` bullet above it),
+  and the corrections-go-to-directives bullet (stated in full under
+  Directives), plus the generic "respond helpfully, concisely, and
+  conversationally" bullet, which is SOUL.md's job and can contradict a
+  persona. Net: the worst-case prompt is 45 chars SMALLER than before this PR.
+
 - **hindsight-watch: detect recall DEGRADATION, not just collapse** — three
   signals for the shape all fourteen existing ones missed. `recall-latency`
   (p95 3 s warn / 6 s page), `recall-quality-regression` (top-hit score and

--- a/profiles/_shared/local-time.md.hbs
+++ b/profiles/_shared/local-time.md.hbs
@@ -1,0 +1,6 @@
+## Local time — never show a human a UTC timestamp
+
+Convert to the agent's zone (`SWITCHROOM_TIMEZONE`, else `TZ`; the container clock is already local).
+
+- **Never hardcode an offset or a zone abbreviation** (`+10:00`, `AEST`) — both move with DST; derive from the zone.
+- **Attach a naive timestamp's true zone before converting** (`.replace(tzinfo=ZoneInfo("UTC"))`) — `.astimezone()` on a naive value assumes the process clock.

--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -16,9 +16,7 @@ You are operating in the **{{topicName}}** {{#if topicEmoji}}{{topicEmoji}} {{/i
 {{/if}}
 
 ## Core Behavior
-- Respond helpfully, concisely, and conversationally.
 - Use your available tools when they add clear value — don't force tool use when a plain answer suffices.
-- Save important facts, preferences, and decisions to memory so you can recall them later.
 - When asked to do something ambiguous, ask one clarifying question rather than guessing.
 - If a task has multiple steps, outline your plan before executing.
 
@@ -58,7 +56,6 @@ Hard rules the agent must follow during reflect — guardrails that are always a
 
 Retain proactively when:
 - The user shares a preference or fact about themselves
-- The user gives you a correction or rule (these go to directives, not retain)
 - A significant decision was made and the rationale matters for next time
 - You did real work and the result + the path you took would be useful next session
 
@@ -67,8 +64,6 @@ Don't retain:
 - Conversation chatter that doesn't carry forward
 - Sensitive content the user explicitly asked you to not remember
 - Things already in a mental model — they'll be re-derived from underlying memories
-
-Auto-retain (see above) covers routine capture; use manual `retain` for high-signal observations you want immediately searchable.
 
 ### When to synthesize — concrete triggers
 
@@ -132,13 +127,6 @@ Discipline (you read peers' attacker-influenced output, nothing taps your shell)
 - **Stay Claude-native.** Never reach for `claude -p`, the API, or the SDK — the subscription-honest pillar still binds you.
 
 Your transcript is this power's audit trail; keep your actions legible.
-{{/if}}
-
-## Tools
-{{#if tools}}
-Use the tools available to you to accomplish tasks effectively. Prefer the simplest tool that gets the job done.
-{{else}}
-Use your available tools when appropriate. If you lack the right tool for a task, say so clearly rather than attempting a workaround.
 {{/if}}
 
 {{#if schedule}}

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -538,6 +538,7 @@ describe("execution-discipline partial — fleet-wide grounding / verify-before-
       renderVaultProtocolFragment,
       renderAgentSelfServiceFragment,
       renderDevProtocolFragment,
+      renderLocalTimeFragment,
       renderDelegationGoldenRuleFragment,
     } = await import("./profiles.js");
     const Handlebars = (await import("handlebars")).default;
@@ -545,6 +546,10 @@ describe("execution-discipline partial — fleet-wide grounding / verify-before-
     const groundingMarker = "Grounding — check before you assert";
     const pacingMarker = "## Delegation";
     const devProtocolMarker = "## Development Protocol";
+    // Every agent on every profile must inherit the "never show a human a
+    // UTC timestamp" rule — the container /etc/localtime fix stops the OS
+    // lying, this stops the AGENT surfacing UTC to a person.
+    const localTimeMarker = "never show a human a UTC timestamp";
 
     const composeForProfile = (profileName: string): string => {
       const profileDir = getProfilePath(profileName);
@@ -553,12 +558,13 @@ describe("execution-discipline partial — fleet-wide grounding / verify-before-
         noEscape: true,
       })({});
       // Mirror scaffold.ts append order: vault, self-service,
-      // discipline, dev-protocol, delegation (last — tail recency).
+      // discipline, dev-protocol, local-time, delegation (last — tail recency).
       for (const frag of [
         renderVaultProtocolFragment(),
         renderAgentSelfServiceFragment(),
         renderExecutionDisciplineFragment(),
         renderDevProtocolFragment(),
+        renderLocalTimeFragment(),
         renderDelegationGoldenRuleFragment(),
       ]) {
         if (frag) rendered = rendered.trimEnd() + "\n\n" + frag + "\n";
@@ -580,6 +586,7 @@ describe("execution-discipline partial — fleet-wide grounding / verify-before-
       expect(rendered, `${name}: grounding marker`).toContain(groundingMarker);
       expect(rendered, `${name}: pacing marker`).toContain(pacingMarker);
       expect(rendered, `${name}: dev-protocol marker`).toContain(devProtocolMarker);
+      expect(rendered, `${name}: local-time marker`).toContain(localTimeMarker);
     }
   });
 });
@@ -744,6 +751,7 @@ describe("delegation single-sourcing + recency (regression #3231)", () => {
       renderAgentSelfServiceFragment,
       renderExecutionDisciplineFragment,
       renderDevProtocolFragment,
+      renderLocalTimeFragment,
       renderDelegationGoldenRuleFragment,
     } = await import("./profiles.js");
     const Handlebars = (await import("handlebars")).default;
@@ -752,12 +760,13 @@ describe("delegation single-sourcing + recency (regression #3231)", () => {
       noEscape: true,
     })({});
     // Mirror scaffold.ts append order EXACTLY: vault, self-service,
-    // execution-discipline, dev-protocol, delegation-golden-rule.
+    // execution-discipline, dev-protocol, local-time, delegation-golden-rule.
     for (const frag of [
       renderVaultProtocolFragment(),
       renderAgentSelfServiceFragment(),
       renderExecutionDisciplineFragment(),
       renderDevProtocolFragment(),
+      renderLocalTimeFragment(),
       renderDelegationGoldenRuleFragment(),
     ]) {
       if (frag) rendered = rendered.trimEnd() + "\n\n" + frag + "\n";
@@ -983,5 +992,60 @@ describe("steer-forwarding guidance — the shared delegation fragment", () => {
         "queue it and say so",
       );
     }
+  });
+});
+
+describe("renderLocalTimeFragment", () => {
+  // The container /etc/localtime fix stops the OS lying about what UTC
+  // is; this fragment stops an AGENT (or a skill it writes) formatting a
+  // correct UTC stamp and showing it to a human, hardcoding an offset or
+  // a DST-varying abbreviation, or calling .astimezone() on a naive
+  // value. Those are prompt-level failures no tzdata correctness
+  // prevents, so the rule has to reach every agent on every profile.
+
+  it("forbids showing a human a UTC timestamp", async () => {
+    const { renderLocalTimeFragment } = await import("./profiles.js");
+    const fragment = renderLocalTimeFragment();
+    expect(fragment.toLowerCase()).toContain("never show a human a utc timestamp");
+  });
+
+  it("names the SWITCHROOM_TIMEZONE -> TZ cascade, not a baked zone", async () => {
+    const { renderLocalTimeFragment } = await import("./profiles.js");
+    const fragment = renderLocalTimeFragment();
+    expect(fragment).toContain("SWITCHROOM_TIMEZONE");
+    expect(fragment).toContain("`TZ`");
+    // Zone-agnostic on purpose: a rule naming one fleet's zone is wrong
+    // on every other install, and threading a resolved zone in would need
+    // a new key mirrored across BOTH scaffold contexts byte-for-byte.
+    expect(fragment).not.toContain("Australia/Melbourne");
+  });
+
+  it("forbids hardcoded offsets and zone abbreviations", async () => {
+    const { renderLocalTimeFragment } = await import("./profiles.js");
+    const fragment = renderLocalTimeFragment();
+    expect(fragment).toContain("Never hardcode an offset or a zone abbreviation");
+    expect(fragment).toContain("AEST");
+    expect(fragment).toContain("DST");
+  });
+
+  it("requires attaching a zone to a naive timestamp rather than assuming one", async () => {
+    const { renderLocalTimeFragment } = await import("./profiles.js");
+    const fragment = renderLocalTimeFragment();
+    expect(fragment).toContain("naive");
+    expect(fragment).toContain(".astimezone()");
+    expect(fragment).toContain("replace(tzinfo=");
+  });
+
+  it("stays inside its prompt budget — a heading plus two bullets", async () => {
+    const { renderLocalTimeFragment } = await import("./profiles.js");
+    const fragment = renderLocalTimeFragment();
+    // Every agent pays this on every turn, and the worst-case CLAUDE.md
+    // sits inside the tests/scaffold.persona.test.ts byte ratchet with
+    // ~60 chars to spare, so ratchet the fragment itself: an edit that
+    // grows the rule back into a section has to find the bytes first.
+    expect(fragment.length).toBeLessThan(500);
+    expect(
+      fragment.split("\n").filter((l) => l.trimStart().startsWith("- ")),
+    ).toHaveLength(2);
   });
 });

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -213,7 +213,7 @@ Handlebars.registerHelper("isNumber", (value: unknown) => {
 // The _shared/ directory is underscore-prefixed (like _base/) and is not
 // listed by listAvailableProfiles() — it's framework-internal.
 const SHARED_FRAGMENTS_DIR = resolve(PROFILES_ROOT, "_shared");
-const SHARED_FRAGMENTS = ["vault-protocol", "agent-self-service", "execution-discipline", "reply-discipline", "dev-protocol"] as const;
+const SHARED_FRAGMENTS = ["vault-protocol", "agent-self-service", "execution-discipline", "reply-discipline", "dev-protocol", "local-time"] as const;
 for (const name of SHARED_FRAGMENTS) {
   const fragPath = join(SHARED_FRAGMENTS_DIR, `${name}.md.hbs`);
   if (existsSync(fragPath)) {
@@ -316,6 +316,60 @@ export function renderDevProtocolFragment(
   profilesRoot: string = PROFILES_ROOT,
 ): string {
   const fragPath = join(resolve(profilesRoot, "_shared"), "dev-protocol.md.hbs");
+  if (!existsSync(fragPath)) return "";
+  const source = readFileSync(fragPath, "utf-8");
+  const template = Handlebars.compile(source, { noEscape: true });
+  return template(context).trimEnd();
+}
+
+/**
+ * Render the local-time fragment standalone for unconditional append to
+ * every agent's CLAUDE.md. Same unconditional-carrier pattern as
+ * {@link renderDevProtocolFragment}.
+ *
+ * Why this is a PROMPT rule and not only a platform fix: the container
+ * `/etc/localtime` defect (Dockerfile.agent de-symlink) stopped the OS
+ * lying about what UTC is, but nothing stops an agent — or a skill it
+ * writes — from correctly reading a UTC stamp and then showing that UTC
+ * stamp to a human, or from hardcoding `+10:00` / `"AEST"` into a
+ * formatter that then breaks at the DST boundary. Those are prompt-level
+ * failures no amount of tzdata correctness prevents.
+ *
+ * Deliberately zone-AGNOSTIC: it names the `SWITCHROOM_TIMEZONE` → `TZ` →
+ * UTC cascade (the same one `bin/timezone-hook.sh`,
+ * `src/config/timezone.ts` and
+ * `vendor/hindsight-memory/scripts/lib/content.py:_resolve_agent_timezone`
+ * use) rather than baking a resolved zone in. That keeps it correct on
+ * every install, and — unlike a rendered zone — needs no new key threaded
+ * through BOTH the `buildWorkspaceContext` scaffold context and the
+ * hand-curated reconcile `claudeContext`, which must mirror each other
+ * byte-for-byte or the reconcile diff-abort trips.
+ *
+ * Not a duplicate of the existing guidance:
+ * `buildSubAgentLocalTimeLine` (src/agents/sub-agent-telegram-prompt.ts)
+ * reaches Task-tool sub-agents only and says "the wall clock is already
+ * local, treat it as now"; `bin/timezone-hook.sh` injects the current
+ * local time per turn. Neither states a rule about how a timestamp must
+ * be FORMATTED before a human sees it, which is the gap this closes.
+ *
+ * Kept to a heading plus two bullets on purpose — this is prompt budget
+ * every agent pays on every turn, and the worst-case CLAUDE.md byte
+ * ratchet (tests/scaffold.persona.test.ts,
+ * scripts/claude-md-byte-ratchet.txt) had ~18 chars of headroom before
+ * this fragment existed. Its 432 chars are funded by deleting duplicated
+ * rules from profiles/default/CLAUDE.md.hbs in the same change, NOT by
+ * raising the ceiling — which that test forbids. A profiles.test.ts
+ * ratchet pins the fragment at < 500 chars so it cannot creep back.
+ *
+ * Returns the rendered Markdown, or an empty string if the fragment
+ * file is missing (e.g. partial install).
+ */
+export function renderLocalTimeFragment(
+  context: Record<string, unknown> = {},
+  /** Override the profiles root; used by tests. */
+  profilesRoot: string = PROFILES_ROOT,
+): string {
+  const fragPath = join(resolve(profilesRoot, "_shared"), "local-time.md.hbs");
   if (!existsSync(fragPath)) return "";
   const source = readFileSync(fragPath, "utf-8");
   const template = Handlebars.compile(source, { noEscape: true });

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -773,6 +773,7 @@ import {
   renderAgentSelfServiceFragment,
   renderExecutionDisciplineFragment,
   renderDevProtocolFragment,
+  renderLocalTimeFragment,
   renderDelegationGoldenRuleFragment,
   renderReplyDisciplineFragment,
 } from "./profiles.js";
@@ -6095,6 +6096,18 @@ export function scaffoldAgent(
             if (devProtocol) {
               rendered = rendered.trimEnd() + "\n\n" + devProtocol + "\n";
             }
+            // Local-time fragment — "never show a human a UTC timestamp",
+            // plus the no-hardcoded-offset and naive-timestamp rules. Same
+            // unconditional-append pattern so it reaches EVERY agent on
+            // EVERY profile; the container /etc/localtime fix stops the OS
+            // lying about UTC, this stops the AGENT surfacing UTC to a
+            // human. ORDER (…, dev-protocol, then local-time, then
+            // delegation-golden-rule) must mirror the reconcile path or the
+            // diff-abort trips on every reconcile.
+            const localTime = renderLocalTimeFragment(context);
+            if (localTime) {
+              rendered = rendered.trimEnd() + "\n\n" + localTime + "\n";
+            }
             // Delegation golden-rule fragment — appended LAST (after
             // execution-discipline and dev-protocol) on purpose so the
             // "prefer delegating execution to a sub-agent" signal regains
@@ -8442,6 +8455,14 @@ function reconcileAgentInner(
       const devProtocol = renderDevProtocolFragment(claudeContext);
       if (devProtocol) {
         rendered = rendered.trimEnd() + "\n\n" + devProtocol + "\n";
+      }
+      // Local-time fragment — ORDER must mirror the first-scaffold path
+      // above (…, dev-protocol, then local-time, then
+      // delegation-golden-rule) or the diff-abort below trips on every
+      // reconcile.
+      const localTime = renderLocalTimeFragment(claudeContext);
+      if (localTime) {
+        rendered = rendered.trimEnd() + "\n\n" + localTime + "\n";
       }
       // Delegation golden-rule fragment — appended LAST (after
       // execution-discipline and dev-protocol) so the "prefer delegating


### PR DESCRIPTION
Split out of #4647. That PR fixes the container-side half — the `/etc/localtime` bind mount was clobbering `/usr/share/zoneinfo/Etc/UTC`, so every by-name UTC lookup in an agent container returned local time. This is the prompt-side half, and it is a separate PR because it costs prompt budget every agent pays on every turn, which has to be argued on its own merits rather than carried in behind a Dockerfile fix.

## Why a prompt rule at all, when the OS bug is fixed

Fixing tzdata stops the *machine* lying about what UTC is. It does not stop an **agent**:

- formatting a technically correct UTC timestamp and showing it to a human;
- hardcoding `+10:00` or `"AEST"` into a formatter — both move with DST, so the formatter is wrong for half the year;
- calling `.astimezone()` on a **naive** timestamp, which silently assumes the process clock and is wrong whenever the source zone is not local. This is exactly the bug that made `vendor/hindsight-memory` render a naive `04:09` UTC as `04:09 AM AEST` instead of `02:09 PM` (documented in #4647).

Those are prompt-level failures no amount of tzdata correctness prevents, and there was **no equivalent rule anywhere in the generated CLAUDE.md** — `grep -i "utc\|timezone\|local time"` over the worst-case render returns nothing on `main`. It is not a duplicate of `buildSubAgentLocalTimeLine` (`src/agents/sub-agent-telegram-prompt.ts`, Task-tool sub-agents only) or of `bin/timezone-hook.sh` (injects the *current time*, not the *rule*).

`profiles/_shared/local-time.md.hbs` is unconditional and appended at **both** scaffold sites in the same order (first-scaffold and reconcile — mismatched order trips the reconcile diff-abort), so no profile can opt out. It is deliberately **zone-agnostic**: naming a zone would mean threading a new key through both `buildWorkspaceContext`'s scaffold context and the hand-curated reconcile `claudeContext`, which must mirror byte-for-byte.

## The byte cost, named explicitly — and paid in full

**The fragment is 432 chars. The ratchet ceiling was NOT raised.**

`tests/scaffold.persona.test.ts` measures the worst-case rendered CLAUDE.md (root-tier agent on the default profile) against `scripts/claude-md-byte-ratchet.txt` (30620) plus a 500-char grace band — a ceiling of **31120**. On `main` the worst case is **31102**: **18 chars of headroom.** Any new prompt content whatsoever breaches it, and the test's own message says raising the ceiling is not the remedy — the remedies it names are "move procedure into an on-demand skill, put tool instructions in the tool description, or **delete a rule that duplicates another**".

An on-demand skill is not available here: a rule about how *every* timestamp reaches a human has to be resident, not loaded on request. So the fragment is funded by the third remedy. Five rules deleted from `profiles/default/CLAUDE.md.hbs`, each of which restates something the same file already says at length:

| Deleted | Already said by |
|---|---|
| the whole `## Tools` section ("use the tools available to you… prefer the simplest tool") | the Core Behavior bullet "Use your available tools when they add clear value — don't force tool use when a plain answer suffices" |
| "Save important facts, preferences, and decisions to memory so you can recall them later" | the entire `## Memory` section, incl. "### What to retain — and what NOT to retain" |
| "Auto-retain (see above) covers routine capture; use manual `retain` for high-signal observations you want immediately searchable" | the `retain` bullet ~20 lines above: "Call manually for significant decisions, corrections, or facts you want immediately searchable" |
| "The user gives you a correction or rule (these go to directives, not retain)" — a *directives* rule filed under the **retain** list | "### Directives": "When the user gives you a correction or 'always do X' rule, create a directive instead" |
| "Respond helpfully, concisely, and conversationally" | `SOUL.md`, named as the persona source of truth three lines earlier as owning "communication style". A generic tone bullet can actively contradict a persona. |

**Net result: the worst-case prompt is 31057 chars — 45 chars SMALLER than `main`, with 63 chars of headroom under the unchanged ceiling.** This PR adds a rule and leaves the prompt shorter than it found it.

A second ratchet in `src/agents/profiles.test.ts` pins the fragment itself at `< 500` chars (down from the 1200 it carried in #4647) so it cannot creep back into a section.

## Rules kept, not weakened

The fragment was compressed from 851 chars to 432 by cutting prose, not rules. All three substantive rules survive and are each pinned by a test:

1. never show a human a UTC timestamp — convert to the agent's zone first (`SWITCHROOM_TIMEZONE`, else `TZ`);
2. never hardcode an offset or a zone abbreviation, **because both move with DST**;
3. attach a naive timestamp's true zone before converting (`.replace(tzinfo=ZoneInfo("UTC"))`), because `.astimezone()` on a naive value assumes the process clock.

## Verification run locally

- `npx vitest run src/agents/profiles.test.ts tests/scaffold.persona.test.ts` → **81 passed** (2 files). This includes the byte-ratchet test, which is the whole point.
- `npx vitest run tests/scaffold.persona.test.ts tests/scaffold.test.ts src/agents/ tests/timezone.integration.test.ts` → **40 files, 806 passed, 1 skipped.**
- `npm run -s lint` → **exit 0** (tsc + ~30 guard scripts, incl. the changelog guard).
- Measured directly, by scaffolding the worst-case stack and printing `claudeMd.length`: `main` **31102** → this branch **31057**, ceiling **31120**.
- `grep -rn` over `src/ tests/ scripts/` confirms no test asserts any of the five deleted strings.

## Reviewer's call

The five deletions are the debatable part, not the fragment. If any one of them is wanted back, the honest options are (a) drop it from this PR and compress the fragment further, or (b) find a different duplicate — **not** a higher ceiling. I would rather be told which line to restore than quietly widen the band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
