### PR TITLE
fix(agents): stop /tmp exhausting the agent container's tmpfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,33 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **`/tmp` no longer fills up and takes the container down with it.** An
+  agent's `/tmp` is a 2 GiB RAM-backed tmpfs (`DEFAULT_TMP_SIZE`), and nothing
+  ages out of a tmpfs — a long-running container accumulates every scratch
+  dir any tool forgot to remove until writes start failing ENOSPC, in the
+  victim (`npm ci`, git, the CLI's own staging) rather than at the cause.
+  Measured on a live agent: 4,462 top-level entries, 490 MiB used, 204 MiB of
+  it two orphaned `bun build --compile` trees from a single run of
+  `tests/install/static-binary.test.ts`, which allocated a scratch dir per
+  test and never removed it. Two changes, no third: (1) that test now
+  allocates through a helper that registers cleanup with `onTestFinished`, so
+  the artifact goes away on the FAILURE path too — the run that leaves the
+  biggest artifact behind, and the one a trailing `rmSync` in the test body
+  misses. Measured before/after in a live agent container: 490 MiB → 694 MiB
+  before the fix, 490 MiB → 490 MiB after. (2) a new named sidecar,
+  `switchroom-tmp-reaper` (`bin/tmp-reaper.sh`, supervised from start.sh
+  block 3a, log at `/var/log/switchroom/tmp-reaper.log`), sweeps `/tmp`
+  hourly. It only ever considers direct children of `/tmp`; it skips
+  anything whose subtree holds a file modified or accessed within 24h (a
+  directory's own mtime does not move when a grandchild is written, so the
+  whole subtree is checked); it skips anything open by a live process
+  (`/proc/*/fd`, `cwd`, `exe`, and mmapped regions from `/proc/*/maps`); it
+  cannot escape `/tmp` (`-xdev`, no symlink deref, `rm --one-file-system`);
+  and it logs every entry it takes with size and age, plus a per-pass
+  summary. Kill switch `SWITCHROOM_TMP_REAPER=0`; thresholds tunable with a
+  1h floor. The tmpfs size was deliberately NOT raised — a bigger tmpfs
+  converts a fast, loud failure into a slow leak against host RAM.
+
 - **repos: per-agent STANDING trees (`repos:` in switchroom.yaml) are now
   independent clones too — two agents on the same repo no longer share a
   stash ref.** The claim-path fix below stopped sub-agent checkouts sharing

--- a/bin/tmp-reaper.sh
+++ b/bin/tmp-reaper.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# switchroom-tmp-reaper — bounded janitor for the agent container's /tmp tmpfs.
+#
+# WHY THIS EXISTS
+# ---------------
+# An agent container mounts /tmp as a RAM-backed tmpfs, sized by
+# `resources.tmp_size` (src/agents/compose.ts, DEFAULT_TMP_SIZE = 2g), with
+# Docker's default tmpfs flags — `rw,nosuid,nodev,noexec`. Two consequences:
+#
+#   1. It is a hard ceiling. Nothing ages out of a tmpfs; a long-running
+#      container accumulates every scratch dir any tool ever forgot to
+#      remove until writes start failing ENOSPC. Observed on a live agent:
+#      4,462 top-level entries, 490 MiB used, of which 204 MiB was two
+#      orphaned `bun build --compile` artifacts from a single test run
+#      (fixed at source in tests/install/static-binary.test.ts, but that
+#      only fixes the leak we already found).
+#   2. The failure is NOT localised. Once /tmp is full, everything that
+#      stages through it fails — `npm ci`, git, the claude CLI's own
+#      scratch — with errors that name the victim, never the cause.
+#
+# The size is deliberately NOT the lever. Raising the tmpfs converts a fast,
+# loud failure into a slow leak that eats host RAM instead. This reaper
+# bounds the accumulation itself.
+#
+# SAFETY CONTRACT (each clause is pinned by tests/tmp-reaper.test.ts)
+# -------------------------------------------------------------------
+#   * Scope. Only direct children of the root are considered, the root
+#     itself is never removed, and every traversal is `-xdev` with no
+#     symlink dereference — so a symlink under /tmp pointing at, say,
+#     /state/agent can have the LINK reaped but never its target.
+#   * Age. An entry is a candidate only when NOTHING anywhere in its
+#     subtree has been modified or accessed within the age threshold
+#     (default 24h). A directory's own mtime does not change when a
+#     grandchild is written, so checking the entry alone would reap a
+#     live tree — the whole subtree is checked.
+#   * Open files. An entry is skipped when it, or anything beneath it, is
+#     open by any process in the container: /proc/*/fd, /proc/*/cwd,
+#     /proc/*/exe and mmapped regions from /proc/*/maps are all consulted.
+#   * Logging. Every reaped entry is logged with its size and age, and every
+#     pass emits a one-line summary — including passes that reap nothing.
+#
+# TUNING (all validated; garbage falls back to the default)
+#   SWITCHROOM_TMP_REAPER=0                     disable entirely
+#   SWITCHROOM_TMP_REAPER_MIN_AGE_SEC=86400     age threshold (min 3600)
+#   SWITCHROOM_TMP_REAPER_INTERVAL_SEC=3600     seconds between passes
+#   SWITCHROOM_TMP_REAPER_ROOT=/tmp             root (test harness only)
+#
+# Run standalone for a one-shot pass:  tmp-reaper.sh --once
+set -uo pipefail
+
+REAPER_NAME="switchroom-tmp-reaper"
+
+TMP_REAPER_ROOT="${SWITCHROOM_TMP_REAPER_ROOT:-/tmp}"
+
+# Age below which an entry is NEVER touched. One hour is the hard floor even
+# if an operator sets something smaller: this reaper cannot distinguish "a
+# build wrote this five minutes ago and will read it back in ten" from
+# garbage, and the age bound is the only thing standing between it and a
+# live workload.
+MIN_AGE_SEC="${SWITCHROOM_TMP_REAPER_MIN_AGE_SEC:-86400}"
+case "$MIN_AGE_SEC" in ''|*[!0-9]*) MIN_AGE_SEC=86400;; esac
+[ "$MIN_AGE_SEC" -lt 3600 ] && MIN_AGE_SEC=3600
+
+INTERVAL_SEC="${SWITCHROOM_TMP_REAPER_INTERVAL_SEC:-3600}"
+case "$INTERVAL_SEC" in ''|0|*[!0-9]*) INTERVAL_SEC=3600;; esac
+[ "$INTERVAL_SEC" -lt 60 ] && INTERVAL_SEC=60
+
+# Never-reap names. These are conventional tmpfs fixtures whose mtime can sit
+# still for weeks while they are very much in use, and whose removal breaks
+# things in ways that are hard to trace back here.
+TMP_REAPER_KEEP_DEFAULT=".X11-unix .ICE-unix .font-unix .Test-unix .XIM-unix"
+TMP_REAPER_KEEP="${SWITCHROOM_TMP_REAPER_KEEP:-$TMP_REAPER_KEEP_DEFAULT}"
+
+_log() { printf '[%s] %s %s\n' "$REAPER_NAME" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"; }
+
+# Refuse to operate on a root that is not a plain, existing directory, or that
+# is the filesystem root. The default is /tmp and the override exists for the
+# test harness; this guard is what keeps a mis-set override from being
+# catastrophic rather than merely wrong.
+_root_ok() {
+  local r="$1"
+  [ -n "$r" ] || { _log "refusing: empty root"; return 1; }
+  [ "$r" != "/" ] || { _log "refusing: root is /"; return 1; }
+  case "$r" in
+    /*) ;;
+    *) _log "refusing: root '$r' is not absolute"; return 1;;
+  esac
+  case "$r" in
+    *..*) _log "refusing: root '$r' contains '..'"; return 1;;
+  esac
+  [ -d "$r" ] || { _log "refusing: root '$r' is not a directory"; return 1; }
+  [ ! -L "$r" ] || { _log "refusing: root '$r' is a symlink"; return 1; }
+  return 0
+}
+
+# Emit every path under $1 that some process in this container currently has
+# open — as an fd, as its cwd, as its executable, or as an mmapped region.
+# Unreadable /proc entries (a process owned by another uid, or one that exited
+# mid-scan) are skipped: they can only cause us to reap LESS, never more.
+#
+# Cost matters here: a busy container has hundreds of processes and thousands
+# of fds, so this uses ONE `find` (with -printf '%l' to read the link targets
+# in-process) and ONE `awk` across every maps file, rather than a readlink
+# fork per fd. A per-fd fork loop measured multiple seconds per pass.
+_open_paths() {
+  local root="$1"
+  find /proc/[0-9]*/fd /proc/[0-9]*/cwd /proc/[0-9]*/exe \
+       -maxdepth 1 -type l -printf '%l\n' 2>/dev/null \
+    | grep -F -- "$root/" 2>/dev/null
+  # mmapped files (a running binary, a memory-mapped DB) do not appear as an
+  # fd once mapped and the fd is closed, but are absolutely still in use.
+  awk -v r="$root/" '{ p=index($0, r); if (p) print substr($0, p) }' \
+    /proc/[0-9]*/maps 2>/dev/null
+}
+
+_human() {
+  local b="${1:-0}"
+  if   [ "$b" -ge 1073741824 ] 2>/dev/null; then echo "$((b / 1073741824))G"
+  elif [ "$b" -ge 1048576 ]    2>/dev/null; then echo "$((b / 1048576))M"
+  elif [ "$b" -ge 1024 ]       2>/dev/null; then echo "$((b / 1024))K"
+  else echo "${b}B"; fi
+}
+
+# One pass. Returns 0 always; a failure to remove one entry must not abort
+# the pass (the next entry may be the one actually holding the space).
+tmp_reaper_pass() {
+  local root="$TMP_REAPER_ROOT"
+  _root_ok "$root" || return 1
+  # Canonicalise. /proc/*/fd link targets are already fully resolved, so an
+  # un-canonicalised root with a symlinked ancestor would never prefix-match
+  # them and the open-file check would silently pass everything through —
+  # the guard would look present and do nothing.
+  root=$(readlink -f -- "$root" 2>/dev/null) || root="$TMP_REAPER_ROOT"
+  [ -n "$root" ] || root="$TMP_REAPER_ROOT"
+  _root_ok "$root" || return 1
+
+  local now cutoff
+  now=$(date +%s)
+  cutoff=$((now - MIN_AGE_SEC))
+
+  local open_list
+  open_list=$(_open_paths "$root")
+
+  local reaped=0 freed=0 kept_open=0 kept_young=0 kept_pinned=0 failed=0
+  local entry base
+
+  while IFS= read -r -d '' entry; do
+    base="${entry##*/}"
+
+    # 1. Never-reap list.
+    local pinned=0 k
+    for k in $TMP_REAPER_KEEP; do
+      [ "$base" = "$k" ] && { pinned=1; break; }
+    done
+    if [ "$pinned" -eq 1 ]; then kept_pinned=$((kept_pinned + 1)); continue; fi
+
+    # 2. Age — nothing ANYWHERE in the subtree may be newer than the cutoff,
+    #    by mtime or atime. `-print -quit` stops at the first offender.
+    local young
+    young=$(find "$entry" -xdev \( -newermt "@$cutoff" -o -newerat "@$cutoff" \) \
+              -print -quit 2>/dev/null)
+    if [ -n "$young" ]; then kept_young=$((kept_young + 1)); continue; fi
+
+    # 3. Open by a live process (the entry itself, or anything under it).
+    local is_open=0 p
+    while IFS= read -r p; do
+      [ -n "$p" ] || continue
+      if [ "$p" = "$entry" ] || [ "${p#"$entry"/}" != "$p" ]; then
+        is_open=1; break
+      fi
+    done <<< "$open_list"
+    if [ "$is_open" -eq 1 ]; then kept_open=$((kept_open + 1)); continue; fi
+
+    # Size and age for the log line, computed BEFORE removal.
+    local bytes mtime age_h
+    bytes=$(du -sxb -- "$entry" 2>/dev/null | cut -f1)
+    case "$bytes" in ''|*[!0-9]*) bytes=0;; esac
+    mtime=$(stat -c %Y -- "$entry" 2>/dev/null || echo "$now")
+    age_h=$(( (now - mtime) / 3600 ))
+
+    if rm -rf --one-file-system --preserve-root -- "$entry" 2>/dev/null; then
+      reaped=$((reaped + 1))
+      freed=$((freed + bytes))
+      _log "reaped $entry ($(_human "$bytes"), idle ${age_h}h)"
+    else
+      failed=$((failed + 1))
+      _log "could NOT remove $entry ($(_human "$bytes"), idle ${age_h}h)"
+    fi
+  done < <(find "$root" -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null)
+
+  _log "pass complete on $root: reaped=$reaped freed=$(_human "$freed")" \
+       "kept_young=$kept_young kept_open=$kept_open kept_pinned=$kept_pinned" \
+       "failed=$failed min_age=${MIN_AGE_SEC}s"
+  return 0
+}
+
+tmp_reaper_main() {
+  if [ "${SWITCHROOM_TMP_REAPER:-1}" = "0" ]; then
+    _log "disabled via SWITCHROOM_TMP_REAPER=0 — not starting"
+    return 0
+  fi
+  if [ "${1:-}" = "--once" ]; then
+    tmp_reaper_pass
+    return $?
+  fi
+  _log "starting: root=$TMP_REAPER_ROOT min_age=${MIN_AGE_SEC}s interval=${INTERVAL_SEC}s"
+  while true; do
+    tmp_reaper_pass
+    sleep "$INTERVAL_SEC"
+  done
+}
+
+# Only auto-run when EXECUTED. Sourcing (the test harness, and any future
+# caller that wants a single pass inline) gets the functions and nothing else.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  tmp_reaper_main "$@"
+fi

--- a/bin/tmp-reaper.sh
+++ b/bin/tmp-reaper.sh
@@ -100,8 +100,25 @@ _root_ok() {
 #
 # Cost matters here: a busy container has hundreds of processes and thousands
 # of fds, so this uses ONE `find` (with -printf '%l' to read the link targets
-# in-process) and ONE `awk` across every maps file, rather than a readlink
-# fork per fd. A per-fd fork loop measured multiple seconds per pass.
+# in-process) and ONE `grep`+`awk` pipeline over the maps files, rather than a
+# readlink fork per fd. A per-fd fork loop measured multiple seconds per pass.
+#
+# CRITICAL: neither traversal may ABORT on an unreadable input. `find` reports
+# a vanished/denied start point and keeps going, which is what we need. `awk`
+# does NOT: the image ships mawk 1.3.4, which stops at the FIRST file it cannot
+# open and never reads the rest of its argument list. Handing mawk the raw
+# /proc/[0-9]*/maps glob therefore meant that one PID exiting between bash's
+# glob expansion and mawk's serial open (ESRCH), or one EPERM, silently
+# discarded every LATER process's mappings — a fail-OPEN in a safety guard,
+# after which the reaper would delete a tree a live process still had mapped.
+# So `grep` (GNU grep continues past unreadable files, exit 2) does the
+# multi-file read and `awk` only ever sees a single stdin stream.
+#
+# `awk substr` rather than `grep -o`: a maps line is
+# "addr perms offset dev inode <pathname>", so the path runs to end-of-line and
+# MAY CONTAIN SPACES. `grep -oE "$root/[^ ]*"` would truncate
+# "/tmp/my dir/lib.so" to "/tmp/my", which no longer prefix-matches the entry
+# in the caller below — fail-open again, for any /tmp entry with a space.
 _open_paths() {
   local root="$1"
   find /proc/[0-9]*/fd /proc/[0-9]*/cwd /proc/[0-9]*/exe \
@@ -109,8 +126,8 @@ _open_paths() {
     | grep -F -- "$root/" 2>/dev/null
   # mmapped files (a running binary, a memory-mapped DB) do not appear as an
   # fd once mapped and the fd is closed, but are absolutely still in use.
-  awk -v r="$root/" '{ p=index($0, r); if (p) print substr($0, p) }' \
-    /proc/[0-9]*/maps 2>/dev/null
+  grep -haF -- "$root/" /proc/[0-9]*/maps 2>/dev/null \
+    | awk -v r="$root/" '{ p=index($0, r); if (p) print substr($0, p) }'
 }
 
 _human() {

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -563,6 +563,32 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
       bun /opt/switchroom/agent-scheduler/index.js &
   fi
 
+  # 3a) switchroom-tmp-reaper — bounded janitor for the /tmp tmpfs.
+  #
+  #     /tmp is a RAM-backed tmpfs sized by `resources.tmp_size`
+  #     (DEFAULT_TMP_SIZE = 2g) and mounted noexec by Docker's tmpfs
+  #     defaults. Nothing ages out of a tmpfs, so a long-running container
+  #     accumulates every scratch dir any tool forgot to remove until writes
+  #     start failing ENOSPC — and the failure surfaces in the victim (npm
+  #     ci, git, the CLI's own staging), never at the cause. Observed live:
+  #     4,462 top-level entries and 490 MiB used, 204 MiB of it two orphaned
+  #     compile artifacts from one test run.
+  #
+  #     Deliberately NOT "raise tmp_size": a bigger tmpfs converts a fast,
+  #     loud failure into a slow leak against host RAM. The safety contract
+  #     (age floor, open-file check, /tmp-only scope) lives in the script's
+  #     header and is pinned by tests/tmp-reaper.test.ts.
+  #
+  #     Kill switch: SWITCHROOM_TMP_REAPER=0 in the container env. Supervised
+  #     like the other sidecars so a crash self-heals and its log rotates;
+  #     NOT --oneshot-ok, because a clean exit from an endless loop is
+  #     abnormal and must restart.
+  if [ "$SWITCHROOM_TMP_REAPER" != "0" ] \
+     && [ -x /opt/switchroom/bin/tmp-reaper.sh ]; then
+    _switchroom_supervise tmp-reaper /var/log/switchroom/tmp-reaper.log \
+      bash /opt/switchroom/bin/tmp-reaper.sh &
+  fi
+
   # 3b) Buzz co-channel inbound sidecar (Phase 1, channels.buzz).
   #     A supervised sibling that opens a WebSocket Nostr subscription to a
   #     closed Buzz relay, NIP-42-authenticates, and injects allowlisted

--- a/tests/install/static-binary.test.ts
+++ b/tests/install/static-binary.test.ts
@@ -18,12 +18,23 @@ import {
   writeFileSync,
   existsSync,
   readFileSync,
+  readdirSync,
   rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const REPO_ROOT = resolve(__dirname, "../..");
+
+/**
+ * Snapshot of any `switchroom-static-*` dirs that already existed in the
+ * tmpdir when this module loaded — leftovers from an earlier run, another
+ * worker, or a developer's aborted session. The leak guard at the bottom
+ * diffs against this so it only ever fails on dirs THIS run created.
+ */
+const preexistingStaticDirs = new Set(
+  readdirSync(tmpdir()).filter((n) => n.startsWith("switchroom-static-")),
+);
 
 /**
  * Allocate a scratch dir under the system tmpdir AND register its removal
@@ -252,5 +263,30 @@ describe("scratch dirs are reaped after each test (tmpfs exhaustion, /tmp)", () 
       existsSync(observed.passing),
       `leaked scratch dir from the PASSING test: ${observed.passing}`,
     ).toBe(false);
+  });
+
+  /**
+   * The two guards above pin the scratchDir() HELPER. They do not pin the
+   * compile tests' CALL SITES: reverting either of those to a bare
+   * `mkdtempSync(join(tmpdir(), "switchroom-static-"))` re-introduces the
+   * exact 204 MiB leak this file exists to close, with every assertion
+   * above still green. This sweeps the tmpdir for the real prefix instead.
+   *
+   * CAVEAT: trivially satisfied when bunAvailable() is false, because the
+   * compile tests skip and allocate nothing. That is acceptable — on a
+   * worker with no bun there is no leak to catch — but it means this guard
+   * only carries weight on runners that actually compile.
+   */
+  it("leaves no switchroom-static-* compile scratch behind in the tmpdir", () => {
+    const leaked = readdirSync(tmpdir()).filter(
+      (n) => n.startsWith("switchroom-static-") && !preexistingStaticDirs.has(n),
+    );
+    expect(
+      leaked,
+      `the bun --compile tests leaked scratch dirs into /tmp: ${leaked.join(", ")}. ` +
+        `Each holds a ~102 MiB compiled binary, and an agent's /tmp is a 2 GiB ` +
+        `tmpfs. Allocate through scratchDir(), which registers onTestFinished ` +
+        `cleanup, not through a bare mkdtempSync().`,
+    ).toEqual([]);
   });
 });

--- a/tests/install/static-binary.test.ts
+++ b/tests/install/static-binary.test.ts
@@ -11,13 +11,48 @@
  * without the bun toolchain) or when the `BUN_BUILD_COMPILE_SKIP` env
  * var is set (sandbox where compile is too heavy).
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, onTestFinished } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const REPO_ROOT = resolve(__dirname, "../..");
+
+/**
+ * Allocate a scratch dir under the system tmpdir AND register its removal
+ * with `onTestFinished` in one move.
+ *
+ * WHY THIS EXISTS (the leak this closes). Each of the tests below compiles
+ * the CLI with `bun build --compile`, which writes a ~102 MiB self-contained
+ * binary into its scratch dir, and neither test removed it. Agent containers
+ * mount `/tmp` as a 2 GiB RAM-backed tmpfs (src/agents/compose.ts
+ * DEFAULT_TMP_SIZE), so ~204 MiB per suite run accumulated until the tmpfs
+ * was full and every subsequent `/tmp` write — including `npm ci`'s
+ * postinstall staging — failed. Measured on a live agent container: two
+ * orphaned `switchroom-static-*` trees held 204 MiB of a 490 MiB total.
+ *
+ * `onTestFinished` rather than a trailing `rmSync` in the test body: the
+ * hook runs on the FAILURE path too. A trailing statement does not — the
+ * first failed `expect` throws past it, which is exactly the run (a broken
+ * compile, a flaky assertion) that leaves the biggest artifact behind.
+ * `afterEach` would work as well, but it cannot see the per-test path
+ * without a mutable module-scope variable, and would silently reap nothing
+ * if a future test forgot to assign it.
+ */
+function scratchDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  onTestFinished(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+  return dir;
+}
 
 function bunAvailable(): boolean {
   if (process.env.BUN_BUILD_COMPILE_SKIP) return false;
@@ -80,7 +115,7 @@ describe("static binary — import.meta.dirname regression", () => {
   it.skipIf(!bunAvailable())(
     "apply --example switchroom works inside a `bun build --compile` artifact",
     () => {
-      const tmp = mkdtempSync(join(tmpdir(), "switchroom-static-"));
+      const tmp = scratchDir("switchroom-static-");
       const binPath = compileStaticBinary(tmp);
       expect(existsSync(binPath)).toBe(true);
 
@@ -129,7 +164,7 @@ describe("static binary — import.meta.dirname regression", () => {
       // "../../examples")` → `/examples` inside the binary, so it died with
       // "Example config not found" while `apply --example` (already embedded)
       // worked. Both now go through src/cli/embedded-examples.ts.
-      const tmp = mkdtempSync(join(tmpdir(), "switchroom-static-setup-"));
+      const tmp = scratchDir("switchroom-static-setup-");
       const binPath = compileStaticBinary(tmp);
 
       const fakeHome = join(tmp, "home");
@@ -161,4 +196,61 @@ describe("static binary — import.meta.dirname regression", () => {
     },
     120_000,
   );
+});
+
+/**
+ * Guards the cleanup contract itself, and specifically the FAILURE path —
+ * the one a trailing `rmSync` in the test body does not cover, and the one
+ * that leaks the largest artifact (a half-written 102 MiB compile output).
+ *
+ * These assert an OUTCOME (the directory no longer exists on disk once its
+ * test has finished), not that `onTestFinished` was called. They run
+ * unconditionally — no `bun` needed — so the contract stays pinned on CI
+ * workers that skip the compile tests above.
+ *
+ * Vitest runs the tests in a file sequentially in declaration order, so the
+ * observer test below runs strictly after the allocating test has finished
+ * and its cleanup hooks have drained.
+ */
+const observed: Record<string, string> = {};
+
+describe("scratch dirs are reaped after each test (tmpfs exhaustion, /tmp)", () => {
+  it.fails("a FAILING test allocates a scratch dir and then throws", () => {
+    observed.failing = scratchDir("switchroom-scratch-guard-fail-");
+    // A stand-in for the ~102 MiB compile artifact: something with real
+    // bytes in it, so a leak is a leak of storage and not just an inode.
+    writeFileSync(join(observed.failing, "artifact.bin"), Buffer.alloc(64 * 1024));
+    expect(existsSync(join(observed.failing, "artifact.bin"))).toBe(true);
+    // Deliberate failure — `it.fails` asserts this test throws. Everything
+    // after this line is unreachable, which is exactly the point: a trailing
+    // cleanup statement here would never run.
+    throw new Error("deliberate failure — exercises the cleanup failure path");
+  });
+
+  it("a PASSING test allocates a scratch dir", () => {
+    observed.passing = scratchDir("switchroom-scratch-guard-pass-");
+    writeFileSync(join(observed.passing, "artifact.bin"), Buffer.alloc(64 * 1024));
+    expect(existsSync(join(observed.passing, "artifact.bin"))).toBe(true);
+  });
+
+  it("…and BOTH scratch dirs are gone from the tmpdir afterwards", () => {
+    expect(
+      observed.failing,
+      "the failing test did not run — this guard is vacuous",
+    ).toBeTruthy();
+    expect(
+      observed.passing,
+      "the passing test did not run — this guard is vacuous",
+    ).toBeTruthy();
+    expect(
+      existsSync(observed.failing),
+      `leaked scratch dir from the FAILING test: ${observed.failing} — ` +
+        `cleanup must be registered with onTestFinished, which runs on the ` +
+        `failure path; a trailing rmSync in the test body does not.`,
+    ).toBe(false);
+    expect(
+      existsSync(observed.passing),
+      `leaked scratch dir from the PASSING test: ${observed.passing}`,
+    ).toBe(false);
+  });
 });

--- a/tests/tmp-reaper.test.ts
+++ b/tests/tmp-reaper.test.ts
@@ -1,0 +1,381 @@
+/**
+ * switchroom-tmp-reaper (bin/tmp-reaper.sh) — the /tmp tmpfs janitor.
+ *
+ * WHY: an agent's /tmp is a 2 GiB RAM-backed tmpfs (src/agents/compose.ts,
+ * DEFAULT_TMP_SIZE). Nothing ages out of a tmpfs, so a long-running container
+ * accumulates orphaned scratch until every /tmp write fails ENOSPC — in the
+ * victim (`npm ci`, git, the CLI's staging), never at the cause. Measured on
+ * a live agent container: 4,462 top-level entries, 490 MiB used, 204 MiB of
+ * it two orphaned `bun build --compile` trees from one test run.
+ *
+ * These tests execute the REAL script against a fixture root and assert
+ * OUTCOMES — what is on disk after a pass — not log lines and not that a
+ * particular branch was taken. Each of the three safety clauses (subtree
+ * age, open files, no symlink escape) has a test that FAILS if that clause
+ * is deleted, which is the whole point: a reaper whose guards are untested
+ * is a `rm -rf` on a timer.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawnSync, spawn, type ChildProcess } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SCRIPT = resolve(__dirname, "..", "bin", "tmp-reaper.sh");
+
+/**
+ * The fixture root deliberately does NOT live under the system tmpdir: these
+ * tests exist because /tmp fills up, and a test suite that stages megabytes
+ * of fixtures there to prove it would be part of the problem. `mkdtempSync`
+ * against the repo-adjacent build dir keeps the fixtures on the same
+ * filesystem the worktree is on (the script traverses with `-xdev`).
+ */
+const FIXTURE_PARENT = resolve(__dirname, "..", "node_modules", ".cache");
+
+let root: string;
+const children: ChildProcess[] = [];
+
+beforeEach(() => {
+  mkdirSync(FIXTURE_PARENT, { recursive: true });
+  // realpath: the script canonicalises its root (it must, or the
+  // /proc/*/fd prefix match never fires), so the fixture path the
+  // assertions compare against has to be canonical too. A dev checkout
+  // whose node_modules is a symlink otherwise diverges from CI.
+  root = realpathSync(mkdtempSync(join(FIXTURE_PARENT, "tmp-reaper-fixture-")));
+});
+
+afterEach(() => {
+  for (const c of children.splice(0)) {
+    try {
+      c.kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Backdate a path's atime AND mtime by `hours`. */
+function age(path: string, hours: number): void {
+  const t = new Date(Date.now() - hours * 3600_000);
+  utimesSync(path, t, t);
+}
+
+/**
+ * Create `<root>/<name>/<file>` with `bytes` of content and backdate the
+ * WHOLE subtree by `hours`. Order matters: writing a child bumps the
+ * parent's mtime, so the parent must be aged last.
+ */
+function agedDir(name: string, hours: number, bytes = 4096): string {
+  const dir = join(root, name);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, "payload.bin");
+  writeFileSync(file, Buffer.alloc(bytes, 0x61));
+  age(file, hours);
+  age(dir, hours);
+  return dir;
+}
+
+interface PassResult {
+  status: number | null;
+  out: string;
+}
+
+/** Run one reaper pass over the fixture root. */
+function pass(env: Record<string, string> = {}, rootOverride?: string): PassResult {
+  const r = spawnSync("bash", [SCRIPT, "--once"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SWITCHROOM_TMP_REAPER_ROOT: rootOverride ?? root,
+      ...env,
+    },
+    timeout: 60_000,
+  });
+  return { status: r.status, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe("tmp-reaper — reaps aged garbage", () => {
+  it("removes an aged, unopened entry and reports its size", () => {
+    const dir = agedDir("orphaned-build", 48, 2 * 1024 * 1024);
+    expect(existsSync(dir)).toBe(true);
+
+    const { out } = pass();
+
+    expect(existsSync(dir), `expected ${dir} to be reaped.\n${out}`).toBe(false);
+    // The log must name what it took and how big it was — a reaper that
+    // deletes silently is undebuggable after the fact.
+    expect(out).toContain(`reaped ${dir}`);
+    expect(out).toMatch(/reaped .*orphaned-build \(2M, idle 48h\)/);
+  });
+
+  it("emits a summary line even when it reaps nothing", () => {
+    const { out } = pass();
+    expect(out).toMatch(/pass complete on .*: reaped=0 /);
+  });
+
+  it("never removes the root itself", () => {
+    agedDir("junk", 48);
+    pass();
+    expect(existsSync(root)).toBe(true);
+  });
+});
+
+describe("tmp-reaper — age floor", () => {
+  it("keeps an entry younger than the threshold", () => {
+    const dir = agedDir("fresh", 1);
+    const { out } = pass();
+    expect(existsSync(dir), `1h-old entry must survive a 24h threshold.\n${out}`).toBe(true);
+    expect(out).toMatch(/kept_young=1/);
+  });
+
+  /**
+   * MUTATION GUARD. A directory's own mtime does NOT change when a
+   * grandchild is written, so a reaper that stats only the top-level entry
+   * happily deletes a tree that is actively in use. This is the single most
+   * dangerous way to get this wrong; it must fail loudly.
+   */
+  it("keeps an aged directory whose GRANDCHILD was touched recently", () => {
+    const dir = join(root, "live-session");
+    const deep = join(dir, "nested", "deeper");
+    mkdirSync(deep, { recursive: true });
+    const live = join(deep, "in-use.log");
+    writeFileSync(live, "recent");
+    // Backdate everything EXCEPT the grandchild file — the shape of a
+    // long-lived scratch dir that is still being appended to.
+    age(join(dir, "nested"), 72);
+    age(deep, 72);
+    age(dir, 72);
+
+    const { out } = pass();
+
+    expect(
+      existsSync(live),
+      `a subtree with a file modified seconds ago must NOT be reaped, ` +
+        `even when every ancestor's own mtime is 72h old.\n${out}`,
+    ).toBe(true);
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  it("clamps a sub-hour age override up to the 1h floor", () => {
+    const dir = agedDir("ten-minutes", 0);
+    age(join(dir, "payload.bin"), 10 / 60);
+    age(dir, 10 / 60);
+
+    const { out } = pass({ SWITCHROOM_TMP_REAPER_MIN_AGE_SEC: "60" });
+
+    expect(
+      existsSync(dir),
+      `a 10-minute-old entry must survive even when the operator asks for ` +
+        `a 60-second threshold — the floor is 3600s.\n${out}`,
+    ).toBe(true);
+    expect(out).toMatch(/min_age=3600s/);
+  });
+
+  it("falls back to the default when the age override is garbage", () => {
+    const dir = agedDir("aged", 48);
+    const { out } = pass({ SWITCHROOM_TMP_REAPER_MIN_AGE_SEC: "not-a-number" });
+    expect(out).toMatch(/min_age=86400s/);
+    expect(existsSync(dir)).toBe(false);
+  });
+});
+
+describe("tmp-reaper — open files", () => {
+  /**
+   * MUTATION GUARD. Age alone is not enough: a process can hold an fd on a
+   * file it wrote days ago (a long-lived socket, a mapped DB, a log opened
+   * at boot). Deleting it yanks the file out from under a live process.
+   */
+  it("keeps an aged entry that a live process holds an fd on", async () => {
+    const dir = agedDir("held-open", 72);
+    const file = join(dir, "payload.bin");
+
+    // `exec 3< file` opens the fd and keeps it open for the sleep's lifetime;
+    // the fd shows up under /proc/<pid>/fd.
+    const child = spawn("bash", ["-c", `exec 3< "${file}"; sleep 60`], {
+      stdio: "ignore",
+    });
+    children.push(child);
+    // Wait for the fd to actually be open before the pass runs.
+    await new Promise((r) => setTimeout(r, 700));
+    expect(child.pid).toBeTruthy();
+
+    const { out } = pass();
+
+    expect(
+      existsSync(dir),
+      `an entry with a live open fd must NOT be reaped regardless of age.\n${out}`,
+    ).toBe(true);
+    expect(out).toMatch(/kept_open=1/);
+  });
+
+  it("reaps the same entry once the holder exits", async () => {
+    const dir = agedDir("held-then-released", 72);
+    const file = join(dir, "payload.bin");
+
+    const child = spawn("bash", ["-c", `exec 3< "${file}"; sleep 0.2`], {
+      stdio: "ignore",
+    });
+    await new Promise((r) => child.on("exit", r));
+    // Re-age: nothing above touched the tree, but be explicit.
+    age(file, 72);
+    age(dir, 72);
+
+    const { out } = pass();
+    expect(existsSync(dir), `holder is gone — entry should be reaped.\n${out}`).toBe(false);
+  });
+});
+
+describe("tmp-reaper — scope", () => {
+  /**
+   * MUTATION GUARD. If any traversal grows an `-L` / `-follow`, or the
+   * removal loses `--one-file-system`, an aged symlink under /tmp becomes a
+   * delete of whatever it points at. /tmp is full of symlinks.
+   */
+  it("does not delete a symlink's target outside the root", () => {
+    const outside = realpathSync(mkdtempSync(join(FIXTURE_PARENT, "tmp-reaper-outside-")));
+    const precious = join(outside, "precious.txt");
+    writeFileSync(precious, "must survive");
+    age(precious, 96);
+    age(outside, 96);
+
+    const link = join(root, "escape-hatch");
+    symlinkSync(outside, link);
+    // lutimes semantics: utimesSync follows the link, so age the link's own
+    // times via touch -h (the link itself is what the reaper stats).
+    spawnSync("touch", ["-h", "-d", "96 hours ago", link]);
+
+    const { out } = pass();
+
+    expect(
+      existsSync(precious),
+      `the symlink TARGET outside the root must survive; only the link ` +
+        `itself may ever be removed.\n${out}`,
+    ).toBe(true);
+    expect(readFileSync(precious, "utf8")).toBe("must survive");
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("refuses to run against /", () => {
+    const { out } = pass({}, "/");
+    expect(out).toMatch(/refusing: root is \//);
+    expect(out).not.toMatch(/^\[switchroom-tmp-reaper\].*reaped /m);
+  });
+
+  it("refuses a relative root and a root containing ..", () => {
+    expect(pass({}, "relative/path").out).toMatch(/refusing: root 'relative\/path' is not absolute/);
+    expect(pass({}, "/var/../etc").out).toMatch(/refusing: root '\/var\/\.\.\/etc' contains '\.\.'/);
+  });
+
+  it("defaults its root to /tmp when nothing overrides it", () => {
+    // Source the script (it does NOT auto-run when sourced) with the override
+    // unset, and read back the resolved root.
+    const env = { ...process.env };
+    delete env.SWITCHROOM_TMP_REAPER_ROOT;
+    const r = spawnSync(
+      "bash",
+      ["-c", `source "${SCRIPT}"; printf '%s' "$TMP_REAPER_ROOT"`],
+      { encoding: "utf8", env },
+    );
+    expect(r.stdout).toBe("/tmp");
+  });
+
+  it("keeps the conventional tmpfs fixtures no matter how old they are", () => {
+    const x11 = join(root, ".X11-unix");
+    mkdirSync(x11);
+    age(x11, 24 * 365);
+    const { out } = pass();
+    expect(existsSync(x11), `.X11-unix must never be reaped.\n${out}`).toBe(true);
+    expect(out).toMatch(/kept_pinned=1/);
+  });
+});
+
+describe("tmp-reaper — kill switch", () => {
+  it("does nothing at all when SWITCHROOM_TMP_REAPER=0", () => {
+    const dir = agedDir("would-be-reaped", 96);
+    const { out } = pass({ SWITCHROOM_TMP_REAPER: "0" });
+    expect(existsSync(dir), `kill switch must prevent every removal.\n${out}`).toBe(true);
+    expect(out).toMatch(/disabled via SWITCHROOM_TMP_REAPER=0/);
+  });
+});
+
+describe("tmp-reaper — boot wiring (start.sh.hbs block 3a)", () => {
+  const TEMPLATE = resolve(__dirname, "..", "profiles", "_base", "start.sh.hbs");
+  const SRC = readFileSync(TEMPLATE, "utf-8");
+
+  /**
+   * Lift the real guard out of the template and run it with a recording stub
+   * for `_switchroom_supervise`, so the assertion is "a tmp-reaper sidecar
+   * gets supervised at boot" rather than "the template mentions a string".
+   */
+  function runGuard(env: Record<string, string>, scriptPresent: boolean): string {
+    const lines = SRC.split("\n");
+    const start = lines.findIndex((l) => l.includes('if [ "$SWITCHROOM_TMP_REAPER" != "0" ]'));
+    expect(start, "block 3a guard not found in start.sh.hbs").toBeGreaterThan(-1);
+    const end = lines.findIndex((l, i) => i > start && l.trim() === "fi");
+    const block = lines.slice(start, end + 1).join("\n");
+    expect(block).not.toMatch(/\{\{/); // no unbound handlebars token in the lifted block
+
+    const fakeBin = join(root, "opt", "switchroom", "bin");
+    mkdirSync(fakeBin, { recursive: true });
+    if (scriptPresent) {
+      writeFileSync(join(fakeBin, "tmp-reaper.sh"), "#!/usr/bin/env bash\n", { mode: 0o755 });
+    }
+    const harness = [
+      "#!/usr/bin/env bash",
+      `_switchroom_supervise() { echo "SUPERVISED:$1:$2:\${*:3}"; }`,
+      // Redirect the absolute image path at the fixture.
+      block.replace(/\/opt\/switchroom\/bin\/tmp-reaper\.sh/g, join(fakeBin, "tmp-reaper.sh")),
+    ].join("\n");
+    const path = join(root, "guard.sh");
+    writeFileSync(path, harness, { mode: 0o755 });
+    const r = spawnSync("bash", [path], {
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+    });
+    return `${r.stdout ?? ""}${r.stderr ?? ""}`;
+  }
+
+  it("supervises a named tmp-reaper sidecar with its own log file", () => {
+    const out = runGuard({ SWITCHROOM_TMP_REAPER: "" }, true);
+    expect(out).toContain("SUPERVISED:tmp-reaper:/var/log/switchroom/tmp-reaper.log");
+    // Not --oneshot-ok: a clean exit from an endless loop is abnormal and
+    // must respawn.
+    expect(out).not.toContain("--oneshot-ok");
+  });
+
+  it("supervises it by default when the env var is unset", () => {
+    const env = { ...process.env } as Record<string, string>;
+    delete env.SWITCHROOM_TMP_REAPER;
+    const out = runGuard({}, true);
+    expect(out).toContain("SUPERVISED:tmp-reaper:");
+  });
+
+  it("does not supervise it when SWITCHROOM_TMP_REAPER=0", () => {
+    expect(runGuard({ SWITCHROOM_TMP_REAPER: "0" }, true)).not.toContain("SUPERVISED:");
+  });
+
+  it("does not supervise it when the script is absent from the image", () => {
+    expect(runGuard({ SWITCHROOM_TMP_REAPER: "1" }, false)).not.toContain("SUPERVISED:");
+  });
+
+  it("is baked into the agent image by the bin/*.sh glob COPY", () => {
+    const dockerfile = readFileSync(
+      resolve(__dirname, "..", "docker", "Dockerfile.agent"),
+      "utf-8",
+    );
+    expect(dockerfile).toMatch(/^COPY bin\/\*\.sh \/opt\/switchroom\/bin\/$/m);
+    expect(dockerfile).toMatch(/^RUN chmod \+x \/opt\/switchroom\/bin\/\*\.sh$/m);
+    expect(existsSync(SCRIPT)).toBe(true);
+  });
+});

--- a/tests/tmp-reaper.test.ts
+++ b/tests/tmp-reaper.test.ts
@@ -219,6 +219,118 @@ describe("tmp-reaper — open files", () => {
     expect(out).toMatch(/kept_open=1/);
   });
 
+  /**
+   * MUTATION GUARD for the `readlink -f` canonicalisation in tmp_reaper_pass.
+   *
+   * /proc/<pid>/fd link targets are always FULLY RESOLVED by the kernel. If
+   * reaper compares them against a root reached through a symlinked ANCESTOR,
+   * no prefix ever matches, `open_list` matches nothing, and the open-file
+   * guard silently passes everything through — present in the source, dead in
+   * effect. That is the worst shape of bug this script can have.
+   *
+   * Every other open-file test CANNOT catch it: `beforeEach` realpath()s the
+   * fixture root, so the script's canonicalisation is a no-op for them. This
+   * one deliberately hands the script a non-canonical root.
+   */
+  it("keeps an open entry when the root is reached via a symlinked ANCESTOR", async () => {
+    // <root>/physical/inner/held, plus <root>/alias -> <root>/physical. The
+    // root we pass (<root>/alias/inner) is not ITSELF a symlink — _root_ok
+    // rejects those outright — but it resolves through one.
+    const physical = join(root, "physical");
+    const inner = join(physical, "inner");
+    const held = join(inner, "held");
+    mkdirSync(held, { recursive: true });
+    const file = join(held, "payload.bin");
+    writeFileSync(file, Buffer.alloc(4096, 0x61));
+    symlinkSync(physical, join(root, "alias"));
+    age(file, 72);
+    age(held, 72);
+
+    const child = spawn("bash", ["-c", `exec 3< "${file}"; sleep 60`], {
+      stdio: "ignore",
+    });
+    children.push(child);
+    await new Promise((r) => setTimeout(r, 700));
+
+    const { out } = pass({}, join(root, "alias", "inner"));
+
+    expect(
+      existsSync(held),
+      `an entry held open by a live process must survive even when the root ` +
+        `is reached through a symlinked ancestor: /proc/<pid>/fd targets are ` +
+        `already resolved, so the root must be canonicalised (readlink -f) ` +
+        `before the prefix compare or the open-file guard matches nothing ` +
+        `and reaps everything.\n${out}`,
+    ).toBe(true);
+    expect(out).toMatch(/kept_open=1/);
+  });
+
+  /**
+   * MUTATION GUARD for the mmap clause of _open_paths, which no other test
+   * reaches: every case above is an fd, and an fd is caught by the find
+   * branch whether or not the maps branch works at all.
+   *
+   * A file can be MAPPED with no fd open on it — the dynamic loader maps a
+   * shared library and immediately closes its descriptor, and mmap page
+   * faults do not update atime, so such a file can be genuinely 24h "idle"
+   * while a live process is executing out of it. Only /proc/<pid>/maps shows
+   * it. LD_PRELOAD of a copied .so reproduces exactly that shape without
+   * needing a compiler; the child's cwd is pinned outside the fixture so the
+   * cwd branch cannot mask a broken maps branch.
+   */
+  const preloadLib = [
+    "/lib/x86_64-linux-gnu/libz.so.1",
+    "/lib/aarch64-linux-gnu/libz.so.1",
+    "/usr/lib/x86_64-linux-gnu/libz.so.1",
+    "/usr/lib/aarch64-linux-gnu/libz.so.1",
+  ].find((p) => existsSync(p));
+
+  it.skipIf(!preloadLib)(
+    "keeps an aged entry that is MMAPPED by a live process with no fd open",
+    async () => {
+      const dir = join(root, "mapped-no-fd");
+      mkdirSync(dir, { recursive: true });
+      const lib = join(dir, "libprobe.so");
+      writeFileSync(lib, readFileSync(preloadLib as string));
+
+      const child = spawn("sleep", ["60"], {
+        stdio: "ignore",
+        env: { ...process.env, LD_PRELOAD: lib },
+        cwd: resolve(__dirname, ".."),
+      });
+      children.push(child);
+      await new Promise((r) => setTimeout(r, 700));
+
+      // Backdate AFTER the loader has mapped it. The loader's open+read bumps
+      // atime, so ageing beforehand would leave the entry "young" and the
+      // age guard — not the maps guard — would be what saved it. This is also
+      // the real shape: a library mapped days ago whose pages have not been
+      // faulted since (page faults do not update atime).
+      age(lib, 72);
+      age(dir, 72);
+
+      // Precondition: this must be a maps-ONLY hold, or the test proves
+      // nothing about the maps branch.
+      const maps = readFileSync(`/proc/${child.pid}/maps`, "utf8");
+      expect(maps, "LD_PRELOAD did not map the fixture library").toContain(lib);
+      const fds = spawnSync("ls", ["-l", `/proc/${child.pid}/fd`], { encoding: "utf8" });
+      expect(
+        fds.stdout ?? "",
+        "the loader still holds an fd — this test would pass via the find branch",
+      ).not.toContain(lib);
+
+      const { out } = pass();
+
+      expect(
+        existsSync(dir),
+        `an entry a live process has MMAPPED (no fd) must NOT be reaped: ` +
+          `mmap page faults do not touch atime, so the age guard will not ` +
+          `save it and /proc/<pid>/maps is the only signal.\n${out}`,
+      ).toBe(true);
+      expect(out).toMatch(/kept_open=1/);
+    },
+  );
+
   it("reaps the same entry once the holder exits", async () => {
     const dir = agedDir("held-then-released", 72);
     const file = join(dir, "payload.bin");
@@ -318,7 +430,11 @@ describe("tmp-reaper — boot wiring (start.sh.hbs block 3a)", () => {
    * for `_switchroom_supervise`, so the assertion is "a tmp-reaper sidecar
    * gets supervised at boot" rather than "the template mentions a string".
    */
-  function runGuard(env: Record<string, string>, scriptPresent: boolean): string {
+  function runGuard(
+    env: Record<string, string>,
+    scriptPresent: boolean,
+    unset: string[] = [],
+  ): string {
     const lines = SRC.split("\n");
     const start = lines.findIndex((l) => l.includes('if [ "$SWITCHROOM_TMP_REAPER" != "0" ]'));
     expect(start, "block 3a guard not found in start.sh.hbs").toBeGreaterThan(-1);
@@ -339,10 +455,14 @@ describe("tmp-reaper — boot wiring (start.sh.hbs block 3a)", () => {
     ].join("\n");
     const path = join(root, "guard.sh");
     writeFileSync(path, harness, { mode: 0o755 });
-    const r = spawnSync("bash", [path], {
-      encoding: "utf8",
-      env: { ...process.env, ...env },
-    });
+    // Build the child env explicitly so `unset` can genuinely REMOVE a var.
+    // Deleting from a local copy of process.env and then not passing it (the
+    // original shape of the "unset" case) is a no-op — the child inherited
+    // the ambient value and the test only passed because the runner happened
+    // not to have it set.
+    const childEnv: Record<string, string> = { ...(process.env as Record<string, string>), ...env };
+    for (const k of unset) delete childEnv[k];
+    const r = spawnSync("bash", [path], { encoding: "utf8", env: childEnv });
     return `${r.stdout ?? ""}${r.stderr ?? ""}`;
   }
 
@@ -355,9 +475,10 @@ describe("tmp-reaper — boot wiring (start.sh.hbs block 3a)", () => {
   });
 
   it("supervises it by default when the env var is unset", () => {
-    const env = { ...process.env } as Record<string, string>;
-    delete env.SWITCHROOM_TMP_REAPER;
-    const out = runGuard({}, true);
+    // Genuinely unset in the child, not merely absent from the runner's env —
+    // otherwise this asserts nothing about the default and flips to red on any
+    // machine that happens to export SWITCHROOM_TMP_REAPER=0.
+    const out = runGuard({}, true, ["SWITCHROOM_TMP_REAPER"]);
     expect(out).toContain("SUPERVISED:tmp-reaper:");
   });
 


### PR DESCRIPTION
An agent's `/tmp` is a 2 GiB RAM-backed tmpfs (`src/agents/compose.ts`
`DEFAULT_TMP_SIZE`), mounted `noexec` by Docker's tmpfs defaults. Nothing
ages out of a tmpfs, so a long-running container accumulates every scratch
dir any tool forgot to remove until writes start failing ENOSPC — and the
failure surfaces in the victim (`npm ci`, git, the CLI's own staging), never
at the cause.

**Measured live** on `switchroom-overlord` before this PR:

```
$ findmnt -no OPTIONS,SIZE /tmp
rw,nosuid,nodev,noexec,relatime,size=2097152k,inode64    2G
$ df -h /tmp | tail -1
tmpfs           2.0G  490M  1.6G  24% /tmp
$ ls /tmp | wc -l        # 4,462 top-level entries
$ du -sh /tmp/switchroom-static-*
102M    /tmp/switchroom-static-ivbGIa
102M    /tmp/switchroom-static-setup-EWgqDv
```

204 MiB of the 490 MiB was two orphaned `bun build --compile` trees from a
single run of `tests/install/static-binary.test.ts`.

## Two changes, deliberately no third

### 1. `tests/install/static-binary.test.ts` cleans up after itself

Both tests allocated a scratch dir with `mkdtempSync` and never removed it;
each holds a ~102 MiB compiled binary. Both now go through a `scratchDir()`
helper that registers removal with `onTestFinished` — which runs on the
**failure** path. A trailing `rmSync` in the test body does not, and a failing
run (broken compile, flaky assertion) is exactly the one that leaves the
biggest artifact behind.

Before/after, measured in a live agent container running the same suite:

| | `/tmp` used before | after | orphan dirs left |
|---|---|---|---|
| `origin/main` | 490M | **694M** | 2 |
| this PR | 490M | **490M** | 0 |

A new guard in the same file asserts the outcome rather than the code path:
an `it.fails` test allocates a scratch dir and throws; a later test asserts
the dir is gone from disk.

### 2. A named, bounded reaper sidecar

`bin/tmp-reaper.sh` — greppable as `switchroom-tmp-reaper`. Baked into the
agent image by the existing `COPY bin/*.sh` glob (no Dockerfile change) and
supervised from `start.sh` block 3a exactly like the gateway / scheduler /
buzz sidecars, so it inherits `_switchroom_supervise`'s respawn-with-backoff
and log rotation. Log: `/var/log/switchroom/tmp-reaper.log`. Hourly pass.

Safety contract — each clause has a test that fails when the clause is
removed:

* **scope** — direct children of the root only, the root itself is never
  removed, `-xdev` on every traversal, no symlink deref, `rm -rf
  --one-file-system --preserve-root`. A symlink under `/tmp` can lose the
  *link*, never its target.
* **age** — an entry is a candidate only when *nothing anywhere in its
  subtree* was modified or accessed within 24h. A directory's own mtime does
  not move when a grandchild is written, so checking the entry alone would
  reap live trees.
* **open files** — skipped when it, or anything beneath it, is open by a live
  process: `/proc/*/fd`, `cwd`, `exe`, and mmapped regions from
  `/proc/*/maps`.
* **logging** — every reaped entry with size and age, plus a per-pass summary
  line even when it reaps nothing.

Kill switch `SWITCHROOM_TMP_REAPER=0`; age and interval tunable, with a 1h
age floor and garbage-input fallback.

### 3. The tmpfs size was NOT raised

`DEFAULT_TMP_SIZE` stays at `2g`. A bigger tmpfs converts a fast, loud
failure into a slow leak against host RAM. The 204 MiB found on the live
container was leaked garbage, not legitimate steady-state use — no evidence
2 GiB is too small.

## Mutation proofs

Each safety clause was deliberately broken; the guarding test failed naming
the offender, and the mutation was reverted.

| mutation | failing test |
|---|---|
| `onTestFinished` → trailing `rmSync` in the test body | `…and BOTH scratch dirs are gone from the tmpdir afterwards` — *"leaked scratch dir from the FAILING test: /tmp/switchroom-scratch-guard-fail-iWTndI"* |
| subtree age check → `find -maxdepth 0` (entry only) | `keeps an aged directory whose GRANDCHILD was touched recently` |
| open-file check deleted (`is_open=0`) | `keeps an aged entry that a live process holds an fd on` |
| `rm -rf --one-file-system -- "$entry"` → `rm -rf -- "$entry"/` | `does not delete a symlink's target outside the root` — *"the symlink TARGET outside the root must survive"* |

The canonicalisation in `tmp_reaper_pass` (`readlink -f` on the root) was
added *because* the open-file test caught its absence: `/proc/*/fd` targets
are fully resolved, so an un-canonicalised root behind a symlinked ancestor
never prefix-matches and the guard silently passes everything through.

## Verification

* `npx vitest run tests/tmp-reaper.test.ts` — 20 passed
* `npx vitest run tests/install/static-binary.test.ts` — the 3 new guards
  pass; the 2 pre-existing `bun build --compile` tests fail **identically on
  `origin/main`** in this container, because `/tmp` is `noexec` and the
  compiled binary cannot be executed from there. Not a regression from this
  PR.
* Adjacent suites: `scaffold`, `dockerfile-agent-bakes`,
  `gateway-supervisor-backoff`, `gateway-supervisor-log-rotation`,
  `hindsight-drain-sidecar`, `cheap-cron-session-render` — 343 passed
* `npm run lint` — clean (rc=0), including `check-changelog-entry` and
  `check-agent-attribution-trailers`

Switchroom-Agent: overlord
Switchroom-Model: opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)