### PR TITLE
fix(hostd): reject a config_propose_edit whose write cannot be observed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,28 @@ now an anomaly worth investigating, not the norm.
   legacy linked worktree → `git worktree remove` from the bare), detected
   by filesystem shape, never a stored kind field.
 
+- **hostd: `config_propose_edit` no longer reports `completed` for a config
+  write it cannot prove landed.** A production edit came back
+  `result: completed, exit_code: 0` with a clean reconcile while the approved
+  block was absent from the config every other process reads. The cause was
+  structural: between the in-place write and the response there was NO re-read
+  of the target file, so `completed` was keyed entirely off `switchroom apply`'s
+  exit code — and an apply that re-reads an UNCHANGED file passes, laundering
+  the false success. The writer's own read-back is length-only (a truncation
+  guard), so a write that neither throws nor lands sailed through it. The apply
+  path now verifies BEFORE reconciling: it re-reads the resolved config path,
+  byte-compares against the exact content it handed the writer, and
+  independently re-classifies the on-disk change set against the set the
+  operator approved. Either check failing rolls back and returns a NEW,
+  distinguishable `E_WRITE_NOT_OBSERVED` (never
+  `E_RECONCILE_FAILED_ROLLED_BACK` — nothing rejected the config; hostd could
+  not prove it changed at all), and the nested case where the rollback ITSELF
+  fails says so rather than implying a clean revert. A successful apply now
+  echoes the resolved path, byte size and mtime into `stdout_tail`, so a future
+  false success leaves evidence in the audit row. Known limitation: read-back
+  goes through the same path as the write, so a hostd whose read and write are
+  both aliased to the WRONG file still verifies clean — asserting path identity
+  is separate work.
 - **worktree: `switchroom worktree claim` now provisions an INDEPENDENT clone,
   not a linked `git worktree` — concurrent sub-agents can no longer collide
   through shared git state.** Linked worktrees share the parent repo's refs

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -444,6 +444,11 @@ export const CONFIG_PROPOSE_EDIT_ERROR_CODES = [
   // validation and the (up to 60-min-delayed) operator approval, so the apply
   // ABORTED under the mutex rather than silently revert the intervening change.
   "E_CONFIG_CHANGED",
+  // #4661 — the apply wrote bytes that are NOT observable at the resolved
+  // config path (or the file on disk no longer carries the approved change
+  // set). Distinct from E_RECONCILE_FAILED_ROLLED_BACK: nothing rejected the
+  // config, hostd could not prove it changed at all.
+  "E_WRITE_NOT_OBSERVED",
 ] as const;
 export type ConfigProposeEditErrorCode =
   (typeof CONFIG_PROPOSE_EDIT_ERROR_CODES)[number];

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -298,6 +298,19 @@ export interface ServerOptions {
     requestId: string;
   }) => Promise<{ exit_code: number; stdout: string; stderr: string }>;
   /**
+   * Test seam: override how the live config file is written during a
+   * `config_propose_edit` apply (both the forward write and the rollback
+   * restores go through it). Default: `writeFileInPlacePreservingInode`.
+   *
+   * Exists so a test can install a write that SILENTLY DOES NOTHING and
+   * assert the RESPONSE, which is the exact production failure the
+   * post-write verification below guards: a write that does not throw but
+   * does not land. Without the seam a test can only reach that state via a
+   * filesystem trick (chattr / a bind mount / a racing writer), none of
+   * which are portable in CI.
+   */
+  writeConfigFile?: (path: string, content: string) => void;
+  /**
    * #1841 — operator-passphrase attestation verifier. Default: a
    * broker-backed verifier that forwards the passphrase to the vault
    * broker at `HOSTD_BROKER_SOCKET_PATH`. Tests inject a stub. Only
@@ -678,6 +691,123 @@ function writeFileInPlacePreservingInode(
       `in-place write short: wrote ${buf.length} bytes but read back ${readBack.length}`,
     );
   }
+}
+
+/**
+ * Outcome of the post-write verification for a `config_propose_edit` apply.
+ * `ok` means the bytes we intended to write are the bytes the next reader of
+ * `configPath` will see, AND that they mean semantically what the operator
+ * approved. `size`/`mtimeMs` are echoed into the audit row on success so a
+ * future false success leaves evidence behind.
+ */
+interface ConfigWriteObservation {
+  ok: boolean;
+  /** Human-readable failure reasons; empty iff `ok`. */
+  reasons: string[];
+  /** Observed bytes, or null when the read-back itself failed. */
+  observed: Buffer | null;
+  size: number | null;
+  mtimeMs: number | null;
+}
+
+/**
+ * #4661 — verify a config write was OBSERVED, not merely un-thrown.
+ *
+ * `writeFileInPlacePreservingInode` returning without throwing proves only
+ * that a `write(2)` to SOME fd reported the right byte count. It does not
+ * prove the bytes are visible at `configPath` to the next reader, and its own
+ * read-back is a LENGTH-ONLY truncation guard. A real incident: a
+ * `config_propose_edit` returned `result: completed, exit_code: 0` with a
+ * clean reconcile while the approved block was absent from the config every
+ * other process reads.
+ *
+ * Two independent assertions, both computed so the failure detail names each
+ * one that tripped:
+ *
+ *  1. BYTE COMPARE — re-read `configPath` and compare against the exact bytes
+ *     we handed the writer. Catches a no-op write, a partial write, and a
+ *     competing writer that landed inside the window.
+ *  2. SEMANTIC CHANGE SET — reclassify `snapshot → observed` and require the
+ *     changed YAML paths to still equal the set the operator approved. This
+ *     is the check that catches "the added block is absent" even if the byte
+ *     compare were ever relaxed or defeated. Compared as a SET (order- and
+ *     duplicate-insensitive) rather than positionally.
+ *
+ * Byte-exactness is safe here: `expected` originates from
+ * `readFileSync(scratch, "utf8")` inside the validator's `applyPatch`, so it
+ * can carry no lone surrogates, and the writer encodes with the same utf-8
+ * codec we decode with — the string→bytes→string round trip is lossless.
+ * `git apply` runs with `--whitespace=nowarn` (warn-suppression, NOT `fix`),
+ * and every transformation applyPatch performs happens BEFORE `expected`
+ * exists, so nothing downstream of the caller's write can legitimately alter
+ * the bytes. The only remaining source of divergence is a writer outside the
+ * apply mutex (documented residual race) — which is exactly what we want to
+ * fail on, not tolerate.
+ *
+ * KNOWN LIMITATION: this reads back the SAME path it wrote. If hostd's read
+ * and write go through the same aliased-or-wrong path, verification passes
+ * and a path-divergence bug survives. Closing that requires asserting path
+ * IDENTITY (the wire `target_path` vs the resolved `configPath`), which is
+ * out of scope here.
+ */
+function verifyConfigWriteObserved(
+  configPath: string,
+  expected: string,
+  snapshot: string,
+  proposedChangedPaths: string[],
+): ConfigWriteObservation {
+  const expectedBuf = Buffer.from(expected, "utf-8");
+  let observed: Buffer;
+  let size: number | null = null;
+  let mtimeMs: number | null = null;
+  try {
+    observed = readFileSync(configPath);
+    const st = statSync(configPath);
+    size = st.size;
+    mtimeMs = st.mtimeMs;
+  } catch (e) {
+    return {
+      ok: false,
+      reasons: [`post-write read-back of ${configPath} failed: ${(e as Error).message}`],
+      observed: null,
+      size: null,
+      mtimeMs: null,
+    };
+  }
+  const reasons: string[] = [];
+  if (!observed.equals(expectedBuf)) {
+    let firstDiff = 0;
+    const min = Math.min(observed.length, expectedBuf.length);
+    while (firstDiff < min && observed[firstDiff] === expectedBuf[firstDiff]) {
+      firstDiff += 1;
+    }
+    reasons.push(
+      `written bytes are not observable at ${configPath} ` +
+        `(expected ${expectedBuf.length} bytes, read back ${observed.length}, ` +
+        `first difference at offset ${firstDiff})`,
+    );
+  }
+  // Independent of the byte compare: does the file on disk still MEAN what
+  // the operator approved? A parse failure fails safe inside
+  // classifyBlastRadius (`["<unparseable>"]`), which cannot match an
+  // approved set, so a corrupted file trips this too.
+  const observedChangedPaths = classifyBlastRadius(
+    snapshot,
+    observed.toString("utf-8"),
+  ).changedPaths;
+  const approvedSet = new Set(proposedChangedPaths);
+  const observedSet = new Set(observedChangedPaths);
+  const sameSet =
+    approvedSet.size === observedSet.size &&
+    [...approvedSet].every((p) => observedSet.has(p));
+  if (!sameSet) {
+    reasons.push(
+      `on-disk change set diverged from what was approved ` +
+        `(approved: [${[...approvedSet].sort().join(", ")}]; ` +
+        `observed on disk: [${[...observedSet].sort().join(", ")}])`,
+    );
+  }
+  return { ok: reasons.length === 0, reasons, observed, size, mtimeMs };
 }
 
 const STATUS_RETENTION_MS = 10 * 60 * 1000; // 10 min
@@ -3657,13 +3787,13 @@ export class HostdServer {
       // switchroom.yaml is itself a read-only bind-mount source mounted
       // into every agent container — see writeFileInPlacePreservingInode.
       try {
-        writeFileInPlacePreservingInode(configPath, postApplyFresh);
+        this.writeLiveConfig(configPath, postApplyFresh);
       } catch (e) {
         // Write failed before any bytes were flushed, OR mid-write. We
         // hold the snapshot, so restore it in place to be safe rather
         // than assume the live file is untouched.
         try {
-          writeFileInPlacePreservingInode(configPath, snapshot);
+          this.writeLiveConfig(configPath, snapshot);
         } catch {
           /* best-effort restore; original error is the one that matters */
         }
@@ -3673,6 +3803,69 @@ export class HostdServer {
         });
         return this.reconcileFailedRolledBack(
           `write failed: ${(e as Error).message}`,
+          req,
+          caller,
+          started,
+        );
+      }
+      // ── #4661 — the write must be OBSERVED before we trust it ──
+      // A write that neither throws nor lands used to flow straight into
+      // reconcile, and a clean `switchroom apply` (which re-reads the
+      // UNCHANGED file, so of course it passes) then returned
+      // `result: completed, exit_code: 0` for an edit that was never applied.
+      // `completed` must be keyed off the file, not off the reconcile's exit
+      // code. Verify BEFORE the reconcile so a false success cannot be
+      // laundered through it.
+      const observation = verifyConfigWriteObserved(
+        configPath,
+        postApplyFresh,
+        snapshot,
+        proposedChangedPaths,
+      );
+      if (!observation.ok) {
+        const why = `post-write verification failed: ${observation.reasons.join("; ")}`;
+        // Bytes may or may not be on disk — we cannot tell, which is the
+        // whole problem — so restore the snapshot unless what we read back
+        // ALREADY is the snapshot (a no-op write: rewriting identical bytes
+        // would only bump mtime and wake config watchers for nothing).
+        const snapshotBuf = Buffer.from(snapshot, "utf-8");
+        const alreadySnapshot =
+          observation.observed !== null && observation.observed.equals(snapshotBuf);
+        let restoreDetail: string;
+        if (alreadySnapshot) {
+          restoreDetail =
+            "live config already byte-identical to the pre-write snapshot; no restore needed";
+        } else {
+          try {
+            this.writeLiveConfig(configPath, snapshot);
+            restoreDetail = "rolled back to the pre-write snapshot";
+          } catch (e) {
+            // Nested failure: verification failed AND the restore failed.
+            // The live file is in an unknown state and no automated path can
+            // recover it — say so loudly rather than implying a clean rollback.
+            restoreDetail =
+              `SNAPSHOT RESTORE ALSO FAILED: ${(e as Error).message} — ` +
+              `live config at ${configPath} is in an UNKNOWN state, inspect it by hand`;
+          }
+        }
+        // Closest available terminal card state — NOT a claim that a
+        // reconcile ran and rejected the config (it never ran; see the
+        // `writeNotObserved` doc comment, which is the WIRE code and IS
+        // precise). `ApprovalResult.finalize`'s `outcome` is a 3-valued
+        // contract — "applied" | "aborted_config_changed" |
+        // "reconcile_failed_rolled_back" — shared with the telegram card
+        // renderer, and old gateways reject an unknown outcome
+        // (mixed-version safety), so widening it to a distinct
+        // "write_not_observed" needs the gateway side to land first.
+        // Same reuse, same reason, as update-notifier.ts's apply_refused
+        // path. Until then the detail below carries the honest cause.
+        // Tracked in #4667 (widen the outcome enum + card renderer).
+        await approval.finalize({
+          outcome: "reconcile_failed_rolled_back",
+          detail: `${why}; ${restoreDetail}`,
+        });
+        return this.writeNotObserved(
+          `${why}; ${restoreDetail}`,
           req,
           caller,
           started,
@@ -3703,13 +3896,22 @@ export class HostdServer {
           affectedAgents: blast.agents,
           fleetWide: blast.fleetWide,
         });
+        // #4661 diagnosability: pin WHICH file this `completed` is a claim
+        // about, and what it looked like immediately after the verified
+        // write. A future false success then leaves evidence in the audit
+        // row instead of an unattributable "exit 0".
+        const writeEvidence =
+          `config write observed: path=${configPath} ` +
+          `size=${observation.size} mtime_ms=${observation.mtimeMs}`;
         return {
           v: 1,
           request_id: req.request_id,
           result: "completed",
           exit_code: 0,
           duration_ms: Date.now() - started,
-          stdout_tail: tail(recRes.stdout),
+          // Appended (not prefixed): `tail` keeps the END of an over-budget
+          // string, so the evidence survives a chatty reconcile.
+          stdout_tail: tail(`${recRes.stdout}\n--- ${writeEvidence} ---`),
           stderr_tail: tail(recRes.stderr),
         };
       }
@@ -3718,7 +3920,7 @@ export class HostdServer {
       // bind-mount safe.
       let rollbackDetail = "";
       try {
-        writeFileInPlacePreservingInode(configPath, snapshot);
+        this.writeLiveConfig(configPath, snapshot);
       } catch (e) {
         rollbackDetail = `snapshot restore failed: ${(e as Error).message}`;
         await approval.finalize({
@@ -3789,6 +3991,51 @@ export class HostdServer {
       .caller(caller.kind === "agent" ? "agent" : "operator")
       .agentName(caller.kind === "agent" ? caller.name : undefined)
       .asDenied()
+      .build(req.request_id, Date.now() - started);
+    return { ...built, error: legacy };
+  }
+
+  /**
+   * The single write path for the live config during a `config_propose_edit`
+   * apply — forward write AND both rollback restores. Routed through the
+   * `writeConfigFile` opt so a test can install a write that silently does
+   * nothing (see the opt's doc comment); defaults to the real bind-mount-safe
+   * in-place writer.
+   */
+  private writeLiveConfig(path: string, content: string): void {
+    (this.opts.writeConfigFile ?? writeFileInPlacePreservingInode)(path, content);
+  }
+
+  /**
+   * #4661 — the apply wrote bytes but they are NOT observable at
+   * `configPath` (or the file on disk no longer means what the operator
+   * approved). Deliberately DISTINCT from `E_RECONCILE_FAILED_ROLLED_BACK`:
+   * that code says "the config changed and switchroom apply rejected it",
+   * this one says "hostd cannot prove the config changed at all". Conflating
+   * them is what let the original incident read as an ordinary reconcile
+   * failure. Infra-class — the agent cannot self-recover by re-proposing,
+   * because the diff was fine; the write path is what is broken.
+   */
+  private writeNotObserved(
+    detail: string,
+    req: Extract<HostdRequest, { op: "config_propose_edit" }>,
+    caller: SocketIdentity,
+    started: number,
+  ): HostdResponse {
+    const legacy = `E_WRITE_NOT_OBSERVED: ${detail}`;
+    const built = err(
+      "E_WRITE_NOT_OBSERVED",
+      "config write could not be observed on the target file; apply aborted before reconcile",
+    )
+      .why(detail)
+      .fixOperatorAction("infra", [
+        "confirm hostd reads and writes the SAME switchroom.yaml the fleet reads (check the hostd bind mount over /state/config/switchroom.yaml)",
+        "check for a competing writer to the config (operator hand-edit or editor daemon) during the apply window",
+        "inspect the live config by hand before re-proposing — the diff was valid, the write path was not",
+      ])
+      .op("config_propose_edit")
+      .caller(caller.kind === "agent" ? "agent" : "operator")
+      .agentName(caller.kind === "agent" ? caller.name : undefined)
       .build(req.request_id, Date.now() - started);
     return { ...built, error: legacy };
   }

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -56,6 +56,7 @@ function makeServer(opts: {
     stdout: string;
     stderr: string;
   }>;
+  writeConfigFile?: (path: string, content: string) => void;
 }) {
   return new HostdServer({
     homeDir: tmp,
@@ -73,6 +74,7 @@ function makeServer(opts: {
     approvalGateway: opts.approvalGateway,
     generateApprovalId: opts.generateApprovalId,
     runReconcile: opts.runReconcile,
+    writeConfigFile: opts.writeConfigFile,
   });
 }
 
@@ -1007,6 +1009,199 @@ describe("hostd config_propose_edit — apply-time re-apply guard (#3084)", () =
  * pre-fix code (the edits landed in the other agent's block / the wrong
  * outcome was finalized).
  */
+// ─────────────────────────────────────────────────────────────────────
+// #4661 — post-write verification. A write that neither throws nor
+// lands used to flow straight into reconcile: `switchroom apply`
+// re-read the UNCHANGED file, passed, and the response came back
+// `result: completed, exit_code: 0` for an edit that was never applied.
+// Pre-fix, case 1 below returns completed/0 — the assertions here are on
+// the RESPONSE and on the file's mtime, never on "a code path ran".
+// ─────────────────────────────────────────────────────────────────────
+describe("hostd config_propose_edit — post-write verification (#4661)", () => {
+  // A base with one real (non-comment) key we can point a semantic diff at.
+  const VERIFY_BASE_YAML =
+    "switchroom:\n" +
+    "  version: 1\n" +
+    "telegram:\n" +
+    '  bot_token: "x"\n' +
+    '  forum_chat_id: "1"\n' +
+    "agents:\n" +
+    "  bob:\n" +
+    '    topic_name: "Twin"\n';
+
+  // Approved change set: exactly ["telegram.forum_chat_id"].
+  const FORUM_ID_DIFF =
+    "--- a/switchroom.yaml\n" +
+    "+++ b/switchroom.yaml\n" +
+    "@@ -3,4 +3,4 @@\n" +
+    " telegram:\n" +
+    '   bot_token: "x"\n' +
+    '-  forum_chat_id: "1"\n' +
+    '+  forum_chat_id: "2"\n' +
+    " agents:\n";
+
+  // What a mis-targeted write lands instead: a DIFFERENT yaml path changes.
+  const WRONG_PATHS_YAML =
+    "switchroom:\n" +
+    "  version: 1\n" +
+    "telegram:\n" +
+    '  bot_token: "x"\n' +
+    '  forum_chat_id: "1"\n' +
+    "agents:\n" +
+    "  bob:\n" +
+    '    topic_name: "Hijacked"\n';
+
+  it("a write that silently does not land returns E_WRITE_NOT_OBSERVED, never 'completed'", async () => {
+    // GOOD_DIFF is comment-only, so the APPROVED change set is empty and the
+    // change-set pin passes trivially (both sides []). The byte compare is
+    // the only thing standing between this and a false `completed` — which
+    // is exactly why it exists.
+    const { gw, finalizeCalls } = stubGateway("approve");
+    let reconcileInvocations = 0;
+    const writes: string[] = [];
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      // The production failure, reproduced honestly: the write returns
+      // normally and throws nothing, but no bytes reach the target.
+      writeConfigFile: (_p, content) => {
+        writes.push(content);
+      },
+      runReconcile: async () => {
+        reconcileInvocations += 1;
+        return { exit_code: 0, stdout: "applied ok", stderr: "" };
+      },
+    });
+    await server.start();
+    const before = readFile(configPath, "utf8");
+    const mtimeBefore = statSync(configPath).mtimeMs;
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "wno-1" });
+
+    // The response is the observable: pre-fix this was completed / exit 0.
+    expect(resp.result).not.toBe("completed");
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/E_WRITE_NOT_OBSERVED/);
+    expect(resp.error_envelope?.code).toBe("E_WRITE_NOT_OBSERVED");
+    expect(resp.error_envelope?.fix?.kind).toBe("operator_action");
+    // Byte compare is the check that caught it; the (empty) change-set pin
+    // could not have.
+    expect(resp.error).toMatch(/not observable at/);
+    expect(resp.error).not.toMatch(/change set diverged/);
+    // The reconcile must NOT have run — a clean apply over an unchanged file
+    // is precisely how the false success used to launder itself.
+    expect(reconcileInvocations).toBe(0);
+    // The target file was never touched: same bytes, same mtime.
+    expect(readFile(configPath, "utf8")).toBe(before);
+    expect(statSync(configPath).mtimeMs).toBe(mtimeBefore);
+    // Forward write attempted once; no pointless snapshot re-write, because
+    // what we read back already WAS the snapshot.
+    expect(writes.length).toBe(1);
+    expect(finalizeCalls.length).toBe(1);
+    expect(finalizeCalls[0]!.outcome).toBe("reconcile_failed_rolled_back");
+    expect(finalizeCalls[0]!.detail).toMatch(/no restore needed/);
+  });
+
+  it("a write that lands at the WRONG yaml paths returns E_WRITE_NOT_OBSERVED naming both change sets", async () => {
+    writeFileSync(configPath, VERIFY_BASE_YAML);
+    const { gw, finalizeCalls } = stubGateway("approve");
+    let reconcileInvocations = 0;
+    let writeCalls = 0;
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      // First call = the mis-targeted write (lands agents.bob.topic_name,
+      // not the approved telegram.forum_chat_id). Later calls = the
+      // rollback restore, which writes honestly.
+      writeConfigFile: (p, content) => {
+        writeCalls += 1;
+        writeFileSync(p, writeCalls === 1 ? WRONG_PATHS_YAML : content);
+      },
+      runReconcile: async () => {
+        reconcileInvocations += 1;
+        return { exit_code: 0, stdout: "applied ok", stderr: "" };
+      },
+    });
+    await server.start();
+    const resp = await send({
+      unified_diff: FORUM_ID_DIFF,
+      request_id: "wno-2",
+    });
+
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/E_WRITE_NOT_OBSERVED/);
+    // The change-set pin fired and reported the ACTUAL on-disk set — proof
+    // it re-classified the file rather than trusting the intent.
+    expect(resp.error).toMatch(/on-disk change set diverged/);
+    expect(resp.error).toMatch(/telegram\.forum_chat_id/);
+    expect(resp.error).toMatch(/agents\.bob\.topic_name/);
+    expect(reconcileInvocations).toBe(0);
+    // Rolled back: the hijacked value is gone and the snapshot is restored.
+    const live = readFile(configPath, "utf8");
+    expect(live).toBe(VERIFY_BASE_YAML);
+    expect(live).not.toContain("Hijacked");
+    expect(writeCalls).toBe(2); // forward write + snapshot restore
+    expect(finalizeCalls[0]!.outcome).toBe("reconcile_failed_rolled_back");
+    expect(finalizeCalls[0]!.detail).toMatch(/rolled back to the pre-write snapshot/);
+  });
+
+  it("verification failure whose rollback ALSO fails says so instead of implying a clean rollback", async () => {
+    const { gw, finalizeCalls } = stubGateway("approve");
+    let writeCalls = 0;
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      writeConfigFile: (p, content) => {
+        writeCalls += 1;
+        if (writeCalls === 1) {
+          // Lands SOMETHING that is neither the intent nor the snapshot, so
+          // the restore branch is genuinely required.
+          writeFileSync(p, `${content}# truncated tail lost\n`);
+          return;
+        }
+        throw new Error("EROFS: read-only file system");
+      },
+      runReconcile: async () => ({ exit_code: 0, stdout: "", stderr: "" }),
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "wno-3" });
+
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/E_WRITE_NOT_OBSERVED/);
+    expect(resp.error).toMatch(/SNAPSHOT RESTORE ALSO FAILED/);
+    expect(resp.error).toMatch(/EROFS/);
+    expect(resp.error).toMatch(/UNKNOWN state/);
+    expect(writeCalls).toBe(2);
+    expect(finalizeCalls[0]!.detail).toMatch(/SNAPSHOT RESTORE ALSO FAILED/);
+  });
+
+  it("happy path still completes, and echoes the resolved path + size + mtime as evidence", async () => {
+    const { gw, finalizeCalls } = stubGateway("approve");
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => ({ exit_code: 0, stdout: "applied ok", stderr: "" }),
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "wno-4" });
+
+    expect(resp.result).toBe("completed");
+    expect(resp.exit_code).toBe(0);
+    expect(readFile(configPath, "utf8")).toContain("# touched by apply-path test");
+    expect(finalizeCalls[0]!.outcome).toBe("applied");
+    // The reconcile's own output is preserved …
+    expect(resp.stdout_tail).toContain("applied ok");
+    // … and the `completed` claim now names the file it is a claim about.
+    const size = statSync(configPath).size;
+    expect(resp.stdout_tail).toContain(`config write observed: path=${configPath}`);
+    expect(resp.stdout_tail).toContain(`size=${size}`);
+    expect(resp.stdout_tail).toMatch(/mtime_ms=\d+/);
+  });
+});
+
 describe("hostd config_propose_edit — relocation guards (#3121 follow-up)", () => {
   // bob is the only agent at PROPOSE time, so the generic (agent-name-free)
   // hunk context below anchors uniquely in bob's block and the self-scope


### PR DESCRIPTION
## The bug

`config_propose_edit` returns `result: "completed"` based on one condition: the reconcile's exit code (`server.ts:3695`). Nothing between the write and the response re-reads the target file. The only existing read-back (`server.ts:671-679`) compares `readBack.length !== buf.length` — a truncation guard, and it reads back the same path it wrote, so it proves nothing about whether the correct file was hit.

This produced a real incident: an approved edit returned `completed` / `exit_code: 0` with a clean reconcile, and the added block was absent from the config every other process reads.

## The fix

After the write, before the reconcile, verify two things independently:

1. **Byte equality** against the expected post-apply content (reports the first differing offset).
2. **Change-set re-classification** — recompute `classifyBlastRadius(snapshot, observed).changedPaths` from what is actually on disk and compare as a Set against the approved set.

The second is the one that catches "the approved block is absent" even if the byte compare somehow passes.

Either check failing rolls back and returns a distinct `E_WRITE_NOT_OBSERVED`. Rollback has three branches, including the nested case where the restore itself fails (`SNAPSHOT RESTORE ALSO FAILED … UNKNOWN state`).

Also: the success return now echoes the resolved path, size and `mtime_ms` into `stdout_tail`, so a future false success leaves evidence in the audit row.

## Byte-stability audit

Strict byte comparison only works if nothing can legitimately alter bytes between write and read-back. Audited `applyPatch` (`config-edit-validator.ts:276-357`): every transformation it performs happens **before** `postApplyContent` exists. `git apply` runs `--whitespace=nowarn` (warning suppression, **not** `fix`) plus `--recount`. No CRLF or trailing-newline normalisation anywhere. So there is no false-positive risk that would block a legitimate apply.

## Deliberate decisions

- **Empty change sets are NOT rejected.** A comment-only or formatting-only edit legitimately yields `[]`, since `changedConfigPaths` compares parsed YAML. Rejecting outright would break a legal edit class. Test 1 covers that case by pinning the byte compare as the sole guard there.
- **One line outside the touched-file scope:** `protocol.ts:451` adds `E_WRITE_NOT_OBSERVED` to `CONFIG_PROPOSE_EDIT_ERROR_CODES`. Returning a code absent from the op's own declared enum is an inconsistency. The enum has zero consumers, so behavioural risk is nil.

## Tests

`tests/host-control/config-propose-edit.test.ts` — new `post-write verification` describe, plus a `writeConfigFile` seam threaded through `makeServer()` so a test can install a silent no-op write and assert the **response** rather than resorting to a filesystem trick.

1. A write that silently does not land → `E_WRITE_NOT_OBSERVED`, never `completed`; asserts unchanged bytes, unchanged `mtimeMs`, and zero reconcile invocations.
2. A write landing at the **wrong** YAML paths → change-set divergence, naming both sets.
3. Verification failure whose rollback also fails → asserts the `UNKNOWN state` reporting.
4. Happy path still completes and echoes path/size/mtime.

**Proof they fail without the guard:** the write seam is part of the fix, so the guard was isolated instead — replacing only the verification block with `{ ok: true }` makes cases 1-3 all return `completed`, reproducing the incident signature exactly.

## Honest limitation

Read-back goes through the same path as the write. A hostd whose read **and** write are both aliased to the wrong file verifies clean. This PR does not close that class — that is path provenance, tracked separately.

Also noted, not fixed: a verification failure finalizes as `reconcile_failed_rolled_back`, which is imprecise since the reconcile never ran. That enum is a three-value wire contract shared with the Telegram card renderer; widening it needs the gateway side. The detail string carries the real cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
