### PR TITLE
fix(repos): provision per-agent standing trees as independent clones, not linked worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,25 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **repos: per-agent STANDING trees (`repos:` in switchroom.yaml) are now
+  independent clones too — two agents on the same repo no longer share a
+  stash ref.** The claim-path fix below stopped sub-agent checkouts sharing
+  git state, but `ensureAgentWorktree` still provisioned every agent's
+  standing tree at `<agentDir>/work/<slug>/` as a linked `git worktree` off
+  the shared bare clone at `~/.switchroom/repos/<slug>.git` — so all agents
+  on a repo shared the bare's object store, refs, and its SINGLE
+  `refs/stash`: a `git stash pop` in one agent's tree could pop another
+  agent's entry. Standing trees are now provisioned with the same remedy
+  shape: an independent local clone (hardlinked objects, own refs/stash),
+  `origin` rewired to the bare's real upstream, and a legacy per-agent
+  branch left in the bare is preserved as the start point on re-provision.
+  Provisioning also refuses an agent dir under `/tmp`/`/var/tmp` via the
+  same `assertBaseDirNotTmp` guard (tmp is `noexec` in agent containers).
+  PRE-EXISTING standing trees are never force-migrated and stay removable:
+  removal is shape-aware (`.git` dir = clone → `rm -rf`; `.git` FILE =
+  legacy linked worktree → `git worktree remove` from the bare), detected
+  by filesystem shape, never a stored kind field.
+
 - **worktree: `switchroom worktree claim` now provisions an INDEPENDENT clone,
   not a linked `git worktree` — concurrent sub-agents can no longer collide
   through shared git state.** Linked worktrees share the parent repo's refs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `resources.memory_reservation` | per-field | Soft memory floor (Docker `mem_reservation` → cgroup `memory.low`). Protects this much from reclaim under host-wide pressure. Must be ≤ `memory`. |
 | `resources.pids_limit` | per-field | Max processes in the cgroup (`pids.max`). Idle agent ≈ 30 PIDs; `npm test`-style workloads spike past 200. |
 | `resources.cpus` | per-field | CPU quota (Docker `cpus`), fractional OK. Unset at every layer → per-profile default (klanker/coding 2.0, default 1.0, lightweight 0.5). |
-| `resources.tmp_size` | per-field | Size of the container's RAM-backed `/tmp` (`tmpfs: - /tmp:size=<this>,mode=1777`). Docker size string (`4g`, `512m`). **Default `2g`.** The container root FS is read-only, so `/tmp` is the *only* scratch space the agent and its sub-agents get — repo clones, `bunx`/`npx`/`pip` toolchain caches. Raise it for agents that fan out several sub-agents at once (the earlier hard-coded 1g was measured 90% full on a busy root-tier agent, 785M of it concurrent sub-agent clones and caches). A tmpfs is a ceiling, not a reservation: it consumes host RAM only for pages actually written, so raising it costs nothing until used — but those pages count against `resources.memory`, so raise both together. Takes effect when the container is recreated (`switchroom apply`), not on a running one. |
+| `resources.tmp_size` | per-field | Size of the container's RAM-backed `/tmp` (`tmpfs: - /tmp:size=<this>,mode=1777`). Docker size string (`4g`, `512m`). **Default `2g`.** The container root FS is read-only, so `/tmp` is the *only* scratch space the agent and its sub-agents get — `bunx`/`npx`/`pip` toolchain caches and similar scratch. (NOT repo checkouts: `/tmp` is mounted `noexec`, so builds there fail with `EACCES` — checkouts are guarded to land under `$HOME`, see `assertBaseDirNotTmp` in `src/worktree/claim.ts`.) Raise it for agents that fan out several sub-agents at once (the earlier hard-coded 1g was measured 90% full on a busy root-tier agent, 785M of it concurrent sub-agent clones and caches). A tmpfs is a ceiling, not a reservation: it consumes host RAM only for pages actually written, so raising it costs nothing until used — but those pages count against `resources.memory`, so raise both together. Takes effect when the container is recreated (`switchroom apply`), not on a running one. |
 | `settings_raw` | deep merge | Escape hatch: raw settings.json overrides |
 | `claude_md_raw` | concatenate | Escape hatch: append to CLAUDE.md on scaffold |
 | `cli_args` | concatenate | Escape hatch: extra `exec claude` flags |
@@ -1367,10 +1367,11 @@ primitives is the right tool:
 
 - **"Agent should edit a git repo (incl. switchroom itself)."** Use
   `repos:` (see `src/config/schema.ts` `AgentRepoEntry`). Switchroom
-  provisions a dedicated worktree at `<agentDir>/work/<slug>/` from
-  a shared bare clone — the agent edits *inside its own sandbox*,
+  provisions a dedicated standing tree at `<agentDir>/work/<slug>/` —
+  an independent clone (its own refs and stash) seeded from a shared
+  bare clone — so the agent edits *inside its own sandbox*,
   not on a mounted host checkout. `bind_mounts:` is not needed and
-  doesn't help: the worktree pattern lets the agent commit + push +
+  doesn't help: the standing-tree pattern lets the agent commit + push +
   open a PR using its own git identity without touching host state.
 - **"Admin agent should deploy a merged change (`switchroom apply`,
   `agent restart`, `update apply`)."** That's the host-control

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -4690,9 +4690,10 @@ export const AgentSchema = z.object({
     )
     .optional()
     .describe(
-      "Repos this agent operates on. Switchroom provisions a dedicated worktree for each " +
-      "repo at <agentDir>/work/<slug>/ on branch agent/<agentName>/main, backed by a " +
-      "shared bare clone at ~/.switchroom/repos/<slug>.git. The worktree path is injected " +
+      "Repos this agent operates on. Switchroom provisions a dedicated standing tree for " +
+      "each repo at <agentDir>/work/<slug>/ on branch agent/<agentName>/main — an " +
+      "independent clone (own refs/stash, hardlinked objects) seeded from a shared bare " +
+      "clone at ~/.switchroom/repos/<slug>.git. The tree's path is injected " +
       "into the agent's environment as SWITCHROOM_REPO_<SLUG_UPPER>. " +
       "Agents without this field continue to work unchanged.",
     ),

--- a/src/repos/agent-worktree.ts
+++ b/src/repos/agent-worktree.ts
@@ -1,23 +1,40 @@
 /**
- * Per-agent worktree management.
+ * Per-agent standing-tree management.
  *
  * Each agent that declares a repo in its switchroom.yaml config gets a
- * dedicated worktree at <agentDir>/work/<slug>/ on branch
- * agent/<agentName>/main. This worktree is:
+ * dedicated standing tree at <agentDir>/work/<slug>/ on branch
+ * agent/<agentName>/main. This tree is:
  *   - Created on the first reconcile after the repo appears in config.
  *   - Fast-forwarded to upstream/main (or the remote's default branch)
- *     on each subsequent reconcile when the worktree is clean.
- *   - Left unchanged (dirty: true) when the worktree has uncommitted
+ *     on each subsequent reconcile when the tree is clean.
+ *   - Left unchanged (dirty: true) when the tree has uncommitted
  *     changes — we never git reset --hard an agent's in-flight work.
  *   - Removed with the agent on `switchroom agent remove`.
  *
- * Isolation: two agents on the same repo get separate worktrees on
- * separate branches; they cannot interfere with each other.
+ * WHY AN INDEPENDENT CLONE AND NOT `git worktree add` (same class of bug
+ * as the claim-path fix in src/worktree/claim.ts, PR #4659): linked
+ * worktrees off the shared bare clone all share the bare's object store
+ * and refs — including the SINGLE `refs/stash` — so a `git stash pop` in
+ * one agent's standing tree can pop a DIFFERENT agent's stash entry, and
+ * `.git/worktrees/<name>` admin metadata in the bare can go stale across
+ * removals. An independent clone shares nothing mutable with the bare or
+ * with any other agent's tree by construction. A local clone hardlinks
+ * the object store (same filesystem), so the disk cost stays near a
+ * worktree's. `origin` is rewired from the local bare-clone path to the
+ * bare's real upstream URL so fetch/push in the tree hit upstream.
+ *
+ * PRE-EXISTING trees provisioned as linked worktrees are left in place
+ * (never force-migrated — that could lose in-flight work) and remain
+ * removable: removal is shape-aware via removeCheckout(), detecting by
+ * filesystem shape (`.git` dir = clone, `.git` file = linked worktree),
+ * never by a stored record field.
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { assertBaseDirNotTmp } from "../worktree/claim.js";
+import { removeCheckout } from "../worktree/remove-checkout.js";
 
 export interface WorktreeState {
   /** Absolute path to the worktree directory */
@@ -105,16 +122,16 @@ function branchExistsInBare(bareClonePath: string, branchName: string): boolean 
 }
 
 /**
- * Resolve the default remote tracking branch for the bare clone.
- * Tries refs/remotes/origin/HEAD → falls back to "main".
+ * Resolve the default remote tracking branch for a repo (bare clone or
+ * checked-out tree). Tries refs/remotes/origin/HEAD → falls back to "main".
  */
-function resolveDefaultBranch(bareClonePath: string): string {
+function resolveDefaultBranch(repoPath: string): string {
   try {
     const out = execFileSync(
       "git",
       ["symbolic-ref", "refs/remotes/origin/HEAD"],
       {
-        cwd: bareClonePath,
+        cwd: repoPath,
         stdio: ["ignore", "pipe", "pipe"],
         encoding: "utf-8",
       },
@@ -128,15 +145,35 @@ function resolveDefaultBranch(bareClonePath: string): string {
 }
 
 /**
- * Ensure a per-agent worktree exists for a given repo.
+ * Check whether a fully-qualified ref exists in a repo.
+ */
+function refExists(repoPath: string, ref: string): boolean {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", "--quiet", ref], {
+      cwd: repoPath,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ensure a per-agent standing tree exists for a given repo.
  *
  * Behaviour:
- *   1. First call: creates <agentDir>/work/<slug>/ as a git worktree on
- *      branch agent/<agentName>/main. The branch is created off the
- *      remote's default branch (e.g. origin/main).
- *   2. Subsequent calls (clean worktree): fetches latest from remote
- *      and fast-forwards agent/<agentName>/main to origin/<defaultBranch>.
- *   3. Subsequent calls (dirty worktree): leaves the worktree unchanged,
+ *   1. First call: creates <agentDir>/work/<slug>/ as an INDEPENDENT
+ *      local clone of the bare clone (own object store, own refs, own
+ *      refs/stash — see module header) on branch agent/<agentName>/main.
+ *      The branch starts at the bare's copy of the per-agent branch when
+ *      one exists (re-provisioning after a pre-fix removal), else at the
+ *      remote's default branch (e.g. origin/main). `origin` is rewired
+ *      to the bare's real upstream URL.
+ *   2. Subsequent calls (clean tree): fetches latest from origin and
+ *      fast-forwards agent/<agentName>/main to origin/<defaultBranch>.
+ *      Works unchanged for PRE-EXISTING linked-worktree trees.
+ *   3. Subsequent calls (dirty tree): leaves the tree unchanged,
  *      returns dirty: true.
  *
  * Synchronous: uses execFileSync internally; exported as a sync function
@@ -155,43 +192,70 @@ export function ensureAgentWorktree(
 ): WorktreeState {
   const worktreePath = agentWorktreePath(agentDir, slug);
   const branch = agentBranchName(agentName);
-  const defaultBranch = resolveDefaultBranch(bareClonePath);
 
   if (!existsSync(worktreePath)) {
-    // First time: create the worktree directory and the agent branch.
-    mkdirSync(join(agentDir, "work"), { recursive: true });
+    // First time: provision an independent clone of the bare clone.
+    // Same remedy shape as the claim path (src/worktree/claim.ts, #4659).
+    const workDir = join(agentDir, "work");
+    // Agent containers mount /tmp noexec — a standing tree there fails the
+    // moment a build runs in it. Same guard as the claim path.
+    assertBaseDirNotTmp(workDir);
+    mkdirSync(workDir, { recursive: true });
 
-    if (branchExistsInBare(bareClonePath, branch)) {
-      // Branch already exists (e.g. re-provisioning after removal).
-      // Add the worktree using the existing branch — don't re-create it.
+    try {
+      // Local clone: hardlinks the bare's object store (same filesystem), so
+      // this is cheap. --no-checkout because we check out the per-agent
+      // branch ourselves in the next step. Cloning a bare repo maps the
+      // bare's refs/heads/* to refs/remotes/origin/* in the clone, so a
+      // legacy per-agent branch left in the bare by the pre-fix
+      // `worktree add -b` provisioning surfaces as origin/<branch> here.
       execFileSync(
         "git",
-        ["worktree", "add", worktreePath, branch],
-        {
-          cwd: bareClonePath,
-          stdio: ["ignore", "pipe", "pipe"],
-        },
+        ["clone", "--quiet", "--no-checkout", bareClonePath, worktreePath],
+        { stdio: ["ignore", "pipe", "pipe"] },
       );
-    } else {
-      // Create the worktree and the per-agent branch together.
-      // The branch starts at origin/<defaultBranch>.
+
+      const defaultBranch = resolveDefaultBranch(worktreePath);
+      const startPoint = refExists(worktreePath, `refs/remotes/origin/${branch}`)
+        ? `origin/${branch}` // preserve the legacy per-agent branch's state
+        : `origin/${defaultBranch}`;
       execFileSync(
         "git",
-        [
-          "worktree", "add",
-          worktreePath,
-          "-b", branch,
-          `origin/${defaultBranch}`,
-        ],
-        {
+        ["checkout", "--quiet", "-b", branch, startPoint],
+        { cwd: worktreePath, stdio: ["ignore", "pipe", "pipe"] },
+      );
+
+      // Rewire `origin` from the local bare-clone path to the bare's real
+      // upstream URL, so fetch/push in the standing tree hit upstream —
+      // matching what a linked worktree (which shared the bare's remote
+      // config) used to give agents. If the bare has no origin, leave the
+      // local path in place.
+      let originUrl: string | undefined;
+      try {
+        originUrl = execFileSync("git", ["remote", "get-url", "origin"], {
           cwd: bareClonePath,
           stdio: ["ignore", "pipe", "pipe"],
-        },
-      );
+          encoding: "utf-8",
+        }).trim();
+      } catch {
+        /* bare clone has no origin remote */
+      }
+      if (originUrl) {
+        execFileSync("git", ["remote", "set-url", "origin", originUrl], {
+          cwd: worktreePath,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      }
+    } catch (err) {
+      // Remove any partial clone: a half-provisioned dir would otherwise be
+      // mistaken for an existing tree (and reported dirty) on the next
+      // reconcile. Mirrors the claim path's failure cleanup.
+      rmSync(worktreePath, { recursive: true, force: true });
+      throw err;
     }
 
     process.stderr.write(
-      `[switchroom] repo "${slug}": worktree ready at ${worktreePath} (branch: ${branch})\n`,
+      `[switchroom] repo "${slug}": standing tree ready at ${worktreePath} (branch: ${branch}, independent clone)\n`,
     );
     return { path: resolve(worktreePath), branch, dirty: false };
   }
@@ -218,6 +282,11 @@ export function ensureAgentWorktree(
       stdio: ["ignore", "pipe", "pipe"],
     });
 
+    // Resolve from the tree itself: works for both shapes (an independent
+    // clone has its own refs/remotes/origin/HEAD; a legacy linked worktree
+    // resolves through the bare clone's refs).
+    const defaultBranch = resolveDefaultBranch(worktreePath);
+
     execFileSync(
       "git",
       ["merge", "--ff-only", `origin/${defaultBranch}`],
@@ -242,13 +311,20 @@ export function ensureAgentWorktree(
 }
 
 /**
- * Remove the per-agent worktree for a given repo.
+ * Remove the per-agent standing tree for a given repo.
  *
  * Steps:
- *   1. `git worktree remove --force <path>` from the bare clone.
- *   2. `git branch -D agent/<agentName>/main` from the bare clone.
+ *   1. Shape-aware removal via removeCheckout(): an independent clone
+ *      (`.git` directory) is `rm -rf`'d — everything lives inside it; a
+ *      PRE-EXISTING linked worktree (`.git` FILE) goes through
+ *      `git worktree remove --force` from the bare clone so the bare's
+ *      `.git/worktrees/<name>` admin entry is cleaned up too. Detection
+ *      is by filesystem shape, never a stored kind field.
+ *   2. `git branch -D agent/<agentName>/main` from the bare clone (a
+ *      legacy leftover for clone-shaped trees; the live branch for
+ *      worktree-shaped ones).
  *
- * Idempotent — safe to call even when the worktree or branch is absent.
+ * Idempotent — safe to call even when the tree or branch is absent.
  *
  * Synchronous: uses execFileSync internally; exported as a sync function
  * so that callers do not need to become async.
@@ -264,14 +340,7 @@ export function removeAgentWorktree(
 
   if (existsSync(worktreePath)) {
     try {
-      execFileSync(
-        "git",
-        ["worktree", "remove", "--force", worktreePath],
-        {
-          cwd: bareClonePath,
-          stdio: ["ignore", "pipe", "pipe"],
-        },
-      );
+      removeCheckout(bareClonePath, worktreePath);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(

--- a/src/repos/bare-clone.ts
+++ b/src/repos/bare-clone.ts
@@ -3,11 +3,14 @@
  *
  * One bare clone per repo slug lives at ~/.switchroom/repos/<slug>.git,
  * shared across all agents. The bare clone is the source from which
- * per-agent worktrees are created (git worktree add).
+ * per-agent standing trees are provisioned — as INDEPENDENT local clones
+ * (see src/repos/agent-worktree.ts), not `git worktree add` (linked
+ * worktrees shared the bare's refs, including the single refs/stash).
  *
- * Design decision: bare clones share .git/objects across all worktrees
- * checked out of them, so five agents on the same 200MB repo cost one
- * clone worth of storage, not five.
+ * Design decision: a local clone hardlinks .git/objects (same
+ * filesystem), so five agents on the same 200MB repo still cost about
+ * one clone worth of storage, not five — without sharing any mutable
+ * git state.
  */
 
 import { execFileSync } from "node:child_process";

--- a/tests/repos.agent-worktree-isolation.test.ts
+++ b/tests/repos.agent-worktree-isolation.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Isolation tests for per-agent STANDING trees (src/repos/agent-worktree.ts)
+ * — the reconcile-path twin of the claim-path fix in PR #4659.
+ *
+ * These assert the OUTCOMES that fail when standing trees are provisioned
+ * as `git worktree add` checkouts off the shared bare clone — every
+ * isolation test here fails on the old provisioning:
+ *
+ *   1. Two agents' standing trees must NOT share a stash ref (a
+ *      `git stash push` in one agent's tree must be invisible to a
+ *      `git stash pop` in the other's).
+ *   2. Provisioning must leave NO `.git/worktrees` admin metadata in the
+ *      shared bare clone, and the tree must have its own git dir.
+ *   3. `origin` in the tree points at the bare clone's real upstream.
+ *   4. A legacy per-agent branch left in the bare (pre-fix provisioning)
+ *      is preserved as the start point on re-provision.
+ *   5. Reconcile still fast-forwards a clean tree, and leaves a dirty
+ *      tree untouched.
+ *   6. An agent dir under /tmp is rejected at provision time (noexec in
+ *      agent containers).
+ *   7. Removal is SHAPE-AWARE: both a clone-shaped tree and a
+ *      PRE-EXISTING linked-worktree tree are removable, detected by
+ *      filesystem shape, and the legacy removal cleans the bare's admin
+ *      entry and per-agent branch.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import {
+  ensureAgentWorktree,
+  removeAgentWorktree,
+  agentWorktreePath,
+} from "../src/repos/agent-worktree.js";
+import { detectCheckoutKind } from "../src/worktree/remove-checkout.js";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, stdio: "pipe", encoding: "utf-8" }).trim();
+}
+
+describe("agent standing trees — independent clones, no shared git state", () => {
+  let base: string;
+  let upstream: string;
+  let bare: string;
+  const origAllowTmp = process.env.SWITCHROOM_WORKTREE_ALLOW_TMP;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "sw-agent-wt-"));
+    // Upstream repo with a commit on main.
+    upstream = join(base, "upstream");
+    mkdirSync(upstream);
+    git(upstream, "init", "-b", "main");
+    git(upstream, "config", "user.email", "test@test.com");
+    git(upstream, "config", "user.name", "Test");
+    writeFileSync(join(upstream, "README.md"), "init\n");
+    writeFileSync(join(upstream, "shared.txt"), "shared content\n");
+    git(upstream, "add", ".");
+    git(upstream, "commit", "-m", "init");
+    // Shared bare clone — what ensureBareClone provisions.
+    bare = join(base, "repos", "my-app.git");
+    mkdirSync(join(base, "repos"), { recursive: true });
+    execFileSync("git", ["clone", "--bare", "--quiet", upstream, bare], { stdio: "pipe" });
+    // Fixtures live under tmpdir; don't let the production noexec guard
+    // reject the test environment itself.
+    process.env.SWITCHROOM_WORKTREE_ALLOW_TMP = "1";
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+    if (origAllowTmp === undefined) delete process.env.SWITCHROOM_WORKTREE_ALLOW_TMP;
+    else process.env.SWITCHROOM_WORKTREE_ALLOW_TMP = origAllowTmp;
+  });
+
+  function agentDirFor(name: string): string {
+    const dir = join(base, "agents", name);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  it("two agents' standing trees do NOT share a stash ref", () => {
+    const aliceDir = agentDirFor("alice");
+    const bobDir = agentDirFor("bob");
+    const a = ensureAgentWorktree("alice", "my-app", bare, aliceDir);
+    const b = ensureAgentWorktree("bob", "my-app", bare, bobDir);
+    expect(a.dirty).toBe(false);
+    expect(b.dirty).toBe(false);
+
+    // Stash creates commits — give the trees an identity (CI runners have
+    // no global git config).
+    for (const p of [a.path, b.path]) {
+      git(p, "config", "user.email", "test@test.com");
+      git(p, "config", "user.name", "Test");
+    }
+
+    // Alice stashes an in-flight edit.
+    writeFileSync(join(a.path, "shared.txt"), "alice's uncommitted change\n");
+    git(a.path, "stash", "push", "-m", "alice-wip");
+    expect(git(a.path, "stash", "list")).toContain("alice-wip");
+
+    // Bob's stash must be EMPTY — on the old linked-worktree provisioning
+    // both trees share the bare clone's single refs/stash, Bob sees Alice's
+    // entry, and a `git stash pop` in Bob's tree pops Alice's work.
+    expect(git(b.path, "stash", "list")).toBe("");
+    expect(() => git(b.path, "stash", "pop")).toThrow();
+    expect(git(b.path, "status", "--porcelain")).toBe("");
+
+    // Alice can still pop her own stash intact.
+    git(a.path, "stash", "pop");
+    expect(git(a.path, "status", "--porcelain")).toContain("shared.txt");
+  });
+
+  it("provisioning leaves NO worktree admin metadata in the bare clone and the tree owns its git dir", () => {
+    const a = ensureAgentWorktree("alice", "my-app", bare, agentDirFor("alice"));
+    expect(detectCheckoutKind(a.path)).toBe("clone");
+    // Old behaviour: the bare grows a worktrees/<name> admin entry.
+    const adminDir = join(bare, "worktrees");
+    const entries = existsSync(adminDir) ? readdirSync(adminDir) : [];
+    expect(entries).toEqual([]);
+    // The tree's git common dir resolves INSIDE the tree, not to the bare.
+    const commonDir = git(a.path, "rev-parse", "--path-format=absolute", "--git-common-dir");
+    expect(commonDir.startsWith(a.path)).toBe(true);
+    // And it is on the expected branch.
+    expect(git(a.path, "rev-parse", "--abbrev-ref", "HEAD")).toBe("agent/alice/main");
+    expect(a.branch).toBe("agent/alice/main");
+  });
+
+  it("origin in the tree points at the bare clone's real upstream", () => {
+    const a = ensureAgentWorktree("alice", "my-app", bare, agentDirFor("alice"));
+    // The bare's origin is the upstream path — the tree must inherit it,
+    // not point at the local bare clone.
+    expect(git(a.path, "remote", "get-url", "origin")).toBe(git(bare, "remote", "get-url", "origin"));
+    expect(git(a.path, "remote", "get-url", "origin")).not.toBe(bare);
+  });
+
+  it("a legacy per-agent branch in the bare is preserved as the start point", () => {
+    // Simulate pre-fix state: the bare carries agent/alice/main at a commit
+    // AHEAD of main (work the old linked worktree committed to the bare).
+    git(upstream, "checkout", "-b", "side");
+    writeFileSync(join(upstream, "legacy.txt"), "legacy work\n");
+    git(upstream, "add", ".");
+    git(upstream, "commit", "-m", "legacy agent work");
+    const legacySha = git(upstream, "rev-parse", "HEAD");
+    git(upstream, "push", "--quiet", bare, "side:refs/heads/agent/alice/main");
+    git(upstream, "checkout", "main");
+
+    const a = ensureAgentWorktree("alice", "my-app", bare, agentDirFor("alice"));
+    expect(git(a.path, "rev-parse", "HEAD")).toBe(legacySha);
+    expect(existsSync(join(a.path, "legacy.txt"))).toBe(true);
+  });
+
+  it("a clean tree fast-forwards to upstream's default branch on re-ensure", () => {
+    const agentDir = agentDirFor("alice");
+    ensureAgentWorktree("alice", "my-app", bare, agentDir);
+
+    // Upstream moves forward.
+    writeFileSync(join(upstream, "new.txt"), "new\n");
+    git(upstream, "add", ".");
+    git(upstream, "commit", "-m", "upstream moves");
+    const newSha = git(upstream, "rev-parse", "HEAD");
+
+    const again = ensureAgentWorktree("alice", "my-app", bare, agentDir);
+    expect(again.dirty).toBe(false);
+    expect(git(again.path, "rev-parse", "HEAD")).toBe(newSha);
+  });
+
+  it("a dirty tree is left untouched (dirty: true, no reset)", () => {
+    const agentDir = agentDirFor("alice");
+    const a = ensureAgentWorktree("alice", "my-app", bare, agentDir);
+    writeFileSync(join(a.path, "shared.txt"), "in-flight edit\n");
+
+    const again = ensureAgentWorktree("alice", "my-app", bare, agentDir);
+    expect(again.dirty).toBe(true);
+    expect(git(again.path, "status", "--porcelain")).toContain("shared.txt");
+  });
+
+  it("rejects an agent dir under /tmp at provision time (noexec guard)", () => {
+    delete process.env.SWITCHROOM_WORKTREE_ALLOW_TMP;
+    const tmpAgentDir = join(tmpdir(), "sw-agent-wt-noexec-agent");
+    expect(() => ensureAgentWorktree("alice", "my-app", bare, tmpAgentDir)).toThrow(/noexec/i);
+    // Nothing was provisioned.
+    expect(existsSync(agentWorktreePath(tmpAgentDir, "my-app"))).toBe(false);
+  });
+
+  it("a failed provision leaves NO partial tree behind", () => {
+    // A bare of an EMPTY repo: the clone step succeeds but the branch
+    // checkout has no start point and fails. The partial clone must be
+    // removed — a leftover dir would be mistaken for an existing (dirty)
+    // tree on every subsequent reconcile.
+    const emptyUpstream = join(base, "empty-upstream");
+    mkdirSync(emptyUpstream);
+    git(emptyUpstream, "init", "-b", "main");
+    const emptyBare = join(base, "repos", "empty.git");
+    execFileSync("git", ["clone", "--bare", "--quiet", emptyUpstream, emptyBare], {
+      stdio: "pipe",
+    });
+
+    const agentDir = agentDirFor("alice");
+    expect(() => ensureAgentWorktree("alice", "empty", emptyBare, agentDir)).toThrow();
+    expect(existsSync(agentWorktreePath(agentDir, "empty"))).toBe(false);
+  });
+
+  it("removes a clone-shaped standing tree", () => {
+    const agentDir = agentDirFor("alice");
+    const a = ensureAgentWorktree("alice", "my-app", bare, agentDir);
+    expect(detectCheckoutKind(a.path)).toBe("clone");
+
+    removeAgentWorktree("alice", "my-app", bare, agentDir);
+    expect(existsSync(a.path)).toBe(false);
+  });
+
+  it("removes a PRE-EXISTING linked-worktree standing tree (shape-aware) and cleans the bare", () => {
+    // Provision the OLD way: linked worktree + per-agent branch in the bare.
+    const agentDir = agentDirFor("alice");
+    const legacyPath = agentWorktreePath(agentDir, "my-app");
+    mkdirSync(join(agentDir, "work"), { recursive: true });
+    execFileSync(
+      "git",
+      ["worktree", "add", "--quiet", "-b", "agent/alice/main", legacyPath, "main"],
+      { cwd: bare, stdio: "pipe" },
+    );
+    expect(detectCheckoutKind(legacyPath)).toBe("worktree");
+
+    removeAgentWorktree("alice", "my-app", bare, agentDir);
+    expect(existsSync(legacyPath)).toBe(false);
+    // The bare's admin entry and the per-agent branch are gone.
+    const adminDir = join(bare, "worktrees");
+    const entries = existsSync(adminDir) ? readdirSync(adminDir) : [];
+    expect(entries).toEqual([]);
+    expect(() => git(bare, "rev-parse", "--verify", "refs/heads/agent/alice/main")).toThrow();
+  });
+});


### PR DESCRIPTION
Follow-up to #4659 (merged as 0fff478), which fixed sub-agent CLAIM checkouts. This PR fixes the same class of bug on the other provisioning path, and closes out the /tmp-checkout audit.

## Job 1 — per-agent standing trees shared refs/stash

`ensureAgentWorktree` (src/repos/agent-worktree.ts) provisioned every agent's standing tree at `<agentDir>/work/<slug>/` via `git worktree add` off the shared bare clone at `~/.switchroom/repos/<slug>.git`. Linked worktrees share the bare's object store and refs — including the SINGLE `refs/stash` — so a `git stash pop` in one agent's standing tree could pop a different agent's stash entry (the exact production failure #4659 documented for claims).

Remedy, same shape as #4659:

- **Independent local clone** of the bare (`git clone --no-checkout` — hardlinked objects, own refs, own `refs/stash`), then `checkout -b agent/<name>/main`. A legacy per-agent branch left in the bare by the pre-fix provisioning is preserved as the start point (it surfaces as `origin/agent/<name>/main` in the clone).
- **`origin` rewired** to the bare's real upstream URL, so fetch/ff-forward and push in the tree hit upstream directly.
- **Shape-aware removal, reusing `removeCheckout()` from #4659** (not a fork of the rule): `.git` directory = clone → `rm -rf`; `.git` FILE = pre-existing linked worktree → `git worktree remove --force` from the bare (admin entry cleaned). Detection is by filesystem shape, never a stored `kind` field. The legacy per-agent branch delete + `worktree prune` in the bare are kept (idempotent, guarded).
- **Pre-existing standing trees are NOT force-migrated** — the reconcile ff/dirty path works unchanged on both shapes; only removal is shape-aware.
- **`assertBaseDirNotTmp` guard** (reused from `src/worktree/claim.ts`, not forked) now also rejects an agent work dir under `/tmp`/`/var/tmp` at provision time.
- A failed provision removes the partial clone (a leftover dir would otherwise read as an existing dirty tree on every later reconcile).

## Job 2 — audit of remaining /tmp checkout/build base dirs

Sites found and disposition (full grep over `tmpdir()`, `mkdtemp`, `mktemp`, hardcoded `/tmp`, `/var/tmp`, `git clone`, `worktree add`, `npm ci`/build across src, bin, scripts, skills, docs, .github):

**Guarded (this PR):**
- `src/repos/agent-worktree.ts` — standing-tree provisioning now calls `assertBaseDirNotTmp` (was unguarded).

**Already guarded (#4659):** `src/worktree/claim.ts` (`worktreesBaseDir` / `SWITCHROOM_WORKTREE_BASE`).

**Deliberately left — no checkout/build can land there, or non-exec scratch:**
- `src/repos/bare-clone.ts` — bare repo under `~/.switchroom/repos/` (home-anchored via `resolveStatePath`; no working tree, nothing executes from it).
- `src/cli/skill.ts`, `src/cli/skill-personal.ts` — `mkdtemp` staging for skill extraction and `python3 -m py_compile` syntax checks (interpreter READS the file; noexec doesn't block it).
- `src/agents/rename-orchestrator.ts` — state-dir snapshot/restore backup (data copy only).
- `src/web/config-diff.ts`, `src/host-control/config-edit-validator.ts` — YAML/diff scratch files.
- `src/vault/resolver.ts` — secret materialization (prefers `XDG_RUNTIME_DIR`; data files only).
- `src/auth/manager.ts` — `.setup-token-tmp-` staging lives under the agent dir, not /tmp.
- `src/cli/hindsight-mcp-shim.ts` — cache-dir HOME fallback to `tmpdir()` (JSON cache).
- `src/cli/drive-mcp-launcher.ts`, `src/cli/m365-mcp-launcher.ts` — caches already deliberately NOT /tmp (per in-file comments).
- `bin/run-hook.sh`, `scripts/ci/*.sh`, `.github/workflows/*` — `mktemp`/`/tmp` for logs/JSON artifacts (hosted runners, data only).
- `skills/*/VENDORED.md` — maintainer vendoring instructions clone into `/tmp` then `cp`; a clone (no build) works on a noexec mount, and these run on dev hosts.
- `src/worktree/gc.ts` `isEphemeralPath` — /tmp is on the never-touch list (correct as-is).
- `src/cli/update.ts --rebuild` — builds in the existing source checkout; does not choose a base dir.

**Docs corrected:** `docs/configuration.md` `resources.tmp_size` row claimed `/tmp` is where "repo clones" go — now states checkouts are guarded to `$HOME` and points at `assertBaseDirNotTmp`. Also updated the `repos:` provisioning wording in `docs/configuration.md` and the `src/config/schema.ts` describe string, plus stale header comments in `src/repos/bare-clone.ts`.

## Tests (outcome-asserting)

`tests/repos.agent-worktree-isolation.test.ts` (10 tests). The stash test asserts the real bleed outcome: two agents' trees off the same bare; Alice stashes; Bob's `stash list` must be EMPTY and his `stash pop` must throw; Alice pops her own stash intact. Verified the outcome is real: reproducing the same scenario with the OLD `git worktree add` provisioning shows Bob's `git stash list` containing `alice-wip`. Also covered: no `worktrees/` admin metadata in the bare + own git common dir; origin rewiring; legacy-branch preservation; clean-tree ff to a new upstream commit; dirty tree untouched; /tmp agent dir rejected (`/noexec/i`); failed provision leaves no partial dir; shape-aware removal of BOTH a clone-shaped tree and a pre-existing linked-worktree tree (bare admin entry + branch cleaned).

## Verification actually run

```
npx vitest run tests/repos.agent-worktree-isolation.test.ts tests/worktree.claim-isolation.test.ts tests/worktree.claim-integration.test.ts tests/scaffold.repo-provisioning.test.ts
# 4 files, 32 tests, all passed (also re-run with GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null)
npx tsc --noEmit   # clean
npm run lint       # all checks OK (incl. changelog entry + attribution trailers)
```

Not run locally: the full test suite and docker e2e — CI is the authority there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)