### PR TITLE
fix(gateway): ignore a reply thread anchor from a different chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,18 +140,30 @@ now an anomaly worth investigating, not the norm.
   B's topic id was attached to the send into A and Telegram rejected the call
   with `400 Bad Request: message thread not found`. A retry fallback resent
   without a thread, so no answer was lost — but every occurrence was a
-  guaranteed-failed first API call. `resolveAnswerThreadId`
-  (`telegram-plugin/gateway/answer-thread-resolve.ts`) now DROPS any anchor
-  whose chat id does not match the send target, before the precedence runs;
-  resolution falls through exactly as if the anchor did not exist. The drop is
-  unconditional across BOTH kill switches (`SWITCHROOM_REPLY_TOPIC_AUTHORITY=0`
-  and `SWITCHROOM_TURN_ORIGIN_ROUTING=0`, whose legacy branch previously passed
-  the live turn's thread through unfiltered): a wrong-chat topic id is an API
-  error, not a routing policy a kill switch should be able to reinstate. The
-  routing, the late-reply recovery tier and the `reply-route` telemetry all
-  derive from the SAME exported `isCrossChatAnchor` predicate, so the log can
-  never disagree with what actually routed. Callers that supply no chat ids are
-  unaffected.
+  guaranteed-failed first API call. The drop is enforced at TWO sites, because
+  the two branches resolve the thread through different code and grepping either
+  function name alone shows only half the fix. (1) `resolveAnswerThreadId`
+  (`telegram-plugin/gateway/answer-thread-resolve.ts`) — the default path and
+  the `SWITCHROOM_REPLY_TOPIC_AUTHORITY=0` path both run through it — now DROPS
+  any anchor whose chat id does not match the send target, before the precedence
+  runs; resolution falls through exactly as if the anchor did not exist. (2) The
+  `SWITCHROOM_TURN_ORIGIN_ROUTING=0` legacy branch never calls that resolver —
+  it passes the pinned turn's thread straight to `resolveThreadId` — so the
+  equivalent guard lives inline in `sendReply`
+  (`telegram-plugin/gateway/outbound-send-path.ts`), on the branch that
+  previously passed the live turn's thread through unfiltered. Net effect: the
+  drop is unconditional across BOTH kill switches — a wrong-chat topic id is an
+  API error, not a routing policy a kill switch should be able to reinstate.
+  Both sites, the late-reply recovery tier and the `reply-route` telemetry
+  derive from the SAME exported `isCrossChatAnchor` predicate, so no second copy
+  of the rule can drift and the log can never disagree with what actually
+  routed; the legacy branch emits the same `CROSS_CHAT_ANCHOR_DROPPED` marker
+  through the same `formatReplyRouteLog` formatter, so a kill-switched
+  deployment keeps the audit trail rather than dropping anchors silently.
+  Note that dropping the anchor does not mean "no thread": the legacy branch
+  still falls through to `resolveThreadId`'s chat-scoped last-seen topic, which
+  can only ever yield a topic valid for the target chat. Callers that supply no
+  chat ids are unaffected.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,26 @@ now an anomaly worth investigating, not the norm.
   unguaranteeable markup is — which beats a 400 that degrades the whole
   message to plain text. Also locks in the blank-line-separated expandable
   shape, the majority corpus shape, which worked but had no test.
+- **gateway: ignore a reply thread anchor from a different chat** — a reply
+  targeting chat A could be anchored to a turn belonging to chat B: the
+  `origin_turn_id` echo lookup is keyed by turn id alone (not chat-scoped), and
+  the LIVE turn is whatever the session happens to be running, which in a
+  multi-chat agent is frequently another chat. When B was a forum supergroup,
+  B's topic id was attached to the send into A and Telegram rejected the call
+  with `400 Bad Request: message thread not found`. A retry fallback resent
+  without a thread, so no answer was lost — but every occurrence was a
+  guaranteed-failed first API call. `resolveAnswerThreadId`
+  (`telegram-plugin/gateway/answer-thread-resolve.ts`) now DROPS any anchor
+  whose chat id does not match the send target, before the precedence runs;
+  resolution falls through exactly as if the anchor did not exist. The drop is
+  unconditional across BOTH kill switches (`SWITCHROOM_REPLY_TOPIC_AUTHORITY=0`
+  and `SWITCHROOM_TURN_ORIGIN_ROUTING=0`, whose legacy branch previously passed
+  the live turn's thread through unfiltered): a wrong-chat topic id is an API
+  error, not a routing policy a kill switch should be able to reinstate. The
+  routing, the late-reply recovery tier and the `reply-route` telemetry all
+  derive from the SAME exported `isCrossChatAnchor` predicate, so the log can
+  never disagree with what actually routed. Callers that supply no chat ids are
+  unaffected.
 
 ### Features
 
@@ -909,7 +929,6 @@ now an anomaly worth investigating, not the norm.
   `Intl`, since Node's ICU reports a correct UTC even on a corrupted host and
   would mask exactly this defect.
 - **gateway: never evict an approval outcome while anything else is droppable**
-- **gateway: ignore a reply thread anchor from a different chat**
 
 ## v0.21.7 — a Fable-pinned agent boots on Fable, a cron edit stops failing on its first try, and the merge queue stops ejecting innocent PRs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,41 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **gateway: ignore a reply thread anchor from a different chat** — a reply
+  targeting chat A could be anchored to a turn belonging to chat B: the
+  `origin_turn_id` echo lookup is keyed by turn id alone (not chat-scoped), and
+  the LIVE turn is whatever the session happens to be running, which in a
+  multi-chat agent is frequently another chat. When B was a forum supergroup,
+  B's topic id was attached to the send into A and Telegram rejected the call
+  with `400 Bad Request: message thread not found`. A retry fallback resent
+  without a thread, so no answer was lost — but every occurrence was a
+  guaranteed-failed first API call. The drop is enforced at TWO sites, because
+  the two branches resolve the thread through different code and grepping either
+  function name alone shows only half the fix. (1) `resolveAnswerThreadId`
+  (`telegram-plugin/gateway/answer-thread-resolve.ts`) — the default path and
+  the `SWITCHROOM_REPLY_TOPIC_AUTHORITY=0` path both run through it — now DROPS
+  any anchor whose chat id does not match the send target, before the precedence
+  runs; resolution falls through exactly as if the anchor did not exist. (2) The
+  `SWITCHROOM_TURN_ORIGIN_ROUTING=0` legacy branch never calls that resolver —
+  it passes the pinned turn's thread straight to `resolveThreadId` — so the
+  equivalent guard lives inline in `sendReply`
+  (`telegram-plugin/gateway/outbound-send-path.ts`), on the branch that
+  previously passed the live turn's thread through unfiltered. Net effect: the
+  drop is unconditional across BOTH kill switches — a wrong-chat topic id is an
+  API error, not a routing policy a kill switch should be able to reinstate.
+  Both sites, the late-reply recovery tier and the `reply-route` telemetry
+  derive from the SAME exported `isCrossChatAnchor` predicate, so no second copy
+  of the rule can drift and the log can never disagree with what actually
+  routed; the legacy branch emits the same `CROSS_CHAT_ANCHOR_DROPPED` marker
+  through the same `formatReplyRouteLog` formatter, so a kill-switched
+  deployment keeps the audit trail rather than dropping anchors silently.
+  Note that dropping the anchor does not mean "no thread": the legacy branch
+  still falls through to `resolveThreadId`'s chat-scoped last-seen topic, which
+  can only ever yield a topic valid for the target chat. Callers that supply no
+  chat ids are unaffected.
+
 ## v0.21.10 — the Telegram render pipeline stops deleting prose and corrupting fenced code, and TTS stops failing on long messages
 
 ### Bug fixes
@@ -132,38 +167,6 @@ now an anomaly worth investigating, not the norm.
   unguaranteeable markup is — which beats a 400 that degrades the whole
   message to plain text. Also locks in the blank-line-separated expandable
   shape, the majority corpus shape, which worked but had no test.
-- **gateway: ignore a reply thread anchor from a different chat** — a reply
-  targeting chat A could be anchored to a turn belonging to chat B: the
-  `origin_turn_id` echo lookup is keyed by turn id alone (not chat-scoped), and
-  the LIVE turn is whatever the session happens to be running, which in a
-  multi-chat agent is frequently another chat. When B was a forum supergroup,
-  B's topic id was attached to the send into A and Telegram rejected the call
-  with `400 Bad Request: message thread not found`. A retry fallback resent
-  without a thread, so no answer was lost — but every occurrence was a
-  guaranteed-failed first API call. The drop is enforced at TWO sites, because
-  the two branches resolve the thread through different code and grepping either
-  function name alone shows only half the fix. (1) `resolveAnswerThreadId`
-  (`telegram-plugin/gateway/answer-thread-resolve.ts`) — the default path and
-  the `SWITCHROOM_REPLY_TOPIC_AUTHORITY=0` path both run through it — now DROPS
-  any anchor whose chat id does not match the send target, before the precedence
-  runs; resolution falls through exactly as if the anchor did not exist. (2) The
-  `SWITCHROOM_TURN_ORIGIN_ROUTING=0` legacy branch never calls that resolver —
-  it passes the pinned turn's thread straight to `resolveThreadId` — so the
-  equivalent guard lives inline in `sendReply`
-  (`telegram-plugin/gateway/outbound-send-path.ts`), on the branch that
-  previously passed the live turn's thread through unfiltered. Net effect: the
-  drop is unconditional across BOTH kill switches — a wrong-chat topic id is an
-  API error, not a routing policy a kill switch should be able to reinstate.
-  Both sites, the late-reply recovery tier and the `reply-route` telemetry
-  derive from the SAME exported `isCrossChatAnchor` predicate, so no second copy
-  of the rule can drift and the log can never disagree with what actually
-  routed; the legacy branch emits the same `CROSS_CHAT_ANCHOR_DROPPED` marker
-  through the same `formatReplyRouteLog` formatter, so a kill-switched
-  deployment keeps the audit trail rather than dropping anchors silently.
-  Note that dropping the anchor does not mean "no thread": the legacy branch
-  still falls through to `resolveThreadId`'s chat-scoped last-seen topic, which
-  can only ever yield a topic valid for the target chat. Callers that supply no
-  chat ids are unaffected.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -909,6 +909,7 @@ now an anomaly worth investigating, not the norm.
   `Intl`, since Node's ICU reports a correct UTC even on a corrupted host and
   would mask exactly this defect.
 - **gateway: never evict an approval outcome while anything else is droppable**
+- **gateway: ignore a reply thread anchor from a different chat**
 
 ## v0.21.7 — a Fable-pinned agent boots on Fable, a cron edit stops failing on its first try, and the merge queue stops ejecting innocent PRs
 

--- a/telegram-plugin/gateway/answer-thread-resolve.test.ts
+++ b/telegram-plugin/gateway/answer-thread-resolve.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { resolveAnswerThreadId, type AnswerThreadInput } from './answer-thread-resolve.js'
+import {
+  resolveAnswerThreadId,
+  isCrossChatAnchor,
+  type AnswerThreadInput,
+} from './answer-thread-resolve.js'
 
 // Distinct symbolic thread ids so an output's provenance is unambiguous (no two
 // tiers share a value): explicit=70, origin=50, live=30, lastEnded=90.
@@ -104,6 +108,143 @@ describe('resolveAnswerThreadId — legacy (frameworkTopicAuthority:false)', () 
         liveThreadId: L,
       }),
     ).toBe(O)
+  })
+})
+
+// ── Cross-chat anchor guard (bug c, 2026-08-13) ─────────────────────────────
+//
+// The live failure: a reply into chat A resolved its thread from an anchor turn
+// owned by forum supergroup B, so B's topic id rode along on the send into A and
+// Telegram answered `400 Bad Request: message thread not found`. The retry
+// fallback resent threadless and succeeded, so the symptom was a guaranteed-
+// failed FIRST API call rather than a lost message. Each case below asserts the
+// RESOLVED THREAD, not that a branch ran.
+const CHAT_A = '12345678' // a DM — the reply target
+const CHAT_B = '-1003831053471' // a forum supergroup — where the anchor lives
+
+describe('resolveAnswerThreadId — cross-chat anchor guard', () => {
+  it("THE bug: a live turn in supergroup B must not lend its topic to a reply into chat A", () => {
+    expect(
+      resolveAnswerThreadId({
+        targetChatId: CHAT_A,
+        originResolved: false,
+        liveTurnPresent: true,
+        liveThreadId: 635, // B's topic — the id Telegram rejected
+        liveChatId: CHAT_B,
+      }),
+    ).toBeUndefined() // → no thread; the send into A is threadless and succeeds
+  })
+
+  it('a cross-chat ORIGIN anchor (origin_turn_id echoed from another chat) is ignored', () => {
+    expect(
+      resolveAnswerThreadId({
+        targetChatId: CHAT_A,
+        originResolved: true,
+        originThreadId: O,
+        originChatId: CHAT_B,
+      }),
+    ).toBeUndefined()
+  })
+
+  it('a dropped cross-chat anchor falls through to the model explicit (its only remaining signal)', () => {
+    expect(
+      resolveAnswerThreadId({
+        targetChatId: CHAT_A,
+        explicitThreadId: T,
+        originResolved: true,
+        originThreadId: O,
+        originChatId: CHAT_B,
+        liveTurnPresent: true,
+        liveThreadId: L,
+        liveChatId: CHAT_B,
+      }),
+    ).toBe(T)
+  })
+
+  it('a dropped cross-chat anchor falls through to the chat-scoped last-ended recovery when there is no explicit', () => {
+    expect(
+      resolveAnswerThreadId({
+        targetChatId: CHAT_A,
+        originResolved: false,
+        liveTurnPresent: true,
+        liveThreadId: L,
+        liveChatId: CHAT_B,
+        lastEndedResolvedForChat: true,
+        lastEndedThreadIdForChat: E,
+      }),
+    ).toBe(E)
+  })
+
+  it('a SAME-chat anchor is untouched — the guard only drops foreign chats', () => {
+    expect(
+      resolveAnswerThreadId({
+        targetChatId: CHAT_B,
+        explicitThreadId: T,
+        originResolved: true,
+        originThreadId: O,
+        originChatId: CHAT_B,
+      }),
+    ).toBe(O)
+  })
+
+  it('an origin in chat A survives while a live turn in chat B is dropped (independent guards)', () => {
+    expect(
+      resolveAnswerThreadId({
+        targetChatId: CHAT_A,
+        originResolved: true,
+        originThreadId: O,
+        originChatId: CHAT_A,
+        liveTurnPresent: true,
+        liveThreadId: L,
+        liveChatId: CHAT_B,
+      }),
+    ).toBe(O)
+  })
+
+  it('the guard also applies under the legacy kill switch — a wrong-chat topic is an API error, not a precedence policy', () => {
+    expect(
+      resolveAnswerThreadId({
+        frameworkTopicAuthority: false,
+        targetChatId: CHAT_A,
+        originResolved: true,
+        originThreadId: O,
+        originChatId: CHAT_B,
+        liveThreadId: L,
+        liveChatId: CHAT_B,
+      }),
+    ).toBeUndefined()
+  })
+
+  it('numeric-vs-string chat ids compare by value, so no anchor is dropped spuriously', () => {
+    expect(
+      resolveAnswerThreadId({
+        targetChatId: CHAT_B,
+        originResolved: true,
+        originThreadId: O,
+        originChatId: String(Number(CHAT_B)),
+      }),
+    ).toBe(O)
+  })
+
+  it('BACK-COMPAT: with no chat ids supplied the guard is inert (identical to pre-guard routing)', () => {
+    expect(
+      resolveAnswerThreadId({
+        originResolved: false,
+        liveTurnPresent: true,
+        liveThreadId: L,
+      }),
+    ).toBe(L)
+  })
+})
+
+describe('isCrossChatAnchor', () => {
+  it('true only when both ids are present and differ', () => {
+    expect(isCrossChatAnchor(CHAT_A, CHAT_B)).toBe(true)
+    expect(isCrossChatAnchor(CHAT_A, CHAT_A)).toBe(false)
+    expect(isCrossChatAnchor(undefined, CHAT_B)).toBe(false)
+    expect(isCrossChatAnchor(CHAT_A, undefined)).toBe(false)
+    expect(isCrossChatAnchor('', CHAT_B)).toBe(false)
+    expect(isCrossChatAnchor(CHAT_A, '')).toBe(false)
   })
 })
 
@@ -237,5 +378,38 @@ describe('resolveAnswerThreadId — total-enumeration proof (54 reachable inputs
 
   it('INV-EXPLICIT-DOMINANCE (legacy): explicit set ⇒ output === explicit, independent of all other fields', () => {
     for (const i of LEGACY) if (i.explicitThreadId != null) expect(resolveAnswerThreadId(i)).toBe(i.explicitThreadId)
+  })
+
+  // ── Cross-chat guard, proved over the same enumeration (both modes) ────────
+  it('INV-CROSS-CHAT: anchors in a FOREIGN chat route exactly as if they did not exist, on all 54 inputs × 2 modes', () => {
+    for (const i of [...FA, ...LEGACY]) {
+      const foreign = resolveAnswerThreadId({
+        ...i,
+        targetChatId: CHAT_A,
+        originChatId: CHAT_B,
+        liveChatId: CHAT_B,
+      })
+      const anchorless = resolveAnswerThreadId({
+        ...i,
+        originResolved: false,
+        originThreadId: undefined,
+        liveTurnPresent: false,
+        liveThreadId: undefined,
+      })
+      expect(foreign).toBe(anchorless)
+    }
+  })
+
+  it('INV-SAME-CHAT: annotating anchors with the TARGET chat changes nothing, on all 54 inputs × 2 modes', () => {
+    for (const i of [...FA, ...LEGACY]) {
+      expect(
+        resolveAnswerThreadId({
+          ...i,
+          targetChatId: CHAT_A,
+          originChatId: CHAT_A,
+          liveChatId: CHAT_A,
+        }),
+      ).toBe(resolveAnswerThreadId(i))
+    }
   })
 })

--- a/telegram-plugin/gateway/answer-thread-resolve.ts
+++ b/telegram-plugin/gateway/answer-thread-resolve.ts
@@ -44,6 +44,20 @@
  *      orphaned-backstop reply lands in its topic instead of defaulting to the
  *      main chat (General). Not the `chatThreadMap` last-seen heuristic.
  *
+ * **(c) cross-chat thread anchor (2026-08-13).** A reply targeting chat A can be
+ * resolved against a turn anchor that belongs to a DIFFERENT chat B — the
+ * `origin_turn_id` echo lookup is keyed by turn id alone (not chat-scoped), and
+ * the LIVE turn is whatever the session is currently running, which in a
+ * multi-chat agent is frequently another chat. When B is a forum supergroup, its
+ * topic id was attached to the send into A and Telegram rejected the call with
+ * `400 Bad Request: message thread not found`. A retry fallback resent with no
+ * thread and succeeded, so nothing was lost — but every occurrence was a
+ * guaranteed-failed first API call (observed 3× since 2026-08-08). Fixed by
+ * IGNORING any anchor whose chat id does not match the target chat: precedence
+ * falls through to the model's explicit thread / no thread, exactly as if the
+ * anchor did not exist. The chat ids are optional inputs, so a caller that
+ * supplies none keeps the pre-existing behaviour verbatim.
+ *
  * Setting `frameworkTopicAuthority: false` (kill switch
  * SWITCHROOM_REPLY_TOPIC_AUTHORITY=0) restores the legacy explicit-first
  * precedence (the model's thread wins outright).
@@ -95,6 +109,33 @@ export interface AnswerThreadInput {
    * true. Kill switch SWITCHROOM_REPLY_TOPIC_AUTHORITY=0.
    */
   frameworkTopicAuthority?: boolean
+  /**
+   * Chat this reply is being SENT to (bug c). When supplied together with an
+   * anchor's chat id, an anchor from a DIFFERENT chat is ignored. Undefined
+   * disables the guard (behaviour identical to before the guard existed).
+   */
+  targetChatId?: string | undefined
+  /** Chat the ORIGIN anchor turn belongs to (`turn.sessionChatId`). */
+  originChatId?: string | undefined
+  /** Chat the LIVE in-flight turn belongs to (`turn.sessionChatId`). */
+  liveChatId?: string | undefined
+}
+
+/**
+ * True when `anchorChatId` names a DIFFERENT chat than the reply's target — i.e.
+ * the anchor's thread must NOT be attached to this send (bug c). Conservative:
+ * returns false when either id is absent, so an un-instrumented caller is
+ * unaffected. Exported so the gateway's telemetry (`via`,
+ * `CROSS_CHAT_ANCHOR_DROPPED`) derives from the SAME predicate that routes,
+ * rather than a second copy that can drift out of sync.
+ */
+export function isCrossChatAnchor(
+  targetChatId: string | undefined,
+  anchorChatId: string | undefined,
+): boolean {
+  if (targetChatId == null || targetChatId === '') return false
+  if (anchorChatId == null || anchorChatId === '') return false
+  return String(anchorChatId) !== String(targetChatId)
 }
 
 /**
@@ -107,26 +148,37 @@ export interface AnswerThreadInput {
  * exists. The chat last-seen `chatThreadMap` heuristic is NOT in this chain.
  */
 export function resolveAnswerThreadId(input: AnswerThreadInput): number | undefined {
+  // Bug (c): an anchor from another chat is not an anchor. Drop it BEFORE the
+  // precedence runs, in both modes — a wrong-chat topic id is an API error, not
+  // a routing policy, so the kill switch must not reinstate it. `lastEnded*` is
+  // already chat-scoped by its lookup, so it needs no guard here.
+  const originCrossChat = isCrossChatAnchor(input.targetChatId, input.originChatId)
+  const liveCrossChat = isCrossChatAnchor(input.targetChatId, input.liveChatId)
+  const originResolved = input.originResolved && !originCrossChat
+  const originThreadId = originCrossChat ? undefined : input.originThreadId
+  const liveTurnPresent = input.liveTurnPresent === true && !liveCrossChat
+  const liveThreadId = liveCrossChat ? undefined : input.liveThreadId
+
   if (input.frameworkTopicAuthority === false) {
     // ── Legacy precedence (kill switch): the model's explicit thread wins. ──
     if (input.explicitThreadId != null) return input.explicitThreadId
-    if (input.originResolved) return input.originThreadId
-    if (input.liveThreadId != null) return input.liveThreadId
+    if (originResolved) return originThreadId
+    if (liveThreadId != null) return liveThreadId
     if (input.lastEndedResolvedForChat) return input.lastEndedThreadIdForChat
-    return input.liveThreadId
+    return liveThreadId
   }
   // ── Framework-authority precedence (default) ───────────────────────────────
   // (1) origin turn → its thread (authoritative across a currentTurn flip; a
   //     General/DM origin yields undefined → main chat / General).
-  if (input.originResolved) return input.originThreadId
+  if (originResolved) return originThreadId
   // (2) a live in-flight turn → its thread. Key off PRESENCE, not the thread
   //     value: a General live turn has an undefined thread but is still the
   //     anchor, so the model's explicit can't pull the reply out of it.
-  if (input.liveTurnPresent) return input.liveThreadId
+  if (liveTurnPresent) return liveThreadId
   // (3) no framework anchor (genuinely orphaned / proactive) → honour the
   //     model's explicit thread, its only signal here.
   if (input.explicitThreadId != null) return input.explicitThreadId
   // (4) late reply, no anchor, no explicit → recover the chat's last-ended topic.
   if (input.lastEndedResolvedForChat) return input.lastEndedThreadIdForChat
-  return input.liveThreadId
+  return liveThreadId
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -737,7 +737,8 @@ import {
   type CardDrainGateCtx,
 } from './emission-authority.js'
 import { CurrentTurnMap } from './current-turn-map.js'
-import { resolveAnswerThreadId } from './answer-thread-resolve.js'
+import { resolveAnswerThreadId, isCrossChatAnchor } from './answer-thread-resolve.js'
+import { formatReplyRouteLog } from './reply-route-log.js'
 import { latestTurnForChat } from './latest-turn-lookup.js'
 import { decideObligationTurnEnd } from './obligation-turn-end.js'
 import { maybeRotate, resolveAgentStateDir, resolveTurnsJsonlPath } from './turns-jsonl-rotate.js'
@@ -3909,19 +3910,11 @@ function resolveReplyOwnerTurn(
  * 2026-06-05 triage showed reply routing was the blind spot: `reply: invoked`
  * logged only chat + char count, so a late reply landing in the wrong topic was
  * invisible without hand-correlating raw tg-post threads against turn-lifecycle
- * timestamps. This wrapper logs, per reply: which precedence tier won (`via`),
- * the resolved thread, the origin turn + its thread, and whether the reply was
- * late (turn already ended). `via=recovered` marks a late reply this fix saved
- * from General; `via=quoted` marks an origin recovered from the framework-owned
- * quoted message_id (no model echo); `UNROUTED` flags a supergroup reply that
- * resolved to no topic with NO owner turn to attribute it to (genuinely lost).
- * `MISROUTE_RISK` flags the irreducible determinism residual: a no-echo,
- * no-quote reply that fell to the LIVE turn while a DIFFERENT topic recently had
- * a turn — the framework cannot tell which topic the bare reply answers, so the
- * routing MIGHT be wrong (HOLE a). It is observability only (the reply still
- * routes to the live turn) — it makes the one case that is genuinely
- * model-dependent visible instead of silently mis-routed. A General-topic turn
- * legitimately has no thread, so its replies are NOT UNROUTED-flagged.
+ * timestamps. The line itself — tier (`via`), resolved thread, owner turn, and
+ * the RECOVERED / QUOTED / UNROUTED / MISROUTE_RISK / CROSS_CHAT_ANCHOR_DROPPED
+ * / EXPLICIT_OVERRIDDEN markers — is built by the pure `formatReplyRouteLog`
+ * (`reply-route-log.ts`), which documents each marker. This wrapper binds the
+ * gateway's stateful lookups and owns the routing call.
  *
  * `originVia` distinguishes how the origin turn was resolved: 'echo' (model
  * echoed origin_turn_id), 'quoted' (framework recovered it from args.reply_to),
@@ -3935,17 +3928,25 @@ function resolveAnswerThreadWithLog(
   liveTurn: CurrentTurn | null,
   surface: 'reply' | 'stream_reply',
 ): number | undefined {
+  // Cross-chat anchor guard (2026-08-13, bug c in `answer-thread-resolve.ts`):
+  // an anchor turn owned by a DIFFERENT chat must not lend its topic id to this
+  // send. `resolveAnswerThreadId` drops it from the ROUTING (below); these
+  // locals apply the same predicate so the recovery tier and the telemetry
+  // agree with what routed.
+  const originAnchor = isCrossChatAnchor(chatId, originTurn?.sessionChatId) ? null : originTurn
+  const liveAnchor = isCrossChatAnchor(chatId, liveTurn?.sessionChatId) ? null : liveTurn
   // Recover ONLY for a genuinely LATE reply — no live turn at all. Gating on
   // `liveTurn?.sessionThreadId == null` (the original) also fired for a
   // threadless DM that still had a live turn, marking every DM reply
   // `via=recovered`/RECOVERED in the telemetry (routing result unchanged —
   // DM → undefined — but it drowned the real supergroup recoveries the marker
-  // exists to surface). `liveTurn == null` is the precise late-reply condition.
+  // exists to surface). No live turn is the precise late-reply condition — and
+  // a cross-chat live turn is, for THIS chat, no live turn.
   const recovered =
     LATE_REPLY_TOPIC_RECOVERY_ENABLED &&
     explicitThreadId == null &&
-    originTurn == null &&
-    liveTurn == null
+    originAnchor == null &&
+    liveAnchor == null
       ? findLatestTurnForChat(chatId, { endedOnly: false })
       : null
   const threadId = resolveAnswerThreadId({
@@ -3957,58 +3958,24 @@ function resolveAnswerThreadWithLog(
     lastEndedResolvedForChat: recovered != null,
     lastEndedThreadIdForChat: recovered?.sessionThreadId,
     frameworkTopicAuthority: REPLY_TOPIC_AUTHORITY_ENABLED,
+    targetChatId: chatId,
+    originChatId: originTurn?.sessionChatId,
+    liveChatId: liveTurn?.sessionChatId,
   })
-  // `via` reflects the ACTIVE precedence so telemetry matches routing.
-  const via = REPLY_TOPIC_AUTHORITY_ENABLED
-    ? (originTurn != null ? (originVia === 'quoted' ? 'quoted' : 'origin')
-      : liveTurn != null ? 'live'
-      : explicitThreadId != null ? 'explicit'
-      : recovered != null ? 'recovered'
-      : 'none')
-    : (explicitThreadId != null ? 'explicit'
-      : originTurn != null ? (originVia === 'quoted' ? 'quoted' : 'origin')
-      : liveTurn?.sessionThreadId != null ? 'live'
-      : recovered != null ? 'recovered'
-      : 'none')
-  // Observability: the model passed an explicit topic but a framework anchor
-  // (origin/live) overrode it. This is the deterministic correction that fixes
-  // the General→CRM misroute; surface it so the model's topic-grabbing is
-  // visible rather than silent.
-  const explicitOverridden =
-    REPLY_TOPIC_AUTHORITY_ENABLED &&
-    explicitThreadId != null &&
-    (originTurn != null || liveTurn != null) &&
-    threadId !== explicitThreadId
-  const ownerTurn = originTurn ?? recovered ?? liveTurn
-  const isSupergroup = chatId.startsWith('-100')
-  // UNROUTED = a supergroup reply that resolved to NO topic with NO owner turn
-  // to attribute it to (genuinely lost). A General-topic turn legitimately has
-  // no thread, so a reply owned by it resolving to `-` is CORRECT, not lost —
-  // gate on `ownerTurn == null` so General replies don't false-alarm (found by
-  // the multi-topic UAT stress, 2026-06-05).
-  const unrouted = isSupergroup && threadId == null && ownerTurn == null
-  // MISROUTE_RISK = the irreducible determinism residual (HOLE a). A no-echo,
-  // no-quote reply fell to the LIVE turn (via=live), but a DIFFERENT topic
-  // recently had a turn for this chat — so this bare reply MIGHT belong to that
-  // other topic and we cannot tell without the model's echo. Observability only;
-  // routing is unchanged. This is the one case framework state cannot
-  // disambiguate, surfaced instead of silently mis-routed.
-  const misrouteRisk =
-    isSupergroup &&
-    via === 'live' &&
-    hasDifferentThreadedRecentTurn(chatId, liveTurn?.sessionThreadId)
   process.stderr.write(
-    `telegram gateway: reply-route surface=${surface} chat=${chatId} ` +
-      `resolved_thread=${threadId ?? '-'} via=${via} late=${liveTurn == null} ` +
-      `originTurn=${ownerTurn?.turnId ?? '-'} origin_thread=${ownerTurn?.sessionThreadId ?? '-'}` +
-      (via === 'recovered' ? ' RECOVERED' : '') +
-      (via === 'quoted' ? ' QUOTED(framework-origin)' : '') +
-      (unrouted ? ' UNROUTED(supergroup→no-topic)' : '') +
-      (misrouteRisk ? ' MISROUTE_RISK(no-echo→live-successor)' : '') +
-      (explicitOverridden
-        ? ` EXPLICIT_OVERRIDDEN(model→${explicitThreadId},routed→${threadId ?? '-'})`
-        : '') +
-      '\n',
+    formatReplyRouteLog({
+      surface,
+      chatId,
+      threadId,
+      explicitThreadId,
+      originTurn,
+      originVia,
+      liveTurn,
+      recovered,
+      frameworkTopicAuthority: REPLY_TOPIC_AUTHORITY_ENABLED,
+      hasDifferentThreadedRecentTurn: (liveThreadId) =>
+        hasDifferentThreadedRecentTurn(chatId, liveThreadId),
+    }),
   )
   return threadId
 }

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -90,6 +90,10 @@ import {
 // `reply-route` telemetry use, so the kill-switch branch below cannot drift
 // from them.
 import { isCrossChatAnchor } from './answer-thread-resolve.js'
+// The ONE `reply-route` line builder — shared with `resolveAnswerThreadWithLog`
+// in gateway.ts so the flag-on and kill-switch branches can never emit two
+// different spellings of the same drop.
+import { formatReplyRouteLog } from './reply-route-log.js'
 import { queueFloodBlockedReply } from './flood-reply-queue.js'
 import { resolveChatIdFallback } from './chat-id-fallback.js'
 import { getBuzzMirror } from './buzz-mirror.js'
@@ -1609,14 +1613,46 @@ export async function sendReply(
     // API error, not a routing policy a kill switch should be able to
     // reinstate. Uses the SAME exported predicate as the routing, the recovery
     // tier and the telemetry, so no second copy of the rule can drift.
-    const anchorThreadId = isCrossChatAnchor(chat_id, turn?.sessionChatId)
-      ? undefined
-      : turn?.sessionThreadId
+    const anchorCrossChat = isCrossChatAnchor(chat_id, turn?.sessionChatId)
+    const anchorThreadId = anchorCrossChat ? undefined : turn?.sessionThreadId
     threadId = resolveThreadId(
       chat_id,
       (args.message_thread_id as string | undefined) ??
         (anchorThreadId != null ? anchorThreadId : undefined),
     )
+    if (anchorCrossChat) {
+      // Telemetry parity with the flag-ON branch, which emits this marker via
+      // `resolveAnswerThreadWithLog`. Without it a `TURN_ORIGIN_ROUTING=0`
+      // deployment still performs the drop but records nothing — losing the
+      // audit trail the rest of the cross-chat fix is built on, on exactly the
+      // branch most likely to be running when something is already suspected
+      // wrong. Reuses the ONE authoritative formatter (`reply-route-log.ts`)
+      // rather than a second, driftable spelling of the same line.
+      const explicitRaw =
+        args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+      process.stderr.write(
+        formatReplyRouteLog({
+          surface: 'reply',
+          chatId: chat_id,
+          threadId,
+          explicitThreadId: Number.isFinite(explicitRaw as number)
+            ? (explicitRaw as number)
+            : undefined,
+          // The legacy branch resolves no origin turn at all — the pinned live
+          // turn IS the anchor that was dropped.
+          originTurn: null,
+          originVia: null,
+          liveTurn: turn,
+          recovered: null,
+          frameworkTopicAuthority: false,
+          // MISROUTE_RISK requires `via === 'live'`, and the formatter nulls a
+          // cross-chat live anchor before computing `via` — so on this arm
+          // (reached only when the anchor IS cross-chat) the predicate is
+          // unreachable and the constant cannot change the emitted line.
+          hasDifferentThreadedRecentTurn: () => false,
+        }),
+      )
+    }
   }
 
   // #4301: track whether `reply_to` came from the quote-opt-in DEFAULT (the

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -85,6 +85,11 @@ import {
   formatInternalSuppression,
   AUDIENCE_INTERNAL,
 } from '../hooks/audience-classify.mjs'
+// Bug (c) cross-chat anchor guard. Pure module, no cycle — the SAME predicate
+// the routing (`resolveAnswerThreadId`), the gateway's recovery tier and the
+// `reply-route` telemetry use, so the kill-switch branch below cannot drift
+// from them.
+import { isCrossChatAnchor } from './answer-thread-resolve.js'
 import { queueFloodBlockedReply } from './flood-reply-queue.js'
 import { resolveChatIdFallback } from './chat-id-fallback.js'
 import { getBuzzMirror } from './buzz-mirror.js'
@@ -1594,10 +1599,23 @@ export async function sendReply(
       'reply',
     )
   } else {
+    // Cross-chat anchor guard (bug c, `answer-thread-resolve.ts`). This legacy
+    // branch does NOT go through `resolveAnswerThreadWithLog`, so the drop that
+    // `resolveAnswerThreadId` performs above never runs here — without this the
+    // pinned turn's thread is passed through even when the turn belongs to a
+    // DIFFERENT chat, handing chat B's topic id to a send into chat A and
+    // earning a `400 Bad Request: message thread not found`. The kill switch
+    // restores the legacy PRECEDENCE, not the wrong-chat topic id: that is an
+    // API error, not a routing policy a kill switch should be able to
+    // reinstate. Uses the SAME exported predicate as the routing, the recovery
+    // tier and the telemetry, so no second copy of the rule can drift.
+    const anchorThreadId = isCrossChatAnchor(chat_id, turn?.sessionChatId)
+      ? undefined
+      : turn?.sessionThreadId
     threadId = resolveThreadId(
       chat_id,
       (args.message_thread_id as string | undefined) ??
-        (turn?.sessionThreadId != null ? turn.sessionThreadId : undefined),
+        (anchorThreadId != null ? anchorThreadId : undefined),
     )
   }
 

--- a/telegram-plugin/gateway/reply-route-log.test.ts
+++ b/telegram-plugin/gateway/reply-route-log.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { formatReplyRouteLog, type ReplyRouteLogInput } from './reply-route-log.js'
+
+const CHAT_A = '12345678' // DM — the reply target
+const CHAT_B = '-1003831053471' // forum supergroup — where the anchor lives
+
+function line(over: Partial<ReplyRouteLogInput> = {}): string {
+  return formatReplyRouteLog({
+    surface: 'reply',
+    chatId: CHAT_A,
+    threadId: undefined,
+    explicitThreadId: undefined,
+    originTurn: null,
+    originVia: null,
+    liveTurn: null,
+    recovered: null,
+    frameworkTopicAuthority: true,
+    hasDifferentThreadedRecentTurn: () => false,
+    ...over,
+  })
+}
+
+describe('formatReplyRouteLog', () => {
+  it('CROSS_CHAT_ANCHOR_DROPPED names BOTH chat ids and the topic that was dropped', () => {
+    const out = line({
+      liveTurn: { turnId: `${CHAT_B}:635#5388`, sessionChatId: CHAT_B, sessionThreadId: 635 },
+    })
+    expect(out).toContain('CROSS_CHAT_ANCHOR_DROPPED(')
+    expect(out).toContain(`target=${CHAT_A}`)
+    expect(out).toContain(`live_chat=${CHAT_B},live_thread=635`)
+    expect(out).toContain('routed→-')
+  })
+
+  it('a dropped cross-chat anchor is NOT counted as the routing tier (via=none, not via=live)', () => {
+    const out = line({
+      chatId: CHAT_B,
+      liveTurn: { turnId: 'x', sessionChatId: '999', sessionThreadId: 7 },
+    })
+    expect(out).toContain('via=none')
+    expect(out).toContain('late=true')
+  })
+
+  it('a dropped cross-chat anchor does NOT raise the UNROUTED alarm (it is a cross-chat send, not a lost reply)', () => {
+    const out = line({
+      chatId: CHAT_B, // supergroup target, resolved to no topic
+      liveTurn: { turnId: 'x', sessionChatId: CHAT_A, sessionThreadId: undefined },
+    })
+    expect(out).not.toContain('UNROUTED')
+    expect(out).toContain('CROSS_CHAT_ANCHOR_DROPPED(')
+  })
+
+  it('a SAME-chat live anchor is untouched: via=live, no cross-chat marker', () => {
+    const out = line({
+      chatId: CHAT_B,
+      threadId: 4,
+      liveTurn: { turnId: `${CHAT_B}:4#1`, sessionChatId: CHAT_B, sessionThreadId: 4 },
+    })
+    expect(out).toContain('via=live')
+    expect(out).toContain('resolved_thread=4')
+    expect(out).not.toContain('CROSS_CHAT_ANCHOR_DROPPED')
+  })
+
+  it('an origin anchor from another chat is dropped and reported with its own chat id', () => {
+    const out = line({
+      originTurn: { turnId: `${CHAT_B}:2#9`, sessionChatId: CHAT_B, sessionThreadId: 2 },
+      originVia: 'echo',
+      explicitThreadId: 11,
+      threadId: 11, // explicit is the only remaining signal
+    })
+    expect(out).toContain(`origin_chat=${CHAT_B},origin_thread=2`)
+    expect(out).toContain('via=explicit')
+    expect(out).not.toContain('EXPLICIT_OVERRIDDEN')
+  })
+
+  it('UNROUTED still fires for a genuine no-owner supergroup reply (guard did not weaken it)', () => {
+    expect(line({ chatId: CHAT_B })).toContain('UNROUTED(supergroup→no-topic)')
+  })
+
+  it('EXPLICIT_OVERRIDDEN still fires when a SAME-chat anchor beats the model explicit', () => {
+    const out = line({
+      chatId: CHAT_B,
+      explicitThreadId: 99,
+      threadId: 4,
+      originTurn: { turnId: `${CHAT_B}:4#1`, sessionChatId: CHAT_B, sessionThreadId: 4 },
+      originVia: 'echo',
+    })
+    expect(out).toContain('EXPLICIT_OVERRIDDEN(model→99,routed→4)')
+    expect(out).toContain('via=origin')
+  })
+
+  it('MISROUTE_RISK reads the FILTERED live anchor — a cross-chat live turn cannot raise it', () => {
+    const out = line({
+      chatId: CHAT_B,
+      liveTurn: { turnId: 'x', sessionChatId: CHAT_A, sessionThreadId: 3 },
+      hasDifferentThreadedRecentTurn: () => true,
+    })
+    expect(out).not.toContain('MISROUTE_RISK')
+  })
+})

--- a/telegram-plugin/gateway/reply-route-log.ts
+++ b/telegram-plugin/gateway/reply-route-log.ts
@@ -1,0 +1,118 @@
+/**
+ * `reply-route` telemetry line — the pure formatter behind the gateway's
+ * `resolveAnswerThreadWithLog`.
+ *
+ * The 2026-06-05 triage showed reply routing was the blind spot: `reply:
+ * invoked` logged only chat + char count, so a late reply landing in the wrong
+ * topic was invisible without hand-correlating raw tg-post threads against
+ * turn-lifecycle timestamps. This module builds, per reply: which precedence
+ * tier won (`via`), the resolved thread, the owner turn + its thread, whether
+ * the reply was late (turn already ended), and the alarm markers.
+ *
+ * Extracted out of `gateway.ts` (#2996 anti-inflation ratchet) so the string
+ * building — which is pure — is unit-testable and the gateway keeps only the
+ * stateful wiring.
+ *
+ * Markers:
+ *   - `RECOVERED`                 — a late reply this fix saved from General.
+ *   - `QUOTED(framework-origin)`  — origin recovered from the framework-owned
+ *     quoted message_id (no model echo).
+ *   - `UNROUTED`                  — a supergroup reply that resolved to NO topic
+ *     with NO owner turn to attribute it to (genuinely lost). A General-topic
+ *     turn legitimately has no thread, so a reply owned by it resolving to `-`
+ *     is CORRECT, not lost — hence the `ownerTurn == null` gate (found by the
+ *     multi-topic UAT stress, 2026-06-05).
+ *   - `MISROUTE_RISK`             — the irreducible determinism residual (HOLE
+ *     a): a no-echo, no-quote reply that fell to the LIVE turn while a DIFFERENT
+ *     topic recently had a turn. Observability only; routing is unchanged.
+ *   - `CROSS_CHAT_ANCHOR_DROPPED` — an anchor turn belonging to another chat was
+ *     ignored (see `answer-thread-resolve.ts` bug c). Carries BOTH chat ids so
+ *     cross-chat replies stay auditable.
+ *   - `EXPLICIT_OVERRIDDEN`       — the model passed an explicit topic and a
+ *     framework anchor overrode it (the General→CRM correction).
+ */
+
+import { isCrossChatAnchor } from './answer-thread-resolve.js'
+
+/** The structural slice of a turn this formatter reads (`CurrentTurn`). */
+export interface RouteLogTurn {
+  turnId?: string
+  sessionChatId: string
+  sessionThreadId: number | undefined
+}
+
+export interface ReplyRouteLogInput {
+  surface: 'reply' | 'stream_reply'
+  /** Chat the reply is being SENT to. */
+  chatId: string
+  /** What `resolveAnswerThreadId` actually resolved. */
+  threadId: number | undefined
+  explicitThreadId: number | undefined
+  /** RAW anchors as looked up — the cross-chat filter is applied here, with the
+   *  same predicate the resolver used, so `via` can never disagree with it. */
+  originTurn: RouteLogTurn | null
+  originVia: 'echo' | 'quoted' | null
+  liveTurn: RouteLogTurn | null
+  recovered: RouteLogTurn | null
+  frameworkTopicAuthority: boolean
+  /** Lazy: only consulted for the MISROUTE_RISK arm, which is the sole caller
+   *  that needs the bounded recent-turn scan. */
+  hasDifferentThreadedRecentTurn: (liveThreadId: number | undefined) => boolean
+}
+
+export function formatReplyRouteLog(i: ReplyRouteLogInput): string {
+  const originCrossChat = isCrossChatAnchor(i.chatId, i.originTurn?.sessionChatId)
+  const liveCrossChat = isCrossChatAnchor(i.chatId, i.liveTurn?.sessionChatId)
+  const crossChatDropped = originCrossChat || liveCrossChat
+  const originAnchor = originCrossChat ? null : i.originTurn
+  const liveAnchor = liveCrossChat ? null : i.liveTurn
+  const explicit = i.explicitThreadId
+  // `via` reflects the ACTIVE precedence so telemetry matches routing.
+  const via = i.frameworkTopicAuthority
+    ? (originAnchor != null ? (i.originVia === 'quoted' ? 'quoted' : 'origin')
+      : liveAnchor != null ? 'live'
+      : explicit != null ? 'explicit'
+      : i.recovered != null ? 'recovered'
+      : 'none')
+    : (explicit != null ? 'explicit'
+      : originAnchor != null ? (i.originVia === 'quoted' ? 'quoted' : 'origin')
+      : liveAnchor?.sessionThreadId != null ? 'live'
+      : i.recovered != null ? 'recovered'
+      : 'none')
+  const explicitOverridden =
+    i.frameworkTopicAuthority &&
+    explicit != null &&
+    (originAnchor != null || liveAnchor != null) &&
+    i.threadId !== explicit
+  const ownerTurn = originAnchor ?? i.recovered ?? liveAnchor
+  const isSupergroup = i.chatId.startsWith('-100')
+  // A dropped cross-chat anchor is NOT a lost reply — the send is a cross-chat
+  // one and the main chat is where it belongs — so it does not raise UNROUTED;
+  // CROSS_CHAT_ANCHOR_DROPPED already explains the line.
+  const unrouted = isSupergroup && i.threadId == null && ownerTurn == null && !crossChatDropped
+  const misrouteRisk =
+    isSupergroup && via === 'live' && i.hasDifferentThreadedRecentTurn(liveAnchor?.sessionThreadId)
+  return (
+    `telegram gateway: reply-route surface=${i.surface} chat=${i.chatId} ` +
+    `resolved_thread=${i.threadId ?? '-'} via=${via} late=${liveAnchor == null} ` +
+    `originTurn=${ownerTurn?.turnId ?? '-'} origin_thread=${ownerTurn?.sessionThreadId ?? '-'}` +
+    (via === 'recovered' ? ' RECOVERED' : '') +
+    (via === 'quoted' ? ' QUOTED(framework-origin)' : '') +
+    (unrouted ? ' UNROUTED(supergroup→no-topic)' : '') +
+    (misrouteRisk ? ' MISROUTE_RISK(no-echo→live-successor)' : '') +
+    (crossChatDropped
+      ? ` CROSS_CHAT_ANCHOR_DROPPED(target=${i.chatId}` +
+        (originCrossChat
+          ? `,origin_chat=${i.originTurn?.sessionChatId},origin_thread=${i.originTurn?.sessionThreadId ?? '-'}`
+          : '') +
+        (liveCrossChat
+          ? `,live_chat=${i.liveTurn?.sessionChatId},live_thread=${i.liveTurn?.sessionThreadId ?? '-'}`
+          : '') +
+        `,routed→${i.threadId ?? '-'})`
+      : '') +
+    (explicitOverridden
+      ? ` EXPLICIT_OVERRIDDEN(model→${explicit},routed→${i.threadId ?? '-'})`
+      : '') +
+    '\n'
+  )
+}

--- a/telegram-plugin/tests/multitopic-routing-wiring.test.ts
+++ b/telegram-plugin/tests/multitopic-routing-wiring.test.ts
@@ -157,6 +157,16 @@ describe('framework-owned origin recovery (determinism residual, 2026-06-05)', (
     // resolver can refuse a foreign anchor (Telegram 400 "message thread not
     // found"). Behaviour is asserted in answer-thread-resolve.test.ts; this
     // pins the WIRING so a refactor cannot silently stop passing them.
+    //
+    // NOT A SAFETY NET — read before relying on it. Like its ~20 siblings in
+    // this file, this is a source-text CALL-SITE RATCHET: it greps gateway.ts
+    // for the argument spellings. Mutating `isCrossChatAnchor` to
+    // `return false` leaves every assertion here GREEN (verified), because the
+    // call site is still spelled the same way. The behavioural oracles are
+    // `answer-thread-resolve.test.ts` (the pure predicate + precedence),
+    // `reply-route-log.test.ts` (the telemetry), and the
+    // `SWITCHROOM_TURN_ORIGIN_ROUTING=0` block in `send-reply-golden.test.ts`
+    // (the legacy branch, at the wire). Those are what fail on a broken guard.
     const fn = gatewaySrc.split('function resolveAnswerThreadWithLog')[1]?.split('\nfunction ')[0] ?? ''
     expect(fn).toMatch(/targetChatId: chatId/)
     expect(fn).toMatch(/originChatId: originTurn\?\.sessionChatId/)

--- a/telegram-plugin/tests/multitopic-routing-wiring.test.ts
+++ b/telegram-plugin/tests/multitopic-routing-wiring.test.ts
@@ -26,7 +26,12 @@ const gatewaySrc =
   // P7 PR-10 (#2996): the InboundMessage envelope assembly (origin_turn_id,
   // topic_scope, meta lane) moved verbatim into gateway/inbound-router.ts
   // (buildInboundEnvelope) — include it in the scraped corpus.
-  readFileSync(resolve(__dirname, '..', 'gateway', 'inbound-router.ts'), 'utf-8')
+  readFileSync(resolve(__dirname, '..', 'gateway', 'inbound-router.ts'), 'utf-8') +
+  '\n' +
+  // The reply-route telemetry line (via/RECOVERED/UNROUTED/MISROUTE_RISK/
+  // CROSS_CHAT_ANCHOR_DROPPED) moved verbatim out of resolveAnswerThreadWithLog
+  // into the pure formatReplyRouteLog (#2996 line ratchet) — scrape it too.
+  readFileSync(resolve(__dirname, '..', 'gateway', 'reply-route-log.ts'), 'utf-8')
 // #2996 P4-A: the enqueue handler (turn ctor: `const turnId = deriveTurnId`,
 // `rememberRecentTurn(next)`, `promoteQueuedStatus`) moved VERBATIM into
 // stream-render.ts with handleSessionEvent. Enqueue-seam assertions span both.
@@ -145,6 +150,19 @@ describe('framework-owned origin recovery (determinism residual, 2026-06-05)', (
     // recent topic, and does NOT change the resolved thread.
     expect(gatewaySrc).toMatch(/const misrouteRisk =/)
     expect(gatewaySrc).toMatch(/via === 'quoted' \? ' QUOTED\(framework-origin\)' : ''/)
+  })
+
+  it('a thread anchor from ANOTHER chat is dropped before it can be sent (cross-chat guard)', () => {
+    // The routing input carries the target + anchor chat ids, so the pure
+    // resolver can refuse a foreign anchor (Telegram 400 "message thread not
+    // found"). Behaviour is asserted in answer-thread-resolve.test.ts; this
+    // pins the WIRING so a refactor cannot silently stop passing them.
+    const fn = gatewaySrc.split('function resolveAnswerThreadWithLog')[1]?.split('\nfunction ')[0] ?? ''
+    expect(fn).toMatch(/targetChatId: chatId/)
+    expect(fn).toMatch(/originChatId: originTurn\?\.sessionChatId/)
+    expect(fn).toMatch(/liveChatId: liveTurn\?\.sessionChatId/)
+    // And the dropped anchor is observable, with both chat ids on the line.
+    expect(gatewaySrc).toMatch(/CROSS_CHAT_ANCHOR_DROPPED\(target=/)
   })
 
   it('the kill switch defaults ON and is independent of TURN_ORIGIN_ROUTING', () => {

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -209,6 +209,10 @@ function makeHarness(opts?: {
   failNext?: Partial<Record<string, unknown[]>>
   voicePlan?: VoiceOutPlan | null
   synth?: (plan: { ttsText: string }) => Promise<Uint8Array | null>
+  /** `SWITCHROOM_TURN_ORIGIN_ROUTING !== '0'` — the gateway's turn-origin
+   *  routing kill switch. Default true (the shipped default); pass false to
+   *  drive the legacy `resolveThreadId` branch. */
+  turnOriginRouting?: boolean
 }): Harness {
   const { api, calls } = makeFakeBot(opts?.failNext)
   const dedup = opts?.dedup ?? new OutboundDedupCache()
@@ -237,7 +241,7 @@ function makeHarness(opts?: {
     getCurrentTurn,
     getLastActiveTurnChatId: () => undefined,
     HISTORY_ENABLED: false,
-    TURN_ORIGIN_ROUTING_ENABLED: true,
+    TURN_ORIGIN_ROUTING_ENABLED: opts?.turnOriginRouting ?? true,
     AUTOCLASSIFY_MIDTURN_SHADOW: false,
     MAX_ATTACHMENT_BYTES: 50 * 1024 * 1024,
     MAX_CHUNK_LIMIT: 4096,
@@ -2125,5 +2129,76 @@ describe('#4176 — a BACKGROUND SUB-AGENT reply can never silently edit over a 
     const sendSrc = readFileSync(new URL('../gateway/outbound-send-path.ts', import.meta.url), 'utf8')
     expect(sendSrc).toContain('subagentReplyAuthority.subagentCouldOwnReply()')
     expect(sendSrc).toContain('subagentCouldOwnReply,')
+  })
+})
+
+// ── cross-chat thread anchor, kill-switch branch (bug c) ──────────────────
+//
+// The default (`TURN_ORIGIN_ROUTING_ENABLED: true`) branch resolves the thread
+// through `resolveAnswerThreadWithLog`, which drops a wrong-chat anchor inside
+// `resolveAnswerThreadId`. The legacy branch (`SWITCHROOM_TURN_ORIGIN_ROUTING=0`)
+// does NOT go through that resolver at all — it passes the pinned turn's
+// `sessionThreadId` straight into `resolveThreadId`. When the pinned turn
+// belongs to a DIFFERENT chat (the routine multi-chat case: one sequential CLI,
+// a singleton live turn, replies fanning out to several chats) that hands chat
+// B's topic id to a send into chat A, and Telegram answers
+// `400 Bad Request: message thread not found` — the exact failure the guard
+// exists to prevent, still reachable behind the switch.
+//
+// These drive the REAL `sendReply` and assert on the `message_thread_id` the
+// send-path actually put on the wire, so they fail on the bug rather than on a
+// refactor of how the decision is spelled.
+describe('kill switch SWITCHROOM_TURN_ORIGIN_ROUTING=0 still drops a cross-chat anchor', () => {
+  const OTHER_CHAT = '2002'
+
+  /** A live turn pinned at executeReply entry, owned by `chatId`. */
+  function turnFor(chatId: string, threadId: number | undefined): CurrentTurn {
+    return {
+      turnId: `turn-${chatId}`,
+      sessionChatId: chatId,
+      sessionThreadId: threadId,
+      replyCalled: false,
+    } as unknown as CurrentTurn
+  }
+
+  const threadOnWire = (h: Harness): unknown =>
+    h.calls.filter((c) => c.method === 'sendRichMessage')[0]!.opts.message_thread_id
+
+  it('a reply into chat A pinned to a chat-B forum turn carries NO thread id', async () => {
+    const h = makeHarness({ turnOriginRouting: false })
+    const res = await sendReply(
+      h.deps,
+      req('The answer to the question asked in chat A.', {}, turnFor(OTHER_CHAT, 77)),
+    )
+    const sends = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(sends).toHaveLength(1)
+    expect(sends[0]!.chat_id).toBe(CHAT)
+    // Pre-fix this is 77 — chat B's topic id on a send into chat A.
+    expect(threadOnWire(h)).toBeUndefined()
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+  })
+
+  it('an explicit message_thread_id from the model does NOT rescue a cross-chat ' +
+    'anchor — but it is still honoured on its own', async () => {
+    // Explicit wins in the legacy branch, so it must survive untouched.
+    const h = makeHarness({ turnOriginRouting: false })
+    await sendReply(
+      h.deps,
+      req('Explicit thread.', { message_thread_id: '31' }, turnFor(OTHER_CHAT, 77)),
+    )
+    expect(threadOnWire(h)).toBe(31)
+  })
+
+  it('BACK-COMPAT: a SAME-chat forum turn still lends its topic id (the guard ' +
+    'must not over-fire and strip legitimate topic routing)', async () => {
+    const h = makeHarness({ turnOriginRouting: false })
+    await sendReply(h.deps, req('Same-chat topic reply.', {}, turnFor(CHAT, 77)))
+    expect(threadOnWire(h)).toBe(77)
+  })
+
+  it('BACK-COMPAT: no pinned turn at all → no thread id, unchanged', async () => {
+    const h = makeHarness({ turnOriginRouting: false })
+    await sendReply(h.deps, req('Orphaned proactive send.'))
+    expect(threadOnWire(h)).toBeUndefined()
   })
 })

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -31,7 +31,7 @@
  *   - structural: gateway constructs EXACTLY ONE OutboundDedupCache and the
  *     extracted module constructs NONE (the re-`new` hard-fail rule)
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { GrammyError } from 'grammy'
 import { readFileSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -213,6 +213,13 @@ function makeHarness(opts?: {
    *  routing kill switch. Default true (the shipped default); pass false to
    *  drive the legacy `resolveThreadId` branch. */
   turnOriginRouting?: boolean
+  /** Backing store for the `resolveThreadId` stub's last-seen fallback — the
+   *  real resolver (`gateway.ts`, `resolveThreadId`) is
+   *  `if (explicit != null) return Number(explicit); return chatThreadMap.get(chat_id)`,
+   *  so a case that cares about what a DROPPED anchor falls through TO must
+   *  populate this. Omitted → empty map → the fallback misses, which is the
+   *  behaviour every pre-existing case here assumes. */
+  chatThreadMap?: Map<string, number>
 }): Harness {
   const { api, calls } = makeFakeBot(opts?.failNext)
   const dedup = opts?.dedup ?? new OutboundDedupCache()
@@ -269,7 +276,12 @@ function makeHarness(opts?: {
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c, explicit) => explicit,
-    resolveThreadId: (_c, explicit) => (explicit != null ? Number(explicit) : undefined),
+    // Mirrors the real `resolveThreadId` (`gateway.ts`): explicit wins, else
+    // the chat's LAST-SEEN topic from `chatThreadMap`. The map is per-harness
+    // and chat-scoped, so a dropped cross-chat anchor falls through to the
+    // TARGET chat's own last-seen topic — never to the anchor chat's.
+    resolveThreadId: (c, explicit) =>
+      explicit != null ? Number(explicit) : (opts?.chatThreadMap?.get(c) ?? undefined),
     getLatestInboundMessageId: () => null,
     recordOutbound: () => effects.push('recordOutbound'),
     emissionAuthorityFor: () =>
@@ -2148,6 +2160,16 @@ describe('#4176 — a BACKGROUND SUB-AGENT reply can never silently edit over a 
 // These drive the REAL `sendReply` and assert on the `message_thread_id` the
 // send-path actually put on the wire, so they fail on the bug rather than on a
 // refactor of how the decision is spelled.
+//
+// What the drop resolves TO: dropping the anchor does NOT mean "no thread id".
+// The legacy branch still calls `resolveThreadId`, whose real body
+// (`gateway.ts`) is `explicit ?? chatThreadMap.get(chat_id)` — so a dropped
+// anchor falls through to the TARGET chat's own last-seen topic. That fallback
+// is chat-scoped, so it can only ever yield a topic id valid for chat A; the
+// class of failure the guard closes (chat B's topic on a send into chat A →
+// `400 message thread not found`) stays closed either way. Cases below cover
+// BOTH ends: an empty map (fallback misses → undefined) and a populated one
+// (fallback hits → chat A's topic).
 describe('kill switch SWITCHROOM_TURN_ORIGIN_ROUTING=0 still drops a cross-chat anchor', () => {
   const OTHER_CHAT = '2002'
 
@@ -2164,7 +2186,11 @@ describe('kill switch SWITCHROOM_TURN_ORIGIN_ROUTING=0 still drops a cross-chat 
   const threadOnWire = (h: Harness): unknown =>
     h.calls.filter((c) => c.method === 'sendRichMessage')[0]!.opts.message_thread_id
 
-  it('a reply into chat A pinned to a chat-B forum turn carries NO thread id', async () => {
+  it('a reply into chat A pinned to a chat-B forum turn does NOT carry chat B\'s ' +
+    'topic id — with no last-seen topic for chat A it resolves to no thread', async () => {
+    // Empty `chatThreadMap`: the post-drop `resolveThreadId` fallback misses,
+    // so the wire carries no thread. This is the fallback-misses END of the
+    // behaviour, not the whole of it — see the populated-map case below.
     const h = makeHarness({ turnOriginRouting: false })
     const res = await sendReply(
       h.deps,
@@ -2175,6 +2201,30 @@ describe('kill switch SWITCHROOM_TURN_ORIGIN_ROUTING=0 still drops a cross-chat 
     expect(sends[0]!.chat_id).toBe(CHAT)
     // Pre-fix this is 77 — chat B's topic id on a send into chat A.
     expect(threadOnWire(h)).toBeUndefined()
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+  })
+
+  it('the dropped anchor falls through to the TARGET chat\'s last-seen topic, ' +
+    'not to no-thread: chat A last saw topic 12 → the send lands in A/12', async () => {
+    // The production shape the empty-map case above cannot show: the agent is
+    // live in supergroup B (topic 77) and replies into forum chat A, whose
+    // `chatThreadMap` last saw topic 12. Dropping B's anchor hands the decision
+    // to `resolveThreadId`, which is chat-scoped — so the send lands in A's own
+    // topic 12. 77 on the wire here would be the `400 message thread not found`
+    // the guard exists to prevent.
+    const h = makeHarness({
+      turnOriginRouting: false,
+      chatThreadMap: new Map([[CHAT, 12], [OTHER_CHAT, 77]]),
+    })
+    const res = await sendReply(
+      h.deps,
+      req('Late answer into chat A.', {}, turnFor(OTHER_CHAT, 77)),
+    )
+    const sends = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(sends).toHaveLength(1)
+    expect(sends[0]!.chat_id).toBe(CHAT)
+    expect(threadOnWire(h)).toBe(12)
+    expect(threadOnWire(h)).not.toBe(77)
     expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
   })
 
@@ -2200,5 +2250,69 @@ describe('kill switch SWITCHROOM_TURN_ORIGIN_ROUTING=0 still drops a cross-chat 
     const h = makeHarness({ turnOriginRouting: false })
     await sendReply(h.deps, req('Orphaned proactive send.'))
     expect(threadOnWire(h)).toBeUndefined()
+  })
+
+  // ── telemetry parity with the flag-on path ──────────────────────────────
+  //
+  // The flag-ON branch emits `CROSS_CHAT_ANCHOR_DROPPED(...)` through
+  // `resolveAnswerThreadWithLog` → `formatReplyRouteLog`. Without the same line
+  // here, a deployment running `SWITCHROOM_TURN_ORIGIN_ROUTING=0` silently
+  // loses the audit trail the rest of this fix is built on: the drop still
+  // happens, but nothing records that it did. The line is built by the SAME
+  // `formatReplyRouteLog` — there is exactly one authoritative implementation.
+  describe('telemetry: the legacy-branch drop is not silent', () => {
+    const captureStderr = (): { lines: string[]; restore: () => void } => {
+      const lines: string[] = []
+      const spy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(((chunk: unknown) => {
+          lines.push(String(chunk))
+          return true
+        }) as unknown as typeof process.stderr.write)
+      return { lines, restore: () => spy.mockRestore() }
+    }
+
+    it('emits CROSS_CHAT_ANCHOR_DROPPED naming both chats and what it routed to', async () => {
+      const h = makeHarness({
+        turnOriginRouting: false,
+        chatThreadMap: new Map([[CHAT, 12]]),
+      })
+      const cap = captureStderr()
+      try {
+        await sendReply(h.deps, req('Late answer into chat A.', {}, turnFor(OTHER_CHAT, 77)))
+      } finally {
+        cap.restore()
+      }
+      const line = cap.lines.find((l) => l.includes('CROSS_CHAT_ANCHOR_DROPPED('))
+      expect(line).toBeDefined()
+      // Same marker shape the flag-on path emits: target chat, the anchor's
+      // chat + topic, and the thread the send actually routed to.
+      expect(line).toContain('reply-route surface=reply')
+      expect(line).toContain(`chat=${CHAT}`)
+      expect(line).toContain(`live_chat=${OTHER_CHAT}`)
+      expect(line).toContain('live_thread=77')
+      expect(line).toContain('routed→12')
+    })
+
+    // NEGATIVE CONTROL (green against the pre-fix code by construction — the
+    // pre-fix branch emits nothing at all). It earns its place under mutation:
+    // asserting on the whole `reply-route` line rather than just the marker is
+    // what makes it fail an UNCONDITIONAL emit, the plausible wrong shape here.
+    // (Asserting only "no CROSS_CHAT_ANCHOR_DROPPED" would NOT — the formatter
+    // omits the marker for a same-chat anchor anyway, so that weaker assertion
+    // passes for a conditional and an unconditional emit alike.) The legacy
+    // branch is a kill-switch path: it must stay byte-silent on the ordinary
+    // send it exists to serve, and only speak when it drops something.
+    it('stays silent on a SAME-chat anchor — no drop, and no reply-route line at all', async () => {
+      const h = makeHarness({ turnOriginRouting: false })
+      const cap = captureStderr()
+      try {
+        await sendReply(h.deps, req('Same-chat topic reply.', {}, turnFor(CHAT, 77)))
+      } finally {
+        cap.restore()
+      }
+      expect(cap.lines.some((l) => l.includes('CROSS_CHAT_ANCHOR_DROPPED'))).toBe(false)
+      expect(cap.lines.some((l) => l.includes('reply-route surface='))).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
## Summary

A reply targeting chat **A** could take its forum-topic id from a turn anchor owned by a **different** chat **B**. Telegram then rejected the send with `400 Bad Request: message thread not found`; `retryWithThreadFallback` resent with no thread and succeeded, so no message was lost — but **every occurrence was a guaranteed-failed first API call**.

Observed 3× in the fleet since 2026-08-08 (carrie ×1, marko ×2, latest 2026-08-13).

## Why it happened

Two anchor tiers are not chat-scoped:

- `findTurnByOriginId` (`telegram-plugin/gateway/gateway.ts:3848`) resolves the echoed `origin_turn_id` by turn id **alone** — unlike its sibling `findTurnByQuotedMessageId` (`:3824`), which already guards with `turn.sessionChatId !== chatId`.
- The **live** turn is simply whatever the session is currently running, which in a multi-chat agent is frequently another chat.

`resolveAnswerThreadId` (`telegram-plugin/gateway/answer-thread-resolve.ts`) then returned `originThreadId` / `liveThreadId` with no check that the anchor's chat equals the target chat, even though `CurrentTurn.sessionChatId` (`gateway.ts:3231`) was in hand at the caller. When B was a forum supergroup, B's topic id rode along on the send into A.

The 400 → `THREAD_NOT_FOUND` mapping is `telegram-plugin/retry-api-call.ts:702`; the threadless resend is `retryWithThreadFallback` (`:788-812`). **That fallback is deliberately left in place as defence in depth** — this PR removes the cause, not the net.

## The fix

`resolveAnswerThreadId` now accepts `targetChatId` alongside `originChatId` / `liveChatId` and drops any anchor whose chat differs, **before** the precedence runs — in *both* precedence modes, because a wrong-chat topic id is an API error, not a routing policy the `SWITCHROOM_REPLY_TOPIC_AUTHORITY=0` kill switch should be able to reinstate. Routing falls through exactly as if the anchor did not exist: model `explicitThreadId` → chat-scoped last-ended recovery → no thread. `lastEnded*` needs no guard (its lookup is already chat-scoped).

The drop is observable: `CROSS_CHAT_ANCHOR_DROPPED(target=…,origin_chat=…,origin_thread=…,live_chat=…,live_thread=…,routed→…)` on the existing `reply-route` line, so cross-chat replies stay auditable. Telemetry (`via`, `UNROUTED`, `MISROUTE_RISK`) is computed from the **same** exported `isCrossChatAnchor` predicate that routes, so the log can never disagree with what was sent. A dropped anchor suppresses `UNROUTED` — the send genuinely belongs in the target chat's main chat, so it is not a lost reply.

The `reply-route` line construction moved out of `gateway.ts` into a new pure module `telegram-plugin/gateway/reply-route-log.ts`: the #2996 line ratchet leaves no headroom for inline growth (main sits at ceiling+slack), and the formatter is pure, so extracting it made it unit-testable. `gateway.ts` **shrinks** 24855 → 24822 lines.

## Test plan

- `telegram-plugin/gateway/answer-thread-resolve.test.ts` — new `cross-chat anchor guard` block asserting the **resolved thread**, plus two new invariants folded into the existing total-enumeration proof:
  - `INV-CROSS-CHAT`: foreign-chat anchors route identically to no anchors at all, over all 54 reachable inputs × 2 modes.
  - `INV-SAME-CHAT`: annotating anchors with the target chat changes nothing, over the same 108 rows.
  - Verified to FAIL without the guard: stubbing the predicate to `false` reds 6 tests (e.g. `expected 635 to be undefined`).
- `telegram-plugin/gateway/reply-route-log.test.ts` (new, 8 tests) — the marker carries both chat ids; a dropped anchor is not counted as the routing tier (`via=none`, not `via=live`); `UNROUTED` / `EXPLICIT_OVERRIDDEN` / `MISROUTE_RISK` are unchanged for same-chat anchors.
- `telegram-plugin/tests/multitopic-routing-wiring.test.ts` — new source-level wiring guard that the gateway keeps passing the chat ids into the resolver; scrape corpus extended with the extracted module.
- Local: `npx vitest run telegram-plugin` → **585 files, 9654 passed, 3 skipped**. `npm run lint` → clean (incl. `check-gateway-line-ratchet`, `check-changelog-entry`, `check-agent-attribution-trailers`).

## Risk

Low and bounded. The guard is inert unless BOTH chat ids are present and differ, so every same-chat path is byte-identical (proved by `INV-SAME-CHAT` across the full enumeration). The behaviour change is confined to the case that currently 400s. One deliberate secondary change: with a cross-chat anchor dropped, the late-reply recovery tier can now fire where it previously could not — that lookup is chat-scoped, so it can only produce a topic valid in the target chat.

Out of scope (noted, not fixed here): `replyRoutedOriginTurn` in `outbound-send-path.ts` is still set from the unfiltered origin turn and feeds `resolveCloseTarget` — a separate concern from thread routing.