### PR TITLE
fix(self-improve): wake the proposing agent on an eval-case card decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,20 @@ now an anomaly worth investigating, not the norm.
   goes through the same path as the write, so a hostd whose read and write are
   both aliased to the WRONG file still verifies clean — asserting path identity
   is separate work.
+- **self-improve: an eval-case proposal card now tells the proposing agent what
+  the operator decided — Approve AND Dismiss both wake it.**
+  `handleEvalCaseProposalCallback` was a copy of the skill-proposal handler that
+  dropped the `deliverResumeSyntheticOrBuffer` line, so both exits set the
+  status, edited the card, and returned. The agent had been steered to end its
+  turn and wait for a wake-up that no code path sent — the CLI propose call is
+  fire-and-forget and the self-improve Stop hook reads eval integrity baselines,
+  not proposal status — so every tap was a silent block. Three new synthetic
+  inbounds close it: `eval_case_applied`, `eval_case_rejected`, and
+  `eval_case_apply_failed` (carrying the applier's output tail, so an approval
+  whose applier failed can't be mistaken for a landed regression test). The deny
+  inbound goes beyond parity with the skill handler, which still stays silent on
+  dismiss; silence is the defect. The `apply-eval-case` shell-out is now an
+  injectable dep, so both approve branches are covered by deterministic tests.
 - **worktree: `switchroom worktree claim` now provisions an INDEPENDENT clone,
   not a linked `git worktree` — concurrent sub-agents can no longer collide
   through shared git state.** Linked worktrees share the parent repo's refs

--- a/telegram-plugin/gateway/callback-query-handlers.ts
+++ b/telegram-plugin/gateway/callback-query-handlers.ts
@@ -75,6 +75,11 @@ import {
   getEvalCaseProposal,
   setEvalCaseProposalStatus,
 } from '../../src/self-improve/eval-case-proposals.js'
+import {
+  buildEvalCaseAppliedInbound,
+  buildEvalCaseRejectedInbound,
+  buildEvalCaseApplyFailedInbound,
+} from './eval-case-proposal-inbound-builders.js'
 import { maskToken } from '../secret-detect/mask.js'
 import {
   defaultVaultWrite,
@@ -464,6 +469,19 @@ export interface CallbackQueryHandlersDeps {
   brokerList?: typeof realListViaBroker
   brokerListGrants?: typeof realListGrantsViaBroker
   brokerVaultTokenFilePath?: typeof realVaultTokenFilePath
+
+  /**
+   * Run the DETERMINISTIC eval-case applier for an approved proposal. Returns
+   * `ok` plus the applier's combined output tail (both go on the card footer
+   * and into the outcome inbound the agent is woken with).
+   *
+   * Injectable for the same reason as the broker seams above: production leaves
+   * it unset and gets the real `switchroom self-improve apply-eval-case`
+   * `execFileSync`, but a unit test cannot shell out to a real CLI, so the
+   * approve path's two branches (applied / apply-failed) were untestable while
+   * this was a bare static import.
+   */
+  runEvalCaseApply?: (id: string) => { ok: boolean; out: string }
 }
 
 // Freshness throttle for the /auth dashboard ↻ refresh button — one live
@@ -625,6 +643,27 @@ export function createCallbackQueryHandlers(deps: CallbackQueryHandlersDeps) {
   const listViaBroker = deps.brokerList ?? realListViaBroker
   const listGrantsViaBroker = deps.brokerListGrants ?? realListGrantsViaBroker
   const vaultTokenFilePath = deps.brokerVaultTokenFilePath ?? realVaultTokenFilePath
+  // Eval-case applier seam. The default body is verbatim the execFileSync that
+  // used to sit inline in handleEvalCaseProposalCallback.
+  const runEvalCaseApply =
+    deps.runEvalCaseApply ??
+    ((id: string): { ok: boolean; out: string } => {
+      const cli = process.env.SWITCHROOM_CLI_PATH ?? 'switchroom'
+      try {
+        const out = execFileSync(
+          cli,
+          ['self-improve', 'apply-eval-case', '--id', id],
+          { encoding: 'utf8', timeout: 15000, env: process.env },
+        ).trim()
+        return { ok: true, out }
+      } catch (err) {
+        const e = err as { stdout?: string; stderr?: string; message?: string }
+        return {
+          ok: false,
+          out: [e.stdout, e.stderr, e.message].filter(Boolean).join('\n').trim(),
+        }
+      }
+    })
 
 /**
  * Handle a callback_query from an auth dashboard button. Parses the
@@ -1377,8 +1416,31 @@ async function handleEvalCaseProposalCallback(ctx: Context, data: string): Promi
     return
   }
 
+  // Same idiom as the skill handler above: the card's own chat/topic is where
+  // the proposing agent was working, so the outcome inbound resumes it there.
+  const cbChatId = String(ctx.chat?.id ?? ctx.from?.id ?? '')
+  const cbThreadId = resolveThreadId(cbChatId, ctx.callbackQuery?.message?.message_thread_id)
+  const inboundCtx = {
+    agent,
+    chat_id: cbChatId,
+    ...(cbThreadId != null ? { threadId: cbThreadId } : {}),
+  }
+
   if (parsed.action === 'deny') {
     setEvalCaseProposalStatus(stateDir, parsed.id, 'rejected')
+    // The agent is TOLD it was dismissed. The skill handler stays silent here;
+    // silence is the defect — a dismissed proposal left the agent waiting on a
+    // wake-up that never came.
+    const denied = deliverResumeSyntheticOrBuffer(
+      agent,
+      buildEvalCaseRejectedInbound({
+        ctx: inboundCtx,
+        proposalId: proposal.id,
+        skillSlug: proposal.skill_slug,
+        heldOut: proposal.held_out,
+        operatorId: senderId,
+      }),
+    )
     await ctx.answerCallbackQuery({ text: '🚫 Dismissed.' }).catch(() => {})
     if (ctx.callbackQuery?.message && 'text' in ctx.callbackQuery.message) {
       await ctx
@@ -1388,6 +1450,10 @@ async function handleEvalCaseProposalCallback(ctx: Context, data: string): Promi
         )
         .catch(() => {})
     }
+    process.stderr.write(
+      `telegram gateway: eval_case_rejected agent=${agent} proposal=${proposal.id} ` +
+      `slug=${proposal.skill_slug} delivered=${denied}\n`,
+    )
     return
   }
 
@@ -1395,20 +1461,7 @@ async function handleEvalCaseProposalCallback(ctx: Context, data: string): Promi
   setEvalCaseProposalStatus(stateDir, parsed.id, 'approved')
   await ctx.answerCallbackQuery({ text: '✅ Adding the eval case…' }).catch(() => {})
 
-  const cli = process.env.SWITCHROOM_CLI_PATH ?? 'switchroom'
-  let applyOk = true
-  let applyOut = ''
-  try {
-    applyOut = execFileSync(
-      cli,
-      ['self-improve', 'apply-eval-case', '--id', parsed.id],
-      { encoding: 'utf8', timeout: 15000, env: process.env },
-    ).trim()
-  } catch (err) {
-    applyOk = false
-    const e = err as { stdout?: string; stderr?: string; message?: string }
-    applyOut = [e.stdout, e.stderr, e.message].filter(Boolean).join('\n').trim()
-  }
+  const { ok: applyOk, out: applyOut } = runEvalCaseApply(parsed.id)
 
   const footer = applyOk
     ? '✅ <i>Added as a regression test.</i>'
@@ -1421,9 +1474,28 @@ async function handleEvalCaseProposalCallback(ctx: Context, data: string): Promi
       )
       .catch(() => {})
   }
+  // Tell the agent the OUTCOME, not just that a tap happened — applied and
+  // apply-failed are different instructions (resume vs. don't assume it exists).
+  const outcomeInbound = applyOk
+    ? buildEvalCaseAppliedInbound({
+        ctx: inboundCtx,
+        proposalId: proposal.id,
+        skillSlug: proposal.skill_slug,
+        heldOut: proposal.held_out,
+        operatorId: senderId,
+      })
+    : buildEvalCaseApplyFailedInbound({
+        ctx: inboundCtx,
+        proposalId: proposal.id,
+        skillSlug: proposal.skill_slug,
+        heldOut: proposal.held_out,
+        operatorId: senderId,
+        applyOut,
+      })
+  const delivered = deliverResumeSyntheticOrBuffer(agent, outcomeInbound)
   process.stderr.write(
     `telegram gateway: eval_case_apply agent=${agent} proposal=${proposal.id} ` +
-    `slug=${proposal.skill_slug} ok=${applyOk}\n`,
+    `slug=${proposal.skill_slug} ok=${applyOk} delivered=${delivered}\n`,
   )
 }
 

--- a/telegram-plugin/gateway/eval-case-proposal-inbound-builders.ts
+++ b/telegram-plugin/gateway/eval-case-proposal-inbound-builders.ts
@@ -1,0 +1,197 @@
+/**
+ * Pure builders for the synthetic inbounds the gateway injects after the
+ * operator taps Approve / Dismiss on a self-improve EVAL-CASE proposal card
+ * (RFC amendment §"corrections as eval cases"). Mirrors
+ * `mental-model-propose-inbound-builders.ts`.
+ *
+ * WHY THIS MODULE EXISTS AT ALL: `handleEvalCaseProposalCallback` was a copy of
+ * `handleSkillProposalCallback` that dropped the
+ * `deliverResumeSyntheticOrBuffer` line. Both of its exits — dismiss and
+ * approve — edited the card and returned, so the PROPOSING AGENT was never
+ * told the outcome. It had been steered to end its turn cleanly and wait for a
+ * wake-up that no code path ever sent: every candidate second delivery path is
+ * empty (the self-improve Stop hook reads eval integrity baselines, not
+ * proposal status; `switchroom self-improve eval-case propose` is
+ * fire-and-forget and returns `ok:true` for POSTING THE CARD, never for the
+ * outcome). These three builders are the inbound half of that fix.
+ *
+ * The shape is load-bearing — `meta.source` is what the bridge keys on to
+ * render `<channel source="eval_case_applied">` / `eval_case_rejected` /
+ * `eval_case_apply_failed` blocks, and the
+ * `meta.{agent,proposal_id,skill_slug,held_out,operator_id}` fields are the
+ * forensic anchor tying the woken turn back to the exact proposal and the
+ * operator who decided it.
+ *
+ * A regression that drops a meta field or changes the source string would
+ * silently break the agent's wake-up: the bridge would route it as a generic
+ * channel event, the model wouldn't know its proposal resolved, and the
+ * conversation would drift back to the silent-block this module fixes. Pinning
+ * these against fixture tests is cheaper than catching that downstream.
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+
+/** Subset of the stored proposal the builders need. Kept narrow so callers
+ *  don't have to pass the full `EvalCaseProposal` record. */
+export interface EvalCaseProposalInboundContext {
+  agent: string
+  /** Telegram chat id where the approval card lived. Used as the inbound's
+   *  chatId so the synthesized turn stays associated with the originating
+   *  conversation. */
+  chat_id: string
+  /** Supergroup forum topic (message_thread_id) the agent was working in when
+   *  it proposed — so the resumed turn's reply lands back in that topic, not
+   *  General. Undefined for DM / non-topic proposals. */
+  threadId?: number
+}
+
+/** The meta every eval-case outcome inbound carries, minus `source`. */
+function commonMeta(opts: {
+  ctx: EvalCaseProposalInboundContext
+  proposalId: string
+  skillSlug: string
+  heldOut: boolean
+  operatorId: string
+}): Record<string, string> {
+  return {
+    agent: opts.ctx.agent,
+    ...(opts.ctx.threadId != null ? { message_thread_id: String(opts.ctx.threadId) } : {}),
+    proposal_id: opts.proposalId,
+    skill_slug: opts.skillSlug,
+    held_out: String(opts.heldOut),
+    operator_id: opts.operatorId,
+  }
+}
+
+/**
+ * Build the synthetic InboundMessage for an approval whose DETERMINISTIC
+ * applier succeeded — the case is now on disk (in the skill's `evals.json`, or
+ * the held-out sink when `heldOut`). Nothing is left for the agent to write.
+ */
+export function buildEvalCaseAppliedInbound(opts: {
+  ctx: EvalCaseProposalInboundContext
+  proposalId: string
+  skillSlug: string
+  heldOut: boolean
+  operatorId: string
+  nowMs?: number
+}): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  const sink = opts.heldOut ? 'the held-out sink' : `\`${opts.skillSlug}\`'s \`evals.json\``
+  return {
+    type: 'inbound',
+    chatId: opts.ctx.chat_id,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
+    messageId: ts, // synthetic — no Telegram message id exists
+    user: 'self-improve',
+    userId: 0,
+    ts,
+    text:
+      `✅ Operator approved your proposed eval case for \`${opts.skillSlug}\` ` +
+      `(proposal ${opts.proposalId}). The case was applied DETERMINISTICALLY by ` +
+      `the gateway and is already written to ${sink} — do NOT write it yourself ` +
+      `and do NOT re-propose it. Resume whatever you were doing.`,
+    meta: {
+      source: 'eval_case_applied',
+      ...commonMeta({
+        ctx: opts.ctx,
+        proposalId: opts.proposalId,
+        skillSlug: opts.skillSlug,
+        heldOut: opts.heldOut,
+        operatorId: opts.operatorId,
+      }),
+    },
+  }
+}
+
+/**
+ * Build the synthetic InboundMessage for an operator dismissal. NOTHING was
+ * written. Steers the agent onward rather than into a re-propose loop.
+ *
+ * This has no sibling in the skill-proposal handler (which stays silent on
+ * dismiss). Silence is the defect being fixed: a dismissed proposal left the
+ * agent waiting on a wake-up that never came.
+ */
+export function buildEvalCaseRejectedInbound(opts: {
+  ctx: EvalCaseProposalInboundContext
+  proposalId: string
+  skillSlug: string
+  heldOut: boolean
+  operatorId: string
+  nowMs?: number
+}): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  return {
+    type: 'inbound',
+    chatId: opts.ctx.chat_id,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
+    messageId: ts,
+    user: 'self-improve',
+    userId: 0,
+    ts,
+    text:
+      `🚫 Operator dismissed your proposed eval case for \`${opts.skillSlug}\` ` +
+      `(proposal ${opts.proposalId}). NOTHING was written — no eval case was ` +
+      `added. Carry on with the original task without it. Do NOT re-propose the ` +
+      `same case without first asking the user.`,
+    meta: {
+      source: 'eval_case_rejected',
+      ...commonMeta({
+        ctx: opts.ctx,
+        proposalId: opts.proposalId,
+        skillSlug: opts.skillSlug,
+        heldOut: opts.heldOut,
+        operatorId: opts.operatorId,
+      }),
+    },
+  }
+}
+
+/**
+ * Build the synthetic InboundMessage for an approval whose applier FAILED
+ * (`switchroom self-improve apply-eval-case` non-zero, timeout, missing skill
+ * dir, a stale/rejected proposal the applier's own status check refused).
+ * The operator tapped Approve but the case did NOT land — be honest so the
+ * agent doesn't assume the regression test exists.
+ *
+ * `applyOut` is the applier's combined stdout/stderr tail, truncated so a
+ * runaway stack trace can't dominate the woken turn's context.
+ */
+export function buildEvalCaseApplyFailedInbound(opts: {
+  ctx: EvalCaseProposalInboundContext
+  proposalId: string
+  skillSlug: string
+  heldOut: boolean
+  operatorId: string
+  applyOut: string
+  nowMs?: number
+}): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  const tail = opts.applyOut.trim().slice(0, 500)
+  return {
+    type: 'inbound',
+    chatId: opts.ctx.chat_id,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
+    messageId: ts,
+    user: 'self-improve',
+    userId: 0,
+    ts,
+    text:
+      `⚠️ The operator approved your proposed eval case for \`${opts.skillSlug}\` ` +
+      `(proposal ${opts.proposalId}) but the applier FAILED. The case was NOT ` +
+      `written — do NOT assume the regression test exists. Applier output:\n` +
+      `${tail.length > 0 ? tail : '(no output)'}\n` +
+      `Carry on with the original task; report the failure to the operator if it ` +
+      `still matters.`,
+    meta: {
+      source: 'eval_case_apply_failed',
+      ...commonMeta({
+        ctx: opts.ctx,
+        proposalId: opts.proposalId,
+        skillSlug: opts.skillSlug,
+        heldOut: opts.heldOut,
+        operatorId: opts.operatorId,
+      }),
+    },
+  }
+}

--- a/telegram-plugin/gateway/subagent-handback-marker.ts
+++ b/telegram-plugin/gateway/subagent-handback-marker.ts
@@ -176,6 +176,18 @@ export const INBOUND_SOURCE_CLASSIFICATION: Record<string, { decoupledCompletion
   mental_model_proposal_failed: { decoupledCompletion: false },
   webhook: { decoupledCompletion: false },
   linear: { decoupledCompletion: false },
+  // Eval-case proposal outcomes (#4662) — the operator's Approve/Dismiss tap on
+  // an eval-case card wakes the PROPOSING agent with one of these, built in
+  // `eval-case-proposal-inbound-builders.ts` and injected via
+  // `deliverResumeSyntheticOrBuffer`. Exactly the `skill_proposal_apply` shape
+  // above: each lands as its OWN live inbound turn, so its reply resolves the
+  // live tier for its own turnId and structurally cannot supersede a different
+  // ended turn — it must NOT stamp. (Left unclassified, the fail-safe default
+  // stamps, holding the content gate chat-wide for 60 s after every eval-case
+  // decision and re-opening the reworded-own-answer visible dup in that window.)
+  eval_case_applied: { decoupledCompletion: false },
+  eval_case_rejected: { decoupledCompletion: false },
+  eval_case_apply_failed: { decoupledCompletion: false },
   // Buzz co-channel (Phase 1): a Nostr kind:9 group message the buzz sidecar
   // injects onto the gateway IPC queue as its OWN live inbound turn (anonymous
   // inject, `meta.source="buzz"`) — never a decoupled completion resolving a

--- a/telegram-plugin/tests/callback-query-handlers.test.ts
+++ b/telegram-plugin/tests/callback-query-handlers.test.ts
@@ -25,7 +25,7 @@
  * broker call, which is exactly the behavior the extraction must not change.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { Context } from 'grammy'
 import {
   createCallbackQueryHandlers,
@@ -42,6 +42,10 @@ import { createSweepableCardStore } from '../gateway/approval-card-stores.js'
 import { createSweepableStore } from '../gateway/pending-state-stores.js'
 import { StagingMap } from '../secret-detect/staging.js'
 import { InlineKeyboard } from 'grammy'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { enqueueEvalCaseProposal } from '../../src/self-improve/eval-case-proposals.js'
 
 // Mock the auth-broker client so the `auth:use:` swap path is observable
 // (spy on setActive) without a live UDS broker. Only handleAuthDashboardCallback
@@ -622,6 +626,144 @@ describe('handleSkillProposalCallback', () => {
     const { ctx, raw } = makeCtx()
     await h.handleSkillProposalCallback(ctx, 'sp:bogus')
     expect(raw.answerCallbackQuery).toHaveBeenCalledWith({ text: 'Bad request' })
+  })
+})
+
+// ── evcase:* — eval-case proposal ───────────────────────────────────────
+//
+// The defect these pin: this handler was a copy of the skill handler that
+// dropped the `deliverResumeSyntheticOrBuffer` call, so BOTH exits — dismiss
+// and approve — edited the card and returned without telling the proposing
+// agent anything. The agent had been steered to end its turn and wait for a
+// wake-up that no code path sent. On unmodified code every assertion below on
+// `deliverResumeSyntheticOrBuffer` fails with 0 calls.
+//
+// `handleEvalCaseProposalCallback` reads the proposal store off disk (not from
+// an injected store), so these drive a REAL tmp state dir via the real
+// `enqueueEvalCaseProposal`. `TELEGRAM_STATE_DIR` is NOT one of
+// `agent-state-dir-guard`'s GUARDED_STATE_DIR_VARS, so the guard neither
+// redirects nor blocks it — setting it here is the whole isolation.
+
+describe('handleEvalCaseProposalCallback', () => {
+  let stateDir: string
+  let prevStateDir: string | undefined
+  let prevAgent: string | undefined
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), 'evcase-cb-'))
+    prevStateDir = process.env.TELEGRAM_STATE_DIR
+    prevAgent = process.env.SWITCHROOM_AGENT_NAME
+    process.env.TELEGRAM_STATE_DIR = stateDir
+    process.env.SWITCHROOM_AGENT_NAME = 'test-agent'
+  })
+
+  afterEach(() => {
+    if (prevStateDir == null) delete process.env.TELEGRAM_STATE_DIR
+    else process.env.TELEGRAM_STATE_DIR = prevStateDir
+    if (prevAgent == null) delete process.env.SWITCHROOM_AGENT_NAME
+    else process.env.SWITCHROOM_AGENT_NAME = prevAgent
+    rmSync(stateDir, { recursive: true, force: true })
+  })
+
+  function seedProposal(over: { heldOut?: boolean } = {}) {
+    return enqueueEvalCaseProposal(stateDir, {
+      skill_slug: 'deploy-checklist',
+      skill_dir: join(stateDir, 'skills', 'deploy-checklist'),
+      case: { prompt: 'the correction, as an input' },
+      fingerprint: 'fp-1',
+      held_out: over.heldOut === true,
+    })
+  }
+
+  it('dismiss wakes the agent with an eval_case_rejected inbound', async () => {
+    const { deps } = makeDeps()
+    const h = createCallbackQueryHandlers(deps)
+    const p = seedProposal()
+    const { ctx } = makeCtx()
+    await h.handleEvalCaseProposalCallback(ctx, `evcase:deny:${p.id}`)
+    expect(deps.deliverResumeSyntheticOrBuffer).toHaveBeenCalledWith(
+      'test-agent',
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          source: 'eval_case_rejected',
+          proposal_id: p.id,
+          skill_slug: 'deploy-checklist',
+        }),
+      }),
+    )
+  })
+
+  it('approve with a successful applier wakes the agent with eval_case_applied', async () => {
+    const runEvalCaseApply = vi.fn(() => ({ ok: true, out: 'added 1 case' }))
+    const { deps } = makeDeps({ runEvalCaseApply })
+    const h = createCallbackQueryHandlers(deps)
+    const p = seedProposal()
+    const { ctx } = makeCtx()
+    await h.handleEvalCaseProposalCallback(ctx, `evcase:approve:${p.id}`)
+    expect(runEvalCaseApply).toHaveBeenCalledWith(p.id)
+    expect(deps.deliverResumeSyntheticOrBuffer).toHaveBeenCalledWith(
+      'test-agent',
+      expect.objectContaining({
+        meta: expect.objectContaining({ source: 'eval_case_applied', proposal_id: p.id }),
+      }),
+    )
+  })
+
+  it('approve with a failing applier wakes the agent with eval_case_apply_failed + the output', async () => {
+    const runEvalCaseApply = vi.fn(() => ({ ok: false, out: 'ENOENT: skill dir missing' }))
+    const { deps, injected } = makeDeps({ runEvalCaseApply })
+    const h = createCallbackQueryHandlers(deps)
+    const p = seedProposal()
+    const { ctx } = makeCtx()
+    await h.handleEvalCaseProposalCallback(ctx, `evcase:approve:${p.id}`)
+    expect(deps.deliverResumeSyntheticOrBuffer).toHaveBeenCalledWith(
+      'test-agent',
+      expect.objectContaining({
+        meta: expect.objectContaining({ source: 'eval_case_apply_failed', proposal_id: p.id }),
+      }),
+    )
+    // The applier's own diagnosis reaches the agent, not just "it failed".
+    expect(injected[0]?.text).toContain('ENOENT: skill dir missing')
+  })
+
+  it('carries the card’s forum topic into the outcome inbound', async () => {
+    const { deps } = makeDeps()
+    const h = createCallbackQueryHandlers(deps)
+    const p = seedProposal()
+    const { ctx } = makeCtx({ threadId: 7 })
+    await h.handleEvalCaseProposalCallback(ctx, `evcase:deny:${p.id}`)
+    expect(deps.deliverResumeSyntheticOrBuffer).toHaveBeenCalledWith(
+      'test-agent',
+      expect.objectContaining({
+        threadId: 7,
+        meta: expect.objectContaining({ message_thread_id: '7' }),
+      }),
+    )
+  })
+
+  it('a second tap injects nothing — the non-pending guard runs before every injection', async () => {
+    const runEvalCaseApply = vi.fn(() => ({ ok: true, out: '' }))
+    const { deps } = makeDeps({ runEvalCaseApply })
+    const h = createCallbackQueryHandlers(deps)
+    const p = seedProposal()
+    const { ctx } = makeCtx()
+    await h.handleEvalCaseProposalCallback(ctx, `evcase:approve:${p.id}`)
+    await h.handleEvalCaseProposalCallback(ctx, `evcase:approve:${p.id}`)
+    await h.handleEvalCaseProposalCallback(ctx, `evcase:deny:${p.id}`)
+    expect(deps.deliverResumeSyntheticOrBuffer).toHaveBeenCalledTimes(1)
+    expect(runEvalCaseApply).toHaveBeenCalledTimes(1)
+  })
+
+  it('a non-allowlisted tapper neither applies nor wakes the agent', async () => {
+    const runEvalCaseApply = vi.fn(() => ({ ok: true, out: '' }))
+    const { deps } = makeDeps({ runEvalCaseApply })
+    const h = createCallbackQueryHandlers(deps)
+    const p = seedProposal()
+    const { ctx, raw } = makeCtx({ senderId: '999' })
+    await h.handleEvalCaseProposalCallback(ctx, `evcase:approve:${p.id}`)
+    expect(raw.answerCallbackQuery).toHaveBeenCalledWith({ text: 'Not authorized.' })
+    expect(runEvalCaseApply).not.toHaveBeenCalled()
+    expect(deps.deliverResumeSyntheticOrBuffer).not.toHaveBeenCalled()
   })
 })
 

--- a/telegram-plugin/tests/eval-case-proposal-inbound-builders.test.ts
+++ b/telegram-plugin/tests/eval-case-proposal-inbound-builders.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Fixture pins for the eval-case outcome inbounds.
+ *
+ * `meta.source` is what the bridge keys on to render the `<channel source=…>`
+ * block that wakes the proposing agent, and the `meta.*` fields are the
+ * forensic anchor back to the proposal + the deciding operator. A silent change
+ * to either would put the agent back where this fix found it — steered to end
+ * its turn and wait for a wake-up nothing recognises. Mirrors
+ * `skill-proposal-card.test.ts`'s `buildSkillProposalApplyInbound` block.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildEvalCaseAppliedInbound,
+  buildEvalCaseRejectedInbound,
+  buildEvalCaseApplyFailedInbound,
+} from '../gateway/eval-case-proposal-inbound-builders.js'
+
+const CTX = { agent: 'klanker', chat_id: '12345' }
+
+describe('buildEvalCaseAppliedInbound', () => {
+  it('pins source and meta for an applied case', () => {
+    const inb = buildEvalCaseAppliedInbound({
+      ctx: CTX,
+      proposalId: 'p1',
+      skillSlug: 'deploy-checklist',
+      heldOut: false,
+      operatorId: '999',
+      nowMs: 1000,
+    })
+    expect(inb.meta.source).toBe('eval_case_applied')
+    expect(inb.meta.agent).toBe('klanker')
+    expect(inb.meta.proposal_id).toBe('p1')
+    expect(inb.meta.skill_slug).toBe('deploy-checklist')
+    expect(inb.meta.held_out).toBe('false')
+    expect(inb.meta.operator_id).toBe('999')
+    expect(inb.chatId).toBe('12345')
+    expect(inb.user).toBe('self-improve')
+    expect(inb.messageId).toBe(1000)
+    expect(inb.ts).toBe(1000)
+    // The agent must NOT re-write a case the gateway already applied.
+    expect(inb.text).toContain('do NOT write it yourself')
+    expect(inb.text).toContain('evals.json')
+  })
+
+  it('names the held-out sink instead of evals.json when held_out', () => {
+    const inb = buildEvalCaseAppliedInbound({
+      ctx: CTX,
+      proposalId: 'p1',
+      skillSlug: 'deploy-checklist',
+      heldOut: true,
+      operatorId: '999',
+    })
+    expect(inb.meta.held_out).toBe('true')
+    expect(inb.text).toContain('held-out sink')
+    expect(inb.text).not.toContain('evals.json')
+  })
+
+  it('carries the forum topic through to threadId and meta', () => {
+    const inb = buildEvalCaseAppliedInbound({
+      ctx: { ...CTX, threadId: 7 },
+      proposalId: 'p1',
+      skillSlug: 's',
+      heldOut: false,
+      operatorId: '999',
+    })
+    expect(inb.threadId).toBe(7)
+    expect(inb.meta.message_thread_id).toBe('7')
+  })
+
+  it('omits threadId/message_thread_id entirely for a DM proposal', () => {
+    const inb = buildEvalCaseAppliedInbound({
+      ctx: CTX,
+      proposalId: 'p1',
+      skillSlug: 's',
+      heldOut: false,
+      operatorId: '999',
+    })
+    expect('threadId' in inb).toBe(false)
+    expect('message_thread_id' in inb.meta).toBe(false)
+  })
+})
+
+describe('buildEvalCaseRejectedInbound', () => {
+  it('pins source and tells the agent nothing was written', () => {
+    const inb = buildEvalCaseRejectedInbound({
+      ctx: CTX,
+      proposalId: 'p2',
+      skillSlug: 'deploy-checklist',
+      heldOut: false,
+      operatorId: '999',
+      nowMs: 2000,
+    })
+    expect(inb.meta.source).toBe('eval_case_rejected')
+    expect(inb.meta.proposal_id).toBe('p2')
+    expect(inb.user).toBe('self-improve')
+    expect(inb.text).toContain('NOTHING was written')
+    expect(inb.text).toContain('Do NOT re-propose')
+  })
+})
+
+describe('buildEvalCaseApplyFailedInbound', () => {
+  it('pins source and refuses to let the agent assume the case landed', () => {
+    const inb = buildEvalCaseApplyFailedInbound({
+      ctx: CTX,
+      proposalId: 'p3',
+      skillSlug: 'deploy-checklist',
+      heldOut: false,
+      operatorId: '999',
+      applyOut: 'ENOENT: skill dir missing',
+      nowMs: 3000,
+    })
+    expect(inb.meta.source).toBe('eval_case_apply_failed')
+    expect(inb.meta.proposal_id).toBe('p3')
+    expect(inb.text).toContain('was NOT')
+    expect(inb.text).toContain('do NOT assume')
+    expect(inb.text).toContain('ENOENT: skill dir missing')
+  })
+
+  it('truncates a runaway applier dump so it cannot dominate the woken turn', () => {
+    const inb = buildEvalCaseApplyFailedInbound({
+      ctx: CTX,
+      proposalId: 'p3',
+      skillSlug: 's',
+      heldOut: false,
+      operatorId: '999',
+      applyOut: 'x'.repeat(5000),
+    })
+    expect(inb.text).toContain('x'.repeat(500))
+    expect(inb.text).not.toContain('x'.repeat(501))
+  })
+
+  it('says "(no output)" rather than emitting an empty line', () => {
+    const inb = buildEvalCaseApplyFailedInbound({
+      ctx: CTX,
+      proposalId: 'p3',
+      skillSlug: 's',
+      heldOut: false,
+      operatorId: '999',
+      applyOut: '   \n  ',
+    })
+    expect(inb.text).toContain('(no output)')
+  })
+})

--- a/telegram-plugin/tests/subagent-handback-marker.test.ts
+++ b/telegram-plugin/tests/subagent-handback-marker.test.ts
@@ -96,6 +96,14 @@ describe('inbound source classification (F1 durability)', () => {
     expect(stampsHandbackMarker('reaction')).toBe(false)
     expect(stampsHandbackMarker('resume_interrupted')).toBe(false)
     expect(stampsHandbackMarker('vault_grant_approved')).toBe(false)
+    // #4662 — the eval-case outcome inbounds. The exhaustiveness test below pins
+    // only their PRESENCE in the registry; these pin the VALUE, which is the part
+    // with runtime consequence: classified `true` (or left to the fail-safe
+    // default) they would hold the content gate chat-wide for 60 s after every
+    // operator tap on an eval-case card.
+    expect(stampsHandbackMarker('eval_case_applied')).toBe(false)
+    expect(stampsHandbackMarker('eval_case_rejected')).toBe(false)
+    expect(stampsHandbackMarker('eval_case_apply_failed')).toBe(false)
   })
 
   it('a normal user inbound (no meta.source) never stamps', () => {


### PR DESCRIPTION
## The bug

When the operator taps Approve or Dismiss on a self-improve eval-case proposal card, **the proposing agent is never told the outcome.** Both exits of `handleEvalCaseProposalCallback` (`callback-query-handlers.ts`) end without ever calling `deliverResumeSyntheticOrBuffer`: deny sets status and edits the card; approve shells `apply-eval-case`, edits the card, writes a stderr line, and ends.

The sibling `handleSkillProposalCallback` twelve lines above **does** inject. The eval-case handler is a copy that dropped that line.

Every candidate second delivery path was checked and came back empty:

- The Stop hook (`src/cli/self-improve-stop.ts`) reads eval **integrity baselines**, not proposal status.
- The CLI propose path (`src/cli/self-improve-eval-case.ts:307-320`) is fire-and-forget: the agent gets `ok:true` for *posting the card*, never for the outcome.

## The fix

New pure module `telegram-plugin/gateway/eval-case-proposal-inbound-builders.ts`, mirroring `mental-model-propose-inbound-builders.ts` 1:1, with three builders covering the three real outcomes: `eval_case_applied`, `eval_case_rejected`, `eval_case_apply_failed`. The apply-failed builder truncates `applyOut` at 500 chars so a runaway stack trace cannot dominate the woken turn.

The handler now injects on all three exits, using the same `resolveThreadId` dep as the skill path so a card raised in a forum topic wakes the agent in that topic.

Also adds an injectable `runEvalCaseApply?: (id) => { ok, out }` dep, defaulting to the existing `execFileSync` verbatim. Every other side effect in that module is already injected; the bare static `execFileSync` import was the only thing blocking a deterministic test of the approve path.

## Behaviour change, stated rather than smuggled

Injecting on **deny** goes beyond strict parity with the skill handler, which stays silent on dismiss. That is deliberate: an agent that is never told it was rejected has no way to stop re-proposing, and silent blocking is the whole premise of this fix.

## Tests

- `callback-query-handlers.test.ts` — new `handleEvalCaseProposalCallback` describe, 6 cases.
- `eval-case-proposal-inbound-builders.test.ts` — 9 builder shape pins.

**Proof they fail on unmodified code:** stashing only the handler change and keeping the tests gives `5 failed | 1 passed`, each failure being `Number of calls: 0` on the `deliverResumeSyntheticOrBuffer` spy — the bug stated numerically. The one that passes unmodified is `a non-allowlisted tapper neither applies nor wakes the agent`, correctly so: that path was never broken, it guards against the fix leaking authorisation.

63/63 pass with the fix; 72/72 including the skill-proposal and eval-case-CLI suites. `npm run lint` clean across all gates.

## Verified, not assumed

- **No bridge change needed.** `deliverResumeSyntheticOrBuffer` is source-agnostic — it consults `decideInboundDelivery` on turn-in-flight, then `sendToAgent`, then buffers. There is no `meta.source` whitelist.
- **Double-tap safe.** The `proposal.status !== 'pending'` guard sits above all three injection points. Asserted, not assumed: three taps → the deliver spy fires exactly once and the applier runs exactly once.
- `held_out` serialises as `'true'`/`'false'` because `InboundMessage.meta` is `Record<string, string>`, matching the sibling `is_new: String(...)` convention.

## Worth knowing

`isTrackableResumeSynthetic` returns `false` for `vault_grant_approved` and every other approval-outcome source, so the three new `eval_case_*` inbounds are not enrolled in the deliver-until-acked sweep. They behave exactly like the existing approval-outcome family: mid-turn they buffer and flush on idle. Consistent with the family, not a gap introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
