### PR TITLE
fix(hostd): prove config_propose_edit writes the file the fleet reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,17 +200,22 @@ now an anomaly worth investigating, not the norm.
   in-place bind-mount-safe write: the reconcile spawn now PINS
   `SWITCHROOM_CONFIG` to the file just written (forward AND rollback
   reconcile), so the child cannot diverge; a mismatch between the write target
-  and `findConfigFile()`'s answer refuses the apply with a distinct
-  `E_CONFIG_PATH_MISMATCH` **before** any card, snapshot, or write; and hostd
-  logs one greppable `hostd-config-path-provenance` line at boot when they
-  disagree — logging, never refusing, because a config-layout change must not
+  and what HOSTD'S OWN `findConfigFile()` names refuses the apply with a
+  distinct `E_CONFIG_PATH_MISMATCH` **before** any card, snapshot, or write;
+  and hostd logs one greppable `hostd-config-path-provenance` line at boot when
+  they disagree — logging, never refusing, because a config-layout change must
+  not
   take the whole daemon (rollouts included) down to protect one verb that
   already refuses on its own. Two names for one file (same `st_dev` + `st_ino`)
   stay silent: the shipped install is exactly that, and a warning that fires
   every boot is a warning nobody reads. Identity is compared as dev+inode, not
   `realpath(2)` — `realpath` collapses neither a bind mount nor a hard link, so
   it would report "different file" for two names that are provably the same
-  bytes.
+  bytes. Scope, stated honestly: the gate and the boot line prove HOSTD-INTERNAL
+  consistency — the write target against hostd's own resolver, inside hostd's
+  cwd, `$HOME` and mount namespace. They cannot speak for an agent container or
+  the operator's host shell, which resolve in namespaces hostd cannot observe;
+  what stops the CHILD diverging is the `SWITCHROOM_CONFIG` pin, not the check.
 
 - **worktree: `switchroom worktree claim` now provisions an INDEPENDENT clone,
   not a linked `git worktree` — concurrent sub-agents can no longer collide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,31 @@ now an anomaly worth investigating, not the norm.
   the notice→evict→notice recursion, whereas `eval_case_suppressed` is never
   produced by eviction and participates in no cycle.
 
+- **hostd: `config_propose_edit` can no longer write one `switchroom.yaml` and
+  reconcile another.** The write target came from the wire literal
+  (`/state/config/switchroom.yaml` — `main.ts` never passes the `configPath`
+  test seam, so production fell through to it), while the `switchroom apply`
+  child resolved its own config through `findConfigFile()`
+  (`$SWITCHROOM_CONFIG` → cwd → `~/.switchroom`). The two agreed only because
+  `hostd install` happens to export `SWITCHROOM_CONFIG` alongside the bind
+  mount; nothing enforced it, and on divergence hostd wrote file X, reconciled
+  file Y cleanly, and returned `completed, exit_code: 0` for a change absent
+  from the file everything else reads. Three changes, and no retarget of the
+  in-place bind-mount-safe write: the reconcile spawn now PINS
+  `SWITCHROOM_CONFIG` to the file just written (forward AND rollback
+  reconcile), so the child cannot diverge; a mismatch between the write target
+  and `findConfigFile()`'s answer refuses the apply with a distinct
+  `E_CONFIG_PATH_MISMATCH` **before** any card, snapshot, or write; and hostd
+  logs one greppable `hostd-config-path-provenance` line at boot when they
+  disagree — logging, never refusing, because a config-layout change must not
+  take the whole daemon (rollouts included) down to protect one verb that
+  already refuses on its own. Two names for one file (same `st_dev` + `st_ino`)
+  stay silent: the shipped install is exactly that, and a warning that fires
+  every boot is a warning nobody reads. Identity is compared as dev+inode, not
+  `realpath(2)` — `realpath` collapses neither a bind mount nor a hard link, so
+  it would report "different file" for two names that are provably the same
+  bytes.
+
 - **worktree: `switchroom worktree claim` now provisions an INDEPENDENT clone,
   not a linked `git worktree` — concurrent sub-agents can no longer collide
   through shared git state.** Linked worktrees share the parent repo's refs

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -142,15 +142,18 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  // #4661 follow-up — is the file `config_propose_edit` writes the file the
-  // fleet reads? The write target is the wire literal
-  // (`/state/config/switchroom.yaml`); everything else — agents, the CLI,
-  // hostd's own loadConfig — goes through findConfigFile. Say so LOUDLY at boot
-  // if they disagree, and do NOT refuse to start: a config-layout change would
-  // otherwise take the whole daemon (rollouts included) down to protect one
-  // verb that already refuses on its own at apply time. Two NAMES for one file
-  // (same dev+inode) stay silent — the shipped install is exactly that, and a
-  // warning that fires every boot is a warning nobody reads.
+  // #4661 follow-up — would `config_propose_edit` write a file hostd itself
+  // would not read back? The write target is the wire literal
+  // (`/state/config/switchroom.yaml`); hostd's own loadConfig and pin journal
+  // go through findConfigFile. This compares those two INSIDE hostd's own cwd,
+  // `$HOME` and mount namespace — it is not, and cannot be, a statement about
+  // an agent container or the operator's host shell, which resolve elsewhere.
+  // Say so LOUDLY at boot if they disagree, and do NOT refuse to start: a
+  // config-layout change would otherwise take the whole daemon (rollouts
+  // included) down to protect one verb that already refuses on its own at
+  // apply time. Two NAMES for one file (same dev+inode) stay silent — the
+  // shipped install is exactly that, and a warning that fires every boot is a
+  // warning nobody reads.
   const provenanceWarning = configPathProvenanceWarning();
   if (provenanceWarning !== null) {
     process.stderr.write(`hostd: ${provenanceWarning}\n`);

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -31,7 +31,7 @@ import {
   type GatewayCandidate,
 } from "./config-degraded.js";
 import { allocateAgentUid } from "../agents/compose.js";
-import { HostdServer } from "./server.js";
+import { HostdServer, configPathProvenanceWarning } from "./server.js";
 import { dockerFleetComponents } from "./prior-pin.js";
 import { SocketApprovalGateway } from "./approval-gateway.js";
 import { SocketRolloutRelay } from "./rollout-relay.js";
@@ -140,6 +140,20 @@ async function main(): Promise<void> {
       "hostd: refusing to start — host_control.enabled is not true in switchroom.yaml\n",
     );
     process.exit(2);
+  }
+
+  // #4661 follow-up — is the file `config_propose_edit` writes the file the
+  // fleet reads? The write target is the wire literal
+  // (`/state/config/switchroom.yaml`); everything else — agents, the CLI,
+  // hostd's own loadConfig — goes through findConfigFile. Say so LOUDLY at boot
+  // if they disagree, and do NOT refuse to start: a config-layout change would
+  // otherwise take the whole daemon (rollouts included) down to protect one
+  // verb that already refuses on its own at apply time. Two NAMES for one file
+  // (same dev+inode) stay silent — the shipped install is exactly that, and a
+  // warning that fires every boot is a warning nobody reads.
+  const provenanceWarning = configPathProvenanceWarning();
+  if (provenanceWarning !== null) {
+    process.stderr.write(`hostd: ${provenanceWarning}\n`);
   }
 
   // Bind a per-agent UDS for EVERY agent, not just admin-flagged ones.

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -384,6 +384,15 @@ export const AgentSmokeRequestSchema = z.object({
 // operator approval card, and an explicit `target_path` that MUST equal the
 // canonical config path — guarding against accidental multi-file diffs and
 // giving the validator a single load-bearing path string to anchor on.
+/**
+ * The one config path this verb is allowed to name on the wire — the container
+ * path `hostd install` bind-mounts `~/.switchroom/switchroom.yaml` onto
+ * (`src/cli/hostd.ts`). Exported so the three places that compare against it
+ * (this schema, hostd's fallback resolution, and the startup path-provenance
+ * assertion in `main.ts`) cannot drift apart independently.
+ */
+export const CANONICAL_CONFIG_PATH = "/state/config/switchroom.yaml" as const;
+
 export const ConfigProposeEditRequestSchema = z.object({
   ...RequestEnvelope,
   op: z.literal("config_propose_edit"),
@@ -399,7 +408,7 @@ export const ConfigProposeEditRequestSchema = z.object({
     /** Must be the canonical path. Rejected dispatcher-side if not —
      *  this is a defense-in-depth check on top of PR 1b's diff-path
      *  validation. */
-    target_path: z.literal("/state/config/switchroom.yaml"),
+    target_path: z.literal(CANONICAL_CONFIG_PATH),
   }),
 });
 
@@ -449,6 +458,13 @@ export const CONFIG_PROPOSE_EDIT_ERROR_CODES = [
   // set). Distinct from E_RECONCILE_FAILED_ROLLED_BACK: nothing rejected the
   // config, hostd could not prove it changed at all.
   "E_WRITE_NOT_OBSERVED",
+  // #4661 follow-up — the file hostd would WRITE is not the file the fleet
+  // READS: the write target and `findConfigFile()`'s answer resolve to
+  // different real paths. Returned BEFORE anything is written (no snapshot, no
+  // approval card), because writing one file and reconciling another produces
+  // an `exit 0, result: completed` for a change that is absent from the config
+  // every other process loads.
+  "E_CONFIG_PATH_MISMATCH",
 ] as const;
 export type ConfigProposeEditErrorCode =
   (typeof CONFIG_PROPOSE_EDIT_ERROR_CODES)[number];

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -298,11 +298,21 @@ export interface ServerOptions {
   runReconcile?: (args: {
     requestId: string;
     /**
-     * The env overlay the production spawn merges onto `process.env` for this
-     * reconcile — the SAME object the real `runSwitchroom` call receives, so a
-     * test asserting on it is asserting the child's environment and not a
-     * parallel construction. Carries `SWITCHROOM_CONFIG` on the
+     * A MIRROR of the env overlay the production spawn merges onto
+     * `process.env` for this reconcile. Carries `SWITCHROOM_CONFIG` on the
      * `config_propose_edit` path (#4661 follow-up).
+     *
+     * It is NOT the child's environment: production never calls this seam, it
+     * calls the default closure, which passes the same variable POSITIONALLY to
+     * `runSwitchroom(args, extraEnv)` and ignores this parameter entirely. Two
+     * independent references to one variable — nothing in the type system ties
+     * them, and dropping the real spawn's argument would leave every
+     * seam-asserting test green. What keeps the mirror honest is the real-spawn
+     * test "spawns the REAL reconcile child (no runReconcile seam) with
+     * SWITCHROOM_CONFIG pinned to the written file" in
+     * `tests/host-control/config-propose-edit.test.ts`, which injects no seam
+     * and reads the variable out of the child's own environment. Keep them in
+     * step: change the spawn, and that test is what fails.
      */
     env?: Record<string, string>;
   }) => Promise<{ exit_code: number; stdout: string; stderr: string }>;
@@ -956,10 +966,15 @@ function statIdentity(path: string): FileIdentity {
  * change absent from the file everything else reads.
  *
  * The reconcile spawn now pins `SWITCHROOM_CONFIG` to the write target, so the
- * CHILD can no longer diverge. This function covers the rest of the fleet —
- * agents, the CLI, hostd's own `loadConfig()` and pin journal — which all go
- * through `findConfigFile`. If that answer is a different file from the one we
- * are about to write, the write is invisible to them and must not happen.
+ * CHILD can no longer diverge. This function covers what is left: HOSTD-INTERNAL
+ * consistency between the write target and hostd's OWN `findConfigFile()`
+ * answer — the same resolver hostd's `loadConfig()` and pin journal use. It
+ * cannot speak for the rest of the fleet: `findConfigFile()` is evaluated inside
+ * the hostd container against hostd's cwd, `$HOME` and mount namespace, while an
+ * agent container or the operator's host shell resolve in namespaces hostd
+ * cannot observe. A divergence hostd CAN see is nonetheless proof that the write
+ * is landing somewhere hostd itself would not read back, so the write must not
+ * happen.
  *
  * Deliberately quiet about the cases that are NOT divergence, because a check
  * that cries wolf on every boot is worse than no check:

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -49,6 +49,7 @@ import {
   deniedResponse,
   IDEMPOTENCY_WINDOW_MS,
   MAX_FRAME_BYTES,
+  CANONICAL_CONFIG_PATH,
   type HostdRequest,
   type HostdResponse,
   type Result,
@@ -296,6 +297,14 @@ export interface ServerOptions {
   /** Test seam: override the `switchroom apply` subprocess invocation. */
   runReconcile?: (args: {
     requestId: string;
+    /**
+     * The env overlay the production spawn merges onto `process.env` for this
+     * reconcile — the SAME object the real `runSwitchroom` call receives, so a
+     * test asserting on it is asserting the child's environment and not a
+     * parallel construction. Carries `SWITCHROOM_CONFIG` on the
+     * `config_propose_edit` path (#4661 follow-up).
+     */
+    env?: Record<string, string>;
   }) => Promise<{ exit_code: number; stdout: string; stderr: string }>;
   /**
    * Test seam: override how the live config file is written during a
@@ -310,6 +319,24 @@ export interface ServerOptions {
    * which are portable in CI.
    */
   writeConfigFile?: (path: string, content: string) => void;
+  /**
+   * Test seam: override how the FLEET's config path is resolved for the
+   * apply-time path-provenance gate (#4661 follow-up). Default:
+   * {@link findConfigFile} — the same resolver every agent, the CLI, and
+   * hostd's own `loadConfig()` go through.
+   *
+   * Exists because the gate's whole subject is a disagreement between two
+   * resolvers, and the production one answers from `$SWITCHROOM_CONFIG` / cwd /
+   * `~/.switchroom` — none of which a test can point at
+   * `/state/config/switchroom.yaml` without root and a real bind mount.
+   */
+  resolveFleetConfigPath?: () => string;
+  /**
+   * Test seam: override the `stat(2)`-based file-identity probe the
+   * path-provenance gate uses to tell two NAMES for one file apart from two
+   * different files.
+   */
+  identifyForProvenance?: (p: string) => FileIdentity;
   /**
    * #1841 — operator-passphrase attestation verifier. Default: a
    * broker-backed verifier that forwards the passphrase to the vault
@@ -744,11 +771,12 @@ interface ConfigWriteObservation {
  * apply mutex (documented residual race) — which is exactly what we want to
  * fail on, not tolerate.
  *
- * KNOWN LIMITATION: this reads back the SAME path it wrote. If hostd's read
- * and write go through the same aliased-or-wrong path, verification passes
- * and a path-divergence bug survives. Closing that requires asserting path
- * IDENTITY (the wire `target_path` vs the resolved `configPath`), which is
- * out of scope here.
+ * SCOPE: this reads back the SAME path it wrote, so it cannot detect a write
+ * to the WRONG file — an aliased-or-wrong path reads back perfectly. That half
+ * is {@link checkConfigPathProvenance}'s job, asserted BEFORE the write
+ * (#4661 follow-up). The two compose and neither subsumes the other: a correct
+ * path can still swallow a write, and a landed write to the wrong file is
+ * still invisible to every other reader.
  */
 function verifyConfigWriteObserved(
   configPath: string,
@@ -880,7 +908,183 @@ interface AutoRolloutLatch {
  *
  * Exported so a test can assert the fallback is the LAST arm, not the first.
  */
-export const HOSTD_FALLBACK_CONFIG_PATH = "/state/config/switchroom.yaml";
+export const HOSTD_FALLBACK_CONFIG_PATH = CANONICAL_CONFIG_PATH;
+
+/**
+ * Result of comparing the file hostd would WRITE against the file the rest of
+ * the fleet READS. `ok: false` is the only interesting case; `detail` is
+ * operator-facing prose naming both paths and how they were compared.
+ */
+export interface ConfigPathProvenance {
+  ok: boolean;
+  /** The write target under scrutiny, verbatim. */
+  writePath: string;
+  /** What the fleet's own resolver named, or null when it could not name one. */
+  resolvedPath: string | null;
+  /**
+   * True when the verdict rests on FILE IDENTITY (`st_dev` + `st_ino`) rather
+   * than a string comparison. A `false` here on a `!ok` verdict means "these
+   * are different strings and we could not prove anything about the inodes".
+   */
+  identityChecked: boolean;
+  detail: string;
+}
+
+/** The `stat(2)` fields that define file identity. */
+export interface FileIdentity {
+  dev: number;
+  ino: number;
+}
+
+/** Default identity probe: `stat(2)`, which follows symlinks. */
+function statIdentity(path: string): FileIdentity {
+  const st = statSync(path);
+  return { dev: st.dev, ino: st.ino };
+}
+
+/**
+ * #4661 follow-up — does hostd write the file the fleet reads?
+ *
+ * `handleConfigProposeEdit` resolves its write target from the WIRE literal
+ * (`req.args.target_path`, pinned to {@link CANONICAL_CONFIG_PATH}) whenever no
+ * explicit `opts.configPath` is set — i.e. in production, since `main.ts` never
+ * passes one. The reconcile child resolves its own config through
+ * {@link findConfigFile} (`$SWITCHROOM_CONFIG` → cwd → `~/.switchroom`). Those
+ * two agree today only because `hostd install` exports `SWITCHROOM_CONFIG`
+ * pointing at the bind mount. Nothing enforced it, and on divergence hostd
+ * wrote file X, reconciled file Y, and returned `completed, exit_code: 0` for a
+ * change absent from the file everything else reads.
+ *
+ * The reconcile spawn now pins `SWITCHROOM_CONFIG` to the write target, so the
+ * CHILD can no longer diverge. This function covers the rest of the fleet —
+ * agents, the CLI, hostd's own `loadConfig()` and pin journal — which all go
+ * through `findConfigFile`. If that answer is a different file from the one we
+ * are about to write, the write is invisible to them and must not happen.
+ *
+ * Deliberately quiet about the cases that are NOT divergence, because a check
+ * that cries wolf on every boot is worse than no check:
+ *
+ *  - **Resolver throws** (`No switchroom.yaml found`) → `ok`. It proves nothing
+ *    about divergence, and the child would fail loudly on its own rather than
+ *    silently reconcile a different file.
+ *  - **Two names for one file** → `ok` when both sides carry the same
+ *    `st_dev` + `st_ino`. `/state/config/switchroom.yaml` IS another name for
+ *    `~/.switchroom/switchroom.yaml` in the shipped install, so comparing raw
+ *    strings would fire on every single boot. Identity is compared as
+ *    dev+inode rather than `realpath(2)` deliberately: `realpath` does NOT
+ *    collapse a bind mount (a file bind-mounted to a second path realpaths to
+ *    that second path) nor a hard link, so a realpath compare would report a
+ *    DIFFERENT file for two names that are provably the same bytes — the exact
+ *    false alarm this check must not raise. dev+inode is the definition.
+ *  - **`stat` throws** (either side missing) → fall back to the string compare
+ *    and SAY so in `detail` (`identityChecked: false`), so a mismatch report is
+ *    never read as inode-level evidence when it is not.
+ *
+ * `findConfigFile` already `resolve()`s a relative `$SWITCHROOM_CONFIG` against
+ * cwd, so a relative env value cannot produce a spurious string mismatch.
+ */
+export function checkConfigPathProvenance(
+  writePath: string,
+  resolveFleetConfig: () => string = findConfigFile,
+  identify: (p: string) => FileIdentity = statIdentity,
+): ConfigPathProvenance {
+  let resolvedPath: string;
+  try {
+    resolvedPath = resolveFleetConfig();
+  } catch (e) {
+    return {
+      ok: true,
+      writePath,
+      resolvedPath: null,
+      identityChecked: false,
+      detail:
+        `fleet config resolver could not name a config file ` +
+        `(${(e as Error).message}) — nothing to compare against ${writePath}`,
+    };
+  }
+  if (resolvedPath === writePath) {
+    return {
+      ok: true,
+      writePath,
+      resolvedPath,
+      identityChecked: false,
+      detail: `write target and fleet config path are the same string (${writePath})`,
+    };
+  }
+  let write: FileIdentity;
+  let fleet: FileIdentity;
+  try {
+    write = identify(writePath);
+    fleet = identify(resolvedPath);
+  } catch (e) {
+    return {
+      ok: false,
+      writePath,
+      resolvedPath,
+      identityChecked: false,
+      detail:
+        `write target ${writePath} differs from the fleet config path ` +
+        `${resolvedPath}, and file identity could not be established ` +
+        `(${(e as Error).message}) — compared as strings, not inodes`,
+    };
+  }
+  if (write.dev === fleet.dev && write.ino === fleet.ino) {
+    return {
+      ok: true,
+      writePath,
+      resolvedPath,
+      identityChecked: true,
+      detail:
+        `write target ${writePath} and fleet config path ${resolvedPath} are ` +
+        `two names for the SAME file (dev=${write.dev} ino=${write.ino})`,
+    };
+  }
+  return {
+    ok: false,
+    writePath,
+    resolvedPath,
+    identityChecked: true,
+    detail:
+      `write target ${writePath} (dev=${write.dev} ino=${write.ino}) is a ` +
+      `DIFFERENT file from the config the fleet reads, ${resolvedPath} ` +
+      `(dev=${fleet.dev} ino=${fleet.ino}) — a write here would be invisible ` +
+      `to every other reader`,
+  };
+}
+
+/**
+ * Greppable tag for the boot-time path-provenance warning. Distinct and
+ * stable so an operator (or a log alert) can match exactly this condition.
+ */
+export const CONFIG_PATH_PROVENANCE_TAG = "hostd-config-path-provenance";
+
+/**
+ * Boot-time assertion that hostd's canonical write target is the file the
+ * fleet reads. Returns the log line to emit, or null when they agree.
+ *
+ * LOGS, never refuses: a config-layout change that trips this would otherwise
+ * take hostd down entirely — losing every other verb, including the rollout
+ * path — to protect one verb that has its own apply-time gate
+ * (`E_CONFIG_PATH_MISMATCH`). A loud line plus a hard gate at the point of
+ * damage beats a crash-loop at boot.
+ */
+export function configPathProvenanceWarning(
+  resolveFleetConfig: () => string = findConfigFile,
+  identify: (p: string) => FileIdentity = statIdentity,
+): string | null {
+  const prov = checkConfigPathProvenance(
+    CANONICAL_CONFIG_PATH,
+    resolveFleetConfig,
+    identify,
+  );
+  if (prov.ok) return null;
+  return (
+    `${CONFIG_PATH_PROVENANCE_TAG}: ${prov.detail}. ` +
+    `config_propose_edit will REFUSE with E_CONFIG_PATH_MISMATCH until this ` +
+    `agrees — check the hostd bind mount over ${CANONICAL_CONFIG_PATH} and ` +
+    `the SWITCHROOM_CONFIG it exports alongside it.`
+  );
+}
 
 /**
  * Resolve the live `switchroom.yaml` this daemon reads/writes.
@@ -3268,6 +3472,29 @@ export class HostdServer {
     }
     const configPath =
       this.opts.configPath ?? req.args.target_path;
+    // ── #4661 follow-up — path provenance, BEFORE anything is read or written ──
+    // When no explicit `opts.configPath` is set (production: `main.ts` never
+    // passes one) the write target is the WIRE literal, NOT hostd's own
+    // `resolveHostdConfigPath`. Prove that literal names the same file the fleet
+    // reads before going anywhere near a snapshot, an approval card, or a write:
+    // writing one file and reconciling another returns `completed, exit_code: 0`
+    // for a change nothing else can see. First check in the handler after the
+    // feature flag, so a mismatch cannot leave half-changed state behind.
+    //
+    // An EXPLICIT `opts.configPath` skips the gate. That arm is the documented
+    // embedder/test override (see the opt's docs and `resolveHostdConfigPath`
+    // arm 1): the embedder has named the file deliberately, and a scratch config
+    // under `tmp/` legitimately differs from whatever `findConfigFile` finds.
+    if (this.opts.configPath === undefined) {
+      const provenance = checkConfigPathProvenance(
+        configPath,
+        this.opts.resolveFleetConfigPath ?? findConfigFile,
+        this.opts.identifyForProvenance ?? statIdentity,
+      );
+      if (!provenance.ok) {
+        return this.configPathMismatch(provenance.detail, req, caller, started);
+      }
+    }
     const verdict = validateConfigEdit({
       configPath,
       targetPath: req.args.target_path,
@@ -3877,6 +4104,18 @@ export class HostdServer {
       // within the gateway's 60s dispatch timeout. Falls back to a
       // full apply when the caller is the operator socket (rare) or
       // `runReconcile` is injected by tests.
+      //
+      // #4661 follow-up — PIN the child's config resolution to the file we just
+      // wrote. Without this the child ran `findConfigFile()` itself
+      // (`$SWITCHROOM_CONFIG` → cwd → `~/.switchroom`) while hostd wrote
+      // `configPath`, and the two agreed only because `hostd install` happens to
+      // export `SWITCHROOM_CONFIG`. Nothing enforced it, and the divergence is
+      // silent by construction: hostd writes X, the child reconciles Y cleanly,
+      // and the response is `completed, exit_code: 0` for a change absent from
+      // the file the fleet reads. One env var makes the agreement structural.
+      // The same overlay is handed to the ROLLBACK reconcile below (same
+      // `runner`), so the restore is reconciled against the same file too.
+      const reconcileEnv = { SWITCHROOM_CONFIG: configPath };
       const runner =
         this.opts.runReconcile ??
         (async () =>
@@ -3884,8 +4123,9 @@ export class HostdServer {
             caller.kind === "agent"
               ? ["apply", "--only", callerName, "--non-interactive"]
               : ["apply", "--non-interactive"],
+            reconcileEnv,
           ));
-      const recRes = await runner({ requestId: approvalId });
+      const recRes = await runner({ requestId: approvalId, env: reconcileEnv });
       if (recRes.exit_code === 0) {
         // Tell the operator which agents must restart for this edit to go
         // live (claude loads config at boot — an applied edit is inert until
@@ -3934,7 +4174,7 @@ export class HostdServer {
           started,
         );
       }
-      const recRes2 = await runner({ requestId: approvalId });
+      const recRes2 = await runner({ requestId: approvalId, env: reconcileEnv });
       const recoveryNote =
         recRes2.exit_code === 0
           ? "rolled back successfully"
@@ -4032,6 +4272,40 @@ export class HostdServer {
         "confirm hostd reads and writes the SAME switchroom.yaml the fleet reads (check the hostd bind mount over /state/config/switchroom.yaml)",
         "check for a competing writer to the config (operator hand-edit or editor daemon) during the apply window",
         "inspect the live config by hand before re-proposing — the diff was valid, the write path was not",
+      ])
+      .op("config_propose_edit")
+      .caller(caller.kind === "agent" ? "agent" : "operator")
+      .agentName(caller.kind === "agent" ? caller.name : undefined)
+      .build(req.request_id, Date.now() - started);
+    return { ...built, error: legacy };
+  }
+
+  /**
+   * #4661 follow-up — the write target is not the file the fleet reads, so the
+   * apply refused before touching anything. Sibling of
+   * {@link HostdServer.writeNotObserved}, and the two compose as before/after
+   * halves of the same guarantee: this one asserts path IDENTITY up front (the
+   * limitation `verifyConfigWriteObserved` documents as out of its scope), the
+   * other asserts the bytes LANDED at that path afterwards. Neither subsumes
+   * the other — a correct path can still swallow a write, and an observed write
+   * to the wrong file still reads back perfectly.
+   */
+  private configPathMismatch(
+    detail: string,
+    req: Extract<HostdRequest, { op: "config_propose_edit" }>,
+    caller: SocketIdentity,
+    started: number,
+  ): HostdResponse {
+    const legacy = `E_CONFIG_PATH_MISMATCH: ${detail}`;
+    const built = err(
+      "E_CONFIG_PATH_MISMATCH",
+      "hostd would write a different switchroom.yaml than the fleet reads; apply refused before any write",
+    )
+      .why(detail)
+      .fixOperatorAction("infra", [
+        `confirm the hostd container bind-mounts the live switchroom.yaml onto ${CANONICAL_CONFIG_PATH}`,
+        "confirm SWITCHROOM_CONFIG inside the hostd container points at that same path (hostd install exports it alongside the mount)",
+        "re-propose once the two agree — the diff was never applied, nothing was written",
       ])
       .op("config_propose_edit")
       .caller(caller.kind === "agent" ? "agent" : "operator")

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -1424,6 +1424,54 @@ describe("hostd config_propose_edit — config path provenance (#4661 follow-up)
     expect(envs[0]!.SWITCHROOM_CONFIG).toBe(configPath);
   });
 
+  // The test above asserts the `runReconcile` SEAM's `env` argument. That
+  // argument is a MIRROR, not the child's environment: production never calls
+  // the seam — it calls the default closure, which passes `reconcileEnv`
+  // positionally to `runSwitchroom(args, extraEnv)` and ignores its own `env`
+  // parameter. They are two independent references to one variable, so deleting
+  // the real `runSwitchroom` argument leaves every seam-based test green.
+  //
+  // This one drives the REAL spawn — no `runReconcile` injection at all —
+  // through the `switchroomBin` stub and reads SWITCHROOM_CONFIG out of the
+  // child's OWN environment. Same pattern as the SWITCHROOM_HOSTD_CONTEXT
+  // assertions in `server.test.ts`. It is the only test that fails if the
+  // production spawn loses the pin.
+  it("spawns the REAL reconcile child (no runReconcile seam) with SWITCHROOM_CONFIG pinned to the written file", async () => {
+    const { gw } = stubGateway("approve");
+    const rec = join(tmp, "reconcile-child-env.txt");
+    // Overwrite the default stub with one that reports its own env + argv.
+    // `switchroomBin` is read at spawn time, so rewriting the same path here
+    // (before the server is constructed) is enough.
+    writeFileSync(
+      stubBin,
+      `#!/bin/sh\n` +
+        `echo "argv: $*" >> "${rec}"\n` +
+        `echo "cfg: $SWITCHROOM_CONFIG" >> "${rec}"\n` +
+        `exit 0\n`,
+    );
+    chmodSync(stubBin, 0o755);
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      // runReconcile deliberately NOT injected — this is the production path.
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "prov-real-1" });
+    expect(resp.result).toBe("completed");
+    expect(resp.exit_code).toBe(0);
+
+    // Exactly one child, and its environment carries the pin. A production
+    // spawn that dropped `reconcileEnv` writes `cfg:` with an empty value here
+    // (the harness does not export SWITCHROOM_CONFIG), which is the pre-fix
+    // bug: the child would re-derive its own path via findConfigFile().
+    const lines = readFile(rec, "utf8").trim().split("\n");
+    expect(lines).toEqual([
+      "argv: apply --only klanker --non-interactive",
+      `cfg: ${configPath}`,
+    ]);
+  });
+
   it("pins the same SWITCHROOM_CONFIG on the ROLLBACK reconcile, not just the forward one", async () => {
     const { gw } = stubGateway("approve");
     const envs: Array<Record<string, string> | undefined> = [];

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -21,11 +21,20 @@ import {
   chmodSync,
   statSync,
   rmSync,
+  symlinkSync,
+  linkSync,
+  realpathSync,
 } from "node:fs";
 import { execSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { HostdServer } from "../../src/host-control/server.js";
+import {
+  HostdServer,
+  checkConfigPathProvenance,
+  configPathProvenanceWarning,
+  CONFIG_PATH_PROVENANCE_TAG,
+} from "../../src/host-control/server.js";
+import { CANONICAL_CONFIG_PATH } from "../../src/host-control/protocol.js";
 import { hostdRequest } from "../../src/host-control/client.js";
 import type {
   ApprovalGateway,
@@ -51,12 +60,17 @@ function makeServer(opts: {
   configPath?: string;
   approvalGateway?: ApprovalGateway;
   generateApprovalId?: () => string;
-  runReconcile?: (args: { requestId: string }) => Promise<{
+  runReconcile?: (args: {
+    requestId: string;
+    env?: Record<string, string>;
+  }) => Promise<{
     exit_code: number;
     stdout: string;
     stderr: string;
   }>;
   writeConfigFile?: (path: string, content: string) => void;
+  resolveFleetConfigPath?: () => string;
+  identifyForProvenance?: (p: string) => { dev: number; ino: number };
 }) {
   return new HostdServer({
     homeDir: tmp,
@@ -75,6 +89,8 @@ function makeServer(opts: {
     generateApprovalId: opts.generateApprovalId,
     runReconcile: opts.runReconcile,
     writeConfigFile: opts.writeConfigFile,
+    resolveFleetConfigPath: opts.resolveFleetConfigPath,
+    identifyForProvenance: opts.identifyForProvenance,
   });
 }
 
@@ -1367,5 +1383,268 @@ describe("hostd config_propose_edit — relocation guards (#3121 follow-up)", ()
     expect(live).not.toContain("mcp__evil__tool");
     expect(reconcileInvocations).toBe(0);
     expect(finalizeCalls[0]!.outcome).toBe("aborted_config_changed");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// #4661 follow-up — CONFIG PATH PROVENANCE. hostd wrote one file and
+// reconciled a potentially different one: the write target came from the wire
+// literal (`opts.configPath` is unset in production — `main.ts` never passes
+// it), while the `switchroom apply` child resolved its own config through
+// `findConfigFile()` (`$SWITCHROOM_CONFIG` → cwd → `~/.switchroom`). They
+// agreed only because `hostd install` happens to export SWITCHROOM_CONFIG.
+// On divergence: write X, reconcile Y cleanly, `completed / exit 0`, and the
+// approved change is absent from the file everything else reads.
+// Assertions here are on the child's ENV, on a distinct error code, and on the
+// target file's bytes + mtime — never on "a code path ran".
+// ─────────────────────────────────────────────────────────────────────
+describe("hostd config_propose_edit — config path provenance (#4661 follow-up)", () => {
+  it("pins the reconcile child's SWITCHROOM_CONFIG to the file that was just written", async () => {
+    const { gw } = stubGateway("approve");
+    const envs: Array<Record<string, string> | undefined> = [];
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async ({ env }) => {
+        envs.push(env);
+        return { exit_code: 0, stdout: "applied ok", stderr: "" };
+      },
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "prov-1" });
+
+    // Happy-path regression: the pin does not change the outcome.
+    expect(resp.result).toBe("completed");
+    expect(resp.exit_code).toBe(0);
+    // The observable: the child's environment. Pre-fix this was `undefined` —
+    // the child re-derived its own config path and could name another file.
+    expect(envs.length).toBe(1);
+    expect(envs[0]).toBeDefined();
+    expect(envs[0]!.SWITCHROOM_CONFIG).toBe(configPath);
+  });
+
+  it("pins the same SWITCHROOM_CONFIG on the ROLLBACK reconcile, not just the forward one", async () => {
+    const { gw } = stubGateway("approve");
+    const envs: Array<Record<string, string> | undefined> = [];
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      // Forward reconcile fails → rollback restore → recovery reconcile. A
+      // rollback reconciled against a DIFFERENT file is the same bug wearing a
+      // different hat, so the recovery spawn must carry the pin too.
+      runReconcile: async ({ env }) => {
+        envs.push(env);
+        return { exit_code: envs.length === 1 ? 1 : 0, stdout: "", stderr: "boom" };
+      },
+    });
+    await server.start();
+    await send({ unified_diff: GOOD_DIFF, request_id: "prov-2" });
+
+    expect(envs.length).toBe(2);
+    for (const env of envs) {
+      expect(env?.SWITCHROOM_CONFIG).toBe(configPath);
+    }
+  });
+
+  it("returns E_CONFIG_PATH_MISMATCH — no card, no write, no reconcile — when the fleet reads a different file", async () => {
+    const { gw, requests, finalizeCalls } = stubGateway("approve");
+    let reconcileInvocations = 0;
+    const writes: string[] = [];
+    server = makeServer({
+      configEditEnabled: true,
+      // configPath deliberately UNSET: reproduce production, where the write
+      // target is the wire literal /state/config/switchroom.yaml.
+      approvalGateway: gw,
+      // …while the fleet's own resolver names an entirely different file.
+      resolveFleetConfigPath: () => configPath,
+      writeConfigFile: (_p, content) => {
+        writes.push(content);
+      },
+      runReconcile: async () => {
+        reconcileInvocations += 1;
+        return { exit_code: 0, stdout: "applied ok", stderr: "" };
+      },
+    });
+    await server.start();
+    const before = readFile(configPath, "utf8");
+    const mtimeBefore = statSync(configPath).mtimeMs;
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "prov-3" });
+
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_CONFIG_PATH_MISMATCH/);
+    expect(resp.error_envelope?.code).toBe("E_CONFIG_PATH_MISMATCH");
+    expect(resp.error_envelope?.fix?.kind).toBe("operator_action");
+    // Both paths are named, so the operator can see WHICH two disagree.
+    expect(resp.error).toContain("/state/config/switchroom.yaml");
+    expect(resp.error).toContain(configPath);
+    // Refused BEFORE the operator was ever asked, and before any write.
+    expect(requests.length).toBe(0);
+    expect(finalizeCalls.length).toBe(0);
+    expect(writes.length).toBe(0);
+    expect(reconcileInvocations).toBe(0);
+    // The file the fleet reads is untouched: same bytes, same mtime.
+    expect(readFile(configPath, "utf8")).toBe(before);
+    expect(statSync(configPath).mtimeMs).toBe(mtimeBefore);
+  });
+
+  it("does NOT fire when the fleet path is an ALIAS of the write target", async () => {
+    const { gw } = stubGateway("approve");
+    server = makeServer({
+      configEditEnabled: true,
+      approvalGateway: gw,
+      resolveFleetConfigPath: () => configPath,
+      // Both names carry the same dev+inode — exactly the shipped install,
+      // where /state/config/switchroom.yaml is a bind mount of
+      // ~/.switchroom/switchroom.yaml. A string-only check would reject it,
+      // and so would a realpath compare (a bind mount does not collapse).
+      identifyForProvenance: () => ({ dev: 42, ino: 99 }),
+      runReconcile: async () => ({ exit_code: 0, stdout: "", stderr: "" }),
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "prov-4" });
+
+    // The gate passed; this request then fails further down the pipeline
+    // (the wire literal does not exist in the test sandbox). What matters is
+    // that the provenance gate did not claim a mismatch.
+    expect(resp.error ?? "").not.toMatch(/E_CONFIG_PATH_MISMATCH/);
+  });
+
+  it("skips the gate when an embedder pins configPath explicitly", async () => {
+    const { gw } = stubGateway("approve");
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      // A scratch config legitimately differs from whatever findConfigFile
+      // finds — an explicit configPath is the documented override, so this
+      // divergence must not be treated as the production bug.
+      resolveFleetConfigPath: () => "/somewhere/else/switchroom.yaml",
+      runReconcile: async () => ({ exit_code: 0, stdout: "applied ok", stderr: "" }),
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "prov-5" });
+    expect(resp.result).toBe("completed");
+  });
+});
+
+describe("checkConfigPathProvenance (unit)", () => {
+  it("passes on an identical path string without touching the filesystem", () => {
+    let statCalls = 0;
+    const prov = checkConfigPathProvenance(
+      "/state/config/switchroom.yaml",
+      () => "/state/config/switchroom.yaml",
+      (_p) => {
+        statCalls += 1;
+        return { dev: 1, ino: 1 };
+      },
+    );
+    expect(prov.ok).toBe(true);
+    expect(statCalls).toBe(0);
+  });
+
+  it("passes on a REAL symlink to the config (same inode, different string)", () => {
+    const link = join(tmp, "aliased.yaml");
+    symlinkSync(configPath, link);
+    const prov = checkConfigPathProvenance(link, () => configPath);
+    expect(prov.ok).toBe(true);
+    expect(prov.identityChecked).toBe(true);
+    expect(prov.detail).toMatch(/two names for the SAME file/);
+  });
+
+  it("passes on a REAL hard link — which a realpath compare would have rejected", () => {
+    const hard = join(tmp, "hardlinked.yaml");
+    linkSync(configPath, hard);
+    // realpathSync(hard) === hard !== realpathSync(configPath), so a realpath
+    // compare calls these different files. They are the same inode: a write
+    // through either name is visible through the other, so refusing the apply
+    // here would be a pure false alarm.
+    expect(realpathSync(hard)).not.toBe(realpathSync(configPath));
+    const prov = checkConfigPathProvenance(hard, () => configPath);
+    expect(prov.ok).toBe(true);
+    expect(prov.identityChecked).toBe(true);
+  });
+
+  it("fails on two genuinely different real files and names both", () => {
+    const other = join(tmp, "other.yaml");
+    writeFileSync(other, VALID_BASE_YAML);
+    const prov = checkConfigPathProvenance(configPath, () => other);
+    expect(prov.ok).toBe(false);
+    expect(prov.identityChecked).toBe(true);
+    expect(prov.detail).toContain(configPath);
+    expect(prov.detail).toContain(other);
+    expect(prov.detail).toMatch(/DIFFERENT file/);
+  });
+
+  it("passes (and says why) when the fleet resolver cannot name a config at all", () => {
+    const prov = checkConfigPathProvenance(configPath, () => {
+      throw new Error("No switchroom.yaml found");
+    });
+    // Nothing to compare against is NOT evidence of divergence, and the child
+    // would fail loudly on its own — so this must not block an apply.
+    expect(prov.ok).toBe(true);
+    expect(prov.resolvedPath).toBeNull();
+    expect(prov.detail).toMatch(/could not name a config file/);
+  });
+
+  it("falls back to the string compare — and admits it — when stat throws", () => {
+    const prov = checkConfigPathProvenance(
+      "/state/config/switchroom.yaml",
+      () => configPath,
+      () => {
+        throw new Error("ENOENT: no such file or directory");
+      },
+    );
+    expect(prov.ok).toBe(false);
+    expect(prov.identityChecked).toBe(false);
+    expect(prov.detail).toMatch(/compared as strings, not inodes/);
+    expect(prov.detail).toMatch(/ENOENT/);
+  });
+});
+
+describe("configPathProvenanceWarning (boot assertion, #4661 follow-up)", () => {
+  it("is silent when the fleet resolver names the canonical wire path", () => {
+    expect(configPathProvenanceWarning(() => CANONICAL_CONFIG_PATH)).toBeNull();
+  });
+
+  it("is silent when the canonical path is another name for the fleet path", () => {
+    expect(
+      configPathProvenanceWarning(
+        () => configPath,
+        () => ({ dev: 7, ino: 7 }),
+      ),
+    ).toBeNull();
+  });
+
+  it("emits one greppable, actionable line on a genuine mismatch", () => {
+    const other = join(tmp, "elsewhere.yaml");
+    writeFileSync(other, VALID_BASE_YAML);
+    let ino = 0;
+    const line = configPathProvenanceWarning(
+      () => other,
+      () => ({ dev: 1, ino: (ino += 1) }),
+    );
+    expect(line).not.toBeNull();
+    expect(line!).toContain(CONFIG_PATH_PROVENANCE_TAG);
+    expect(line!).toContain(CANONICAL_CONFIG_PATH);
+    expect(line!).toContain(other);
+    // Names the consequence and the fix, not just the fact.
+    expect(line!).toMatch(/E_CONFIG_PATH_MISMATCH/);
+    expect(line!).toMatch(/SWITCHROOM_CONFIG/);
+    // One line — a multi-line warning gets truncated by log collectors.
+    expect(line!.includes("\n")).toBe(false);
+  });
+
+  it("does not refuse: the boot check only ever returns a string or null", () => {
+    // The deliberate design choice — a config-layout change must not take the
+    // whole daemon down (rollouts included) to protect one verb that refuses
+    // on its own at apply time. Assert the shape that makes that true.
+    let ino = 0;
+    const line = configPathProvenanceWarning(
+      () => "/nope/switchroom.yaml",
+      () => ({ dev: 1, ino: (ino += 1) }),
+    );
+    expect(typeof line).toBe("string");
   });
 });

--- a/tests/host-control/hostd-config-path-provenance-callsite.test.ts
+++ b/tests/host-control/hostd-config-path-provenance-callsite.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The boot-time config-path-provenance warning is load-bearing and silent
+ * when missing.
+ *
+ * `configPathProvenanceWarning()` is a pure function returning a string or
+ * null, and every one of its branches is unit-tested in
+ * `config-propose-edit.test.ts`. What those tests cannot reach is that
+ * `main.ts` actually CALLS it and puts the line on stderr: a behavioural test
+ * would have to construct the daemon the way `main.ts` does, which is the very
+ * thing at issue. Delete the call and nothing fails — the fleet just loses its
+ * only advance notice that hostd would write a `switchroom.yaml` it would not
+ * itself read back, and the condition first surfaces as an
+ * `E_CONFIG_PATH_MISMATCH` at the worst possible moment: mid-apply, on a change
+ * the operator has already approved.
+ *
+ * So this is a static callsite assertion — same shape as
+ * `hostd-fleet-components-callsite.test.ts` — pinning the one wiring that
+ * exists to the one place it belongs.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const mainSrc = readFileSync(
+  join(repoRoot, "src", "host-control", "main.ts"),
+  "utf8",
+);
+
+describe("hostd asserts config-path provenance at its composition root", () => {
+  it("main.ts imports the boot assertion from server.ts", () => {
+    expect(mainSrc).toMatch(
+      /import\s*\{[^}]*\bconfigPathProvenanceWarning\b[^}]*\}\s*from\s*"\.\/server\.js"/,
+    );
+  });
+
+  it("main.ts CALLS it during boot", () => {
+    // A call expression, not a mention: the doc comment above the callsite
+    // names the function too, and a comment is not a wiring.
+    expect(mainSrc).toMatch(/\bconfigPathProvenanceWarning\s*\(\s*\)/);
+  });
+
+  it("main.ts writes the warning to stderr rather than swallowing it", () => {
+    // The warning is worth nothing if it is computed and dropped. Bounded
+    // window so an unrelated later `process.stderr.write` cannot satisfy this.
+    expect(mainSrc).toMatch(
+      /configPathProvenanceWarning\s*\(\s*\)[\s\S]{0,400}?process\.stderr\.write\(/,
+    );
+  });
+});


### PR DESCRIPTION
> **Stacked on #4661.** Base is `fix/hostd-write-not-observed`, so the diff here shows only this change. GitHub will retarget to `main` automatically when #4661 merges.

## The bug

`config_propose_edit` wrote one `switchroom.yaml` and reconciled a potentially different one, and nothing in the pipeline could detect it.

The write target resolved as `this.opts.configPath ?? req.args.target_path`. `main.ts` never passes `configPath` (it is documented as a test seam), so production fell through to the wire literal `/state/config/switchroom.yaml`. The reconcile spawn passed no `extraEnv`, so the `switchroom apply` child resolved its own config through `findConfigFile()`: `$SWITCHROOM_CONFIG`, then cwd, then `~/.switchroom`.

The two agreed only because `hostd install` happens to export `SWITCHROOM_CONFIG` alongside the `:/state/config/switchroom.yaml:rw` mount. Nothing enforced it.

The divergence is silent by construction. hostd writes X, the child reconciles Y cleanly, the response is `completed` with `exit_code: 0`, and the approved change is absent from the file everything else loads. `config-edit-validator.ts` matches diff headers against only the **basename** of the target, so path identity was asserted nowhere in the pipeline.

## The fix, and what it deliberately is not

This is detection and enforcement. It is **not** a retarget of the write.

The in-place inode-preserving write exists because `rename` returned `EBUSY` on the bind mount. Changing which file a live fleet writes, to fix a divergence that is currently theoretical, is the riskier trade. Rejected on purpose.

**1. The reconcile child is pinned to the file that was just written.** `SWITCHROOM_CONFIG` is passed as `extraEnv` on the forward reconcile and on the rollback recovery reconcile, via the same `reconcileEnv` object. The rollback one was not in the original plan; a rollback reconciled against a different file is the same bug wearing a different hat.

In the shipped install this value is identical to what the container already exports, so it is structural enforcement with no behavioural change there. `src/cli/hostd.ts` sets the export and the matching mount.

**2. `E_CONFIG_PATH_MISMATCH`.** When the write target and `findConfigFile()`'s answer are different files, the apply refuses as the first thing after the feature flag: before `validateConfigEdit`, before the `beforeContent` read, before the approval card, before the snapshot, before any write. Built as a sibling of #4661's `writeNotObserved()`, with `.fixOperatorAction("infra", [...])`.

**3. A boot-time assertion.** `main.ts` logs one greppable `hostd-config-path-provenance` line when the canonical path and the fleet path disagree. It logs, it never refuses: a config-layout change must not take the whole daemon down, rollouts included, to protect one verb that already refuses on its own.

Also adds `CANONICAL_CONFIG_PATH` so the three places comparing that string (the wire schema, `HOSTD_FALLBACK_CONFIG_PATH`, the boot check) cannot drift, and updates #4661's `KNOWN LIMITATION` block, which explicitly said path identity was out of its scope, to point here.

## Identity is `st_dev` + `st_ino`, not `realpath(2)`

The original plan specified `realpathSync`. That is the weaker test for exactly the false alarm it was meant to prevent.

`realpath` collapses neither a bind mount nor a hard link. A file bind-mounted to a second path realpaths to that second path, not the source. So a realpath compare would report "different file" for two names that are provably the same bytes, refusing a working apply and firing a boot warning on every boot. A warning that fires spuriously is worse than silence, because it trains people to ignore it.

`dev` + `ino` is the definition of "same file". A test creates a real hard link and asserts `realpathSync(hard) !== realpathSync(configPath)` before asserting the check passes, so it fails under the approach the plan called for.

String compare short-circuits first, so the common case does no filesystem I/O. If `stat` throws, the verdict falls back to the string compare and says so in `detail` with `identityChecked: false`.

## The one skip arm, stated plainly

**The gate is skipped when `opts.configPath` is set explicitly.** It has to be: every existing test pins a scratch config that legitimately differs from `findConfigFile()`, and `resolveHostdConfigPath` arm 1 already documents explicit-wins. An unconditional check false-failed 36 existing tests.

Production always takes the un-pinned arm, because `main.ts` passes nothing, so the gate is live where it matters. Documented at the call site.

## How this composes with #4661

Orthogonal, neither redundant nor unreachable.

This gate asserts path **identity** before anything happens. #4661's `verifyConfigWriteObserved` asserts the **bytes landed** after the write. Neither subsumes the other: a correct path can still swallow a write, and a landed write to the wrong file still reads back perfectly.

Both are reachable. The gate's only skip is the explicit-`configPath` embedder override; #4661's verify runs unconditionally.

## Tests

15 new. Three assert behaviour that fails with the two production hunks reverted:

- `pins the reconcile child's SWITCHROOM_CONFIG to the file that was just written` — pre-fix `expected undefined to be defined`
- `pins the same SWITCHROOM_CONFIG on the ROLLBACK reconcile, not just the forward one` — pre-fix `expected undefined to be '/tmp/hostd-config-edit-.../switchroom.yaml'`
- `returns E_CONFIG_PATH_MISMATCH — no card, no write, no reconcile — when the fleet reads a different file` — pre-fix `expected 'E_PATCH_APPLY_FAILED: git apply --check failed…' to match /^E_CONFIG_PATH_MISMATCH/`, because the divergent request sailed past into validation

That last one asserts observables only: distinct code, envelope and `fix.kind`, both paths named, `requests.length === 0` (never asked the operator), `finalizeCalls.length === 0`, `writes.length === 0`, `reconcileInvocations === 0`, and the fleet-read file's unchanged bytes **and** unchanged `mtimeMs`. The first test doubles as the happy-path regression.

Nine unit tests cover `checkConfigPathProvenance` (string identity with zero stat calls, real symlink, real hard link, two different files, resolver throws, stat throws) and `configPathProvenanceWarning` (silent on canonical, silent on same-inode, one actionable line on mismatch, always `string | null`, never throws).

Two are false-positive guards that pass pre-fix by construction: `does NOT fire when the fleet path is an ALIAS` and `skips the gate when an embedder pins configPath explicitly`. Honest framing: they guard the fix's blast radius, they do not prove the bug.

## Verification

- `npx tsc --noEmit` clean repo-wide.
- `npm run lint` clean, including `check-changelog-entry`, `check-agent-attribution-trailers` and `check-hostd-template-guard`.
- `tests/host-control/config-propose-edit.test.ts`: **51 passed / 0 failed / 1 skipped**, up from 36 on the base.
- Pre-existing environmental noise in this container (`server.test.ts` + `config-propose-edit-idempotency.test.ts`, mostly `ENOENT` on `/tmp/hostd-test-*` fixtures): **49 failed / 50 passed before and after**, and the sorted `FAIL` sets are identical name for name, so nothing was swapped. CI is the authority.

## Known limitations

- **A host-direct hostd** with no `/state/config` will now boot with the warning and return `E_CONFIG_PATH_MISMATCH`. I believe that is a true positive: the write to a nonexistent `/state/config/` would have failed anyway, previously surfacing as a misleading `E_APPLY_REJECTED` that blamed the operator's diff. Not confirmed against a real host-direct hostd.
- **Residual the gate cannot see.** Two separate bind mounts of the same host file share `dev`+`ino`, so that case is covered. A container where `SWITCHROOM_CONFIG` is unset and `~/.switchroom` is mounted separately from a *copy* would be indistinguishable. `check-hostd-template-guard` pins the template that sets the env, so the shipped shape cannot drift into it silently.
- **A weak negative assertion** at the alias test: it checks `expect(resp.error ?? "").not.toMatch(/E_CONFIG_PATH_MISMATCH/)`, which would also pass if the request failed for an unrelated reason. The test's own comment admits it. Not blocking, but it is the softest assertion in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
