### PR TITLE
fix(worktree): provision claims as independent clones, not linked worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,28 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **worktree: `switchroom worktree claim` now provisions an INDEPENDENT clone,
+  not a linked `git worktree` — concurrent sub-agents can no longer collide
+  through shared git state.** Linked worktrees share the parent repo's refs
+  (including the single `refs/stash`), object store, and
+  `.git/worktrees/<name>` admin metadata. Observed in production: one worker's
+  `git stash pop` popped a DIFFERENT worker's stash entry, leaving conflict
+  markers in unrelated files; stale worktree admin metadata survived
+  `worktree remove --force` + `rm -rf` + `prune` and resurrected a previous
+  claim's dirty index state on re-claim; and workers operating in the shared
+  parent repo flipped it to detached HEAD mid-run. Those are inherent to
+  `git worktree` semantics, so the fix avoids worktrees rather than patching
+  around them: each claim is a local `git clone` (hardlinked object store —
+  near-worktree cost on the same filesystem) on its own task branch, with
+  `origin` rewired to the source repo's real remote so fetch/push still hit
+  upstream. The claim also now REJECTS a checkout base under `/tmp`/`/var/tmp`
+  (agent containers mount tmp `noexec`, so builds there fail with
+  `spawnSync … EACCES` minutes into a task) with a clear error at claim time —
+  escape hatch `SWITCHROOM_WORKTREE_ALLOW_TMP=1` for exec-mounted hosts.
+  Release, reap, and gc are shape-aware (`.git` dir = clone → `rm -rf`;
+  `.git` file = legacy linked worktree → `git worktree remove`), so records
+  written before this fix stay removable.
+
 - **hindsight: the cooccurrence sweep now RESUMES instead of restarting when the
   outer retry re-enters.** `_run_cooccurrence_prune` (Pass 3 of
   `graph_maintenance`, patched in via `docker/Dockerfile.hindsight`) kept its

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -184,14 +184,24 @@ switchroom web                                    # Web dashboard
 Migrating credentials from OpenClaw is covered in
 [vs-openclaw.md](vs-openclaw.md#migrating-credentials).
 
-## `switchroom worktree` — git worktree isolation for parallel agents
+## `switchroom worktree` — isolated checkouts for parallel agents
 
 Multiple agents (and sub-agents) can run concurrently on one host and
 touch the same repo. Working directly on a repo's primary checkout
 collides: mid-edit files, branch switches under another agent's feet,
 half-staged commits clobbered. `switchroom worktree` is the supported
-way to hand each task its own isolated git worktree on a fresh branch,
+way to hand each task its own isolated checkout on a fresh branch,
 with a registry so stale ones get reaped instead of accumulating.
+
+Each claim is an **independent clone** — not a linked `git worktree`
+off the source repo, which shares the stash ref, refs, and
+`.git/worktrees` admin metadata across concurrent tasks and lets them
+corrupt each other. The clone hardlinks the object store on the same
+filesystem, so it costs about what a worktree did, and its `origin` is
+rewired to the source repo's real remote so `git fetch` / `git push`
+work as usual. The checkout base must live under `$HOME` (default
+`~/.switchroom/worktree-checkouts`); a base under `/tmp` is rejected
+at claim time because agent containers mount tmp `noexec`.
 
 ```sh
 switchroom worktree claim <repo> [--task <name>] [--agent <name>] [--json]
@@ -200,18 +210,19 @@ switchroom worktree release <id> [--json]
 switchroom worktree reap [--dry-run] [--json]
 ```
 
-- **`claim <repo>`** claims a worktree for a repo (alias or absolute
-  path). Prints the worktree **id**, **branch**, and **path**. `--task`
-  becomes the branch suffix so the branch name says what it is for;
-  `--agent` associates the claim with an agent so the registry shows
-  who owns it.
+- **`claim <repo>`** claims an isolated checkout for a repo (alias or
+  absolute path). Prints the claim **id**, **branch**, and **path**.
+  `--task` becomes the branch suffix so the branch name says what it is
+  for; `--agent` associates the claim with an agent so the registry
+  shows who owns it.
 - **`list`** shows every active claim, with repo, branch, path, owning
   agent, and heartbeat age. `fresh` means the heartbeat is under 120s
   old.
-- **`release <id>`** releases a claim by id. If the underlying `git
-  worktree remove` fails (e.g. dirty tree) the registry entry is still
-  cleaned up and the result is reported as *partial* so it does not
-  leak.
+- **`release <id>`** releases a claim by id. Removal is shape-aware:
+  clone checkouts are deleted outright; legacy linked worktrees go
+  through `git worktree remove --force`. If removal fails the registry
+  entry is still cleaned up and the result is reported as *partial* so
+  it does not leak.
 - **`reap`** removes stale / orphaned worktrees (no heartbeat for
   >10 min). `--dry-run` prints what *would* be reaped without acting.
   Always sanity-check with `--dry-run` first on a shared host.

--- a/src/worktree/claim.ts
+++ b/src/worktree/claim.ts
@@ -1,21 +1,36 @@
 /**
- * claim_worktree: atomically reserve a git worktree for a sub-agent.
+ * claim_worktree: atomically reserve an isolated checkout for a sub-agent.
  *
  * Protocol:
  *   1. Resolve repo path from alias or absolute path.
  *   2. Check concurrency cap.
  *   3. Write registry record BEFORE running git (atomic claim).
- *   4. Run git worktree add with the generated branch.
+ *   4. Provision an INDEPENDENT CLONE of the repo on the generated branch.
  *   5. Return { id, path, branch }.
  *
  * If git fails after the registry write, we clean up the record so the
  * claim doesn't ghost.
+ *
+ * WHY A CLONE AND NOT `git worktree add` (worktree-collision fix):
+ * linked worktrees share the parent repo's object store, refs — including
+ * the SINGLE `refs/stash` — and `.git/worktrees/<name>` admin metadata.
+ * Observed in production: one worker's `git stash pop` popped a DIFFERENT
+ * worker's stash entry, leaving conflict markers in unrelated files; stale
+ * `.git/worktrees/<name>` index metadata survived `worktree remove --force`
+ * + `rm -rf` + `prune` and resurrected a previous claim's dirty state; and
+ * workers stepping into the shared parent repo flipped it to detached HEAD
+ * mid-run. Those are inherent to worktree semantics — no amount of naming
+ * or locking discipline fixes a shared stash ref. An independent clone
+ * shares NOTHING mutable with the source repo, so concurrent claims cannot
+ * collide by construction. A local clone hardlinks the object store (same
+ * filesystem), so the disk/time cost is near a worktree's, not a full
+ * re-download.
  */
 
 import { execFileSync } from "node:child_process";
-import { closeSync, mkdirSync, openSync, existsSync, unlinkSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { homedir } from "node:os";
+import { closeSync, mkdirSync, openSync, existsSync, rmSync, unlinkSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
+import { homedir, tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
 import { writeRecord, countByRepo, deleteRecord, registryDir } from "./registry.js";
 import type { ClaimInput, ClaimResult, CodeRepoEntry } from "./types.js";
@@ -60,11 +75,40 @@ function acquireRepoLock(repoPath: string): () => void {
 /** Default max simultaneous worktrees per repo. */
 export const DEFAULT_CONCURRENCY = 5;
 
-/** Base directory where worktrees are created. */
+/** Base directory where task checkouts are created. */
 export function worktreesBaseDir(): string {
   return resolve(
     process.env.SWITCHROOM_WORKTREE_BASE ?? join(homedir(), ".switchroom", "worktree-checkouts"),
   );
+}
+
+/**
+ * Reject a checkout base directory under a tmp mount.
+ *
+ * Agent containers mount /tmp `noexec`, so a checkout placed there fails the
+ * moment anything tries to run a binary out of it (`npm ci` →
+ * `spawnSync .../esbuild EACCES`). That failure surfaces minutes into a task
+ * and looks like a toolchain bug; failing the CLAIM with a clear message is
+ * the deterministic version of the "never /tmp, always $HOME" prose rule.
+ *
+ * Escape hatch: SWITCHROOM_WORKTREE_ALLOW_TMP=1 (tests and hosts whose tmp
+ * is exec-mounted).
+ */
+export function assertBaseDirNotTmp(baseDir: string): void {
+  if (process.env.SWITCHROOM_WORKTREE_ALLOW_TMP === "1") return;
+  const base = resolve(baseDir);
+  const tmpRoots = new Set([resolve(tmpdir()), "/tmp", "/var/tmp"]);
+  for (const root of tmpRoots) {
+    if (base === root || base.startsWith(root + sep)) {
+      throw new Error(
+        `Refusing to provision a checkout under "${base}": tmp filesystems are ` +
+        `mounted noexec in agent containers, so builds there fail with EACCES ` +
+        `(e.g. npm ci spawning esbuild). Set SWITCHROOM_WORKTREE_BASE to a ` +
+        `directory under $HOME (default: ~/.switchroom/worktree-checkouts), or ` +
+        `set SWITCHROOM_WORKTREE_ALLOW_TMP=1 if this host's tmp is exec-mounted.`,
+      );
+    }
+  }
 }
 
 /**
@@ -166,8 +210,9 @@ export async function claimWorktree(
     const taskSuffix = input.taskName ? sanitizeTaskName(input.taskName) : "task";
     branch = `task/${taskSuffix}-${id}`;
 
-    // Compute worktree path
+    // Compute checkout path — enforced OUTSIDE tmp (noexec in containers).
     const baseDir = worktreesBaseDir();
+    assertBaseDirNotTmp(baseDir);
     mkdirSync(baseDir, { recursive: true });
     worktreePath = join(baseDir, `${id}-${taskSuffix}`);
 
@@ -193,6 +238,7 @@ export async function claimWorktree(
       createdAt: now,
       heartbeatAt: now,
       ownerAgent,
+      kind: "clone" as const,
     };
 
     // ATOMIC: write registry record BEFORE git operation.
@@ -205,16 +251,54 @@ export async function claimWorktree(
   }
 
   try {
-    // git worktree add -b <branch> <path>
-    execFileSync("git", ["worktree", "add", "-b", branch, worktreePath], {
+    // Provision an INDEPENDENT clone (see module header for why not
+    // `git worktree add`). Branch from the source repo's current HEAD
+    // commit — the same starting point `worktree add -b` used — resolved
+    // BEFORE cloning so a detached-HEAD source still works.
+    const headSha = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd: repoPath,
       stdio: "pipe",
+      encoding: "utf-8",
+    }).trim();
+
+    // Local clone: hardlinks the object store on the same filesystem, so
+    // this is cheap. --no-checkout because we check out the task branch
+    // ourselves in the next step.
+    execFileSync("git", ["clone", "--quiet", "--no-checkout", repoPath, worktreePath], {
+      stdio: "pipe",
     });
+    execFileSync("git", ["checkout", "--quiet", "-b", branch, headSha], {
+      cwd: worktreePath,
+      stdio: "pipe",
+    });
+
+    // Rewire `origin` from the local source path to the source repo's real
+    // remote, so `git fetch origin` / `git push origin` in the checkout hit
+    // upstream — matching what a linked worktree (which shared the parent's
+    // remotes) used to give workers. If the source has no origin, leave the
+    // local path in place.
+    let originUrl: string | undefined;
+    try {
+      originUrl = execFileSync("git", ["remote", "get-url", "origin"], {
+        cwd: repoPath,
+        stdio: "pipe",
+        encoding: "utf-8",
+      }).trim();
+    } catch {
+      /* source repo has no origin remote */
+    }
+    if (originUrl) {
+      execFileSync("git", ["remote", "set-url", "origin", originUrl], {
+        cwd: worktreePath,
+        stdio: "pipe",
+      });
+    }
   } catch (err) {
-    // Clean up the registry record since git failed
+    // Clean up the registry record AND any partial clone since git failed.
     deleteRecord(id);
+    rmSync(worktreePath, { recursive: true, force: true });
     const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`git worktree add failed: ${msg}`);
+    throw new Error(`checkout provisioning (git clone) failed: ${msg}`);
   }
 
   return { id, path: worktreePath, branch };

--- a/src/worktree/gc.ts
+++ b/src/worktree/gc.ts
@@ -45,6 +45,7 @@ import { homedir } from "node:os";
 import { join, resolve, basename } from "node:path";
 import { listRecords } from "./registry.js";
 import { probePathInUse, type PathUseState } from "./reaper.js";
+import { detectCheckoutKind } from "./remove-checkout.js";
 
 // ── pure helpers ────────────────────────────────────────────────────────────
 
@@ -817,6 +818,14 @@ export function applyGc(plan: GcPlan, deps: ApplyDeps = {}): GcApplyResult {
   for (const r of plan.registered) {
     if (r.verdict !== "remove") continue;
     try {
+      if (detectCheckoutKind(r.path) === "clone") {
+        // Independent clone (post worktree-collision fix): the task branch,
+        // refs, and metadata all live INSIDE the directory — removing it is
+        // the whole cleanup. Nothing to delete or prune in the source repo.
+        rmSync(r.path, { recursive: true, force: true });
+        res.removed.push(r.path);
+        continue;
+      }
       exec("git", ["-C", r.repo, "worktree", "remove", "--force", r.path]);
       res.removed.push(r.path);
       if (r.branch) {

--- a/src/worktree/reaper.ts
+++ b/src/worktree/reaper.ts
@@ -40,6 +40,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { listRecords, deleteRecord } from "./registry.js";
+import { removeCheckout } from "./remove-checkout.js";
 import type { WorktreeRecord } from "./types.js";
 
 /** Heartbeat age threshold in ms. Claims older than this are stale. */
@@ -187,15 +188,16 @@ function hasUncommittedChanges(_repoPath: string, worktreePath: string): boolean
   }
 }
 
-/** Default force-remove: `git worktree remove --force <path>` from the repo. */
+/**
+ * Default force-remove — shape-aware (see remove-checkout.ts): independent
+ * clones are `rm -rf`d, legacy linked worktrees go through
+ * `git worktree remove --force`.
+ */
 function defaultRemoveWorktree(repoPath: string, worktreePath: string): void {
   try {
-    execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
-      cwd: repoPath,
-      stdio: "pipe",
-    });
+    removeCheckout(repoPath, worktreePath);
   } catch {
-    // If git remove fails, the caller still deletes the record. The path may
+    // If removal fails, the caller still deletes the record. The path may
     // have been manually deleted or the repo moved.
   }
 }

--- a/src/worktree/release.ts
+++ b/src/worktree/release.ts
@@ -1,18 +1,21 @@
 /**
- * release_worktree: tear down a claimed worktree.
+ * release_worktree: tear down a claimed checkout.
  *
  * Best-effort cleanup:
  *   1. Read the registry record.
- *   2. Run `git worktree remove --force` on the path.
+ *   2. Remove the checkout — shape-aware: independent clones are `rm -rf`d
+ *      (nothing lives outside the directory), legacy linked worktrees go
+ *      through `git worktree remove --force` so the source repo's admin
+ *      entry is pruned too (see remove-checkout.ts).
  *   3. Delete the registry record.
  *
  * If any step fails, we continue and report `released: false`.
  * The reaper will handle orphans on its next run.
  */
 
-import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readRecord, deleteRecord } from "./registry.js";
+import { removeCheckout } from "./remove-checkout.js";
 import type { ReleaseInput, ReleaseResult } from "./types.js";
 
 /**
@@ -30,12 +33,9 @@ export function releaseWorktree(input: ReleaseInput): ReleaseResult {
   let gitSuccess = true;
   if (existsSync(record.path)) {
     try {
-      execFileSync("git", ["worktree", "remove", "--force", record.path], {
-        cwd: record.repo,
-        stdio: "pipe",
-      });
+      removeCheckout(record.repo, record.path);
     } catch {
-      // git remove failed — path may have been deleted externally, or
+      // removal failed — path may have been deleted externally, or the
       // repo is gone. Don't block the record cleanup.
       gitSuccess = false;
     }

--- a/src/worktree/remove-checkout.ts
+++ b/src/worktree/remove-checkout.ts
@@ -1,0 +1,80 @@
+/**
+ * Shape-aware removal of a claimed checkout.
+ *
+ * Claims are provisioned as INDEPENDENT CLONES (see claim.ts), but records
+ * written before that fix point at `git worktree add` checkouts. The two
+ * need different teardown:
+ *
+ *   - clone    → `rm -rf` of the directory. Nothing else exists: the task
+ *                branch, index, stash, and worktree metadata all live inside
+ *                the clone, so no state can go stale in the source repo.
+ *   - worktree → `git worktree remove --force` run from the source repo, so
+ *                the source repo's `.git/worktrees/<name>` admin entry is
+ *                cleaned up along with the directory.
+ *
+ * Detection is by FILESYSTEM SHAPE, not by the registry record's `kind`
+ * field: a full clone has a `.git` directory, a linked worktree has a `.git`
+ * FILE (a gitdir pointer). Shape can't drift from reality the way a record
+ * field can, and it handles legacy records that predate the `kind` field.
+ */
+
+import { execFileSync } from "node:child_process";
+import { rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export type CheckoutKind = "clone" | "worktree" | "missing" | "unknown";
+
+/**
+ * Classify a checkout directory by the shape of its `.git` entry.
+ *   - `.git` is a directory → independent clone
+ *   - `.git` is a file      → linked `git worktree`
+ *   - path (or `.git`) absent → "missing"
+ *   - anything else          → "unknown"
+ */
+export function detectCheckoutKind(checkoutPath: string): CheckoutKind {
+  let gitStat;
+  try {
+    gitStat = statSync(join(checkoutPath, ".git"));
+  } catch {
+    try {
+      statSync(checkoutPath);
+    } catch {
+      return "missing"; // path itself is gone
+    }
+    return "unknown"; // path exists but has no .git entry
+  }
+  if (gitStat.isDirectory()) return "clone";
+  if (gitStat.isFile()) return "worktree";
+  return "unknown";
+}
+
+/**
+ * Remove a claimed checkout, whatever its provisioning shape.
+ * Throws on failure (callers decide whether that is fatal).
+ *
+ * @param repoPath     Source repo the claim was made against (used only for
+ *                     the legacy `git worktree remove` path).
+ * @param checkoutPath Directory of the checkout to remove.
+ */
+export function removeCheckout(repoPath: string, checkoutPath: string): void {
+  const kind = detectCheckoutKind(checkoutPath);
+
+  if (kind === "clone") {
+    // Independent clone: the directory is the whole claim. No metadata in
+    // the source repo to prune, no branch to delete there.
+    rmSync(checkoutPath, { recursive: true, force: true });
+    return;
+  }
+
+  if (kind === "missing") {
+    // Already gone — treat as removed (idempotent).
+    return;
+  }
+
+  // Legacy linked worktree (or unknown shape): let git do the removal so the
+  // source repo's .git/worktrees admin entry goes with it.
+  execFileSync("git", ["worktree", "remove", "--force", checkoutPath], {
+    cwd: repoPath,
+    stdio: "pipe",
+  });
+}

--- a/src/worktree/types.ts
+++ b/src/worktree/types.ts
@@ -22,6 +22,17 @@ export interface WorktreeRecord {
   heartbeatAt: string;
   /** Agent name that claimed this worktree (optional) */
   ownerAgent?: string;
+  /**
+   * How the checkout was provisioned.
+   *   - "clone"    — an independent `git clone` with its own object store,
+   *                  refs, stash, and HEAD (the default since the
+   *                  worktree-collision fix).
+   *   - "worktree" — a legacy `git worktree add` off the source repo
+   *                  (records written before the fix). Absent means legacy.
+   * Removal paths do NOT trust this field; they detect the checkout shape
+   * on disk (`.git` dir vs `.git` file) so legacy records stay removable.
+   */
+  kind?: "clone" | "worktree";
 }
 
 /** Input to claim_worktree */

--- a/tests/worktree.claim-integration.test.ts
+++ b/tests/worktree.claim-integration.test.ts
@@ -34,8 +34,12 @@ describe("claim / release / list integration", () => {
   let checkoutsDir: string;
   const origReg = process.env.SWITCHROOM_WORKTREE_DIR;
   const origBase = process.env.SWITCHROOM_WORKTREE_BASE;
+  const origAllowTmp = process.env.SWITCHROOM_WORKTREE_ALLOW_TMP;
 
   beforeEach(() => {
+    // Test fixtures live under tmpdir; the production /tmp-noexec guard
+    // must not reject them.
+    process.env.SWITCHROOM_WORKTREE_ALLOW_TMP = "1";
     repoDir = initTempRepo();
     const base = mkdtempSync(join(tmpdir(), "sw-int-test-"));
     regDir = join(base, "registry");
@@ -58,6 +62,8 @@ describe("claim / release / list integration", () => {
     else process.env.SWITCHROOM_WORKTREE_DIR = origReg;
     if (origBase === undefined) delete process.env.SWITCHROOM_WORKTREE_BASE;
     else process.env.SWITCHROOM_WORKTREE_BASE = origBase;
+    if (origAllowTmp === undefined) delete process.env.SWITCHROOM_WORKTREE_ALLOW_TMP;
+    else process.env.SWITCHROOM_WORKTREE_ALLOW_TMP = origAllowTmp;
   });
 
   it("claim returns id, path, and branch", async () => {

--- a/tests/worktree.claim-isolation.test.ts
+++ b/tests/worktree.claim-isolation.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Isolation tests for the worktree-collision fix (#claim-as-independent-clone).
+ *
+ * These assert the OUTCOMES that failed in production when claims were
+ * `git worktree add` checkouts off a shared repo — every test here fails on
+ * the old provisioning:
+ *
+ *   1. Two concurrent claims must NOT share a stash ref (a `git stash push`
+ *      in one must be invisible to a `git stash pop` in the other).
+ *   2. A claim must leave NO admin metadata in the source repo
+ *      (`.git/worktrees/<name>` was where stale index state survived
+ *      remove --force + rm -rf + prune and resurrected dirty trees).
+ *   3. A checkout in a claim must not move the source repo's HEAD, and the
+ *      claim must have its own git dir (no shared object/ref store).
+ *   4. Release + re-claim of the same task name must yield a CLEAN tree.
+ *   5. A /tmp checkout base is rejected in code (noexec in containers).
+ *   6. Legacy `git worktree add` records are still releasable (shape-aware
+ *      removal).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { claimWorktree, assertBaseDirNotTmp } from "../src/worktree/claim.js";
+import { releaseWorktree } from "../src/worktree/release.js";
+import { listRecords, writeRecord } from "../src/worktree/registry.js";
+import { detectCheckoutKind } from "../src/worktree/remove-checkout.js";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, stdio: "pipe", encoding: "utf-8" }).trim();
+}
+
+function initTempRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "sw-iso-repo-"));
+  git(dir, "init");
+  git(dir, "config", "user.email", "test@test.com");
+  git(dir, "config", "user.name", "Test");
+  writeFileSync(join(dir, "README.md"), "init\n");
+  writeFileSync(join(dir, "shared.txt"), "shared content\n");
+  git(dir, "add", ".");
+  git(dir, "commit", "-m", "init");
+  return dir;
+}
+
+describe("claim isolation — independent clones, no shared git state", () => {
+  let repoDir: string;
+  let base: string;
+  const origReg = process.env.SWITCHROOM_WORKTREE_DIR;
+  const origBase = process.env.SWITCHROOM_WORKTREE_BASE;
+  const origAllowTmp = process.env.SWITCHROOM_WORKTREE_ALLOW_TMP;
+
+  beforeEach(() => {
+    repoDir = initTempRepo();
+    base = mkdtempSync(join(tmpdir(), "sw-iso-test-"));
+    process.env.SWITCHROOM_WORKTREE_DIR = join(base, "registry");
+    process.env.SWITCHROOM_WORKTREE_BASE = join(base, "checkouts");
+    // Fixtures live under tmpdir; don't let the production noexec guard
+    // reject the test environment itself.
+    process.env.SWITCHROOM_WORKTREE_ALLOW_TMP = "1";
+  });
+
+  afterEach(() => {
+    for (const rec of listRecords()) {
+      try { releaseWorktree({ id: rec.id }); } catch { /* best-effort */ }
+    }
+    rmSync(repoDir, { recursive: true, force: true });
+    rmSync(base, { recursive: true, force: true });
+    if (origReg === undefined) delete process.env.SWITCHROOM_WORKTREE_DIR;
+    else process.env.SWITCHROOM_WORKTREE_DIR = origReg;
+    if (origBase === undefined) delete process.env.SWITCHROOM_WORKTREE_BASE;
+    else process.env.SWITCHROOM_WORKTREE_BASE = origBase;
+    if (origAllowTmp === undefined) delete process.env.SWITCHROOM_WORKTREE_ALLOW_TMP;
+    else process.env.SWITCHROOM_WORKTREE_ALLOW_TMP = origAllowTmp;
+  });
+
+  it("two claims do NOT share a stash ref — a stash in one is invisible to the other", async () => {
+    const a = await claimWorktree({ repo: repoDir, taskName: "worker-a" });
+    const b = await claimWorktree({ repo: repoDir, taskName: "worker-b" });
+
+    // Worker A stashes an in-flight edit.
+    writeFileSync(join(a.path, "shared.txt"), "worker A's uncommitted change\n");
+    git(a.path, "stash", "push", "-m", "worker-a-wip");
+    expect(git(a.path, "stash", "list")).toContain("worker-a-wip");
+
+    // Worker B's stash must be EMPTY — on shared-worktree provisioning
+    // (the old behaviour) refs/stash is shared and B sees A's entry, and a
+    // `git stash pop` in B would pop A's work into B's tree.
+    expect(git(b.path, "stash", "list")).toBe("");
+    expect(() => git(b.path, "stash", "pop")).toThrow();
+
+    // And B's file is untouched.
+    expect(git(b.path, "status", "--porcelain")).toBe("");
+
+    // A can still pop its own stash intact.
+    git(a.path, "stash", "pop");
+    expect(git(a.path, "status", "--porcelain")).toContain("shared.txt");
+  });
+
+  it("claiming leaves NO worktree admin metadata in the source repo", async () => {
+    await claimWorktree({ repo: repoDir, taskName: "meta-check" });
+    // Old behaviour: .git/worktrees/<name> exists in the source repo — the
+    // exact metadata that went stale and resurrected dirty state.
+    const adminDir = join(repoDir, ".git", "worktrees");
+    const entries = existsSync(adminDir) ? readdirSync(adminDir) : [];
+    expect(entries).toEqual([]);
+    // And `git worktree list` in the source shows only the source itself.
+    const list = git(repoDir, "worktree", "list", "--porcelain");
+    expect(list.split("\n").filter((l) => l.startsWith("worktree "))).toHaveLength(1);
+  });
+
+  it("a claim has its own git dir and checkouts never move the source repo's HEAD", async () => {
+    const sourceHeadBefore = git(repoDir, "rev-parse", "HEAD");
+    const sourceBranchBefore = git(repoDir, "rev-parse", "--abbrev-ref", "HEAD");
+
+    const a = await claimWorktree({ repo: repoDir, taskName: "own-gitdir" });
+    expect(detectCheckoutKind(a.path)).toBe("clone");
+
+    // The claim's git common dir resolves INSIDE the claim, not to the
+    // source repo (a linked worktree resolves to the source's .git).
+    const commonDir = git(a.path, "rev-parse", "--path-format=absolute", "--git-common-dir");
+    expect(commonDir.startsWith(a.path)).toBe(true);
+
+    // Detach / branch-switch inside the claim; source repo must not move.
+    git(a.path, "checkout", "--detach", "HEAD");
+    expect(git(repoDir, "rev-parse", "HEAD")).toBe(sourceHeadBefore);
+    expect(git(repoDir, "rev-parse", "--abbrev-ref", "HEAD")).toBe(sourceBranchBefore);
+  });
+
+  it("origin in the claim points at the source repo's real remote", async () => {
+    git(repoDir, "remote", "add", "origin", "https://github.com/example/upstream.git");
+    const a = await claimWorktree({ repo: repoDir, taskName: "origin-rewire" });
+    expect(git(a.path, "remote", "get-url", "origin")).toBe(
+      "https://github.com/example/upstream.git",
+    );
+  });
+
+  it("release + re-claim with the same task name yields a clean tree (no resurrected state)", async () => {
+    const first = await claimWorktree({ repo: repoDir, taskName: "reuse-me" });
+    // Dirty the tree the way the production failure did, then force-release.
+    writeFileSync(join(first.path, "shared.txt"), "dirty leftover\n");
+    writeFileSync(join(first.path, "junk.txt"), "junk\n");
+    const rel = releaseWorktree({ id: first.id });
+    expect(rel.released).toBe(true);
+    expect(existsSync(first.path)).toBe(false);
+
+    const second = await claimWorktree({ repo: repoDir, taskName: "reuse-me" });
+    expect(git(second.path, "status", "--porcelain")).toBe("");
+    expect(existsSync(join(second.path, "junk.txt"))).toBe(false);
+  });
+
+  it("rejects a checkout base under /tmp with a clear noexec error", async () => {
+    delete process.env.SWITCHROOM_WORKTREE_ALLOW_TMP;
+    process.env.SWITCHROOM_WORKTREE_BASE = join(tmpdir(), "sw-noexec-base");
+    await expect(
+      claimWorktree({ repo: repoDir, taskName: "tmp-reject" }),
+    ).rejects.toThrow(/noexec/i);
+    // No ghost record may survive the rejection.
+    expect(listRecords()).toHaveLength(0);
+  });
+
+  it("assertBaseDirNotTmp rejects /tmp and /var/tmp, allows $HOME-shaped paths", () => {
+    delete process.env.SWITCHROOM_WORKTREE_ALLOW_TMP;
+    expect(() => assertBaseDirNotTmp("/tmp/checkouts")).toThrow(/noexec/i);
+    expect(() => assertBaseDirNotTmp("/var/tmp/checkouts")).toThrow(/noexec/i);
+    expect(() => assertBaseDirNotTmp("/home/agent/.switchroom/worktree-checkouts")).not.toThrow();
+    process.env.SWITCHROOM_WORKTREE_ALLOW_TMP = "1";
+    expect(() => assertBaseDirNotTmp("/tmp/checkouts")).not.toThrow();
+  });
+
+  it("legacy `git worktree add` records are still releasable (shape-aware removal)", () => {
+    // Simulate a pre-fix claim: a real linked worktree + its registry record.
+    const legacyPath = join(base, "checkouts", "legacy-wt");
+    mkdirSync(join(base, "checkouts"), { recursive: true });
+    execFileSync("git", ["worktree", "add", "-b", "task/legacy-1", legacyPath], {
+      cwd: repoDir,
+      stdio: "pipe",
+    });
+    expect(detectCheckoutKind(legacyPath)).toBe("worktree");
+    const now = new Date().toISOString();
+    writeRecord({
+      id: "legacy01",
+      repo: repoDir,
+      repoName: repoDir,
+      branch: "task/legacy-1",
+      path: legacyPath,
+      createdAt: now,
+      heartbeatAt: now,
+    });
+
+    const rel = releaseWorktree({ id: "legacy01" });
+    expect(rel.released).toBe(true);
+    expect(existsSync(legacyPath)).toBe(false);
+    // The source repo's admin entry is gone too (git did the removal).
+    const adminDir = join(repoDir, ".git", "worktrees");
+    const entries = existsSync(adminDir) ? readdirSync(adminDir) : [];
+    expect(entries).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Concurrent sub-agents doing code work off a shared checkout corrupted each other's work. Five observed failure modes (all real, from klanker's fleet):

1. A worker's worktree deleted out from under it mid-task by a concurrent worker.
2. `git stash pop` in one worktree popped a DIFFERENT worker's stash entry — linked worktrees share the single `refs/stash` with the parent repo — leaving conflict markers in unrelated files.
3. The shared repo flipped to detached HEAD mid-run when a worker checked something out in it.
4. Stale `.git/worktrees/<name>` admin metadata survived `worktree remove --force` + `rm -rf` + `prune` and resurrected a previous claim's dirty state on re-claim.
5. `/tmp` is mounted `noexec` in agent containers, so a checkout there fails `npm ci` with `spawnSync … esbuild EACCES`.

The only defence was prose in dispatch prompts. Per `skills/dev-protocol/SKILL.md` ("prefer a deterministic mechanism over prompt discipline"), this makes the sanctioned mechanism (`switchroom worktree claim`) structurally collision-proof instead.

## Fix

- **`claimWorktree` provisions an independent local `git clone`** (hardlinked object store — near-worktree cost on the same filesystem) on the task branch, instead of `git worktree add` off the shared repo. Concurrent claims now share NO mutable git state: own stash, own refs, own HEAD, no admin metadata in the source repo. `origin` is rewired to the source repo's real remote so fetch/push hit upstream as before.
- **`/tmp` and `/var/tmp` checkout bases are rejected at claim time** with a clear noexec error (`assertBaseDirNotTmp`); escape hatch `SWITCHROOM_WORKTREE_ALLOW_TMP=1` for exec-mounted hosts/tests.
- **Release / reap / gc are shape-aware** (`src/worktree/remove-checkout.ts`): `.git` directory = clone → `rm -rf`; `.git` file = legacy linked worktree → `git worktree remove --force` (+ branch delete in gc). Records written before this fix stay removable; detection is by filesystem shape, not a record field, so it cannot drift.

## Failure-mode coverage

Structurally prevented for claims through this mechanism: **2, 3, 4** (no shared stash/refs/metadata exists), **5** (rejected in code). **1** is prevented in the sense that no worker's git commands (`worktree remove/prune`, checkouts) can touch another claim's state anymore; a rogue `rm -rf` of an arbitrary path is out of scope for any provisioning layer. Hand-rolled worktrees that bypass `switchroom worktree claim` entirely are likewise out of scope — the point of this PR is that the sanctioned path is now safe to mandate.

Known follow-up (out of scope, single-concern): per-agent standing trees from `ensureAgentWorktree` (`src/repos/agent-worktree.ts`) are still linked worktrees off the shared bare clone, so two AGENTS' standing trees on the same repo still share `refs/stash`. Same clone-based fix applies if wanted.

## Tests

`tests/worktree.claim-isolation.test.ts` — every test asserts an outcome that FAILS on the old provisioning (verified by demonstrating the old behaviour manually: stash from worktree A visible in worktree B; `.git/worktrees/{wa,wb}` populated):

- stash in claim A invisible to claim B; `stash pop` in B fails; A pops its own intact
- claim leaves zero `.git/worktrees` entries in the source repo
- claim has its own `--git-common-dir`; detaching inside a claim never moves the source repo's HEAD
- release + re-claim same task name yields a clean tree (no resurrected state)
- `/tmp` base rejected with a noexec error, no ghost registry record
- legacy `git worktree add` record still releasable (shape-aware removal)

`vitest run` on all 6 worktree test files: 109/109 pass. `npm run lint` green (tsc, changelog gate, attribution trailers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)