### PR TITLE
fix(obligation): stop escalating on top of an answer the user already got

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ now an anomaly worth investigating, not the norm.
   which `Number()` coerces to `0`) is treated as unset, so a stray space in an
   env file cannot silently turn a guard off.
 
+  The router's `answerRouteOverrides.note(...)` write is the whole premise of the
+  reroute fallback, and it is a side effect no pure module carries — so it is now
+  pinned by a test that drives the real gateway router against the real registry
+  (`answer-route-side-effect.test.ts`). Deleting that one call previously left
+  the entire suite green while silently restoring the nag.
+
   **Scope:** this fixes the ESCALATE branch only. It narrows the standing
   duplicate-reply family (switchroom/switchroom#2472) rather than closing it —
   the REPRESENT branch is untouched: `represent-guard.ts` is still thread-scoped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,19 @@ now an anomaly worth investigating, not the norm.
   in the same thread in those few seconds — the override carries no message id.
   Both guards stay bounded: a genuinely unanswered obligation still escalates one
   settle window later (the 2026-08-12 case, whose real answer was 41s away, is
-  unaffected), the settle window is clamped at 60s so a config typo cannot
-  suppress escalation for a day, and a fallback-scope close logs `via=reroute`
-  so its blast radius is measurable in production. New
-  `escalation-staleness.ts` carries the evidence and the derivation; kill switch
-  `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0`.
+  unaffected), and both windows are clamped so a config typo cannot silently
+  widen them. The freshness window is measured back from the settle gate's own
+  *first* "unanswered" read, not from whenever the re-check runs — the sweep's
+  earlier gates can skip ticks outright for minutes, and anchoring at the
+  re-check would let a starved sweep age a still-fresh record out of the window
+  and nag on top of the answer anyway. Both paths are logged so the fallback is
+  measurable in production without a rebuild: a fallback-scope close logs
+  `via=reroute`, and a record the freshness bound *rejects* logs
+  `reroute record rejected age=…ms window=…ms`. New `escalation-staleness.ts`
+  carries the evidence and the derivation. Each guard has its OWN kill switch —
+  `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0` disables the settle gate (and only
+  the settle gate), `SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS=0` disables the
+  reroute fallback (and only the fallback); set both for the pre-fix behaviour.
 
   **Scope:** this fixes the ESCALATE branch only. It narrows the standing
   duplicate-reply family (switchroom/switchroom#2472) rather than closing it —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,25 +35,35 @@ now an anomaly worth investigating, not the norm.
   07:52:34.400 → delivered 07:52:37.209). The check now keeps its thread scope
   and adds a fallback to *only* the thread the router RECORDED an answer
   addressed to this obligation's topic as having been routed to (new
-  `answer-route-overrides.ts`), reading history from **that record's own
-  instant** and only while the record is **fresh** (settle window + two sweep
+  `answer-route-overrides.ts`), reading history **only across that record's own
+  instant plus the match window** — bounded at *both* ends, so a delivery in the
+  routed topic can be paired with the record neither before it nor minutes after
+  it — and only while the record is itself **fresh** (settle window + two sweep
   ticks = 18.5s at the default); and a new settle gate requires the "unanswered"
   read to hold across an 8.5s window — derived as 3× the worst observed
   decision→delivery lag, rounded up to the next 500ms, and at least one 5s sweep
-  tick so a re-check actually runs — before the nudge goes out. Both narrowings
-  on the fallback are load-bearing, and each has a field counter-example: a
-  chat-wide "did anything long land in this chat" query has no relationship to
-  the obligation at all, and an override-gated query cut at `openedAt` is the
-  same defect wearing a gate — on 2026-08-13 obligation `…:4#5462` (thread 4,
-  opened 03:50:02.807, escalated 04:03:06.140) it pairs a stale
-  `EXPLICIT_OVERRIDDEN(model→4,routed→3)` from 03:53:11.225 with an unrelated
-  295-char delivery in thread 3 at 04:02:51.987 — a *different* question's
-  answer, 594.8s later — and closes a genuinely unanswered message in silence.
-  That is the defect `turn-flush-suppression.ts` was written to close, and it
-  escalates correctly pre-fix, so it would have been a regression. The freshness
-  window rejects it. Residual, stated plainly: inside the window the fallback
-  still cannot tell the rerouted answer from a second ≥200-char delivery landing
-  in the same thread in those few seconds — the override carries no message id.
+  tick so a re-check actually runs — before the nudge goes out. All three
+  narrowings on the fallback are load-bearing, and each has a field
+  counter-example: a chat-wide "did anything long land in this chat" query has no
+  relationship to the obligation at all; an override-gated query cut at
+  `openedAt` is the same defect wearing a gate — on 2026-08-13 obligation
+  `…:4#5462` (thread 4, opened 03:50:02.807, escalated 04:03:06.140) it pairs a
+  stale `EXPLICIT_OVERRIDDEN(model→4,routed→3)` from 03:53:11.225 with an
+  unrelated 295-char delivery in thread 3 at 04:02:51.987 — a *different*
+  question's answer, 594.8s later — and closes a genuinely unanswered message in
+  silence; and an override-gated query cut at the record's own instant but left
+  *open-ended forward* is that same defect reached from the other side, because
+  freshness is judged at the first "unanswered" read while the history row is
+  read at the re-check, and the sweep can be starved for minutes in between (a
+  short reply rerouted to topic M at T+0 leaves the obligation correctly open,
+  an unrelated ≥200-char answer lands in M at T+90, and the sweep that finally
+  runs at T+107 closes the obligation `via=reroute`). That is the defect
+  `turn-flush-suppression.ts` was written to close, and the 2026-08-13 case
+  escalates correctly pre-fix, so either would have been a regression. Residual,
+  stated plainly: inside `[record, record + window]` the fallback still cannot
+  tell the rerouted answer from a second ≥200-char delivery landing in the same
+  thread in those few seconds — the override carries no message id. That interval
+  is fixed by the record's own timestamp, so a starved sweep cannot widen it.
   Both guards stay bounded: a genuinely unanswered obligation still escalates one
   settle window later (the 2026-08-12 case, whose real answer was 41s away, is
   unaffected), and both windows are clamped so a config typo cannot silently
@@ -61,7 +71,10 @@ now an anomaly worth investigating, not the norm.
   *first* "unanswered" read, not from whenever the re-check runs — the sweep's
   earlier gates can skip ticks outright for minutes, and anchoring at the
   re-check would let a starved sweep age a still-fresh record out of the window
-  and nag on top of the answer anyway. Both paths are logged so the fallback is
+  and nag on top of the answer anyway — which is precisely why the *delivery*
+  needs its own forward bound: that anchor keeps the record readable across the
+  starvation gap, and without an upper bound the query would then reach across
+  the whole of it. Both paths are logged so the fallback is
   measurable in production without a rebuild: a fallback-scope close logs
   `via=reroute`, and a record the freshness bound *rejects* logs
   `reroute record rejected age=…ms window=…ms`. New `escalation-staleness.ts`
@@ -69,6 +82,9 @@ now an anomaly worth investigating, not the norm.
   `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0` disables the settle gate (and only
   the settle gate), `SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS=0` disables the
   reroute fallback (and only the fallback); set both for the pre-fix behaviour.
+  Both switches read only an explicit `0`: a whitespace-only value (`KEY=" "`,
+  which `Number()` coerces to `0`) is treated as unset, so a stray space in an
+  env file cannot silently turn a guard off.
 
   **Scope:** this fixes the ESCALATE branch only. It narrows the standing
   duplicate-reply family (switchroom/switchroom#2472) rather than closing it —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,53 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **an obligation ESCALATION no longer nags on top of an answer the user
+  already received.** The escalate branch of the obligation sweep sends a
+  user-visible "⚠️ I may have missed an earlier message" nudge, gated on a
+  staleness check that is supposed to stand it down when the agent has already
+  answered. Two mechanisms let that check miss a delivered answer, and both fired
+  together on the two confirmed 2026-08-10 incidents. First it was keyed on the
+  obligation's *thread*, while the model can name a topic on its `reply` and have
+  the framework's topic authority override it — the router logs exactly that,
+  `EXPLICIT_OVERRIDDEN(model→N,routed→M)` — so the answer is written to history
+  under a thread the check never queries (06:36:07.921
+  `EXPLICIT_OVERRIDDEN(model→4,routed→635)` for an obligation in thread 4, nag
+  126ms later; 07:52 the same shape with the answer routed to the chat root).
+  Second it is a point-in-time read, and the answer is often still *in flight* at
+  the instant the sweep decides — the reply tool has been invoked but no history
+  row exists yet (decision 06:36:08.047 → delivered 06:36:09.281; decision
+  07:52:34.400 → delivered 07:52:37.209). The check now keeps its thread scope
+  and adds a fallback to *only* the threads the router RECORDED an answer
+  addressed to this obligation's topic as having been routed to (new
+  `answer-route-overrides.ts`), and a new settle gate requires the "unanswered"
+  read to hold across an 8.5s window — derived as 3× the worst observed
+  decision→delivery lag, rounded up to the next 500ms, and at least one 5s sweep
+  tick so a re-check actually runs — before the nudge goes out. The fallback is
+  deliberately NOT chat-wide: a "did anything long land in this chat" query has
+  no relationship to the obligation, and in a busy forum it would silently close
+  an unanswered obligation in topic A because an unrelated answer landed in topic
+  B — the exact defect `turn-flush-suppression.ts` was written to close, and the
+  exact shape of the 2026-08-13 incident where an answer to a *different*
+  question in another topic would have swallowed a genuinely unanswered message.
+  Both guards stay bounded: a genuinely unanswered obligation still escalates one
+  settle window later (the 2026-08-12 case, whose real answer was 41s away, is
+  unaffected), the settle window is clamped at 60s so a config typo cannot
+  suppress escalation for a day, and a fallback-scope close logs `via=reroute`
+  so its blast radius is measurable in production. New
+  `escalation-staleness.ts` carries the evidence and the derivation; kill switch
+  `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0`.
+
+  **Scope:** this fixes the ESCALATE branch only. It narrows the standing
+  duplicate-reply family (switchroom/switchroom#2472) rather than closing it —
+  the REPRESENT branch is untouched: `represent-guard.ts` is still thread-scoped
+  at both its cutoffs, the #4341 delivery-time backstop in
+  `represent-delivery-guard.ts` forwards that same `threadId` and is therefore
+  cross-topic-blind too, and the represent branch has no settle gate at all, so a
+  re-present can still fire on top of a rerouted or in-flight answer. Tracked in
+  switchroom/switchroom#4700.
+
 ## v0.21.10 — the Telegram render pipeline stops deleting prose and corrupting fenced code, and TTS stops failing on long messages
 
 ### Bug fixes
@@ -290,51 +337,6 @@ now an anomaly worth investigating, not the norm.
   incident it did catch.
 
 ### Bug fixes
-
-- **an obligation ESCALATION no longer nags on top of an answer the user
-  already received.** The escalate branch of the obligation sweep sends a
-  user-visible "⚠️ I may have missed an earlier message" nudge, gated on a
-  staleness check that is supposed to stand it down when the agent has already
-  answered. Two mechanisms let that check miss a delivered answer, and both fired
-  together on the two confirmed 2026-08-10 incidents. First it was keyed on the
-  obligation's *thread*, while the model can name a topic on its `reply` and have
-  the framework's topic authority override it — the router logs exactly that,
-  `EXPLICIT_OVERRIDDEN(model→N,routed→M)` — so the answer is written to history
-  under a thread the check never queries (06:36:07.921
-  `EXPLICIT_OVERRIDDEN(model→4,routed→635)` for an obligation in thread 4, nag
-  126ms later; 07:52 the same shape with the answer routed to the chat root).
-  Second it is a point-in-time read, and the answer is often still *in flight* at
-  the instant the sweep decides — the reply tool has been invoked but no history
-  row exists yet (decision 06:36:08.047 → delivered 06:36:09.281; decision
-  07:52:34.400 → delivered 07:52:37.209). The check now keeps its thread scope
-  and adds a fallback to *only* the threads the router RECORDED an answer
-  addressed to this obligation's topic as having been routed to (new
-  `answer-route-overrides.ts`), and a new settle gate requires the "unanswered"
-  read to hold across an 8.5s window — derived as 3× the worst observed
-  decision→delivery lag, rounded up to the next 500ms, and at least one 5s sweep
-  tick so a re-check actually runs — before the nudge goes out. The fallback is
-  deliberately NOT chat-wide: a "did anything long land in this chat" query has
-  no relationship to the obligation, and in a busy forum it would silently close
-  an unanswered obligation in topic A because an unrelated answer landed in topic
-  B — the exact defect `turn-flush-suppression.ts` was written to close, and the
-  exact shape of the 2026-08-13 incident where an answer to a *different*
-  question in another topic would have swallowed a genuinely unanswered message.
-  Both guards stay bounded: a genuinely unanswered obligation still escalates one
-  settle window later (the 2026-08-12 case, whose real answer was 41s away, is
-  unaffected), the settle window is clamped at 60s so a config typo cannot
-  suppress escalation for a day, and a fallback-scope close logs `via=reroute`
-  so its blast radius is measurable in production. New
-  `escalation-staleness.ts` carries the evidence and the derivation; kill switch
-  `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0`.
-
-  **Scope:** this fixes the ESCALATE branch only. It narrows the standing
-  duplicate-reply family (switchroom/switchroom#2472) rather than closing it —
-  the REPRESENT branch is untouched: `represent-guard.ts` is still thread-scoped
-  at both its cutoffs, the #4341 delivery-time backstop in
-  `represent-delivery-guard.ts` forwards that same `threadId` and is therefore
-  cross-topic-blind too, and the represent branch has no settle gate at all, so a
-  re-present can still fire on top of a rerouted or in-flight answer. Tracked in
-  switchroom/switchroom#4700.
 
 - **the three Claude CLI version pins are now held in lockstep by an
   executable check, not by prose.** The bundled CLI version is written down in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,18 +33,27 @@ now an anomaly worth investigating, not the norm.
   the instant the sweep decides — the reply tool has been invoked but no history
   row exists yet (decision 06:36:08.047 → delivered 06:36:09.281; decision
   07:52:34.400 → delivered 07:52:37.209). The check now keeps its thread scope
-  and adds a fallback to *only* the threads the router RECORDED an answer
+  and adds a fallback to *only* the thread the router RECORDED an answer
   addressed to this obligation's topic as having been routed to (new
-  `answer-route-overrides.ts`), and a new settle gate requires the "unanswered"
+  `answer-route-overrides.ts`), reading history from **that record's own
+  instant** and only while the record is **fresh** (settle window + two sweep
+  ticks = 18.5s at the default); and a new settle gate requires the "unanswered"
   read to hold across an 8.5s window — derived as 3× the worst observed
   decision→delivery lag, rounded up to the next 500ms, and at least one 5s sweep
-  tick so a re-check actually runs — before the nudge goes out. The fallback is
-  deliberately NOT chat-wide: a "did anything long land in this chat" query has
-  no relationship to the obligation, and in a busy forum it would silently close
-  an unanswered obligation in topic A because an unrelated answer landed in topic
-  B — the exact defect `turn-flush-suppression.ts` was written to close, and the
-  exact shape of the 2026-08-13 incident where an answer to a *different*
-  question in another topic would have swallowed a genuinely unanswered message.
+  tick so a re-check actually runs — before the nudge goes out. Both narrowings
+  on the fallback are load-bearing, and each has a field counter-example: a
+  chat-wide "did anything long land in this chat" query has no relationship to
+  the obligation at all, and an override-gated query cut at `openedAt` is the
+  same defect wearing a gate — on 2026-08-13 obligation `…:4#5462` (thread 4,
+  opened 03:50:02.807, escalated 04:03:06.140) it pairs a stale
+  `EXPLICIT_OVERRIDDEN(model→4,routed→3)` from 03:53:11.225 with an unrelated
+  295-char delivery in thread 3 at 04:02:51.987 — a *different* question's
+  answer, 594.8s later — and closes a genuinely unanswered message in silence.
+  That is the defect `turn-flush-suppression.ts` was written to close, and it
+  escalates correctly pre-fix, so it would have been a regression. The freshness
+  window rejects it. Residual, stated plainly: inside the window the fallback
+  still cannot tell the rerouted answer from a second ≥200-char delivery landing
+  in the same thread in those few seconds — the override carries no message id.
   Both guards stay bounded: a genuinely unanswered obligation still escalates one
   settle window later (the 2026-08-12 case, whose real answer was 41s away, is
   unaffected), the settle window is clamped at 60s so a config typo cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,30 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **an obligation escalation no longer nags on top of an answer the user
+  already received.** The escalate branch of the obligation sweep sends a
+  user-visible "⚠️ I may have missed an earlier message" nudge, gated on a
+  staleness check that is supposed to stand it down when the agent has already
+  answered. Two mechanisms let that check miss a delivered answer. First it was
+  keyed on the obligation's *thread*, while the reply router routinely resolves
+  an answer to a different topic and logs the override
+  (`EXPLICIT_OVERRIDDEN(model→N,routed→M)`) — so a cross-topic answer was
+  invisible to it (marko 2026-08-13: obligation in thread 4, its 295-char answer
+  delivered to thread 3 at 04:02:51.987, nag fired anyway 14.2s later). Second
+  it is a point-in-time read, and the answer is often still *in flight* at the
+  instant the sweep decides — the reply tool has been invoked but no history row
+  exists yet (marko 2026-08-10: decision 06:36:08.047, answer delivered
+  06:36:09.281; and decision 07:52:34.400, answer delivered 07:52:37.209). The
+  check is now chat-scoped (thread first, chat as the cross-topic fallback), and
+  a new settle gate requires the "unanswered" read to hold across an 8.5s window
+  — derived as 3× the worst observed decision→delivery lag, rounded up to the
+  next 500ms, and at least one 5s sweep tick so a re-check actually runs — before
+  the nudge goes out. Both guards stay bounded: a genuinely unanswered obligation
+  still escalates one settle window later (the 2026-08-12 case, whose real answer
+  was 41s away, is unaffected). New `escalation-staleness.ts` carries the
+  evidence and the derivation; kill switch
+  `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0`.
+
 - **the three Claude CLI version pins are now held in lockstep by an
   executable check, not by prose.** The bundled CLI version is written down in
   `docker/Dockerfile.base` (`ARG CLAUDE_CODE_VERSION`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,29 +291,50 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
-- **an obligation escalation no longer nags on top of an answer the user
+- **an obligation ESCALATION no longer nags on top of an answer the user
   already received.** The escalate branch of the obligation sweep sends a
   user-visible "⚠️ I may have missed an earlier message" nudge, gated on a
   staleness check that is supposed to stand it down when the agent has already
-  answered. Two mechanisms let that check miss a delivered answer. First it was
-  keyed on the obligation's *thread*, while the reply router routinely resolves
-  an answer to a different topic and logs the override
-  (`EXPLICIT_OVERRIDDEN(model→N,routed→M)`) — so a cross-topic answer was
-  invisible to it (marko 2026-08-13: obligation in thread 4, its 295-char answer
-  delivered to thread 3 at 04:02:51.987, nag fired anyway 14.2s later). Second
-  it is a point-in-time read, and the answer is often still *in flight* at the
-  instant the sweep decides — the reply tool has been invoked but no history row
-  exists yet (marko 2026-08-10: decision 06:36:08.047, answer delivered
-  06:36:09.281; and decision 07:52:34.400, answer delivered 07:52:37.209). The
-  check is now chat-scoped (thread first, chat as the cross-topic fallback), and
-  a new settle gate requires the "unanswered" read to hold across an 8.5s window
-  — derived as 3× the worst observed decision→delivery lag, rounded up to the
-  next 500ms, and at least one 5s sweep tick so a re-check actually runs — before
-  the nudge goes out. Both guards stay bounded: a genuinely unanswered obligation
-  still escalates one settle window later (the 2026-08-12 case, whose real answer
-  was 41s away, is unaffected). New `escalation-staleness.ts` carries the
-  evidence and the derivation; kill switch
+  answered. Two mechanisms let that check miss a delivered answer, and both fired
+  together on the two confirmed 2026-08-10 incidents. First it was keyed on the
+  obligation's *thread*, while the model can name a topic on its `reply` and have
+  the framework's topic authority override it — the router logs exactly that,
+  `EXPLICIT_OVERRIDDEN(model→N,routed→M)` — so the answer is written to history
+  under a thread the check never queries (06:36:07.921
+  `EXPLICIT_OVERRIDDEN(model→4,routed→635)` for an obligation in thread 4, nag
+  126ms later; 07:52 the same shape with the answer routed to the chat root).
+  Second it is a point-in-time read, and the answer is often still *in flight* at
+  the instant the sweep decides — the reply tool has been invoked but no history
+  row exists yet (decision 06:36:08.047 → delivered 06:36:09.281; decision
+  07:52:34.400 → delivered 07:52:37.209). The check now keeps its thread scope
+  and adds a fallback to *only* the threads the router RECORDED an answer
+  addressed to this obligation's topic as having been routed to (new
+  `answer-route-overrides.ts`), and a new settle gate requires the "unanswered"
+  read to hold across an 8.5s window — derived as 3× the worst observed
+  decision→delivery lag, rounded up to the next 500ms, and at least one 5s sweep
+  tick so a re-check actually runs — before the nudge goes out. The fallback is
+  deliberately NOT chat-wide: a "did anything long land in this chat" query has
+  no relationship to the obligation, and in a busy forum it would silently close
+  an unanswered obligation in topic A because an unrelated answer landed in topic
+  B — the exact defect `turn-flush-suppression.ts` was written to close, and the
+  exact shape of the 2026-08-13 incident where an answer to a *different*
+  question in another topic would have swallowed a genuinely unanswered message.
+  Both guards stay bounded: a genuinely unanswered obligation still escalates one
+  settle window later (the 2026-08-12 case, whose real answer was 41s away, is
+  unaffected), the settle window is clamped at 60s so a config typo cannot
+  suppress escalation for a day, and a fallback-scope close logs `via=reroute`
+  so its blast radius is measurable in production. New
+  `escalation-staleness.ts` carries the evidence and the derivation; kill switch
   `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0`.
+
+  **Scope:** this fixes the ESCALATE branch only. It narrows the standing
+  duplicate-reply family (switchroom/switchroom#2472) rather than closing it —
+  the REPRESENT branch is untouched: `represent-guard.ts` is still thread-scoped
+  at both its cutoffs, the #4341 delivery-time backstop in
+  `represent-delivery-guard.ts` forwards that same `threadId` and is therefore
+  cross-topic-blind too, and the represent branch has no settle gate at all, so a
+  re-present can still fire on top of a rerouted or in-flight answer. Tracked in
+  switchroom/switchroom#4700.
 
 - **the three Claude CLI version pins are now held in lockstep by an
   executable check, not by prose.** The bundled CLI version is written down in

--- a/telegram-plugin/gateway/answer-route-overrides.ts
+++ b/telegram-plugin/gateway/answer-route-overrides.ts
@@ -1,0 +1,118 @@
+/**
+ * answer-route-overrides.ts — a bounded, in-memory record of the reply router's
+ * EXPLICIT-THREAD OVERRIDES, so a later consumer can ask "was an answer the model
+ * addressed to topic N actually delivered somewhere else?".
+ *
+ * WHY THIS EXISTS. `resolveAnswerThreadWithLog` already computes this fact and
+ * logs it (`EXPLICIT_OVERRIDDEN(model→4,routed→635)`): the model named a topic
+ * on its `reply`, and the framework's topic authority overrode that with the
+ * origin/live turn's topic. The answer therefore lands under a DIFFERENT
+ * `thread_id` than the one the model was answering — invisible to any
+ * thread-keyed history query for the topic the model meant.
+ *
+ * The obligation-escalation staleness check is exactly such a query, and the
+ * override is the ONLY per-turn evidence that ties an answer delivered in topic
+ * B to a question asked in topic A. Recording it turns "an answer landed
+ * somewhere in this chat" (an unfalsifiable chat-wide guess) into "an answer the
+ * model addressed to THIS topic landed in that topic" — a specific, checkable
+ * claim. See `escalation-staleness.ts` for the consumer and the field evidence.
+ *
+ * Bounded by construction: at most `maxKeys` (chat, intended-thread) keys and
+ * `maxPerKey` recent routings each, evicted oldest-first. Losing an entry can
+ * only ever cost one over-escalation (the safe direction — an extra advisory,
+ * never a swallowed message).
+ */
+
+/** One observed override: the model meant `intendedThreadId`, it went here. */
+export interface AnswerRouteOverride {
+  /** Where the answer actually went. `null` = chat root / no topic (history
+   *  stores `thread_id IS NULL` for these — `recordOutbound` does `?? null`). */
+  routedThreadId: number | null
+  /** Wall-clock ms at which the routing decision was made. */
+  atMs: number
+}
+
+export interface NoteOverrideArgs {
+  chatId: string
+  /** `REPLY_TOPIC_AUTHORITY_ENABLED` — no authority, no override. */
+  enabled: boolean
+  /** The topic the model named on its reply, if any. */
+  explicitThreadId: number | undefined
+  /** Whether a framework anchor (origin or live turn) was present to override with. */
+  anchored: boolean
+  /** The thread the router actually resolved. `undefined` = chat root. */
+  routedThreadId: number | undefined
+  nowMs: number
+}
+
+export interface AnswerRouteOverrides {
+  /**
+   * Record the routing decision iff it WAS an explicit-thread override, and
+   * return whether it was — so the caller can use the same boolean for its
+   * telemetry instead of computing the predicate twice.
+   */
+  note(args: NoteOverrideArgs): boolean
+  /**
+   * Threads that an answer addressed to `intendedThreadId` was actually routed
+   * to, at or after `sinceMs`. Empty when no override was observed — which is
+   * the common case and means "no reason to look outside this topic".
+   */
+  routedThreadsSince(
+    chatId: string,
+    intendedThreadId: number | null | undefined,
+    sinceMs: number,
+  ): (number | null)[]
+  /** Live key count. Test/diagnostic surface. */
+  size(): number
+}
+
+function keyFor(chatId: string, threadId: number | null | undefined): string {
+  return `${chatId}:${threadId ?? '_'}`
+}
+
+export function createAnswerRouteOverrides(maxKeys = 64, maxPerKey = 8): AnswerRouteOverrides {
+  // Insertion-ordered Map; eviction is oldest-INSERTED-first (FIFO), not
+  // least-recently-used — entries are not re-inserted on read.
+  const byKey = new Map<string, AnswerRouteOverride[]>()
+  return {
+    note(args: NoteOverrideArgs): boolean {
+      const overridden =
+        args.enabled &&
+        args.explicitThreadId != null &&
+        args.anchored &&
+        args.routedThreadId !== args.explicitThreadId
+      if (!overridden) return false
+      const key = keyFor(args.chatId, args.explicitThreadId)
+      const list = byKey.get(key) ?? []
+      list.push({ routedThreadId: args.routedThreadId ?? null, atMs: args.nowMs })
+      while (list.length > maxPerKey) list.shift()
+      byKey.set(key, list)
+      while (byKey.size > maxKeys) {
+        const oldest = byKey.keys().next().value
+        if (oldest === undefined) break
+        byKey.delete(oldest)
+      }
+      return true
+    },
+    routedThreadsSince(chatId, intendedThreadId, sinceMs): (number | null)[] {
+      const list = byKey.get(keyFor(chatId, intendedThreadId))
+      if (list == null) return []
+      const out: (number | null)[] = []
+      for (const e of list) {
+        if (e.atMs < sinceMs) continue
+        if (!out.includes(e.routedThreadId)) out.push(e.routedThreadId)
+      }
+      return out
+    },
+    size(): number {
+      return byKey.size
+    },
+  }
+}
+
+/**
+ * Process-wide registry. The gateway is a single process and the router is the
+ * only writer; obligation-wiring is the only reader. Injected as a value into
+ * the pure decision functions so tests never touch this instance.
+ */
+export const answerRouteOverrides = createAnswerRouteOverrides()

--- a/telegram-plugin/gateway/answer-route-overrides.ts
+++ b/telegram-plugin/gateway/answer-route-overrides.ts
@@ -70,8 +70,31 @@ export interface AnswerRouteOverrides {
     intendedThreadId: number | null | undefined,
     notBeforeMs: number,
   ): AnswerRouteOverride[]
+  /**
+   * The MOST RECENT override recorded for `intendedThreadId` at or after
+   * `notBeforeMs`, or `undefined` if there is none.
+   *
+   * Diagnostic-only, and deliberately separate from `routedOverridesSince`:
+   * that one returns the EARLIEST in-window record per routed thread because a
+   * consumer uses `atMs` as a history cutoff and wants the widest correct one.
+   * A consumer asking "did a record exist that my freshness bound rejected, and
+   * by how much?" wants the other end — the near-miss. Kept as its own method so
+   * answering that can never perturb the accept path's cutoff.
+   */
+  newestOverrideSince(
+    chatId: string,
+    intendedThreadId: number | null | undefined,
+    notBeforeMs: number,
+  ): AnswerRouteOverride | undefined
   /** Live key count. Test/diagnostic surface. */
   size(): number
+  /**
+   * Drop every recorded override. Test surface: the process-wide registry below
+   * is a module singleton, so without a reset one test's records leak into the
+   * next and a scenario silently depends on its neighbours' timestamps. Not
+   * called in production — the bounded eviction owns lifetime there.
+   */
+  clear(): void
 }
 
 function keyFor(chatId: string, threadId: number | null | undefined): string {
@@ -113,8 +136,21 @@ export function createAnswerRouteOverrides(maxKeys = 64, maxPerKey = 8): AnswerR
       }
       return out
     },
+    newestOverrideSince(chatId, intendedThreadId, notBeforeMs): AnswerRouteOverride | undefined {
+      const list = byKey.get(keyFor(chatId, intendedThreadId))
+      if (list == null) return undefined
+      let newest: AnswerRouteOverride | undefined
+      for (const e of list) {
+        if (e.atMs < notBeforeMs) continue
+        if (newest == null || e.atMs > newest.atMs) newest = e
+      }
+      return newest == null ? undefined : { ...newest }
+    },
     size(): number {
       return byKey.size
+    },
+    clear(): void {
+      byKey.clear()
     },
   }
 }

--- a/telegram-plugin/gateway/answer-route-overrides.ts
+++ b/telegram-plugin/gateway/answer-route-overrides.ts
@@ -53,15 +53,23 @@ export interface AnswerRouteOverrides {
    */
   note(args: NoteOverrideArgs): boolean
   /**
-   * Threads that an answer addressed to `intendedThreadId` was actually routed
-   * to, at or after `sinceMs`. Empty when no override was observed — which is
-   * the common case and means "no reason to look outside this topic".
+   * Overrides recorded for `intendedThreadId` at or after `notBeforeMs`, one per
+   * distinct routed thread (the EARLIEST in-window record for that thread wins,
+   * so a consumer using `atMs` as a cutoff gets the widest correct one). Empty
+   * when no override was observed — which is the common case and means "no
+   * reason to look outside this topic".
+   *
+   * The caller MUST use each entry's `atMs` as the lower bound of whatever it
+   * looks up next, and MUST pass a `notBeforeMs` that bounds how old an override
+   * may be. An override only licenses a query for the answer THAT routing
+   * produced; it is not a standing licence to accept anything ever delivered in
+   * that thread. See `escalation-staleness.ts` for the incident that proves it.
    */
-  routedThreadsSince(
+  routedOverridesSince(
     chatId: string,
     intendedThreadId: number | null | undefined,
-    sinceMs: number,
-  ): (number | null)[]
+    notBeforeMs: number,
+  ): AnswerRouteOverride[]
   /** Live key count. Test/diagnostic surface. */
   size(): number
 }
@@ -94,13 +102,14 @@ export function createAnswerRouteOverrides(maxKeys = 64, maxPerKey = 8): AnswerR
       }
       return true
     },
-    routedThreadsSince(chatId, intendedThreadId, sinceMs): (number | null)[] {
+    routedOverridesSince(chatId, intendedThreadId, notBeforeMs): AnswerRouteOverride[] {
       const list = byKey.get(keyFor(chatId, intendedThreadId))
       if (list == null) return []
-      const out: (number | null)[] = []
+      const out: AnswerRouteOverride[] = []
       for (const e of list) {
-        if (e.atMs < sinceMs) continue
-        if (!out.includes(e.routedThreadId)) out.push(e.routedThreadId)
+        if (e.atMs < notBeforeMs) continue
+        if (out.some((seen) => seen.routedThreadId === e.routedThreadId)) continue
+        out.push({ ...e })
       }
       return out
     },

--- a/telegram-plugin/gateway/escalation-staleness.ts
+++ b/telegram-plugin/gateway/escalation-staleness.ts
@@ -30,21 +30,38 @@
  *      routed to, read from the router's own override record
  *      (`answer-route-overrides.ts`).
  *
- *      NOT a chat-wide fallback. A chat-wide "did anything long land since
- *      openedAt" query has no relationship to the obligation beyond the chat id,
- *      and in a busy forum it silently closes an obligation in topic A because
- *      an unrelated answer landed in topic B — dropping the user's message with
- *      no nudge and no re-present. The repo already states that principle for
- *      the sibling predicate (`turn-flush-suppression.ts`, "a background
- *      worker's progress_update … or a reply in a DIFFERENT forum topic all
- *      suppressed the flush, and the branch then CLOSED the delivery obligation
- *      — the user's real answer was dropped"). The field data agrees: on
- *      2026-08-13 obligation `…:4#5462` (thread 4) escalated at 04:03:06.140
- *      after a 292-char answer landed at 04:02:50.521 — but that answer was
- *      `via=origin` to turn `…:3#5480`, a DIFFERENT question in topic 3, and no
- *      override was logged in the whole represent→escalate window. Topic 4's
- *      message was genuinely unanswered. A chat-wide fallback would have closed
- *      it silently; the override-gated fallback correctly declines to.
+ *      NOT a chat-wide fallback, and NOT an open-ended one. Both weaker forms
+ *      were tried on this branch and both silently drop a real message:
+ *
+ *      (i) CHAT-WIDE ("did anything long land in this chat since openedAt") has
+ *      no relationship to the obligation beyond the chat id, so in a busy forum
+ *      it closes an obligation in topic A because an unrelated answer landed in
+ *      topic B. The repo already states that principle for the sibling
+ *      predicate (`turn-flush-suppression.ts`, "a background worker's
+ *      progress_update … or a reply in a DIFFERENT forum topic all suppressed
+ *      the flush, and the branch then CLOSED the delivery obligation — the
+ *      user's real answer was dropped").
+ *
+ *      (ii) OVERRIDE-GATED BUT CUT AT `openedAt` — "an override to topic M
+ *      exists, therefore accept anything ≥200 chars ever delivered in M since
+ *      this obligation opened" — is the same defect wearing a gate. The override
+ *      proves a reroute HAPPENED; it says nothing about a delivery minutes
+ *      later. The counter-example is 2026-08-13 obligation `…:4#5462`
+ *      (thread 4, opened 03:50:02.807, escalated 04:03:06.140). Its window
+ *      contains THREE `EXPLICIT_OVERRIDDEN(model→4,routed→3)` records
+ *      (03:50:44.201, 03:51:43.108, 03:53:11.225) AND a later, unrelated 295-char
+ *      delivery in thread 3 at 04:02:51.987 answering a DIFFERENT question
+ *      (`via=origin` to turn `…:3#5480`). Cut at `openedAt`, the fallback pairs
+ *      the stale override with that unrelated delivery and closes topic 4's
+ *      genuinely-unanswered message in silence — pre-fix this escalates
+ *      correctly, so that shape is a REGRESSION, not a fix.
+ *
+ *      So the fallback's cutoff is the OVERRIDE'S OWN `atMs`, and an override is
+ *      only consulted while it is fresh (`resolveRerouteMatchWindowMs`). An
+ *      override licenses a look for the answer THAT routing produced, in the
+ *      moments after it — nothing more. On 2026-08-13 the newest override is
+ *      594.9 s stale at the decision, so no fallback runs at all and the
+ *      escalation fires, as it must.
  *
  *   2. NO SETTLE. The check is a point-in-time read of history, but the answer
  *      is frequently still IN FLIGHT at the instant the sweep decides: the reply
@@ -112,6 +129,41 @@ export const OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT = 8_500
 export const OBLIGATION_ESCALATE_SETTLE_MS_MAX = 60_000
 
 /**
+ * Slack added to the settle window to get the reroute-match window (below).
+ *
+ * Two 5,000 ms sweep ticks. The sweep is the only caller, so the decision that
+ * consults the override record can only land on a tick boundary: one tick of
+ * scheduling slack past the settle deadline, plus one more for a busy tick.
+ */
+export const REROUTE_MATCH_GRACE_MS = 10_000
+
+/**
+ * How stale an `EXPLICIT_OVERRIDDEN` record may be and still license a look in
+ * the thread it names.
+ *
+ * This bound is the whole correctness argument for the reroute fallback, so it
+ * is derived, not picked. The escalate decision that actually consults the
+ * record is the one AFTER the settle gate, so a legitimate override is at most
+ * `settleMs` old (the answer was in flight when the first decision deferred),
+ * plus up to two sweep ticks of scheduling slack — `REROUTE_MATCH_GRACE_MS`.
+ * At the default that is 8,500 + 10,000 = 18,500 ms.
+ *
+ * Both justifying incidents sit far inside it (2026-08-10 06:36 override
+ * :07.921 → delivery :09.281 = 1.36 s; 07:52 override :36.026 → delivery
+ * :37.209 = 1.18 s), and the counter-example sits far outside it (2026-08-13
+ * newest override 03:53:11.225 → the unrelated delivery at 04:02:51.987 =
+ * 594.8 s, a 32× margin over the window). Nothing observed lives in between.
+ *
+ * RESIDUAL, stated plainly: within the window the fallback still cannot tell
+ * the rerouted answer from a second ≥200-char delivery that lands in the same
+ * thread in those few seconds — the override carries no message id to tie it to
+ * one row. The window is what bounds that exposure; it is not eliminated.
+ */
+export function resolveRerouteMatchWindowMs(settleMs: number): number {
+  return Math.max(settleMs, 0) + REROUTE_MATCH_GRACE_MS
+}
+
+/**
  * Resolve the settle window from the environment.
  *
  * Lives here rather than beside the other obligation constants in gateway.ts:
@@ -145,7 +197,11 @@ export interface EscalationStalenessDeps {
     threadId?: number | null,
   ) => boolean
   /** The router's explicit-thread override record (answer-route-overrides.ts). */
-  routeOverrides: Pick<AnswerRouteOverrides, 'routedThreadsSince'>
+  routeOverrides: Pick<AnswerRouteOverrides, 'routedOverridesSince'>
+  /** Decision instant. The reroute fallback is anchored to it, not to `openedAt`. */
+  nowMs: number
+  /** How stale an override may be — `resolveRerouteMatchWindowMs(settleMs)`. */
+  rerouteMatchWindowMs: number
 }
 
 export interface EscalationStalenessObligation {
@@ -178,14 +234,18 @@ export interface AnsweredSinceOpenResult {
  *      `hasOutboundDeliveredSince`; that is unchanged.)
  *   2. REROUTE — only the topics the router RECORDED an answer addressed to this
  *      obligation's topic as having been routed to
- *      (`EXPLICIT_OVERRIDDEN(model→N,routed→M)`, since `openedAt`). No override
- *      on record ⇒ no second query ⇒ an unrelated message in another topic can
- *      never stand this escalation down. See the module header for the field
- *      case where a chat-wide fallback would have got that wrong.
+ *      (`EXPLICIT_OVERRIDDEN(model→N,routed→M)`), and only for as long as that
+ *      record is FRESH (`rerouteMatchWindowMs` before `nowMs`). Each override is
+ *      queried from ITS OWN `atMs`, never from `openedAt`: the record licenses a
+ *      look for the answer that routing produced, not for anything the thread
+ *      has carried since the obligation opened. No fresh override ⇒ no second
+ *      query ⇒ an unrelated message in another topic can never stand this
+ *      escalation down. Both weaker cutoffs are counter-exampled in the module
+ *      header with the log lines that break them.
  *
  * Both scopes keep the caller's substantive-length floor (200 chars in the
- * escalate branch, so a bare ack never stands an escalation down) and the
- * `openedAt` cutoff.
+ * escalate branch, so a bare ack never stands an escalation down), and neither
+ * can ever reach back past `openedAt`.
  *
  * Falls back to "not answered" (never suppresses) when history is unavailable.
  */
@@ -198,12 +258,18 @@ export function answeredSinceOpen(
   if (deps.hasOutboundDeliveredSince(o.chatId, o.openedAt, o.threadId)) {
     return { answered: true, via: 'thread' }
   }
-  for (const routed of deps.routeOverrides.routedThreadsSince(o.chatId, o.threadId, o.openedAt)) {
-    // `routed` is already the history's thread semantics: a number for a topic,
-    // `null` for the chat root (`thread_id IS NULL`). Never `undefined`, which
-    // would re-open the chat-wide any-thread query this guard exists to avoid.
-    if (deps.hasOutboundDeliveredSince(o.chatId, o.openedAt, routed)) {
-      return { answered: true, via: 'reroute', routedThreadId: routed }
+  // Freshness floor: never older than the window, and never before the
+  // obligation existed. A stale override licenses nothing.
+  const notBefore = Math.max(o.openedAt, deps.nowMs - deps.rerouteMatchWindowMs)
+  for (const ovr of deps.routeOverrides.routedOverridesSince(o.chatId, o.threadId, notBefore)) {
+    // `routedThreadId` is already the history's thread semantics: a number for a
+    // topic, `null` for the chat root (`thread_id IS NULL`). Never `undefined`,
+    // which would re-open the chat-wide any-thread query this guard avoids.
+    // The cutoff is the override's OWN instant — see the module header for the
+    // incident that an `openedAt` cutoff regresses.
+    const since = Math.max(ovr.atMs, o.openedAt)
+    if (deps.hasOutboundDeliveredSince(o.chatId, since, ovr.routedThreadId)) {
+      return { answered: true, via: 'reroute', routedThreadId: ovr.routedThreadId }
     }
   }
   return NOT_ANSWERED

--- a/telegram-plugin/gateway/escalation-staleness.ts
+++ b/telegram-plugin/gateway/escalation-staleness.ts
@@ -1,0 +1,203 @@
+/**
+ * escalation-staleness.ts — the two guards that stand an obligation ESCALATION
+ * down when the agent has, in fact, already answered.
+ *
+ * The escalate branch of the obligation sweep sends a user-visible
+ * "⚠️ I may have missed an earlier message" nudge. That nudge is only correct
+ * when the agent genuinely never answered. Two mechanisms in the pre-fix code
+ * let it fire on top of an answer the user had already received:
+ *
+ *   1. THREAD SCOPING. The staleness check was keyed on the obligation's
+ *      `threadId`. The reply router routinely resolves an answer to a DIFFERENT
+ *      topic than the obligation's (it logs this explicitly, e.g.
+ *      `EXPLICIT_OVERRIDDEN(model→4,routed→635)`), so the delivered answer lives
+ *      under another `thread_id` and a thread-keyed query can never see it.
+ *      Confirmed on marko 2026-08-13: obligation `<chat>:4#5462`
+ *      (thread 4) was answered by message 5494 (295 chars) delivered to thread 3
+ *      at 04:02:51.987 — and the nag still fired 14.2s later at 04:03:06.140.
+ *      Fix: `answeredSinceOpen` asks CHAT scope, falling back from the thread
+ *      scope, so an answer delivered anywhere in the chat counts.
+ *
+ *   2. NO SETTLE. The check is a point-in-time read of history, but the answer
+ *      is frequently still IN FLIGHT at the instant the sweep decides: the reply
+ *      tool has been invoked (or is about to be) and its history row does not
+ *      exist yet. Confirmed on marko 2026-08-10 06:36 (reply tool invoked at
+ *      :07.917, escalation decided at :08.047, answer 5215 delivered at :09.281 —
+ *      1.23s AFTER the decision) and 2026-08-10 07:52 (decision :34.400, answer
+ *      5232 delivered :37.209 — 2.81s after). A backward-looking widening of the
+ *      cutoff cannot fix this: the cutoff is already `openedAt`, minutes in the
+ *      past, so a delivered row would have matched. The row simply is not there
+ *      yet. Fix: `createEscalationSettleGate` requires the staleness check to
+ *      have read "not answered" ACROSS a settle window before the nudge is
+ *      allowed out — the escalation is deferred once, re-checked on a later
+ *      sweep, and only sent if the answer still has not landed.
+ *
+ * Both guards are deliberately bounded: the settle gate delays a genuine
+ * escalation by the settle window and no more, and the chat-scoped check keeps
+ * the caller's substantive-length floor, so an escalation for a genuinely
+ * unanswered message still fires.
+ */
+
+/**
+ * Escalation settle window, in milliseconds.
+ *
+ * Derived from the observed decision→delivery lag on the confirmed false
+ * escalations where the answer was in flight at decision time:
+ *
+ *   - marko 2026-08-10 06:36:08.047 decision → 06:36:09.281 delivery = 1,234 ms
+ *   - marko 2026-08-10 07:52:34.400 decision → 07:52:37.209 delivery = 2,809 ms
+ *
+ * The window must (a) exceed the WORST observed lag with real margin — a send
+ * can additionally sit behind the per-chat send-gate pacing — and (b) span at
+ * least one 5,000 ms sweep tick, or no re-check ever runs and the gate is a pure
+ * delay. 3 × 2,809 = 8,427 ms, rounded up to the nearest 500 ms → 8,500 ms,
+ * which satisfies both.
+ *
+ * The upper bound is the genuinely-unanswered case that MUST still escalate:
+ * marko 2026-08-12 09:08:14.524 decision → the agent's real answer (5357) at
+ * 09:08:56 = 41,331 ms. 8,500 ms sits 4.9× below that, so a settle re-check
+ * cannot swallow it.
+ *
+ * Kill switch: 0 disables the gate (pre-fix, escalate on the first decision).
+ */
+export const OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT = 8_500
+
+/**
+ * Resolve the settle window from the environment.
+ *
+ * Lives here rather than beside the other obligation constants in gateway.ts:
+ * that file is under the anti-inflation line ratchet (#2996 P0.5) with zero
+ * headroom, and the ratchet's whole point is that new logic lands in a module.
+ * `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0` is the kill switch (pre-fix
+ * behaviour: escalate on the first decision); a non-numeric or negative value
+ * falls back to the default rather than silently disabling the guard.
+ */
+export function resolveEscalateSettleMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS
+  if (raw == null || raw === '') return OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 0 ? n : OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT
+}
+
+export interface EscalationStalenessDeps {
+  /** History available? When false the check reports "not answered" (safe: never suppresses). */
+  historyEnabled: boolean
+  /**
+   * The history predicate. `threadId === undefined` means CHAT scope (any
+   * thread); an explicit number/null scopes to that thread.
+   */
+  hasOutboundDeliveredSince: (
+    chatId: string,
+    sinceMs: number,
+    threadId?: number | null,
+  ) => boolean
+}
+
+export interface EscalationStalenessObligation {
+  chatId: string
+  openedAt: number
+  threadId?: number | null
+}
+
+/**
+ * True when a substantive outbound was delivered to the obligation's CHAT since
+ * it was opened — i.e. the agent answered and the nudge would be redundant.
+ *
+ * Scope is the chat, not the thread. A thread-scoped hit is a strict subset of a
+ * chat-scoped hit, so this is the thread check plus the cross-topic fallback the
+ * router's `EXPLICIT_OVERRIDDEN(model→N,routed→M)` reroutes demand.
+ *
+ * The widening is deliberate but is NOT unbounded: it is still floored by the
+ * caller's substantive-length threshold (200 chars in the escalate branch, so a
+ * bare ack never stands an escalation down) and by `openedAt`. The residual
+ * risk it accepts is a busy multi-topic chat where a long answer to topic B
+ * suppresses the nag for an unanswered obligation in topic A. That trade is
+ * correct here: the escalate branch only runs after the whole re-present ladder
+ * has been exhausted (minutes of re-asking), and a false nag on top of a
+ * delivered answer is the user-visible defect, whereas a suppressed nag merely
+ * loses one advisory the re-present ladder already made several times.
+ *
+ * Falls back to `false` (never suppresses) when history is unavailable.
+ */
+export function answeredSinceOpen(
+  o: EscalationStalenessObligation,
+  deps: EscalationStalenessDeps,
+): boolean {
+  if (!deps.historyEnabled) return false
+  // Thread scope first — the precise answer when the reply landed where the
+  // obligation lives. Chat scope second — the cross-topic reroute fallback.
+  if (
+    o.threadId !== undefined &&
+    deps.hasOutboundDeliveredSince(o.chatId, o.openedAt, o.threadId)
+  ) {
+    return true
+  }
+  return deps.hasOutboundDeliveredSince(o.chatId, o.openedAt)
+}
+
+export interface EscalationSettleGate {
+  /**
+   * Called each time the sweep reaches the escalate decision for `id` and the
+   * staleness check said "not answered". Returns true to DEFER (leave the
+   * obligation open; a later sweep re-checks), false to proceed with the nudge.
+   */
+  shouldDefer(id: string, now: number): boolean
+  /** Forget `id` — call on every terminal (silent close, escalation driven). */
+  clear(id: string): void
+  /** Live entry count. Test/diagnostic surface. */
+  size(): number
+}
+
+/**
+ * A settle gate: an escalation is only sent once the "no answer delivered" read
+ * has held for `settleMs`.
+ *
+ * The first decision records `now` and defers. Subsequent decisions for the same
+ * id proceed once `settleMs` has elapsed since that first read. Because the
+ * caller only reaches this gate when the staleness check reported "not
+ * answered", proceeding means the check was false at BOTH ends of the window —
+ * so an answer that lands anywhere inside it suppresses the nudge instead.
+ *
+ * Bounded by construction: the delay is exactly `settleMs`; it cannot grow, and
+ * a genuinely unanswered obligation still escalates one settle window later.
+ * `settleMs <= 0` disables the gate (never defers).
+ *
+ * The id map is LRU-bounded so a long-lived gateway cannot grow it without
+ * limit. Ids are per-message origin turn ids, so an evicted entry can only ever
+ * cost one extra settle window, never a wrong decision for another obligation.
+ */
+export function createEscalationSettleGate(
+  settleMs: number,
+  maxKeys = 256,
+): EscalationSettleGate {
+  const firstDecidedAt = new Map<string, number>()
+  return {
+    shouldDefer(id: string, now: number): boolean {
+      if (!(settleMs > 0)) return false
+      const first = firstDecidedAt.get(id)
+      if (first == null) {
+        firstDecidedAt.set(id, now)
+        if (firstDecidedAt.size > maxKeys) {
+          const oldest = firstDecidedAt.keys().next().value
+          if (oldest !== undefined) firstDecidedAt.delete(oldest)
+        }
+        return true
+      }
+      // A clock that jumped backwards must not pin the gate open forever:
+      // re-anchor and defer exactly one more window.
+      if (now < first) {
+        firstDecidedAt.set(id, now)
+        return true
+      }
+      return now - first < settleMs
+    },
+    clear(id: string): void {
+      firstDecidedAt.delete(id)
+    },
+    size(): number {
+      return firstDecidedAt.size
+    },
+  }
+}

--- a/telegram-plugin/gateway/escalation-staleness.ts
+++ b/telegram-plugin/gateway/escalation-staleness.ts
@@ -6,9 +6,9 @@
  * "⚠️ I may have missed an earlier message" nudge. That nudge is only correct
  * when the agent genuinely never answered. Two mechanisms in the pre-fix code
  * let it fire on top of an answer the user had already received. Both are
- * reproduced from marko's `gateway-supervisor.log`, chat `-100…471` (the chat id
- * and the message bodies are deliberately NOT reproduced here — only ids,
- * topics and timings, which is all the derivation needs):
+ * reproduced from a production `gateway-supervisor.log` (the chat id and the
+ * message bodies are deliberately NOT reproduced here — only thread ids,
+ * message numbers and timings, which is all the derivation needs):
  *
  *   1. REROUTED ANSWER. The staleness check was keyed on the obligation's
  *      `threadId`. When the model names a topic on its `reply` and the
@@ -131,22 +131,47 @@ export const OBLIGATION_ESCALATE_SETTLE_MS_MAX = 60_000
 /**
  * Slack added to the settle window to get the reroute-match window (below).
  *
- * Two 5,000 ms sweep ticks. The sweep is the only caller, so the decision that
- * consults the override record can only land on a tick boundary: one tick of
- * scheduling slack past the settle deadline, plus one more for a busy tick.
+ * Two 5,000 ms sweep ticks. The window is measured from the settle gate's own
+ * `firstAt` — the instant the decision FIRST read "unanswered" — so this slack
+ * only has to cover the jitter between the routing decision and that first
+ * read: the sweep runs on a 5,000 ms interval, and the read can land anywhere
+ * inside a tick, so one tick of phase plus one more for a busy tick.
+ *
+ * It deliberately does NOT have to cover the gap to the RE-check. That gap is
+ * unbounded in principle — the sweep's earlier gates (`turnInFlightForGate`,
+ * the background-work / session-busy defer, and the escalate/represent graces)
+ * can SKIP ticks entirely, not merely delay them, for minutes at a time — which
+ * is exactly why the anchor is `firstAt` and not the re-check's `now`. See
+ * `EscalationSettleGate.firstAt`.
  */
 export const REROUTE_MATCH_GRACE_MS = 10_000
+
+/**
+ * Hard ceiling on the reroute-match window.
+ *
+ * Same reasoning as `OBLIGATION_ESCALATE_SETTLE_MS_MAX`, mirrored for the other
+ * direction of harm: a fat-fingered `SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS`
+ * widens the window in which an unrelated delivery can be mistaken for this
+ * obligation's rerouted answer — i.e. it widens the SILENT-CLOSE exposure, the
+ * one failure this module treats as unacceptable. The ceiling is the largest
+ * value the derivation itself can ever produce (the clamped maximum settle
+ * window plus the grace), so every legitimate tuning fits under it and anything
+ * above it is a typo. Clamped, not rejected, for the same reason as the settle
+ * ceiling: a clamped guard still guards.
+ */
+export const OBLIGATION_REROUTE_MATCH_MS_MAX =
+  OBLIGATION_ESCALATE_SETTLE_MS_MAX + REROUTE_MATCH_GRACE_MS
 
 /**
  * How stale an `EXPLICIT_OVERRIDDEN` record may be and still license a look in
  * the thread it names.
  *
  * This bound is the whole correctness argument for the reroute fallback, so it
- * is derived, not picked. The escalate decision that actually consults the
- * record is the one AFTER the settle gate, so a legitimate override is at most
- * `settleMs` old (the answer was in flight when the first decision deferred),
- * plus up to two sweep ticks of scheduling slack — `REROUTE_MATCH_GRACE_MS`.
- * At the default that is 8,500 + 10,000 = 18,500 ms.
+ * is derived, not picked. Staleness is measured from the settle gate's
+ * `firstAt`, so a legitimate override is at most `settleMs` old (the answer was
+ * in flight when that first decision deferred), plus up to two sweep ticks of
+ * scheduling slack — `REROUTE_MATCH_GRACE_MS`. At the default that is
+ * 8,500 + 10,000 = 18,500 ms.
  *
  * Both justifying incidents sit far inside it (2026-08-10 06:36 override
  * :07.921 → delivery :09.281 = 1.36 s; 07:52 override :36.026 → delivery
@@ -154,13 +179,31 @@ export const REROUTE_MATCH_GRACE_MS = 10_000
  * newest override 03:53:11.225 → the unrelated delivery at 04:02:51.987 =
  * 594.8 s, a 32× margin over the window). Nothing observed lives in between.
  *
+ * KILL SWITCH: `SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS=0` disables the reroute
+ * fallback entirely (thread scope only — pre-fix behaviour for this half of the
+ * fix). It is its OWN switch: `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0`
+ * disables the settle gate and NOTHING ELSE. The fallback needs one because it
+ * is the only mechanism here that can close a genuinely unanswered obligation
+ * silently; the settle gate can only ever DELAY a nudge. A non-numeric or
+ * negative value falls back to the derivation rather than silently disabling or
+ * widening the guard; a value above `OBLIGATION_REROUTE_MATCH_MS_MAX` is
+ * clamped.
+ *
  * RESIDUAL, stated plainly: within the window the fallback still cannot tell
  * the rerouted answer from a second ≥200-char delivery that lands in the same
  * thread in those few seconds — the override carries no message id to tie it to
  * one row. The window is what bounds that exposure; it is not eliminated.
  */
-export function resolveRerouteMatchWindowMs(settleMs: number): number {
-  return Math.max(settleMs, 0) + REROUTE_MATCH_GRACE_MS
+export function resolveRerouteMatchWindowMs(
+  settleMs: number,
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const derived = Math.max(settleMs, 0) + REROUTE_MATCH_GRACE_MS
+  const raw = env.SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS
+  if (raw == null || raw === '') return derived
+  const n = Number(raw)
+  if (!(Number.isFinite(n) && n >= 0)) return derived
+  return Math.min(n, OBLIGATION_REROUTE_MATCH_MS_MAX)
 }
 
 /**
@@ -197,10 +240,24 @@ export interface EscalationStalenessDeps {
     threadId?: number | null,
   ) => boolean
   /** The router's explicit-thread override record (answer-route-overrides.ts). */
-  routeOverrides: Pick<AnswerRouteOverrides, 'routedOverridesSince'>
-  /** Decision instant. The reroute fallback is anchored to it, not to `openedAt`. */
-  nowMs: number
-  /** How stale an override may be — `resolveRerouteMatchWindowMs(settleMs)`. */
+  routeOverrides: Pick<AnswerRouteOverrides, 'routedOverridesSince' | 'newestOverrideSince'>
+  /**
+   * The instant the freshness window is measured BACK from — the settle gate's
+   * `firstAt` for this obligation when a settle window is already open, else
+   * this decision's `now`.
+   *
+   * NOT the re-check instant. The sweep's earlier gates can skip ticks outright
+   * (an in-flight turn is unbounded; the background-work/session-busy defer is
+   * bounded at 20 min; the escalate and represent graces add tens of seconds),
+   * so the decision that consults the override record can run minutes after the
+   * one that deferred. Anchored at `now`, a record that was fresh when the
+   * question "has this been answered?" was FIRST asked reads as stale purely
+   * because the sweep was starved — and the nudge fires on top of the answer.
+   * Anchored at `firstAt`, the window means what its derivation says it means.
+   */
+  anchorMs: number
+  /** How stale an override may be — `resolveRerouteMatchWindowMs(settleMs)`.
+   *  `<= 0` disables the reroute fallback entirely (kill switch). */
   rerouteMatchWindowMs: number
 }
 
@@ -219,6 +276,17 @@ export interface AnsweredSinceOpenResult {
   via: AnsweredVia | null
   /** The thread the reroute-scope hit was found in. Only set when `via` is 'reroute'. */
   routedThreadId?: number | null
+  /**
+   * Age (relative to `anchorMs`) of the NEWEST override the freshness bound
+   * rejected, when the fallback found nothing AND a record for this obligation
+   * existed. Absent when there was simply no record.
+   *
+   * Negative-path telemetry: without it "no reroute on record" and "a reroute
+   * was on record and the bound threw it away" are the same silent result, and
+   * the bound — which is the whole correctness argument for the fallback — is
+   * unmeasurable in production. The caller logs it.
+   */
+  staleOverrideAgeMs?: number
 }
 
 /**
@@ -258,9 +326,14 @@ export function answeredSinceOpen(
   if (deps.hasOutboundDeliveredSince(o.chatId, o.openedAt, o.threadId)) {
     return { answered: true, via: 'thread' }
   }
-  // Freshness floor: never older than the window, and never before the
-  // obligation existed. A stale override licenses nothing.
-  const notBefore = Math.max(o.openedAt, deps.nowMs - deps.rerouteMatchWindowMs)
+  // Kill switch. A zero/negative window means "no reroute fallback at all", not
+  // "a zero-width window an override recorded at this very instant slips
+  // through" — an off-switch that still fires for one timing is not one.
+  if (!(deps.rerouteMatchWindowMs > 0)) return NOT_ANSWERED
+  // Freshness floor: never older than the window (measured back from the FIRST
+  // "unanswered" read — see `anchorMs`), and never before the obligation
+  // existed. A stale override licenses nothing.
+  const notBefore = Math.max(o.openedAt, deps.anchorMs - deps.rerouteMatchWindowMs)
   for (const ovr of deps.routeOverrides.routedOverridesSince(o.chatId, o.threadId, notBefore)) {
     // `routedThreadId` is already the history's thread semantics: a number for a
     // topic, `null` for the chat root (`thread_id IS NULL`). Never `undefined`,
@@ -271,6 +344,12 @@ export function answeredSinceOpen(
     if (deps.hasOutboundDeliveredSince(o.chatId, since, ovr.routedThreadId)) {
       return { answered: true, via: 'reroute', routedThreadId: ovr.routedThreadId }
     }
+  }
+  // Nothing matched. Distinguish "no record" from "a record the bound rejected"
+  // so the bound is observable in production (the caller logs the age).
+  const newest = deps.routeOverrides.newestOverrideSince(o.chatId, o.threadId, o.openedAt)
+  if (newest != null && newest.atMs < notBefore) {
+    return { answered: false, via: null, staleOverrideAgeMs: Math.max(0, deps.anchorMs - newest.atMs) }
   }
   return NOT_ANSWERED
 }
@@ -288,6 +367,22 @@ export interface EscalationSettleGate {
    * re-check.
    */
   shouldDefer(id: string, now: number, openedAt: number): boolean
+  /**
+   * The instant this obligation's OPEN settle window started — the decision that
+   * first read "not answered" for this episode. `undefined` when no window is
+   * open for `id` (first decision, gate disabled, or the entry was evicted).
+   *
+   * This is the freshness anchor for the reroute fallback (`anchorMs`). Read
+   * BEFORE `shouldDefer`, so the first decision anchors at its own `now` and
+   * every re-check anchors at that same instant however many ticks were skipped
+   * in between. `openedAt` is matched for the same reason `shouldDefer` matches
+   * it: a re-opened obligation under the same origin id must not inherit the
+   * previous episode's anchor.
+   *
+   * Fails in the safe direction: no entry ⇒ the caller anchors at `now`, which
+   * can only make an override look OLDER, i.e. over-escalate.
+   */
+  firstAt(id: string, openedAt: number): number | undefined
   /** Forget `id` — call on EVERY obligation terminal (silent close, cancel,
    *  escalation driven), so the map never retains closed obligations. */
   clear(id: string): void
@@ -342,6 +437,11 @@ export function createEscalationSettleGate(
         return true
       }
       return now - prev.firstAt < settleMs
+    },
+    firstAt(id: string, openedAt: number): number | undefined {
+      const prev = entries.get(id)
+      if (prev == null || prev.openedAt !== openedAt) return undefined
+      return prev.firstAt
     },
     clear(id: string): void {
       entries.delete(id)

--- a/telegram-plugin/gateway/escalation-staleness.ts
+++ b/telegram-plugin/gateway/escalation-staleness.ts
@@ -5,38 +5,71 @@
  * The escalate branch of the obligation sweep sends a user-visible
  * "⚠️ I may have missed an earlier message" nudge. That nudge is only correct
  * when the agent genuinely never answered. Two mechanisms in the pre-fix code
- * let it fire on top of an answer the user had already received:
+ * let it fire on top of an answer the user had already received. Both are
+ * reproduced from marko's `gateway-supervisor.log`, chat `-100…471` (the chat id
+ * and the message bodies are deliberately NOT reproduced here — only ids,
+ * topics and timings, which is all the derivation needs):
  *
- *   1. THREAD SCOPING. The staleness check was keyed on the obligation's
- *      `threadId`. The reply router routinely resolves an answer to a DIFFERENT
- *      topic than the obligation's (it logs this explicitly, e.g.
- *      `EXPLICIT_OVERRIDDEN(model→4,routed→635)`), so the delivered answer lives
- *      under another `thread_id` and a thread-keyed query can never see it.
- *      Confirmed on marko 2026-08-13: obligation `<chat>:4#5462`
- *      (thread 4) was answered by message 5494 (295 chars) delivered to thread 3
- *      at 04:02:51.987 — and the nag still fired 14.2s later at 04:03:06.140.
- *      Fix: `answeredSinceOpen` asks CHAT scope, falling back from the thread
- *      scope, so an answer delivered anywhere in the chat counts.
+ *   1. REROUTED ANSWER. The staleness check was keyed on the obligation's
+ *      `threadId`. When the model names a topic on its `reply` and the
+ *      framework's topic authority overrides it — the router logs exactly this,
+ *      `EXPLICIT_OVERRIDDEN(model→N,routed→M)` — the answer is written to
+ *      history under thread M while the obligation lives under thread N, so a
+ *      thread-N query can never see it.
+ *
+ *      2026-08-10 06:36:07.921, obligation `…:4#5191` (thread 4):
+ *      `EXPLICIT_OVERRIDDEN(model→4,routed→635)` — the model was answering the
+ *      thread-4 obligation, the answer went to thread 635, and the nag fired
+ *      126 ms later at 06:36:08.047.
+ *      2026-08-10 07:52:36.026, obligation `…:3#5200` (thread 3):
+ *      `EXPLICIT_OVERRIDDEN(model→3,routed→-)` — answer written with
+ *      `thread_id IS NULL`; the nag had already fired at 07:52:34.400.
+ *
+ *      Fix: `answeredSinceOpen` keeps the thread scope and adds a fallback to
+ *      the threads an answer ADDRESSED TO THIS OBLIGATION'S TOPIC was actually
+ *      routed to, read from the router's own override record
+ *      (`answer-route-overrides.ts`).
+ *
+ *      NOT a chat-wide fallback. A chat-wide "did anything long land since
+ *      openedAt" query has no relationship to the obligation beyond the chat id,
+ *      and in a busy forum it silently closes an obligation in topic A because
+ *      an unrelated answer landed in topic B — dropping the user's message with
+ *      no nudge and no re-present. The repo already states that principle for
+ *      the sibling predicate (`turn-flush-suppression.ts`, "a background
+ *      worker's progress_update … or a reply in a DIFFERENT forum topic all
+ *      suppressed the flush, and the branch then CLOSED the delivery obligation
+ *      — the user's real answer was dropped"). The field data agrees: on
+ *      2026-08-13 obligation `…:4#5462` (thread 4) escalated at 04:03:06.140
+ *      after a 292-char answer landed at 04:02:50.521 — but that answer was
+ *      `via=origin` to turn `…:3#5480`, a DIFFERENT question in topic 3, and no
+ *      override was logged in the whole represent→escalate window. Topic 4's
+ *      message was genuinely unanswered. A chat-wide fallback would have closed
+ *      it silently; the override-gated fallback correctly declines to.
  *
  *   2. NO SETTLE. The check is a point-in-time read of history, but the answer
  *      is frequently still IN FLIGHT at the instant the sweep decides: the reply
  *      tool has been invoked (or is about to be) and its history row does not
- *      exist yet. Confirmed on marko 2026-08-10 06:36 (reply tool invoked at
- *      :07.917, escalation decided at :08.047, answer 5215 delivered at :09.281 —
- *      1.23s AFTER the decision) and 2026-08-10 07:52 (decision :34.400, answer
- *      5232 delivered :37.209 — 2.81s after). A backward-looking widening of the
- *      cutoff cannot fix this: the cutoff is already `openedAt`, minutes in the
- *      past, so a delivered row would have matched. The row simply is not there
- *      yet. Fix: `createEscalationSettleGate` requires the staleness check to
- *      have read "not answered" ACROSS a settle window before the nudge is
- *      allowed out — the escalation is deferred once, re-checked on a later
- *      sweep, and only sent if the answer still has not landed.
+ *      exist yet. Same two 2026-08-10 incidents: 06:36 (reply invoked :07.919,
+ *      escalation decided :08.047, answer delivered :09.281 — 1.23 s AFTER the
+ *      decision) and 07:52 (decision :34.400, reply invoked :36.026, delivered
+ *      :37.209 — 2.81 s after). A backward-looking widening of the cutoff cannot
+ *      fix this: the cutoff is already `openedAt`, minutes in the past, so a
+ *      delivered row would have matched. The row simply is not there yet. Fix:
+ *      `createEscalationSettleGate` requires the staleness check to have read
+ *      "not answered" ACROSS a settle window before the nudge is allowed out —
+ *      the escalation is deferred once, re-checked on a later sweep, and only
+ *      sent if the answer still has not landed.
+ *
+ * Both incidents needed BOTH guards: each answer was rerouted AND still in
+ * flight at the decision instant, so neither guard alone suppresses either nag.
  *
  * Both guards are deliberately bounded: the settle gate delays a genuine
- * escalation by the settle window and no more, and the chat-scoped check keeps
- * the caller's substantive-length floor, so an escalation for a genuinely
- * unanswered message still fires.
+ * escalation by the settle window and no more, the reroute fallback only looks
+ * where the router says this topic's answer went, and both keep the caller's
+ * substantive-length floor — so an escalation for a genuinely unanswered
+ * message still fires.
  */
+import type { AnswerRouteOverrides } from './answer-route-overrides.js'
 
 /**
  * Escalation settle window, in milliseconds.
@@ -44,8 +77,8 @@
  * Derived from the observed decision→delivery lag on the confirmed false
  * escalations where the answer was in flight at decision time:
  *
- *   - marko 2026-08-10 06:36:08.047 decision → 06:36:09.281 delivery = 1,234 ms
- *   - marko 2026-08-10 07:52:34.400 decision → 07:52:37.209 delivery = 2,809 ms
+ *   - 2026-08-10 06:36:08.047 decision → 06:36:09.281 delivery = 1,234 ms
+ *   - 2026-08-10 07:52:34.400 decision → 07:52:37.209 delivery = 2,809 ms
  *
  * The window must (a) exceed the WORST observed lag with real margin — a send
  * can additionally sit behind the per-chat send-gate pacing — and (b) span at
@@ -54,13 +87,29 @@
  * which satisfies both.
  *
  * The upper bound is the genuinely-unanswered case that MUST still escalate:
- * marko 2026-08-12 09:08:14.524 decision → the agent's real answer (5357) at
- * 09:08:56 = 41,331 ms. 8,500 ms sits 4.9× below that, so a settle re-check
- * cannot swallow it.
+ * 2026-08-12 09:08:14.524 decision → the agent's real answer at 09:08:56 =
+ * 41,331 ms. 8,500 ms sits 4.9× below that, so a settle re-check cannot swallow
+ * it.
  *
  * Kill switch: 0 disables the gate (pre-fix, escalate on the first decision).
  */
 export const OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT = 8_500
+
+/**
+ * Hard ceiling on the settle window.
+ *
+ * The gate trades a bounded DELAY of a genuine nudge for suppression of a false
+ * one, and that trade is only honest while the delay stays small next to the
+ * ladder that precedes it. A fat-fingered
+ * `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=85000000` would otherwise silently
+ * suppress every escalation for a day — a config typo turning a guard into an
+ * outage. 60 s is ~7× the derived default and still well under the represent
+ * ladder's own minutes-long cadence, so any legitimate tuning fits under it and
+ * anything above it is a typo, not an intent. Values above the ceiling are
+ * CLAMPED (not rejected): clamping keeps the guard working, whereas falling back
+ * to the default would silently ignore a deliberate 90 s choice.
+ */
+export const OBLIGATION_ESCALATE_SETTLE_MS_MAX = 60_000
 
 /**
  * Resolve the settle window from the environment.
@@ -70,7 +119,8 @@ export const OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT = 8_500
  * headroom, and the ratchet's whole point is that new logic lands in a module.
  * `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0` is the kill switch (pre-fix
  * behaviour: escalate on the first decision); a non-numeric or negative value
- * falls back to the default rather than silently disabling the guard.
+ * falls back to the default rather than silently disabling the guard; a value
+ * above `OBLIGATION_ESCALATE_SETTLE_MS_MAX` is clamped to it.
  */
 export function resolveEscalateSettleMs(
   env: Record<string, string | undefined> = process.env,
@@ -78,7 +128,8 @@ export function resolveEscalateSettleMs(
   const raw = env.SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS
   if (raw == null || raw === '') return OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT
   const n = Number(raw)
-  return Number.isFinite(n) && n >= 0 ? n : OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT
+  if (!(Number.isFinite(n) && n >= 0)) return OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT
+  return Math.min(n, OBLIGATION_ESCALATE_SETTLE_MS_MAX)
 }
 
 export interface EscalationStalenessDeps {
@@ -93,6 +144,8 @@ export interface EscalationStalenessDeps {
     sinceMs: number,
     threadId?: number | null,
   ) => boolean
+  /** The router's explicit-thread override record (answer-route-overrides.ts). */
+  routeOverrides: Pick<AnswerRouteOverrides, 'routedThreadsSince'>
 }
 
 export interface EscalationStalenessObligation {
@@ -101,40 +154,59 @@ export interface EscalationStalenessObligation {
   threadId?: number | null
 }
 
+/** How the answer was found — carried into the sweep's log so a reroute-scope
+ *  hit is distinguishable from a plain same-topic hit in production. */
+export type AnsweredVia = 'thread' | 'reroute'
+
+export interface AnsweredSinceOpenResult {
+  answered: boolean
+  via: AnsweredVia | null
+  /** The thread the reroute-scope hit was found in. Only set when `via` is 'reroute'. */
+  routedThreadId?: number | null
+}
+
 /**
- * True when a substantive outbound was delivered to the obligation's CHAT since
- * it was opened — i.e. the agent answered and the nudge would be redundant.
+ * True when a substantive outbound that can be tied to THIS obligation was
+ * delivered since it was opened — i.e. the agent answered and the nudge would be
+ * redundant.
  *
- * Scope is the chat, not the thread. A thread-scoped hit is a strict subset of a
- * chat-scoped hit, so this is the thread check plus the cross-topic fallback the
- * router's `EXPLICIT_OVERRIDDEN(model→N,routed→M)` reroutes demand.
+ * Two scopes, in order:
  *
- * The widening is deliberate but is NOT unbounded: it is still floored by the
- * caller's substantive-length threshold (200 chars in the escalate branch, so a
- * bare ack never stands an escalation down) and by `openedAt`. The residual
- * risk it accepts is a busy multi-topic chat where a long answer to topic B
- * suppresses the nag for an unanswered obligation in topic A. That trade is
- * correct here: the escalate branch only runs after the whole re-present ladder
- * has been exhausted (minutes of re-asking), and a false nag on top of a
- * delivered answer is the user-visible defect, whereas a suppressed nag merely
- * loses one advisory the re-present ladder already made several times.
+ *   1. THREAD — the obligation's own topic. The precise, pre-existing check.
+ *      (An obligation with `threadId === undefined` — a DM, or a turn the
+ *      gateway never resolved a topic for — has always meant "any thread" to
+ *      `hasOutboundDeliveredSince`; that is unchanged.)
+ *   2. REROUTE — only the topics the router RECORDED an answer addressed to this
+ *      obligation's topic as having been routed to
+ *      (`EXPLICIT_OVERRIDDEN(model→N,routed→M)`, since `openedAt`). No override
+ *      on record ⇒ no second query ⇒ an unrelated message in another topic can
+ *      never stand this escalation down. See the module header for the field
+ *      case where a chat-wide fallback would have got that wrong.
  *
- * Falls back to `false` (never suppresses) when history is unavailable.
+ * Both scopes keep the caller's substantive-length floor (200 chars in the
+ * escalate branch, so a bare ack never stands an escalation down) and the
+ * `openedAt` cutoff.
+ *
+ * Falls back to "not answered" (never suppresses) when history is unavailable.
  */
 export function answeredSinceOpen(
   o: EscalationStalenessObligation,
   deps: EscalationStalenessDeps,
-): boolean {
-  if (!deps.historyEnabled) return false
-  // Thread scope first — the precise answer when the reply landed where the
-  // obligation lives. Chat scope second — the cross-topic reroute fallback.
-  if (
-    o.threadId !== undefined &&
-    deps.hasOutboundDeliveredSince(o.chatId, o.openedAt, o.threadId)
-  ) {
-    return true
+): AnsweredSinceOpenResult {
+  const NOT_ANSWERED: AnsweredSinceOpenResult = { answered: false, via: null }
+  if (!deps.historyEnabled) return NOT_ANSWERED
+  if (deps.hasOutboundDeliveredSince(o.chatId, o.openedAt, o.threadId)) {
+    return { answered: true, via: 'thread' }
   }
-  return deps.hasOutboundDeliveredSince(o.chatId, o.openedAt)
+  for (const routed of deps.routeOverrides.routedThreadsSince(o.chatId, o.threadId, o.openedAt)) {
+    // `routed` is already the history's thread semantics: a number for a topic,
+    // `null` for the chat root (`thread_id IS NULL`). Never `undefined`, which
+    // would re-open the chat-wide any-thread query this guard exists to avoid.
+    if (deps.hasOutboundDeliveredSince(o.chatId, o.openedAt, routed)) {
+      return { answered: true, via: 'reroute', routedThreadId: routed }
+    }
+  }
+  return NOT_ANSWERED
 }
 
 export interface EscalationSettleGate {
@@ -142,9 +214,16 @@ export interface EscalationSettleGate {
    * Called each time the sweep reaches the escalate decision for `id` and the
    * staleness check said "not answered". Returns true to DEFER (leave the
    * obligation open; a later sweep re-checks), false to proceed with the nudge.
+   *
+   * `openedAt` is the obligation's open instant, carried as an EPOCH: an
+   * obligation closed and later RE-OPENED under the same origin turn id gets a
+   * new `openedAt`, and a mismatch resets the window — so a stale entry from the
+   * previous episode can never let the new one's first escalation skip its
+   * re-check.
    */
-  shouldDefer(id: string, now: number): boolean
-  /** Forget `id` — call on every terminal (silent close, escalation driven). */
+  shouldDefer(id: string, now: number, openedAt: number): boolean
+  /** Forget `id` — call on EVERY obligation terminal (silent close, cancel,
+   *  escalation driven), so the map never retains closed obligations. */
   clear(id: string): void
   /** Live entry count. Test/diagnostic surface. */
   size(): number
@@ -164,40 +243,45 @@ export interface EscalationSettleGate {
  * a genuinely unanswered obligation still escalates one settle window later.
  * `settleMs <= 0` disables the gate (never defers).
  *
- * The id map is LRU-bounded so a long-lived gateway cannot grow it without
- * limit. Ids are per-message origin turn ids, so an evicted entry can only ever
- * cost one extra settle window, never a wrong decision for another obligation.
+ * The id map is bounded and evicted oldest-INSERTED-first (FIFO — entries are
+ * not re-inserted on access, so this is deliberately not an LRU) so a long-lived
+ * gateway cannot grow it without limit. Ids are per-obligation origin turn ids,
+ * so an evicted entry can only ever cost one extra settle window, never a wrong
+ * decision for another obligation.
  */
 export function createEscalationSettleGate(
   settleMs: number,
   maxKeys = 256,
 ): EscalationSettleGate {
-  const firstDecidedAt = new Map<string, number>()
+  const entries = new Map<string, { firstAt: number; openedAt: number }>()
   return {
-    shouldDefer(id: string, now: number): boolean {
+    shouldDefer(id: string, now: number, openedAt: number): boolean {
       if (!(settleMs > 0)) return false
-      const first = firstDecidedAt.get(id)
-      if (first == null) {
-        firstDecidedAt.set(id, now)
-        if (firstDecidedAt.size > maxKeys) {
-          const oldest = firstDecidedAt.keys().next().value
-          if (oldest !== undefined) firstDecidedAt.delete(oldest)
+      const prev = entries.get(id)
+      // Absent, or belonging to a PREVIOUS episode of the same origin id →
+      // start a fresh window.
+      if (prev == null || prev.openedAt !== openedAt) {
+        entries.set(id, { firstAt: now, openedAt })
+        while (entries.size > maxKeys) {
+          const oldest = entries.keys().next().value
+          if (oldest === undefined) break
+          entries.delete(oldest)
         }
         return true
       }
       // A clock that jumped backwards must not pin the gate open forever:
       // re-anchor and defer exactly one more window.
-      if (now < first) {
-        firstDecidedAt.set(id, now)
+      if (now < prev.firstAt) {
+        entries.set(id, { firstAt: now, openedAt })
         return true
       }
-      return now - first < settleMs
+      return now - prev.firstAt < settleMs
     },
     clear(id: string): void {
-      firstDecidedAt.delete(id)
+      entries.delete(id)
     },
     size(): number {
-      return firstDecidedAt.size
+      return entries.size
     },
   }
 }

--- a/telegram-plugin/gateway/escalation-staleness.ts
+++ b/telegram-plugin/gateway/escalation-staleness.ts
@@ -30,8 +30,9 @@
  *      routed to, read from the router's own override record
  *      (`answer-route-overrides.ts`).
  *
- *      NOT a chat-wide fallback, and NOT an open-ended one. Both weaker forms
- *      were tried on this branch and both silently drop a real message:
+ *      NOT a chat-wide fallback, and NOT an open-ended one at EITHER end. Three
+ *      weaker forms were tried on this branch and every one silently drops a
+ *      real message:
  *
  *      (i) CHAT-WIDE ("did anything long land in this chat since openedAt") has
  *      no relationship to the obligation beyond the chat id, so in a busy forum
@@ -56,12 +57,28 @@
  *      genuinely-unanswered message in silence — pre-fix this escalates
  *      correctly, so that shape is a REGRESSION, not a fix.
  *
- *      So the fallback's cutoff is the OVERRIDE'S OWN `atMs`, and an override is
- *      only consulted while it is fresh (`resolveRerouteMatchWindowMs`). An
- *      override licenses a look for the answer THAT routing produced, in the
- *      moments after it — nothing more. On 2026-08-13 the newest override is
- *      594.9 s stale at the decision, so no fallback runs at all and the
- *      escalation fires, as it must.
+ *      (iii) OVERRIDE-GATED, CUT AT `atMs`, BUT OPEN-ENDED FORWARD — "this
+ *      override is fresh, therefore accept anything ≥200 chars delivered in M
+ *      from `atMs` onwards, however long onwards turns out to be" — is the SAME
+ *      defect once more, now leaking out the other end of the window. Freshness
+ *      is judged at the settle gate's `firstAt` (the instant the question was
+ *      FIRST asked) while the history row is read at the RE-CHECK, and the gates
+ *      above this branch can starve the sweep for minutes between the two. So
+ *      the override is fresh, the delivery is not, and they are paired anyway:
+ *      a short reply is rerouted to topic M at T+0, the obligation correctly
+ *      stays open (under the substantive floor), an unrelated ≥200-char answer
+ *      lands in M at T+90, the next sweep runs at T+107 and closes the
+ *      obligation `via=reroute`. Same shape as (ii), reached by a different
+ *      route. Test (f).
+ *
+ *      So the fallback's window is bounded at BOTH ends by the OVERRIDE'S OWN
+ *      `atMs` — `[atMs, atMs + rerouteMatchWindowMs]` — and an override is only
+ *      consulted while it is itself fresh (`resolveRerouteMatchWindowMs`). Both
+ *      ends are absolute instants fixed by the record, so neither moves when the
+ *      sweep is starved. An override licenses a look for the answer THAT routing
+ *      produced, in the moments after it — nothing more. On 2026-08-13 the
+ *      newest override is 594.9 s stale at the decision, so no fallback runs at
+ *      all and the escalation fires, as it must.
  *
  *   2. NO SETTLE. The check is a point-in-time read of history, but the answer
  *      is frequently still IN FLIGHT at the instant the sweep decides: the reply
@@ -189,10 +206,27 @@ export const OBLIGATION_REROUTE_MATCH_MS_MAX =
  * widening the guard; a value above `OBLIGATION_REROUTE_MATCH_MS_MAX` is
  * clamped.
  *
- * RESIDUAL, stated plainly: within the window the fallback still cannot tell
- * the rerouted answer from a second ≥200-char delivery that lands in the same
- * thread in those few seconds — the override carries no message id to tie it to
- * one row. The window is what bounds that exposure; it is not eliminated.
+ * The window bounds the fallback TWICE, and the distinction matters because one
+ * of the two was missing and re-opened the silent close (#4681, form (iii) in
+ * the module header):
+ *
+ *   - it bounds which OVERRIDES are consulted — no record older than the window
+ *     (measured back from `anchorMs`) licenses anything; and
+ *   - it bounds which DELIVERIES a consulted override may be paired with — only
+ *     rows inside `[atMs, atMs + window]`, the interval in which the answer that
+ *     routing produced could actually land.
+ *
+ * The second is not implied by the first. Freshness is judged at `anchorMs` (the
+ * settle gate's `firstAt`) while the history row is read at the re-check, and the
+ * sweep can be starved for minutes in between — so without the delivery bound a
+ * legitimately fresh override reaches arbitrarily far forward.
+ *
+ * RESIDUAL, stated plainly: inside `[atMs, atMs + window]` the fallback still
+ * cannot tell the rerouted answer from a second ≥200-char delivery that lands in
+ * the same thread in those few seconds — the override carries no message id to
+ * tie it to one row. That interval is fixed by the record's own timestamp, so it
+ * does not widen when the sweep is starved; it is what bounds the exposure, and
+ * the exposure is bounded, not eliminated.
  */
 export function resolveRerouteMatchWindowMs(
   settleMs: number,
@@ -200,7 +234,10 @@ export function resolveRerouteMatchWindowMs(
 ): number {
   const derived = Math.max(settleMs, 0) + REROUTE_MATCH_GRACE_MS
   const raw = env.SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS
-  if (raw == null || raw === '') return derived
+  // `.trim()`, not `=== ''`: `Number(' ') === 0`, so a whitespace-only value —
+  // the shape a stray `KEY=" "` in an env file produces — would otherwise read
+  // as a deliberate 0 and silently DISABLE the fallback with no log.
+  if (raw == null || raw.trim() === '') return derived
   const n = Number(raw)
   if (!(Number.isFinite(n) && n >= 0)) return derived
   return Math.min(n, OBLIGATION_REROUTE_MATCH_MS_MAX)
@@ -221,7 +258,9 @@ export function resolveEscalateSettleMs(
   env: Record<string, string | undefined> = process.env,
 ): number {
   const raw = env.SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS
-  if (raw == null || raw === '') return OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT
+  // `.trim()`, not `=== ''` — `Number(' ') === 0`, which would read as the kill
+  // switch and silently disable the gate. See `resolveRerouteMatchWindowMs`.
+  if (raw == null || raw.trim() === '') return OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT
   const n = Number(raw)
   if (!(Number.isFinite(n) && n >= 0)) return OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT
   return Math.min(n, OBLIGATION_ESCALATE_SETTLE_MS_MAX)
@@ -231,12 +270,38 @@ export interface EscalationStalenessDeps {
   /** History available? When false the check reports "not answered" (safe: never suppresses). */
   historyEnabled: boolean
   /**
-   * The history predicate. `threadId === undefined` means CHAT scope (any
-   * thread); an explicit number/null scopes to that thread.
+   * The history predicate, open-ended forward. `threadId === undefined` means
+   * CHAT scope (any thread); an explicit number/null scopes to that thread.
+   *
+   * Used ONLY for the obligation's own topic, where open-ended is correct: that
+   * scope is the obligation itself, so anything substantive delivered there
+   * since it opened is its answer. The reroute fallback must not use this — see
+   * `hasOutboundDeliveredBetween`.
    */
   hasOutboundDeliveredSince: (
     chatId: string,
     sinceMs: number,
+    threadId?: number | null,
+  ) => boolean
+  /**
+   * The same predicate BOUNDED AT BOTH ENDS — `[sinceMs, untilMs]`.
+   *
+   * The reroute fallback's only history call. An `EXPLICIT_OVERRIDDEN` record is
+   * evidence about ONE INSTANT: at `atMs` the router sent this topic's answer
+   * elsewhere. It licenses a look for the delivery THAT routing produced, which
+   * lands within the match window of `atMs` — and for nothing else the routed
+   * topic carries before or after. A forward-open query turns that instant of
+   * evidence into a standing licence over the routed topic, which is precisely
+   * the silent close this module exists to prevent.
+   *
+   * Deliberately a SEPARATE dep rather than an optional argument on the one
+   * above: an optional bound is one a caller — or a test stub — can drop without
+   * anything failing, and the bound is load-bearing.
+   */
+  hasOutboundDeliveredBetween: (
+    chatId: string,
+    sinceMs: number,
+    untilMs: number,
     threadId?: number | null,
   ) => boolean
   /** The router's explicit-thread override record (answer-route-overrides.ts). */
@@ -303,13 +368,15 @@ export interface AnsweredSinceOpenResult {
  *   2. REROUTE — only the topics the router RECORDED an answer addressed to this
  *      obligation's topic as having been routed to
  *      (`EXPLICIT_OVERRIDDEN(model→N,routed→M)`), and only for as long as that
- *      record is FRESH (`rerouteMatchWindowMs` before `nowMs`). Each override is
- *      queried from ITS OWN `atMs`, never from `openedAt`: the record licenses a
- *      look for the answer that routing produced, not for anything the thread
- *      has carried since the obligation opened. No fresh override ⇒ no second
- *      query ⇒ an unrelated message in another topic can never stand this
- *      escalation down. Both weaker cutoffs are counter-exampled in the module
- *      header with the log lines that break them.
+ *      record is FRESH (`rerouteMatchWindowMs` before `anchorMs`). Each override
+ *      is queried across ITS OWN `[atMs, atMs + rerouteMatchWindowMs]` — never
+ *      from `openedAt`, and never open-ended forward: the record licenses a look
+ *      for the answer that routing produced, in the moments after it, not for
+ *      anything the thread has carried since the obligation opened nor for
+ *      anything it carries minutes later. No fresh override ⇒ no second query ⇒
+ *      an unrelated message in another topic can never stand this escalation
+ *      down. All three weaker cutoffs are counter-exampled in the module header
+ *      with the log lines that break them.
  *
  * Both scopes keep the caller's substantive-length floor (200 chars in the
  * escalate branch, so a bare ack never stands an escalation down), and neither
@@ -338,10 +405,16 @@ export function answeredSinceOpen(
     // `routedThreadId` is already the history's thread semantics: a number for a
     // topic, `null` for the chat root (`thread_id IS NULL`). Never `undefined`,
     // which would re-open the chat-wide any-thread query this guard avoids.
-    // The cutoff is the override's OWN instant — see the module header for the
-    // incident that an `openedAt` cutoff regresses.
+    //
+    // BOTH ends of the query are the override's OWN instant ± the match window.
+    // Lower: the delivery cannot predate the routing that produced it (and never
+    // reaches back past `openedAt`) — see the module header for the incident an
+    // `openedAt` cutoff regresses. Upper: the record is evidence about that
+    // instant only, so it licenses a look across the window in which that answer
+    // could land and no further — see the header's form (iii).
     const since = Math.max(ovr.atMs, o.openedAt)
-    if (deps.hasOutboundDeliveredSince(o.chatId, since, ovr.routedThreadId)) {
+    const until = ovr.atMs + deps.rerouteMatchWindowMs
+    if (deps.hasOutboundDeliveredBetween(o.chatId, since, until, ovr.routedThreadId)) {
       return { answered: true, via: 'reroute', routedThreadId: ovr.routedThreadId }
     }
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3920,8 +3920,13 @@ function resolveReplyOwnerTurn(
  * `originVia` distinguishes how the origin turn was resolved: 'echo' (model
  * echoed origin_turn_id), 'quoted' (framework recovered it from args.reply_to),
  * or null (no origin turn). It only affects the `via` label, never the routing.
+ *
+ * Exported ONLY as a test seam: the `answerRouteOverrides.note()` call below is
+ * a SIDE EFFECT no pure module carries, so nothing else can prove it still
+ * happens (`answer-route-side-effect.test.ts`). No production caller — the
+ * gateway still hands it to `sendReply` through the deps object.
  */
-function resolveAnswerThreadWithLog(
+export function resolveAnswerThreadWithLog(
   chatId: string,
   explicitThreadId: number | undefined,
   originTurn: CurrentTurn | null,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -738,6 +738,7 @@ import {
 } from './emission-authority.js'
 import { CurrentTurnMap } from './current-turn-map.js'
 import { resolveAnswerThreadId } from './answer-thread-resolve.js'
+import { answerRouteOverrides } from './answer-route-overrides.js'
 import { latestTurnForChat } from './latest-turn-lookup.js'
 import { decideObligationTurnEnd } from './obligation-turn-end.js'
 import { maybeRotate, resolveAgentStateDir, resolveTurnsJsonlPath } from './turns-jsonl-rotate.js'
@@ -3973,12 +3974,11 @@ function resolveAnswerThreadWithLog(
   // Observability: the model passed an explicit topic but a framework anchor
   // (origin/live) overrode it. This is the deterministic correction that fixes
   // the General→CRM misroute; surface it so the model's topic-grabbing is
-  // visible rather than silent.
-  const explicitOverridden =
-    REPLY_TOPIC_AUTHORITY_ENABLED &&
-    explicitThreadId != null &&
-    (originTurn != null || liveTurn != null) &&
-    threadId !== explicitThreadId
+  // visible rather than silent. `note` also RECORDS it — obligation escalation
+  // needs it to tell "topic A's answer landed in B" from "something unrelated
+  // landed in B" (predicate + rationale: answer-route-overrides.ts).
+  const explicitOverridden = answerRouteOverrides.note({ chatId, enabled: REPLY_TOPIC_AUTHORITY_ENABLED,
+    explicitThreadId, anchored: originTurn != null || liveTurn != null, routedThreadId: threadId, nowMs: Date.now() })
   const ownerTurn = originTurn ?? recovered ?? liveTurn
   const isSupergroup = chatId.startsWith('-100')
   // UNROUTED = a supergroup reply that resolved to NO topic with NO owner turn

--- a/telegram-plugin/gateway/obligation-wiring.ts
+++ b/telegram-plugin/gateway/obligation-wiring.ts
@@ -23,6 +23,11 @@ import { buildObligationRepresentInbound, type Obligation } from './obligation-l
 import { driveEscalation } from './escalation-drive.js'
 import { shouldSuppressRepresent } from './represent-guard.js'
 import { shouldDeferEscalationForBridge } from './escalation-bridge-gate.js'
+import {
+  answeredSinceOpen,
+  createEscalationSettleGate,
+  resolveEscalateSettleMs,
+} from './escalation-staleness.js'
 import { parkedTurnStartCount } from './stream-render.js'
 
 export function createObligationWiring(deps: ObligationWiringDeps) {
@@ -49,6 +54,11 @@ export function createObligationWiring(deps: ObligationWiringDeps) {
     bridgeAlive,
     sendEscalationNudge,
   } = deps
+
+  // Escalation settle gate (see escalation-staleness.ts). One instance per
+  // wiring — the sweep is the only caller, and the gate must remember the FIRST
+  // escalate decision for an obligation across sweep ticks.
+  const escalateSettleGate = createEscalationSettleGate(resolveEscalateSettleMs())
 
 /**
  * PR2 obligation-ledger CLOSE. Called when a SUBSTANTIVE final answer lands
@@ -304,11 +314,35 @@ function obligationSweep(): void {
     )
     return
   }
-  if (HISTORY_ENABLED && hasOutboundDeliveredSince(o.chatId, o.openedAt, o.threadId)) {
+  // The settle-gate key folds `openedAt` in beside the origin id: an obligation
+  // that is closed and later RE-OPENED under the same origin turn id gets a new
+  // `openedAt`, hence a new key, hence its own fresh settle window — a stale
+  // entry from the previous episode can never let its first escalation skip the
+  // re-check.
+  const settleKey = `${o.originTurnId}@${o.openedAt}`
+  // SCOPE: chat, not thread. The reply router demonstrably resolves an answer to
+  // a different topic than the obligation's — it logs the override
+  // (`EXPLICIT_OVERRIDDEN(model→4,routed→635)`) — so a thread-keyed query cannot
+  // see the delivered answer and nags on top of it. Rationale + evidence in
+  // escalation-staleness.ts.
+  if (answeredSinceOpen(o, { historyEnabled: HISTORY_ENABLED, hasOutboundDeliveredSince })) {
     process.stderr.write(
       `telegram gateway: obligation closed silently — outbound delivered since open origin=${o.originTurnId}\n`,
     )
+    escalateSettleGate.clear(settleKey)
     obligationLedger.close(o.originTurnId)
+    return
+  }
+  // SETTLE. The check above is a point-in-time read, and the answer is often
+  // still IN FLIGHT at this instant (reply tool invoked, history row not yet
+  // written) — confirmed lags of 1.23s and 2.81s between this decision and the
+  // answer landing. Defer the first decision and re-check on a later sweep, so
+  // the nudge only goes out when "unanswered" held across the settle window.
+  // Bounded: a genuinely unanswered obligation escalates one window later.
+  if (escalateSettleGate.shouldDefer(settleKey, now)) {
+    process.stderr.write(
+      `telegram gateway: obligation escalation deferred — settling (re-checking for an in-flight answer) origin=${o.originTurnId}\n`,
+    )
     return
   }
   // Proceed with escalation: send ONE operator-visible nudge and close the
@@ -337,6 +371,11 @@ function obligationSweep(): void {
     maxAttempts: OBLIGATION_ESCALATE_MAX,
     deadlineMs: OBLIGATION_ESCALATE_SEND_DEADLINE_MS,
   })
+  // Terminal for this settle episode. A send that FAILS leaves the obligation
+  // open and re-drives on a later sweep; that retry then opens its own fresh
+  // settle window, which is the same "re-check before nagging" guarantee, not a
+  // regression. Keeps the gate map from retaining closed obligations.
+  escalateSettleGate.clear(settleKey)
 }
 
   return {

--- a/telegram-plugin/gateway/obligation-wiring.ts
+++ b/telegram-plugin/gateway/obligation-wiring.ts
@@ -27,6 +27,7 @@ import {
   answeredSinceOpen,
   createEscalationSettleGate,
   resolveEscalateSettleMs,
+  resolveRerouteMatchWindowMs,
 } from './escalation-staleness.js'
 import { answerRouteOverrides } from './answer-route-overrides.js'
 import { parkedTurnStartCount } from './stream-render.js'
@@ -59,7 +60,12 @@ export function createObligationWiring(deps: ObligationWiringDeps) {
   // Escalation settle gate (see escalation-staleness.ts). One instance per
   // wiring — the sweep is the only caller, and the gate must remember the FIRST
   // escalate decision for an obligation across sweep ticks.
-  const escalateSettleGate = createEscalationSettleGate(resolveEscalateSettleMs())
+  const escalateSettleMs = resolveEscalateSettleMs()
+  const escalateSettleGate = createEscalationSettleGate(escalateSettleMs)
+  // How stale an EXPLICIT_OVERRIDDEN record may be and still license a look in
+  // the thread it names. Derived from the settle window, because the decision
+  // that consults it is the one AFTER the gate. See escalation-staleness.ts.
+  const rerouteMatchWindowMs = resolveRerouteMatchWindowMs(escalateSettleMs)
 
 /**
  * PR2 obligation-ledger CLOSE. Called when a SUBSTANTIVE final answer lands
@@ -322,15 +328,17 @@ function obligationSweep(): void {
     )
     return
   }
-  // SCOPE: the obligation's own topic, PLUS the topics the router recorded an
-  // answer addressed to that topic as actually having been routed to
-  // (`EXPLICIT_OVERRIDDEN(model→N,routed→M)`). Deliberately NOT chat-wide: an
-  // unrelated long message in another topic must not stand this escalation down.
-  // Rationale + field evidence in escalation-staleness.ts.
+  // SCOPE: the obligation's own topic, PLUS — only while the router's
+  // `EXPLICIT_OVERRIDDEN(model→N,routed→M)` record is still FRESH, and only from
+  // that record's own instant — the topic it names. Deliberately neither
+  // chat-wide nor cut at `openedAt`: both of those close a genuinely unanswered
+  // obligation in silence. Field evidence for each in escalation-staleness.ts.
   const answered = answeredSinceOpen(o, {
     historyEnabled: HISTORY_ENABLED,
     hasOutboundDeliveredSince,
     routeOverrides: answerRouteOverrides,
+    nowMs: now,
+    rerouteMatchWindowMs: rerouteMatchWindowMs,
   })
   if (answered.answered) {
     // The two scopes log DISTINGUISHABLY: a `via=reroute` close is the widened

--- a/telegram-plugin/gateway/obligation-wiring.ts
+++ b/telegram-plugin/gateway/obligation-wiring.ts
@@ -329,10 +329,11 @@ function obligationSweep(): void {
     return
   }
   // SCOPE: the obligation's own topic, PLUS — only while the router's
-  // `EXPLICIT_OVERRIDDEN(model→N,routed→M)` record is still FRESH, and only from
-  // that record's own instant — the topic it names. Deliberately neither
-  // chat-wide nor cut at `openedAt`: both of those close a genuinely unanswered
-  // obligation in silence. Field evidence for each in escalation-staleness.ts.
+  // `EXPLICIT_OVERRIDDEN(model→N,routed→M)` record is still FRESH, and only
+  // across that record's own instant + the match window — the topic it names.
+  // Deliberately neither chat-wide, nor cut at `openedAt`, nor open-ended
+  // forward: all three close a genuinely unanswered obligation in silence. Field
+  // evidence for each in escalation-staleness.ts.
   //
   // FRESHNESS ANCHOR: the settle gate's `firstAt` for this obligation when a
   // window is already open, else this decision's `now`. NOT the re-check
@@ -340,10 +341,18 @@ function obligationSweep(): void {
   // session-busy defer, the escalate and represent graces) can SKIP sweep ticks
   // outright, so the decision that consults the record may run minutes after the
   // one that deferred, and a record that was fresh when the question was first
-  // asked would read as stale purely because the sweep was starved.
+  // asked would read as stale purely because the sweep was starved. That same
+  // starvation is why the DELIVERY needs its own upper bound: the anchor makes
+  // the override read fresh at a re-check minutes later, and without a forward
+  // bound it would then reach the whole of that gap. See `#4681` / form (iii).
   const answered = answeredSinceOpen(o, {
     historyEnabled: HISTORY_ENABLED,
     hasOutboundDeliveredSince,
+    // The reroute fallback's query, bounded at BOTH ends. `minChars` stays at
+    // the history default (200 — the escalate branch's substantive floor); only
+    // the upper time bound is added.
+    hasOutboundDeliveredBetween: (chatId, sinceMs, untilMs, threadId) =>
+      hasOutboundDeliveredSince(chatId, sinceMs, threadId, undefined, untilMs),
     routeOverrides: answerRouteOverrides,
     anchorMs: escalateSettleGate.firstAt(o.originTurnId, o.openedAt) ?? now,
     rerouteMatchWindowMs: rerouteMatchWindowMs,

--- a/telegram-plugin/gateway/obligation-wiring.ts
+++ b/telegram-plugin/gateway/obligation-wiring.ts
@@ -28,6 +28,7 @@ import {
   createEscalationSettleGate,
   resolveEscalateSettleMs,
 } from './escalation-staleness.js'
+import { answerRouteOverrides } from './answer-route-overrides.js'
 import { parkedTurnStartCount } from './stream-render.js'
 
 export function createObligationWiring(deps: ObligationWiringDeps) {
@@ -96,7 +97,12 @@ function closeObligationOnSubstantiveReply(
       ? routedOriginTurn.turnId
       : null
   const target = obligationLedger.resolveCloseTarget(echoed?.turnId, liveTurn?.turnId, routedOriginId)
-  if (target != null) obligationLedger.close(target)
+  if (target != null) {
+    obligationLedger.close(target)
+    // The settle gate must forget every terminal, not just the escalate-branch
+    // ones, or a closed obligation's entry lives on until FIFO eviction.
+    escalateSettleGate.clear(target)
+  }
 }
 
 /**
@@ -155,6 +161,7 @@ function cancelInterruptedObligation(): void {
   const turn = getCurrentTurn()
   if (turn == null) return
   if (obligationLedger.close(turn.turnId)) {
+    escalateSettleGate.clear(turn.turnId)
     process.stderr.write(
       `telegram gateway: obligation cancelled by interrupt origin=${turn.turnId}\n`,
     )
@@ -254,6 +261,7 @@ function obligationSweep(): void {
       process.stderr.write(
         `telegram gateway: obligation closed silently — reply delivered since last represent (no re-fire) origin=${o.originTurnId}\n`,
       )
+      escalateSettleGate.clear(o.originTurnId)
       obligationLedger.close(o.originTurnId)
       return
     }
@@ -314,22 +322,27 @@ function obligationSweep(): void {
     )
     return
   }
-  // The settle-gate key folds `openedAt` in beside the origin id: an obligation
-  // that is closed and later RE-OPENED under the same origin turn id gets a new
-  // `openedAt`, hence a new key, hence its own fresh settle window — a stale
-  // entry from the previous episode can never let its first escalation skip the
-  // re-check.
-  const settleKey = `${o.originTurnId}@${o.openedAt}`
-  // SCOPE: chat, not thread. The reply router demonstrably resolves an answer to
-  // a different topic than the obligation's — it logs the override
-  // (`EXPLICIT_OVERRIDDEN(model→4,routed→635)`) — so a thread-keyed query cannot
-  // see the delivered answer and nags on top of it. Rationale + evidence in
-  // escalation-staleness.ts.
-  if (answeredSinceOpen(o, { historyEnabled: HISTORY_ENABLED, hasOutboundDeliveredSince })) {
+  // SCOPE: the obligation's own topic, PLUS the topics the router recorded an
+  // answer addressed to that topic as actually having been routed to
+  // (`EXPLICIT_OVERRIDDEN(model→N,routed→M)`). Deliberately NOT chat-wide: an
+  // unrelated long message in another topic must not stand this escalation down.
+  // Rationale + field evidence in escalation-staleness.ts.
+  const answered = answeredSinceOpen(o, {
+    historyEnabled: HISTORY_ENABLED,
+    hasOutboundDeliveredSince,
+    routeOverrides: answerRouteOverrides,
+  })
+  if (answered.answered) {
+    // The two scopes log DISTINGUISHABLY: a `via=reroute` close is the widened
+    // path, so its blast radius is measurable in production without a rebuild.
+    const scope =
+      answered.via === 'reroute'
+        ? `via=reroute routed_thread=${answered.routedThreadId ?? '-'}`
+        : 'via=thread'
     process.stderr.write(
-      `telegram gateway: obligation closed silently — outbound delivered since open origin=${o.originTurnId}\n`,
+      `telegram gateway: obligation closed silently — outbound delivered since open ${scope} origin=${o.originTurnId}\n`,
     )
-    escalateSettleGate.clear(settleKey)
+    escalateSettleGate.clear(o.originTurnId)
     obligationLedger.close(o.originTurnId)
     return
   }
@@ -339,7 +352,7 @@ function obligationSweep(): void {
   // answer landing. Defer the first decision and re-check on a later sweep, so
   // the nudge only goes out when "unanswered" held across the settle window.
   // Bounded: a genuinely unanswered obligation escalates one window later.
-  if (escalateSettleGate.shouldDefer(settleKey, now)) {
+  if (escalateSettleGate.shouldDefer(o.originTurnId, now, o.openedAt)) {
     process.stderr.write(
       `telegram gateway: obligation escalation deferred — settling (re-checking for an in-flight answer) origin=${o.originTurnId}\n`,
     )
@@ -375,7 +388,7 @@ function obligationSweep(): void {
   // open and re-drives on a later sweep; that retry then opens its own fresh
   // settle window, which is the same "re-check before nagging" guarantee, not a
   // regression. Keeps the gate map from retaining closed obligations.
-  escalateSettleGate.clear(settleKey)
+  escalateSettleGate.clear(o.originTurnId)
 }
 
   return {

--- a/telegram-plugin/gateway/obligation-wiring.ts
+++ b/telegram-plugin/gateway/obligation-wiring.ts
@@ -333,11 +333,19 @@ function obligationSweep(): void {
   // that record's own instant — the topic it names. Deliberately neither
   // chat-wide nor cut at `openedAt`: both of those close a genuinely unanswered
   // obligation in silence. Field evidence for each in escalation-staleness.ts.
+  //
+  // FRESHNESS ANCHOR: the settle gate's `firstAt` for this obligation when a
+  // window is already open, else this decision's `now`. NOT the re-check
+  // instant — every gate above (`turnInFlightForGate`, the background-work /
+  // session-busy defer, the escalate and represent graces) can SKIP sweep ticks
+  // outright, so the decision that consults the record may run minutes after the
+  // one that deferred, and a record that was fresh when the question was first
+  // asked would read as stale purely because the sweep was starved.
   const answered = answeredSinceOpen(o, {
     historyEnabled: HISTORY_ENABLED,
     hasOutboundDeliveredSince,
     routeOverrides: answerRouteOverrides,
-    nowMs: now,
+    anchorMs: escalateSettleGate.firstAt(o.originTurnId, o.openedAt) ?? now,
     rerouteMatchWindowMs: rerouteMatchWindowMs,
   })
   if (answered.answered) {
@@ -353,6 +361,17 @@ function obligationSweep(): void {
     escalateSettleGate.clear(o.originTurnId)
     obligationLedger.close(o.originTurnId)
     return
+  }
+  if (answered.staleOverrideAgeMs != null) {
+    // NEGATIVE-PATH telemetry for the freshness bound. A reroute WAS on record
+    // for this obligation and the bound threw it away — indistinguishable from
+    // "no reroute at all" without this line, which makes the bound (the whole
+    // correctness argument for the fallback) unmeasurable in production. A near
+    // miss here is the signal that the window is mis-tuned.
+    process.stderr.write(
+      `telegram gateway: obligation reroute record rejected age=${answered.staleOverrideAgeMs}ms ` +
+        `window=${rerouteMatchWindowMs}ms origin=${o.originTurnId}\n`,
+    )
   }
   // SETTLE. The check above is a point-in-time read, and the answer is often
   // still IN FLIGHT at this instant (reply tool invoked, history row not yet

--- a/telegram-plugin/gateway/reply-route-log.test.ts
+++ b/telegram-plugin/gateway/reply-route-log.test.ts
@@ -88,6 +88,41 @@ describe('formatReplyRouteLog', () => {
     expect(out).toContain('via=origin')
   })
 
+  // The two `explicitOverridden` clauses the escalation drift matrix
+  // (`tests/escalation-staleness.test.ts`) cannot pin, because it drives the
+  // REAL router: with authority off the router returns the explicit topic, and a
+  // dropped cross-chat anchor falls back to it too — so `threadId !== explicit`
+  // is never true on either arm there. Both combinations are reachable only by
+  // calling this pure formatter directly, and without these two cases both
+  // mutants (drop the authority clause; read the RAW turns instead of the
+  // cross-chat-filtered anchors) survive all 64 matrix cases.
+  it('authority DISABLED never claims the framework overrode the model, even when ' +
+    'the routed thread differs from the explicit one', () => {
+    const out = line({
+      chatId: CHAT_B,
+      frameworkTopicAuthority: false,
+      explicitThreadId: 99,
+      threadId: 4,
+      originTurn: { turnId: `${CHAT_B}:4#1`, sessionChatId: CHAT_B, sessionThreadId: 4 },
+      originVia: 'echo',
+    })
+    expect(out).not.toContain('EXPLICIT_OVERRIDDEN')
+  })
+
+  it('EXPLICIT_OVERRIDDEN reads the FILTERED anchors — a cross-chat origin overrode ' +
+    'nothing, so it must not be reported as if it had', () => {
+    const out = line({
+      chatId: CHAT_B,
+      explicitThreadId: 99,
+      // The target chat's own last-seen topic, not the dropped anchor's.
+      threadId: 4,
+      originTurn: { turnId: 'x', sessionChatId: CHAT_A, sessionThreadId: 635 },
+      originVia: 'echo',
+    })
+    expect(out).toContain('CROSS_CHAT_ANCHOR_DROPPED(')
+    expect(out).not.toContain('EXPLICIT_OVERRIDDEN')
+  })
+
   it('MISROUTE_RISK reads the FILTERED live anchor — a cross-chat live turn cannot raise it', () => {
     const out = line({
       chatId: CHAT_B,

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -1263,6 +1263,20 @@ export function getRecentOutboundCount(
  *   - explicit number → only that thread (precise for supergroups with topics)
  *   - explicit null → only chat-root (non-thread) messages
  *
+ * `untilMs` semantics — the optional UPPER bound (#4681):
+ *   - omitted → open-ended forward, the original behaviour. Correct for a caller
+ *     whose SCOPE is already tied to the obligation (its own topic): anything
+ *     substantive delivered there since it opened is plausibly its answer.
+ *   - a number → only rows at or before it. Required by any caller whose scope is
+ *     licensed by a SEPARATE, time-bounded piece of evidence — the obligation
+ *     escalate branch's reroute fallback, where an `EXPLICIT_OVERRIDDEN` record
+ *     licenses a look in ANOTHER topic. There an open-ended forward query lets
+ *     unrelated traffic in that topic, arriving arbitrarily later, be mistaken
+ *     for the answer that routing produced. See `escalation-staleness.ts`.
+ *   Applied at SECOND granularity like the lower bound, rounded UP (ceil) so
+ *   rounding can only ever ADMIT a borderline row, never drop a legitimate one —
+ *   the false-negative-safe direction for this predicate.
+ *
  * Falls back to false (safe: never suppresses escalation) if history is not yet
  * initialised or the query fails.
  */
@@ -1271,6 +1285,7 @@ export function hasOutboundDeliveredSince(
   sinceMs: number,
   threadId?: number | null,
   minChars = 200,
+  untilMs?: number,
 ): boolean {
   try {
     const cutoffSec = Math.floor(sinceMs / 1000)
@@ -1287,6 +1302,12 @@ export function hasOutboundDeliveredSince(
     // edits / typing indicators are structurally excluded.
     let sql =
       "SELECT 1 FROM messages WHERE chat_id = ? AND role = 'assistant' AND ts >= ? AND LENGTH(text) >= ?"
+    if (untilMs != null && Number.isFinite(untilMs)) {
+      // Ceil: `ts` is whole seconds, so a bound of e.g. 18_500 ms past the
+      // second boundary must still admit the row written in that second.
+      sql += ' AND ts <= ?'
+      params.push(Math.ceil(untilMs / 1000))
+    }
     if (threadId !== undefined) {
       if (threadId === null) {
         sql += ' AND thread_id IS NULL'

--- a/telegram-plugin/tests/answer-route-side-effect.test.ts
+++ b/telegram-plugin/tests/answer-route-side-effect.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The override RECORD is a side effect, and only the real gateway body performs
+ * it. This file is the mechanism that proves it still does.
+ *
+ * WHY A SEPARATE FILE FROM THE DRIFT GUARD. `escalation-staleness.test.ts`
+ * ("the recorded override and the EXPLICIT_OVERRIDDEN marker cannot drift
+ * apart") re-spells `resolveAnswerThreadWithLog`'s body in the test and calls
+ * `createAnswerRouteOverrides().note(...)` on its own instance. That proves the
+ * two PREDICATES agree; it cannot prove the gateway CALLS either one. Delete
+ * `answerRouteOverrides.note({...})` from `gateway.ts` and every one of those 64
+ * cases stays green, the whole vitest suite stays green, and `tsc --noEmit`
+ * exits 0 — while the escalation sweep silently loses the only evidence that
+ * ties "topic A's answer landed in B" to "an answer was delivered at all", and
+ * resumes nagging on top of answers the user already received.
+ *
+ * That is not hypothetical: the call site has conflicted twice already. On main,
+ * #4680 extracted the surrounding block into the pure `formatReplyRouteLog` and
+ * dropped the `note()` call in the process. The next person to resolve that
+ * conflict in main's favour reverts this PR's entire premise with a green tree.
+ * Round 3 caught it by hand — this file replaces that prompt discipline with a
+ * deterministic red.
+ *
+ * HOW. It calls the REAL `resolveAnswerThreadWithLog` from `gateway.ts` (exported
+ * as a test seam; no production caller) and asserts on the PROCESS-WIDE
+ * `answerRouteOverrides` singleton that obligation escalation reads. Nothing here
+ * re-derives the override predicate: the only thing asserted is that driving the
+ * real router mutated the real registry.
+ *
+ * Note for future readers: gateway.ts IS importable from a test runner. Several
+ * older comments in this directory claim otherwise ("the gateway IIFE is too
+ * entangled to instantiate in-process"); that was true before the P0e import
+ * cleanup and is stale now — the boot work is `isGatewayMain`-gated, so a plain
+ * `import` is inert.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { resolveAnswerThreadWithLog } from '../gateway/gateway.js'
+import { answerRouteOverrides } from '../gateway/answer-route-overrides.js'
+import type { CurrentTurn } from '../gateway/gateway.js'
+
+const CHAT = '-100999'
+/** The topic the model addressed its reply to (marko, 2026-08-10 06:36). */
+const MODEL_TOPIC = 4
+/** The topic the framework's authority actually routed it into. */
+const ROUTED_TOPIC = 635
+
+const turn = (chatId: string, threadId: number | undefined): CurrentTurn =>
+  ({
+    turnId: 't1',
+    sessionChatId: chatId,
+    sessionThreadId: threadId,
+    replyCalled: false,
+  }) as unknown as CurrentTurn
+
+describe('the gateway router RECORDS the override it performs (side-effect pin)', () => {
+  beforeEach(() => {
+    // Module singleton — without this a neighbouring file's records leak in and
+    // a deleted `note()` could still look satisfied.
+    answerRouteOverrides.clear()
+    // The router writes its `reply-route` line to stderr; keep the run quiet.
+    vi.spyOn(process.stderr, 'write').mockImplementation((() => true) as never)
+  })
+
+  it('a model-steered reply overridden by a same-chat anchor lands in the registry ' +
+    'obligation escalation reads', () => {
+    expect(answerRouteOverrides.routedOverridesSince(CHAT, MODEL_TOPIC, 0)).toEqual([])
+
+    const routed = resolveAnswerThreadWithLog(
+      CHAT,
+      MODEL_TOPIC,
+      turn(CHAT, ROUTED_TOPIC),
+      'echo',
+      null,
+      'reply',
+    )
+
+    // Precondition: this really is the override shape, not an agreeing route.
+    expect(routed).toBe(ROUTED_TOPIC)
+    expect(routed).not.toBe(MODEL_TOPIC)
+
+    // THE PIN. Empty here means `answerRouteOverrides.note(...)` no longer runs
+    // in `resolveAnswerThreadWithLog` — the escalation sweep has lost its only
+    // per-turn evidence and will nag on top of delivered answers.
+    const recorded = answerRouteOverrides.routedOverridesSince(CHAT, MODEL_TOPIC, 0)
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0]!.routedThreadId).toBe(ROUTED_TOPIC)
+    expect(recorded[0]!.atMs).toBeGreaterThan(0)
+  })
+
+  it('records under the topic the MODEL named, not the one it routed to — the ' +
+    'consumer keys its lookup by the intended topic', () => {
+    resolveAnswerThreadWithLog(CHAT, MODEL_TOPIC, turn(CHAT, ROUTED_TOPIC), 'echo', null, 'reply')
+    expect(answerRouteOverrides.routedOverridesSince(CHAT, ROUTED_TOPIC, 0)).toEqual([])
+    expect(answerRouteOverrides.routedOverridesSince(CHAT, MODEL_TOPIC, 0)).toHaveLength(1)
+  })
+
+  it('NEGATIVE CONTROL: a route that overrode nothing records nothing (so the ' +
+    'pin above cannot be satisfied by an unconditional write)', () => {
+    // Anchor agrees with the model's topic — no override, nothing to record.
+    const routed = resolveAnswerThreadWithLog(
+      CHAT,
+      MODEL_TOPIC,
+      turn(CHAT, MODEL_TOPIC),
+      'echo',
+      null,
+      'reply',
+    )
+    expect(routed).toBe(MODEL_TOPIC)
+    expect(answerRouteOverrides.routedOverridesSince(CHAT, MODEL_TOPIC, 0)).toEqual([])
+    expect(answerRouteOverrides.size()).toBe(0)
+  })
+})

--- a/telegram-plugin/tests/escalation-staleness.test.ts
+++ b/telegram-plugin/tests/escalation-staleness.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   answeredSinceOpen,
   createEscalationSettleGate,
@@ -6,6 +6,7 @@ import {
   resolveRerouteMatchWindowMs,
   OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT,
   OBLIGATION_ESCALATE_SETTLE_MS_MAX,
+  OBLIGATION_REROUTE_MATCH_MS_MAX,
   REROUTE_MATCH_GRACE_MS,
 } from "../gateway/escalation-staleness.js";
 import {
@@ -93,19 +94,29 @@ function overridesWithReroute(
 
 const NO_OVERRIDES = createAnswerRouteOverrides();
 
+// `answerRouteOverrides` is a process-wide module singleton and the end-to-end
+// scenarios below note real records into it with wall-clock timestamps. Reset it
+// before every test so no scenario inherits (or silently depends on) another's.
+beforeEach(() => {
+  answerRouteOverrides.clear();
+});
+
 /** The reroute-fallback deps, with the freshness window the sweep really uses. */
 function stalenessDeps(over: {
   hasOutboundDeliveredSince: (chatId: string, sinceMs: number, threadId?: number | null) => boolean;
   routeOverrides: Parameters<typeof answeredSinceOpen>[1]["routeOverrides"];
   nowMs?: number;
   historyEnabled?: boolean;
+  rerouteMatchWindowMs?: number;
 }) {
   return {
     historyEnabled: over.historyEnabled ?? true,
     hasOutboundDeliveredSince: over.hasOutboundDeliveredSince,
     routeOverrides: over.routeOverrides,
-    nowMs: over.nowMs ?? 2_000,
-    rerouteMatchWindowMs: resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT),
+    anchorMs: over.nowMs ?? 2_000,
+    rerouteMatchWindowMs:
+      over.rerouteMatchWindowMs ??
+      resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT),
   };
 }
 
@@ -183,6 +194,35 @@ describe("answerRouteOverrides — records only genuine explicit-thread override
     expect(reg.routedOverridesSince(CHAT, 4, 0)).toEqual([{ routedThreadId: 3, atMs: 1000 }]);
     // With a later floor, the earliest SURVIVING record wins.
     expect(reg.routedOverridesSince(CHAT, 4, 1600)).toEqual([{ routedThreadId: 3, atMs: 2000 }]);
+  });
+
+  it("clear() drops every record (the process-wide singleton's test reset)", () => {
+    const reg = overridesWithReroute(4, 635, 1000);
+    expect(reg.routedOverridesSince(CHAT, 4, 0)).toHaveLength(1);
+    reg.clear();
+    expect(reg.routedOverridesSince(CHAT, 4, 0)).toEqual([]);
+    expect(reg.newestOverrideSince(CHAT, 4, 0)).toBeUndefined();
+    expect(reg.size()).toBe(0);
+  });
+
+  it("newestOverrideSince returns the LATEST in-window record, not the earliest", () => {
+    const reg = createAnswerRouteOverrides();
+    for (const atMs of [1000, 1500, 2000]) {
+      reg.note({
+        chatId: CHAT,
+        enabled: true,
+        explicitThreadId: 4,
+        anchored: true,
+        routedThreadId: 3,
+        nowMs: atMs,
+      });
+    }
+    // `routedOverridesSince` deliberately yields the earliest (widest cutoff);
+    // the diagnostic asks the opposite question — how NEAR the miss was.
+    expect(reg.routedOverridesSince(CHAT, 4, 0)[0]?.atMs).toBe(1000);
+    expect(reg.newestOverrideSince(CHAT, 4, 0)).toEqual({ routedThreadId: 3, atMs: 2000 });
+    expect(reg.newestOverrideSince(CHAT, 4, 2500)).toBeUndefined();
+    expect(reg.newestOverrideSince(CHAT, 99, 0)).toBeUndefined();
   });
 
   it("bounds both the key count and the per-key history", () => {
@@ -287,7 +327,10 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
     );
     // Cut at `openedAt` this reads {answered: true, via: "reroute"} and the
     // user's message is dropped in silence.
-    expect(answered).toEqual({ answered: false, via: null });
+    expect(answered.answered).toBe(false);
+    expect(answered.via).toBe(null);
+    // …and the rejection is reported rather than silent (594.6s stale).
+    expect(answered.staleOverrideAgeMs).toBe(NOW - 188_418);
   });
 
   it("DOES follow an override that is still fresh, from the override's own instant", () => {
@@ -367,6 +410,64 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
       }),
     );
     expect(answered.answered).toBe(false);
+  });
+
+  it("reports WHY the fallback found nothing when a record existed but was stale", () => {
+    // Negative-path telemetry. "No override on record" and "an override was on
+    // record and the freshness bound rejected it" are operationally different —
+    // the second is the bound doing its job (or being mis-tuned), and without a
+    // signal the 18.5s window is unmeasurable in production. Same 2026-08-13
+    // shape: newest override 188_418, decision 783_000 → 594.6s stale.
+    const reg = createAnswerRouteOverrides();
+    for (const atMs of [41_394, 100_301, 188_418]) {
+      reg.note({
+        chatId: CHAT,
+        enabled: true,
+        explicitThreadId: OBLIGATION_THREAD,
+        anchored: true,
+        routedThreadId: UNRELATED_THREAD,
+        nowMs: atMs,
+      });
+    }
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 0, threadId: OBLIGATION_THREAD },
+      stalenessDeps({
+        hasOutboundDeliveredSince: historyWithAnswer(769_180, UNRELATED_THREAD),
+        routeOverrides: reg,
+        nowMs: 783_000,
+      }),
+    );
+    expect(answered.answered).toBe(false);
+    // The NEWEST rejected record's age — the near-miss the bound must be judged on.
+    expect(answered.staleOverrideAgeMs).toBe(783_000 - 188_418);
+  });
+
+  it("reports NO stale-override age when there was simply no record to reject", () => {
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
+      stalenessDeps({
+        hasOutboundDeliveredSince: historyWithAnswer(2000, UNRELATED_THREAD),
+        routeOverrides: NO_OVERRIDES,
+      }),
+    );
+    expect(answered).toEqual({ answered: false, via: null });
+  });
+
+  it("a ZERO reroute-match window disables the fallback outright (kill switch)", () => {
+    // The fallback is the one new mechanism that can silently close a genuinely
+    // unanswered obligation, so it needs its own off-switch — and the switch
+    // must mean "no fallback", not "a zero-width window an override recorded at
+    // this very instant still slips through".
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1_000, threadId: OBLIGATION_THREAD },
+      stalenessDeps({
+        hasOutboundDeliveredSince: historyWithAnswer(6_000, ROUTED_THREAD),
+        routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, 6_000),
+        nowMs: 6_000,
+        rerouteMatchWindowMs: 0,
+      }),
+    );
+    expect(answered).toEqual({ answered: false, via: null });
   });
 
   it("reports not-answered when history is unavailable (never suppresses on doubt)", () => {
@@ -488,6 +589,45 @@ describe("resolveRerouteMatchWindowMs — how stale an override may be", () => {
     const w = resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT);
     expect(w).toBeGreaterThan(2_809); // worst real override→delivery lag, with margin
     expect(w).toBeLessThan(594_800); // 2026-08-13's stale-override→unrelated-delivery gap
+  });
+
+  it("has its OWN kill switch — SETTLE_MS=0 does not disable the fallback", () => {
+    // The settle gate's kill switch only disables the settle gate. The reroute
+    // fallback is a separate mechanism with a separate failure mode (it can
+    // close a genuinely unanswered obligation SILENTLY), so it gets its own
+    // off-switch. Every sibling guard in this family already has one.
+    expect(
+      resolveRerouteMatchWindowMs(0, { SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS: "0" }),
+    ).toBe(REROUTE_MATCH_GRACE_MS); // still live — the settle switch is not this switch
+    expect(
+      resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT, {
+        SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS: "0",
+      }),
+    ).toBe(0); // and this one really does turn it off
+  });
+
+  it("passes a deliberate override through, and falls back to the derivation on garbage", () => {
+    const derived = resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT);
+    expect(
+      resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT, {
+        SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS: "5000",
+      }),
+    ).toBe(5_000);
+    for (const raw of ["", "soon", "-1", "Infinity"]) {
+      expect(
+        resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT, {
+          SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS: raw,
+        }),
+      ).toBe(derived);
+    }
+  });
+
+  it("clamps an absurd override so a typo cannot widen the silent-close window for a day", () => {
+    expect(
+      resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT, {
+        SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS: "85000000",
+      }),
+    ).toBe(OBLIGATION_REROUTE_MATCH_MS_MAX);
   });
 });
 
@@ -622,6 +762,112 @@ describe("obligationSweep escalate branch — nag only when the answer really is
     }
 
     expect(nudges).toEqual([ORIGIN_D]); // topic 4's message is NOT silently dropped
+  });
+
+  it("every scenario starts from an EMPTY process-wide override registry", () => {
+    // `answerRouteOverrides` is a module singleton and these scenarios write to
+    // it with wall-clock timestamps, so without a reset (b)'s `CHAT:4` record is
+    // still FRESH when (a) and (c) — same topic — run, and (a)/(c) pass only
+    // because their history stubs happen to reject the routed thread. Loosen a
+    // stub and (b) silently changes another test's outcome.
+    expect(answerRouteOverrides.routedOverridesSince(CHAT, OBLIGATION_THREAD, 0)).toEqual([]);
+    expect(answerRouteOverrides.size()).toBe(0);
+  });
+
+  it("(e) a SKIPPED sweep tick does not turn a fresh reroute record stale (freshness anchor)", () => {
+    // The freshness bound must be anchored to the instant the decision FIRST
+    // read "unanswered" — the settle gate's own `firstAt` — not to whenever the
+    // re-check happens to run. A tick is not merely DELAYED, it can be skipped
+    // outright: `turnInFlightForGate()` (unbounded), the background-work /
+    // session-busy defer (bounded at 20 min), and the escalate/represent graces
+    // all sit ABOVE this branch. The 2026-08-13 log shows the sweep deferring
+    // for minutes at a time.
+    //
+    //   T+0      the router reroutes topic 45's answer to thread 635
+    //   T+0.1    first escalate decision — answer still in flight → settle defer
+    //   T+1.4    the rerouted answer lands in thread 635
+    //   T+107    the next decision that actually RUNS (ticks in between skipped)
+    //
+    // Anchored at the re-check, the record is 107s old, the fallback is skipped
+    // and the user is nagged on top of the answer they already have — the exact
+    // bug this PR exists to fix, surviving for that timing.
+    const THREAD_E = 45;
+    const ORIGIN_E = `${CHAT}:${THREAD_E}#5464`;
+    const ledger = new ObligationLedger(2);
+    const base = Date.now();
+    const DELIVERED_AT = base + 1_400;
+    const { wiring, nudges } = makeWiring({
+      ledger,
+      hasOutboundDeliveredSince: (chatId, sinceMs, threadId) =>
+        chatId === CHAT &&
+        (threadId === undefined || threadId === ROUTED_THREAD) &&
+        Date.now() >= DELIVERED_AT &&
+        DELIVERED_AT >= sinceMs,
+    });
+    answerRouteOverrides.note({
+      chatId: CHAT,
+      enabled: true,
+      explicitThreadId: THREAD_E,
+      anchored: true,
+      routedThreadId: ROUTED_THREAD,
+      nowMs: base,
+    });
+    openExhausted(ledger, base - 60_000, ORIGIN_E, THREAD_E);
+
+    const realNow = Date.now;
+    try {
+      Date.now = () => base + 100;
+      wiring.obligationSweep(); // decision 1 — answer in flight → settle
+      expect(nudges).toEqual([]);
+      // …and now the sweep is starved for 107s by the gates above this branch.
+      Date.now = () => base + 107_000;
+      wiring.obligationSweep();
+    } finally {
+      Date.now = realNow;
+    }
+
+    expect(nudges).toEqual([]); // no nag on top of the delivered answer
+    expect(ledger.isOpen(ORIGIN_E)).toBe(false); // closed silently instead
+  });
+
+  it("logs the stale-override rejection so the freshness bound is measurable in production", () => {
+    // The `via=reroute` close is logged because the fallback's blast radius must
+    // be observable without a rebuild. The bound that makes the fallback safe
+    // deserves the same: a rejection currently looks identical to "no record".
+    const THREAD_F = 46;
+    const ORIGIN_F = `${CHAT}:${THREAD_F}#5465`;
+    const ledger = new ObligationLedger(2);
+    const base = Date.now();
+    const { wiring } = makeWiring({
+      ledger,
+      hasOutboundDeliveredSince: historyWithAnswer(base - 14_200, UNRELATED_THREAD),
+    });
+    answerRouteOverrides.note({
+      chatId: CHAT,
+      enabled: true,
+      explicitThreadId: THREAD_F,
+      anchored: true,
+      routedThreadId: UNRELATED_THREAD,
+      nowMs: base - 594_900,
+    });
+    openExhausted(ledger, base - 783_300, ORIGIN_F, THREAD_F);
+
+    const lines: string[] = [];
+    const realWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      lines.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      wiring.obligationSweep();
+    } finally {
+      process.stderr.write = realWrite;
+    }
+
+    const rejected = lines.find((l) => l.includes("reroute record rejected"));
+    expect(rejected).toBeDefined();
+    expect(rejected).toContain("window=18500ms");
+    expect(rejected).toMatch(/age=59[45]\d{3}ms/);
   });
 
   it("(a) an answer that lands while the first escalate decision is settling suppresses the nudge", () => {

--- a/telegram-plugin/tests/escalation-staleness.test.ts
+++ b/telegram-plugin/tests/escalation-staleness.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect } from "vitest";
+import {
+  answeredSinceOpen,
+  createEscalationSettleGate,
+  resolveEscalateSettleMs,
+  OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT,
+} from "../gateway/escalation-staleness.js";
+import { ObligationLedger } from "../gateway/obligation-ledger.js";
+import { createObligationWiring } from "../gateway/obligation-wiring.js";
+import type { InboundMessage } from "../gateway/ipc-protocol.js";
+
+// Regression suite for the false "⚠️ I may have missed an earlier message"
+// escalation that lands ON TOP of an answer the user already received.
+//
+// Two defects in the escalate branch's staleness check, both confirmed in
+// marko's gateway-supervisor.log:
+//
+//   1. THREAD SCOPING (2026-08-13 04:03). Obligation `<chat>:4#5462` lived in
+//      thread 4; the agent's answer (message 5494, 295 chars) was routed to
+//      thread 3 and delivered at 04:02:51.987. The thread-keyed check never saw
+//      it and the nag fired 14.2s LATER, at 04:03:06.140.
+//
+//   2. NO SETTLE (2026-08-10 06:36 and 07:52). The answer was still in flight at
+//      the moment the sweep decided — the reply tool had been invoked but the
+//      history row did not exist yet. Decision 06:36:08.047 → delivery
+//      06:36:09.281 (1,234 ms) and decision 07:52:34.400 → delivery
+//      07:52:37.209 (2,809 ms).
+//
+// And the invariant the fix must NOT break: 2026-08-12 09:08, where the agent
+// genuinely had not answered — its real reply (5357) landed 41,331 ms after the
+// escalation decision. That obligation must still escalate.
+
+const CHAT = "-100999";
+const OBLIGATION_THREAD = 4;
+const ANSWER_THREAD = 3; // the router's `EXPLICIT_OVERRIDDEN(model→4,routed→3)` reroute
+
+/**
+ * Models the real history predicate: an assistant row delivered at `deliveredAt`
+ * under `thread`. `threadId === undefined` from the caller means CHAT scope.
+ */
+function historyWithAnswer(deliveredAt: number, thread: number | null) {
+  return (chatId: string, sinceMs: number, threadId?: number | null): boolean => {
+    if (chatId !== CHAT) return false;
+    if (threadId !== undefined && threadId !== thread) return false;
+    return deliveredAt >= sinceMs;
+  };
+}
+
+describe("answeredSinceOpen — cross-topic delivered answer must stand the escalation down", () => {
+  it("counts an answer delivered to a DIFFERENT thread in the same chat (2026-08-13 04:03)", () => {
+    // Pre-fix this asked history for thread 4 only, found nothing, and nagged.
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
+      {
+        historyEnabled: true,
+        hasOutboundDeliveredSince: historyWithAnswer(2000, ANSWER_THREAD),
+      },
+    );
+    expect(answered).toBe(true);
+  });
+
+  it("counts an answer delivered to the chat ROOT when the obligation is in a topic", () => {
+    // 2026-08-10 07:52: obligation in thread 3, answer 5232 recorded thread_id NULL.
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1000, threadId: 3 },
+      { historyEnabled: true, hasOutboundDeliveredSince: historyWithAnswer(2000, null) },
+    );
+    expect(answered).toBe(true);
+  });
+
+  it("still counts a same-thread answer (the pre-existing behaviour is preserved)", () => {
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
+      {
+        historyEnabled: true,
+        hasOutboundDeliveredSince: historyWithAnswer(2000, OBLIGATION_THREAD),
+      },
+    );
+    expect(answered).toBe(true);
+  });
+
+  it("does NOT count an answer in a DIFFERENT chat (the widening is chat-scoped, not global)", () => {
+    const answered = answeredSinceOpen(
+      { chatId: "-100777", openedAt: 1000, threadId: OBLIGATION_THREAD },
+      {
+        historyEnabled: true,
+        hasOutboundDeliveredSince: historyWithAnswer(2000, ANSWER_THREAD),
+      },
+    );
+    expect(answered).toBe(false);
+  });
+
+  it("does NOT count an answer that PREDATES the obligation", () => {
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 5000, threadId: OBLIGATION_THREAD },
+      {
+        historyEnabled: true,
+        hasOutboundDeliveredSince: historyWithAnswer(2000, ANSWER_THREAD),
+      },
+    );
+    expect(answered).toBe(false);
+  });
+
+  it("reports false when history is unavailable (never suppresses on doubt)", () => {
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
+      { historyEnabled: false, hasOutboundDeliveredSince: () => true },
+    );
+    expect(answered).toBe(false);
+  });
+});
+
+describe("createEscalationSettleGate — the nudge waits out an in-flight answer", () => {
+  const ID = "-100999:4#5462";
+
+  it("defers the FIRST decision and proceeds only after the settle window", () => {
+    const gate = createEscalationSettleGate(8_500);
+    expect(gate.shouldDefer(ID, 0)).toBe(true); // first look — settle
+    expect(gate.shouldDefer(ID, 5_000)).toBe(true); // next 5s sweep, still settling
+    expect(gate.shouldDefer(ID, 8_499)).toBe(true);
+    expect(gate.shouldDefer(ID, 8_500)).toBe(false); // window elapsed → escalate
+  });
+
+  it("is disabled by a zero window (kill switch → pre-fix immediate escalate)", () => {
+    const gate = createEscalationSettleGate(0);
+    expect(gate.shouldDefer(ID, 0)).toBe(false);
+  });
+
+  it("clear() forgets the episode so a later escalate settles afresh", () => {
+    const gate = createEscalationSettleGate(8_500);
+    expect(gate.shouldDefer(ID, 0)).toBe(true);
+    expect(gate.shouldDefer(ID, 9_000)).toBe(false);
+    gate.clear(ID);
+    expect(gate.size()).toBe(0);
+    expect(gate.shouldDefer(ID, 10_000)).toBe(true); // fresh window, not stale-proceed
+  });
+
+  it("tracks obligations independently", () => {
+    const gate = createEscalationSettleGate(8_500);
+    expect(gate.shouldDefer("a", 0)).toBe(true);
+    expect(gate.shouldDefer("b", 8_000)).toBe(true);
+    expect(gate.shouldDefer("a", 9_000)).toBe(false); // a's window elapsed
+    expect(gate.shouldDefer("b", 9_000)).toBe(true); // b's has not
+  });
+
+  it("a backwards clock jump re-anchors instead of pinning the gate open forever", () => {
+    const gate = createEscalationSettleGate(8_500);
+    expect(gate.shouldDefer(ID, 100_000)).toBe(true);
+    expect(gate.shouldDefer(ID, 10_000)).toBe(true); // jumped back → re-anchor
+    expect(gate.shouldDefer(ID, 18_500)).toBe(false); // one window from the new anchor
+  });
+
+  it("bounds its id map (a long-lived gateway cannot grow it without limit)", () => {
+    const gate = createEscalationSettleGate(8_500, 4);
+    for (let i = 0; i < 50; i++) gate.shouldDefer(`id-${i}`, i);
+    expect(gate.size()).toBeLessThanOrEqual(4);
+  });
+});
+
+describe("resolveEscalateSettleMs", () => {
+  it("defaults to the derived window", () => {
+    expect(resolveEscalateSettleMs({})).toBe(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT);
+  });
+  it("honours an explicit 0 kill switch", () => {
+    expect(resolveEscalateSettleMs({ SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS: "0" })).toBe(0);
+  });
+  it("falls back to the default on garbage rather than disabling the guard", () => {
+    expect(resolveEscalateSettleMs({ SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS: "soon" })).toBe(
+      OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT,
+    );
+    expect(resolveEscalateSettleMs({ SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS: "-1" })).toBe(
+      OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT,
+    );
+  });
+});
+
+// End-to-end through the real sweep: the assertion is the OUTCOME the user sees —
+// did the "I may have missed this" nudge go out, and was the obligation closed?
+describe("obligationSweep escalate branch — no nag on top of a delivered answer", () => {
+  const ORIGIN = `${CHAT}:${OBLIGATION_THREAD}#5462`;
+
+  function makeWiring(opts: {
+    ledger: ObligationLedger;
+    hasOutboundDeliveredSince: (chatId: string, sinceMs: number, threadId?: number | null) => boolean;
+  }) {
+    const nudges: string[] = [];
+    const deps = {
+      OBLIGATION_LEDGER_ENABLED: true,
+      HISTORY_ENABLED: true,
+      OBLIGATION_BACKGROUND_WORK_GRACE_MS: 0,
+      OBLIGATION_ESCALATE_GRACE_MS: 0,
+      OBLIGATION_REPRESENT_GRACE_MS: 0,
+      OBLIGATION_REPRESENT_MAX: 2,
+      OBLIGATION_REPRESENT_GUARD_MIN_REPLY_CHARS: 1,
+      OBLIGATION_ESCALATE_MAX: 3,
+      OBLIGATION_ESCALATE_SEND_DEADLINE_MS: 10_000,
+      obligationLedger: opts.ledger,
+      obligationEscalateInFlight: new Set<string>(),
+      pendingCrossTurnGate: { set: () => {} },
+      pendingInboundBuffer: { depth: () => 0, push: () => true },
+      capturedResume: { dispatch: () => {} },
+      getCurrentTurn: () => null,
+      turnInFlightForGate: () => false,
+      agentHasInFlightBackgroundWork: () => false,
+      hasOutboundDeliveredSince: opts.hasOutboundDeliveredSince,
+      findTurnByOriginId: () => undefined,
+      bridgeAlive: () => true,
+      sendEscalationNudge: (o: { originTurnId: string }) => {
+        nudges.push(o.originTurnId);
+        return Promise.resolve();
+      },
+    };
+    const wiring = createObligationWiring(
+      deps as unknown as Parameters<typeof createObligationWiring>[0],
+    );
+    return { wiring, nudges };
+  }
+
+  /** Open an obligation whose represent ladder is already exhausted → escalate. */
+  function openExhausted(ledger: ObligationLedger, openedAt: number): void {
+    ledger.openIfAbsent({
+      originTurnId: ORIGIN,
+      chatId: CHAT,
+      threadId: OBLIGATION_THREAD,
+      messageId: 5462,
+      text: "review lukes sales report",
+      openedAt,
+    });
+    ledger.markRepresented(ORIGIN);
+    ledger.markRepresented(ORIGIN); // count == max → decideAtIdle returns 'escalate'
+  }
+
+  it("(b) an answer delivered to a DIFFERENT thread in the same chat suppresses the nudge", () => {
+    // 2026-08-13 04:03 reproduction. Pre-fix: the thread-4 query misses the
+    // thread-3 answer and the nag fires. Post-fix: closed silently, no nudge.
+    const ledger = new ObligationLedger(2);
+    const openedAt = Date.now() - 60_000;
+    const { wiring, nudges } = makeWiring({
+      ledger,
+      hasOutboundDeliveredSince: historyWithAnswer(Date.now() - 14_200, ANSWER_THREAD),
+    });
+    openExhausted(ledger, openedAt);
+
+    wiring.obligationSweep();
+
+    expect(nudges).toEqual([]); // the user is NOT nagged on top of their answer
+    expect(ledger.isOpen(ORIGIN)).toBe(false); // closed silently
+  });
+
+  it("(a) an answer that lands while the first escalate decision is settling suppresses the nudge", () => {
+    // 2026-08-10 06:36 / 07:52 reproduction: at the first decision the reply is
+    // in flight and no history row exists yet; it appears ~1-3s later. Pre-fix
+    // the nudge is sent on that very first decision.
+    const ledger = new ObligationLedger(2);
+    const openedAt = Date.now() - 60_000;
+    let answerDelivered = false;
+    const { wiring, nudges } = makeWiring({
+      ledger,
+      // Reads false until the in-flight reply is recorded, then true.
+      hasOutboundDeliveredSince: (chatId, sinceMs) =>
+        answerDelivered && chatId === CHAT && Date.now() >= sinceMs,
+    });
+    openExhausted(ledger, openedAt);
+
+    wiring.obligationSweep(); // decision 1 — answer still in flight
+    expect(nudges).toEqual([]); // settling, not sent
+    expect(ledger.isOpen(ORIGIN)).toBe(true); // and not lost
+
+    answerDelivered = true; // the reply's history row lands 1.2s later
+    wiring.obligationSweep(); // next sweep re-checks
+
+    expect(nudges).toEqual([]); // still no nag
+    expect(ledger.isOpen(ORIGIN)).toBe(false); // closed silently instead
+  });
+
+  it("(c) a genuinely unanswered obligation STILL escalates once the settle window elapses", () => {
+    // 2026-08-12 09:08: the agent really had not answered (its reply was 41s
+    // away). The guards must not swallow this — the nudge is the whole point.
+    const ledger = new ObligationLedger(2);
+    const { wiring, nudges } = makeWiring({
+      ledger,
+      hasOutboundDeliveredSince: () => false, // nothing was ever delivered
+    });
+    openExhausted(ledger, Date.now() - 600_000);
+
+    wiring.obligationSweep(); // decision 1 — settles
+    expect(nudges).toEqual([]);
+    expect(ledger.isOpen(ORIGIN)).toBe(true); // held open, not dropped
+
+    // A later sweep, past the settle window. The gate reads the wall clock the
+    // sweep passes it, so advance real time by stubbing Date.now.
+    const realNow = Date.now;
+    try {
+      const t = realNow() + OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT + 1_000;
+      Date.now = () => t;
+      wiring.obligationSweep();
+    } finally {
+      Date.now = realNow;
+    }
+
+    expect(nudges).toEqual([ORIGIN]); // the genuine escalation fires
+  });
+
+  it("the settle deferral is bounded — it cannot silence a genuine escalation indefinitely", () => {
+    const ledger = new ObligationLedger(2);
+    const { wiring, nudges } = makeWiring({ ledger, hasOutboundDeliveredSince: () => false });
+    openExhausted(ledger, Date.now() - 600_000);
+
+    const realNow = Date.now;
+    try {
+      const base = realNow();
+      // Sweep every 5s across the settle window, as the real 5s interval does.
+      for (const offset of [0, 5_000, 10_000]) {
+        Date.now = () => base + offset;
+        wiring.obligationSweep();
+      }
+    } finally {
+      Date.now = realNow;
+    }
+    // Escalated within two sweep ticks of the first decision — not swallowed.
+    expect(nudges).toEqual([ORIGIN]);
+  });
+});

--- a/telegram-plugin/tests/escalation-staleness.test.ts
+++ b/telegram-plugin/tests/escalation-staleness.test.ts
@@ -3,8 +3,10 @@ import {
   answeredSinceOpen,
   createEscalationSettleGate,
   resolveEscalateSettleMs,
+  resolveRerouteMatchWindowMs,
   OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT,
   OBLIGATION_ESCALATE_SETTLE_MS_MAX,
+  REROUTE_MATCH_GRACE_MS,
 } from "../gateway/escalation-staleness.js";
 import {
   createAnswerRouteOverrides,
@@ -39,18 +41,24 @@ import { createObligationWiring } from "../gateway/obligation-wiring.js";
 //   - 2026-08-12 09:08, where the agent genuinely had not answered — its real
 //     reply landed 41,331 ms after the escalation decision. That obligation must
 //     still escalate.
-//   - 2026-08-13 04:03, where obligation `…:4#5462` (thread 4) escalated at
-//     04:03:06.140 while a 292-char answer had landed at 04:02:50.521 — but that
-//     answer was `via=origin` to turn `…:3#5480`, a DIFFERENT question in topic
-//     3, with NO override logged anywhere in the represent→escalate window.
-//     Topic 4's message was genuinely unanswered. A chat-wide "did anything long
-//     land" fallback would have closed it silently; the override-gated fallback
-//     must not.
+//   - 2026-08-13 04:03, where obligation `…:4#5462` (thread 4, opened
+//     03:50:02.807) escalated at 04:03:06.140. Its window holds THREE
+//     `EXPLICIT_OVERRIDDEN(model→4,routed→3)` records (03:50:44.201,
+//     03:51:43.108, 03:53:11.225) AND a later, unrelated 295-char delivery in
+//     thread 3 at 04:02:51.987 answering a DIFFERENT question (`via=origin` to
+//     turn `…:3#5480`). Topic 4's message was genuinely unanswered, so this
+//     obligation MUST escalate. It is the counter-example that kills both weaker
+//     fallbacks: chat-wide, and override-gated-but-cut-at-`openedAt` (which
+//     pairs the 03:53 override with the 04:02 delivery). The newest override is
+//     594.8 s stale at the decision, so the freshness window rejects it.
 
 const CHAT = "-100999";
 const OBLIGATION_THREAD = 4;
 const ROUTED_THREAD = 635; // the router's `EXPLICIT_OVERRIDDEN(model→4,routed→635)` reroute
 const UNRELATED_THREAD = 3;
+// A separate intended topic for the end-to-end counter-example, so its entries
+// in the process-wide override registry cannot collide with another test's.
+const THREAD_D = 44;
 
 /**
  * Models the real history predicate: an assistant row delivered at `deliveredAt`
@@ -85,6 +93,22 @@ function overridesWithReroute(
 
 const NO_OVERRIDES = createAnswerRouteOverrides();
 
+/** The reroute-fallback deps, with the freshness window the sweep really uses. */
+function stalenessDeps(over: {
+  hasOutboundDeliveredSince: (chatId: string, sinceMs: number, threadId?: number | null) => boolean;
+  routeOverrides: Parameters<typeof answeredSinceOpen>[1]["routeOverrides"];
+  nowMs?: number;
+  historyEnabled?: boolean;
+}) {
+  return {
+    historyEnabled: over.historyEnabled ?? true,
+    hasOutboundDeliveredSince: over.hasOutboundDeliveredSince,
+    routeOverrides: over.routeOverrides,
+    nowMs: over.nowMs ?? 2_000,
+    rerouteMatchWindowMs: resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT),
+  };
+}
+
 describe("answerRouteOverrides — records only genuine explicit-thread overrides", () => {
   it("records the reroute the router logs as EXPLICIT_OVERRIDDEN", () => {
     const reg = createAnswerRouteOverrides();
@@ -98,14 +122,14 @@ describe("answerRouteOverrides — records only genuine explicit-thread override
         nowMs: 1000,
       }),
     ).toBe(true);
-    expect(reg.routedThreadsSince(CHAT, 4, 0)).toEqual([635]);
+    expect(reg.routedOverridesSince(CHAT, 4, 0)).toEqual([{ routedThreadId: 635, atMs: 1000 }]);
   });
 
   it("maps a chat-root routing to an explicit NULL thread, never to 'any thread'", () => {
     // 2026-08-10 07:52: `EXPLICIT_OVERRIDDEN(model→3,routed→-)`; recordOutbound
     // writes `thread_id IS NULL` for a threadless send.
     const reg = overridesWithReroute(3, undefined, 1000);
-    expect(reg.routedThreadsSince(CHAT, 3, 0)).toEqual([null]);
+    expect(reg.routedOverridesSince(CHAT, 3, 0)).toEqual([{ routedThreadId: null, atMs: 1000 }]);
   });
 
   it("does NOT record when the routing agreed with the model", () => {
@@ -120,7 +144,7 @@ describe("answerRouteOverrides — records only genuine explicit-thread override
         nowMs: 1000,
       }),
     ).toBe(false);
-    expect(reg.routedThreadsSince(CHAT, 4, 0)).toEqual([]);
+    expect(reg.routedOverridesSince(CHAT, 4, 0)).toEqual([]);
   });
 
   it("does NOT record when the model named no topic, or no anchor could override it", () => {
@@ -134,13 +158,31 @@ describe("answerRouteOverrides — records only genuine explicit-thread override
 
   it("scopes by chat and by intended thread", () => {
     const reg = overridesWithReroute(4, 635, 1000);
-    expect(reg.routedThreadsSince("-100777", 4, 0)).toEqual([]);
-    expect(reg.routedThreadsSince(CHAT, 3, 0)).toEqual([]);
+    expect(reg.routedOverridesSince("-100777", 4, 0)).toEqual([]);
+    expect(reg.routedOverridesSince(CHAT, 3, 0)).toEqual([]);
   });
 
-  it("ignores an override that predates the cutoff", () => {
+  it("ignores an override older than the caller's freshness floor", () => {
     const reg = overridesWithReroute(4, 635, 1000);
-    expect(reg.routedThreadsSince(CHAT, 4, 5000)).toEqual([]);
+    expect(reg.routedOverridesSince(CHAT, 4, 5000)).toEqual([]);
+  });
+
+  it("returns the EARLIEST in-window record per routed thread (the widest correct cutoff)", () => {
+    // 2026-08-13 shape: three overrides, same intended topic, same routed topic.
+    const reg = createAnswerRouteOverrides();
+    for (const atMs of [1000, 1500, 2000]) {
+      reg.note({
+        chatId: CHAT,
+        enabled: true,
+        explicitThreadId: 4,
+        anchored: true,
+        routedThreadId: 3,
+        nowMs: atMs,
+      });
+    }
+    expect(reg.routedOverridesSince(CHAT, 4, 0)).toEqual([{ routedThreadId: 3, atMs: 1000 }]);
+    // With a later floor, the earliest SURVIVING record wins.
+    expect(reg.routedOverridesSince(CHAT, 4, 1600)).toEqual([{ routedThreadId: 3, atMs: 2000 }]);
   });
 
   it("bounds both the key count and the per-key history", () => {
@@ -166,7 +208,7 @@ describe("answerRouteOverrides — records only genuine explicit-thread override
         nowMs: i,
       });
     }
-    expect(reg.routedThreadsSince(CHAT, 4, 0).length).toBeLessThanOrEqual(2);
+    expect(reg.routedOverridesSince(CHAT, 4, 0).length).toBeLessThanOrEqual(2);
   });
 });
 
@@ -175,11 +217,10 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
     // Pre-fix this asked history for thread 4 only, found nothing, and nagged.
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
-      {
-        historyEnabled: true,
+      stalenessDeps({
         hasOutboundDeliveredSince: historyWithAnswer(2000, ROUTED_THREAD),
         routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, 1500),
-      },
+      }),
     );
     expect(answered).toEqual({ answered: true, via: "reroute", routedThreadId: ROUTED_THREAD });
   });
@@ -187,11 +228,10 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
   it("counts an answer rerouted to the chat ROOT (2026-08-10 07:52)", () => {
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: 3 },
-      {
-        historyEnabled: true,
+      stalenessDeps({
         hasOutboundDeliveredSince: historyWithAnswer(2000, null),
         routeOverrides: overridesWithReroute(3, undefined, 1500),
-      },
+      }),
     );
     expect(answered).toEqual({ answered: true, via: "reroute", routedThreadId: null });
   });
@@ -199,11 +239,10 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
   it("still counts a same-thread answer (the pre-existing behaviour is preserved)", () => {
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
-      {
-        historyEnabled: true,
+      stalenessDeps({
         hasOutboundDeliveredSince: historyWithAnswer(2000, OBLIGATION_THREAD),
         routeOverrides: NO_OVERRIDES,
-      },
+      }),
     );
     expect(answered).toEqual({ answered: true, via: "thread" });
   });
@@ -213,24 +252,85 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
     // question must not close topic 4's genuinely-unanswered obligation.
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
-      {
-        historyEnabled: true,
+      stalenessDeps({
         hasOutboundDeliveredSince: historyWithAnswer(2000, UNRELATED_THREAD),
         routeOverrides: NO_OVERRIDES,
-      },
+      }),
     );
     expect(answered).toEqual({ answered: false, via: null });
+  });
+
+  it("does NOT pair a STALE override with a later unrelated delivery (2026-08-13 04:03)", () => {
+    // The real 4#5462 shape, and the one an `openedAt` cutoff gets WRONG.
+    // Opened at 0. Overrides model→4,routed→3 at 41s / 100s / 188s. The
+    // delivery in thread 3 is at 769s — a DIFFERENT question's answer, 594.8s
+    // after the newest override. Decision at 783s.
+    const NOW = 783_000;
+    const reg = createAnswerRouteOverrides();
+    for (const atMs of [41_394, 100_301, 188_418]) {
+      reg.note({
+        chatId: CHAT,
+        enabled: true,
+        explicitThreadId: OBLIGATION_THREAD,
+        anchored: true,
+        routedThreadId: UNRELATED_THREAD,
+        nowMs: atMs,
+      });
+    }
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 0, threadId: OBLIGATION_THREAD },
+      stalenessDeps({
+        hasOutboundDeliveredSince: historyWithAnswer(769_180, UNRELATED_THREAD),
+        routeOverrides: reg,
+        nowMs: NOW,
+      }),
+    );
+    // Cut at `openedAt` this reads {answered: true, via: "reroute"} and the
+    // user's message is dropped in silence.
+    expect(answered).toEqual({ answered: false, via: null });
+  });
+
+  it("DOES follow an override that is still fresh, from the override's own instant", () => {
+    // Same shape, but the decision happens while the override is still inside
+    // the window — the 2026-08-10 case, re-checked after a settle deferral.
+    const NOW = 188_418 + OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT + 1_000;
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 0, threadId: OBLIGATION_THREAD },
+      stalenessDeps({
+        hasOutboundDeliveredSince: historyWithAnswer(189_800, UNRELATED_THREAD),
+        routeOverrides: overridesWithReroute(OBLIGATION_THREAD, UNRELATED_THREAD, 188_418),
+        nowMs: NOW,
+      }),
+    );
+    expect(answered).toEqual({
+      answered: true,
+      via: "reroute",
+      routedThreadId: UNRELATED_THREAD,
+    });
+  });
+
+  it("does NOT accept a delivery that PREDATES the override it is paired with", () => {
+    // The override is fresh, but the only delivery in the routed thread landed
+    // before that routing decision — it cannot be the answer it produced.
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1_000, threadId: OBLIGATION_THREAD },
+      stalenessDeps({
+        hasOutboundDeliveredSince: historyWithAnswer(4_999, ROUTED_THREAD),
+        routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, 5_000),
+        nowMs: 6_000,
+      }),
+    );
+    expect(answered.answered).toBe(false);
   });
 
   it("does NOT follow a reroute recorded for a DIFFERENT topic", () => {
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
-      {
-        historyEnabled: true,
+      stalenessDeps({
         hasOutboundDeliveredSince: historyWithAnswer(2000, ROUTED_THREAD),
         // The override belongs to topic 3's answer, not topic 4's.
         routeOverrides: overridesWithReroute(UNRELATED_THREAD, ROUTED_THREAD, 1500),
-      },
+      }),
     );
     expect(answered.answered).toBe(false);
   });
@@ -238,11 +338,11 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
   it("does NOT follow a reroute that PREDATES the obligation", () => {
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 5000, threadId: OBLIGATION_THREAD },
-      {
-        historyEnabled: true,
+      stalenessDeps({
         hasOutboundDeliveredSince: historyWithAnswer(6000, ROUTED_THREAD),
         routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, 1500),
-      },
+        nowMs: 6000,
+      }),
     );
     expect(answered.answered).toBe(false);
   });
@@ -250,11 +350,10 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
   it("does NOT count an answer in a DIFFERENT chat", () => {
     const answered = answeredSinceOpen(
       { chatId: "-100777", openedAt: 1000, threadId: OBLIGATION_THREAD },
-      {
-        historyEnabled: true,
+      stalenessDeps({
         hasOutboundDeliveredSince: historyWithAnswer(2000, ROUTED_THREAD),
         routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, 1500),
-      },
+      }),
     );
     expect(answered.answered).toBe(false);
   });
@@ -262,11 +361,10 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
   it("does NOT count an answer that PREDATES the obligation", () => {
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 5000, threadId: OBLIGATION_THREAD },
-      {
-        historyEnabled: true,
+      stalenessDeps({
         hasOutboundDeliveredSince: historyWithAnswer(2000, OBLIGATION_THREAD),
         routeOverrides: NO_OVERRIDES,
-      },
+      }),
     );
     expect(answered.answered).toBe(false);
   });
@@ -274,11 +372,11 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
   it("reports not-answered when history is unavailable (never suppresses on doubt)", () => {
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
-      {
-        historyEnabled: false,
+      stalenessDeps({
         hasOutboundDeliveredSince: () => true,
         routeOverrides: NO_OVERRIDES,
-      },
+        historyEnabled: false,
+      }),
     );
     expect(answered.answered).toBe(false);
   });
@@ -373,6 +471,26 @@ describe("resolveEscalateSettleMs", () => {
   });
 });
 
+describe("resolveRerouteMatchWindowMs — how stale an override may be", () => {
+  it("tracks the settle window, because the consulting decision comes after it", () => {
+    expect(resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT)).toBe(
+      OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT + REROUTE_MATCH_GRACE_MS,
+    );
+    expect(resolveRerouteMatchWindowMs(20_000)).toBe(20_000 + REROUTE_MATCH_GRACE_MS);
+  });
+
+  it("still allows a window with the settle gate killed (decision is immediate)", () => {
+    expect(resolveRerouteMatchWindowMs(0)).toBe(REROUTE_MATCH_GRACE_MS);
+    expect(resolveRerouteMatchWindowMs(-5_000)).toBe(REROUTE_MATCH_GRACE_MS);
+  });
+
+  it("stays far below the observed false-pairing gap and far above the real ones", () => {
+    const w = resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT);
+    expect(w).toBeGreaterThan(2_809); // worst real override→delivery lag, with margin
+    expect(w).toBeLessThan(594_800); // 2026-08-13's stale-override→unrelated-delivery gap
+  });
+});
+
 // End-to-end through the real sweep: the assertion is the OUTCOME the user sees —
 // did the "I may have missed this" nudge go out, and was the obligation closed?
 describe("obligationSweep escalate branch — nag only when the answer really is missing", () => {
@@ -416,11 +534,16 @@ describe("obligationSweep escalate branch — nag only when the answer really is
   }
 
   /** Open an obligation whose represent ladder is already exhausted → escalate. */
-  function openExhausted(ledger: ObligationLedger, openedAt: number, origin = ORIGIN): void {
+  function openExhausted(
+    ledger: ObligationLedger,
+    openedAt: number,
+    origin = ORIGIN,
+    threadId = OBLIGATION_THREAD,
+  ): void {
     ledger.openIfAbsent({
       originTurnId: origin,
       chatId: CHAT,
-      threadId: OBLIGATION_THREAD,
+      threadId,
       messageId: 5462,
       text: "synthetic fixture question about the widget report",
       openedAt,
@@ -454,24 +577,42 @@ describe("obligationSweep escalate branch — nag only when the answer really is
     expect(ledger.isOpen(ORIGIN)).toBe(false); // closed silently
   });
 
-  it("(d) an UNRELATED long message in another topic does NOT suppress the nudge (2026-08-13 04:03)", () => {
-    // The blocker this guard exists for. Obligation open in topic 4; a long
-    // assistant message lands in topic 3 answering a DIFFERENT question, with no
-    // reroute on record. A chat-wide fallback closes topic 4's obligation
-    // silently and the user's message is dropped with no nudge and no
-    // re-present. It must escalate instead.
+  it("(d) a STALE reroute record does NOT license an unrelated later delivery (2026-08-13 04:03)", () => {
+    // The blocker this guard exists for, built to the REAL 4#5462 shape — the
+    // overrides the incident actually had, not a scenario without them:
+    //
+    //   opened      03:50:02.807   (T-783.3s from the escalate decision)
+    //   overrides   03:50:44.201 / 03:51:43.108 / 03:53:11.225  model→4,routed→3
+    //   delivery    04:02:51.987   295 chars, thread 3, a DIFFERENT question
+    //   decision    04:03:06.140
+    //
+    // The newest override is 594.8s stale when the sweep decides. Cut at
+    // `openedAt`, the fallback pairs it with that unrelated delivery, closes
+    // topic 4's obligation silently, and the user's message is dropped with no
+    // nudge and no re-present. It must escalate instead.
     const ledger = new ObligationLedger(2);
-    const ORIGIN_D = `${CHAT}:${OBLIGATION_THREAD}#5463`;
+    const ORIGIN_D = `${CHAT}:${THREAD_D}#5463`;
+    const base = Date.now();
     const { wiring, nudges } = makeWiring({
       ledger,
-      // A substantive assistant row exists in topic 3 — and ONLY in topic 3.
-      hasOutboundDeliveredSince: historyWithAnswer(Date.now() - 15_000, UNRELATED_THREAD),
+      // A substantive assistant row in topic 3 — and ONLY in topic 3.
+      hasOutboundDeliveredSince: historyWithAnswer(base - 14_200, UNRELATED_THREAD),
     });
-    openExhausted(ledger, Date.now() - 600_000, ORIGIN_D);
+    // The three real overrides, all long stale by the time the sweep decides.
+    for (const ago of [741_900, 683_000, 594_900]) {
+      answerRouteOverrides.note({
+        chatId: CHAT,
+        enabled: true,
+        explicitThreadId: THREAD_D,
+        anchored: true,
+        routedThreadId: UNRELATED_THREAD,
+        nowMs: base - ago,
+      });
+    }
+    openExhausted(ledger, base - 783_300, ORIGIN_D, THREAD_D);
 
     const realNow = Date.now;
     try {
-      const base = realNow();
       for (const offset of [0, 5_000, 10_000]) {
         Date.now = () => base + offset;
         wiring.obligationSweep();

--- a/telegram-plugin/tests/escalation-staleness.test.ts
+++ b/telegram-plugin/tests/escalation-staleness.test.ts
@@ -62,14 +62,45 @@ const UNRELATED_THREAD = 3;
 const THREAD_D = 44;
 
 /**
- * Models the real history predicate: an assistant row delivered at `deliveredAt`
- * under `thread`. `threadId === undefined` from the caller means CHAT scope.
+ * The history table as the module sees it. `threadId === undefined` from the
+ * caller means CHAT scope; `untilMs` is the reroute fallback's UPPER bound —
+ * modelled here, not ignored, or every test that depends on it passes vacuously.
  */
-function historyWithAnswer(deliveredAt: number, thread: number | null) {
-  return (chatId: string, sinceMs: number, threadId?: number | null): boolean => {
+type HistoryStub = (
+  chatId: string,
+  sinceMs: number,
+  threadId?: number | null,
+  untilMs?: number,
+) => boolean;
+
+/**
+ * Models the real history predicate: an assistant row delivered at `deliveredAt`
+ * under `thread`.
+ */
+function historyWithAnswer(deliveredAt: number, thread: number | null): HistoryStub {
+  return (chatId, sinceMs, threadId, untilMs): boolean => {
     if (chatId !== CHAT) return false;
     if (threadId !== undefined && threadId !== thread) return false;
+    if (untilMs != null && deliveredAt > untilMs) return false;
     return deliveredAt >= sinceMs;
+  };
+}
+
+/**
+ * Fan ONE history stub out into the two deps `answeredSinceOpen` takes, exactly
+ * as obligation-wiring does: the obligation's own topic is queried open-ended,
+ * the reroute fallback is queried bounded at both ends.
+ */
+function historyDeps(stub: HistoryStub) {
+  return {
+    hasOutboundDeliveredSince: (chatId: string, sinceMs: number, threadId?: number | null) =>
+      stub(chatId, sinceMs, threadId),
+    hasOutboundDeliveredBetween: (
+      chatId: string,
+      sinceMs: number,
+      untilMs: number,
+      threadId?: number | null,
+    ) => stub(chatId, sinceMs, threadId, untilMs),
   };
 }
 
@@ -103,7 +134,7 @@ beforeEach(() => {
 
 /** The reroute-fallback deps, with the freshness window the sweep really uses. */
 function stalenessDeps(over: {
-  hasOutboundDeliveredSince: (chatId: string, sinceMs: number, threadId?: number | null) => boolean;
+  hasOutboundDeliveredSince: HistoryStub;
   routeOverrides: Parameters<typeof answeredSinceOpen>[1]["routeOverrides"];
   nowMs?: number;
   historyEnabled?: boolean;
@@ -111,7 +142,7 @@ function stalenessDeps(over: {
 }) {
   return {
     historyEnabled: over.historyEnabled ?? true,
-    hasOutboundDeliveredSince: over.hasOutboundDeliveredSince,
+    ...historyDeps(over.hasOutboundDeliveredSince),
     routeOverrides: over.routeOverrides,
     anchorMs: over.nowMs ?? 2_000,
     rerouteMatchWindowMs:
@@ -366,6 +397,39 @@ describe("answeredSinceOpen — a REROUTED answer stands the escalation down", (
     expect(answered.answered).toBe(false);
   });
 
+  it("does NOT accept a delivery that lands long AFTER a still-fresh override", () => {
+    // The other end of the same bound, and the one #4681 was missing. The
+    // override is fresh at `anchorMs` (which is the settle gate's `firstAt`, so
+    // it stays fresh however long the sweep is starved), but the only delivery
+    // in the routed thread landed 90s after that routing decision — far outside
+    // the window in which the answer it produced could have landed. It is
+    // someone else's answer.
+    const WINDOW = resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT);
+    const OVERRIDE_AT = 10_000;
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1_000, threadId: OBLIGATION_THREAD },
+      stalenessDeps({
+        hasOutboundDeliveredSince: historyWithAnswer(OVERRIDE_AT + 90_000, ROUTED_THREAD),
+        routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, OVERRIDE_AT),
+        // Anchored at the first "unanswered" read, so the override IS fresh.
+        nowMs: OVERRIDE_AT + 100,
+      }),
+    );
+    expect(answered.answered).toBe(false);
+    // …and one that lands at the very edge of the window still counts, so the
+    // bound is a bound and not a blanket refusal.
+    expect(
+      answeredSinceOpen(
+        { chatId: CHAT, openedAt: 1_000, threadId: OBLIGATION_THREAD },
+        stalenessDeps({
+          hasOutboundDeliveredSince: historyWithAnswer(OVERRIDE_AT + WINDOW, ROUTED_THREAD),
+          routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, OVERRIDE_AT),
+          nowMs: OVERRIDE_AT + 100,
+        }),
+      ),
+    ).toEqual({ answered: true, via: "reroute", routedThreadId: ROUTED_THREAD });
+  });
+
   it("does NOT follow a reroute recorded for a DIFFERENT topic", () => {
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
@@ -570,6 +634,16 @@ describe("resolveEscalateSettleMs", () => {
       20_000,
     );
   });
+  it("treats a WHITESPACE-ONLY value as unset, not as the kill switch", () => {
+    // `Number(' ') === 0`, so a bare `=== ''` check lets a stray `KEY=" "` in an
+    // env file silently disable the guard with no log. Empty and whitespace must
+    // mean the same thing: unset.
+    for (const raw of [" ", "  ", "\t", "\n"]) {
+      expect(resolveEscalateSettleMs({ SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS: raw })).toBe(
+        OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT,
+      );
+    }
+  });
 });
 
 describe("resolveRerouteMatchWindowMs — how stale an override may be", () => {
@@ -613,7 +687,9 @@ describe("resolveRerouteMatchWindowMs — how stale an override may be", () => {
         SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS: "5000",
       }),
     ).toBe(5_000);
-    for (const raw of ["", "soon", "-1", "Infinity"]) {
+    // Whitespace-only is UNSET, not the kill switch: `Number(' ') === 0`, so a
+    // bare `=== ''` check lets a stray `KEY=" "` turn the fallback off silently.
+    for (const raw of ["", " ", "  ", "\t", "\n", "soon", "-1", "Infinity"]) {
       expect(
         resolveRerouteMatchWindowMs(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT, {
           SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS: raw,
@@ -636,10 +712,7 @@ describe("resolveRerouteMatchWindowMs — how stale an override may be", () => {
 describe("obligationSweep escalate branch — nag only when the answer really is missing", () => {
   const ORIGIN = `${CHAT}:${OBLIGATION_THREAD}#5462`;
 
-  function makeWiring(opts: {
-    ledger: ObligationLedger;
-    hasOutboundDeliveredSince: (chatId: string, sinceMs: number, threadId?: number | null) => boolean;
-  }) {
+  function makeWiring(opts: { ledger: ObligationLedger; hasOutboundDeliveredSince: HistoryStub }) {
     const nudges: string[] = [];
     const deps = {
       OBLIGATION_LEDGER_ENABLED: true,
@@ -659,7 +732,16 @@ describe("obligationSweep escalate branch — nag only when the answer really is
       getCurrentTurn: () => null,
       turnInFlightForGate: () => false,
       agentHasInFlightBackgroundWork: () => false,
-      hasOutboundDeliveredSince: opts.hasOutboundDeliveredSince,
+      // The REAL history signature the gateway injects — `minChars` 4th,
+      // `untilMs` 5th — so obligation-wiring's own bounded-query adapter is under
+      // test here, not bypassed by a convenience stub.
+      hasOutboundDeliveredSince: (
+        chatId: string,
+        sinceMs: number,
+        threadId?: number | null,
+        _minChars?: number,
+        untilMs?: number,
+      ) => opts.hasOutboundDeliveredSince(chatId, sinceMs, threadId, untilMs),
       findTurnByOriginId: () => undefined,
       bridgeAlive: () => true,
       sendEscalationNudge: (o: { originTurnId: string }) => {
@@ -764,12 +846,30 @@ describe("obligationSweep escalate branch — nag only when the answer really is
     expect(nudges).toEqual([ORIGIN_D]); // topic 4's message is NOT silently dropped
   });
 
-  it("every scenario starts from an EMPTY process-wide override registry", () => {
-    // `answerRouteOverrides` is a module singleton and these scenarios write to
-    // it with wall-clock timestamps, so without a reset (b)'s `CHAT:4` record is
-    // still FRESH when (a) and (c) — same topic — run, and (a)/(c) pass only
+  // The leak guard is a PAIR, and deliberately so. Asserting "the registry is
+  // empty" on its own passes vacuously the moment the tests that write to the
+  // singleton are moved below it — the guard would then be green precisely when
+  // it has stopped guarding. Pinning its own polluter immediately above it makes
+  // it order-independent: whatever else moves, this assertion always runs one
+  // test after a write it can see.
+  it("leak guard 1/2 — pollute the process-wide override registry", () => {
+    // `answerRouteOverrides` is a module singleton and the scenarios here write
+    // to it with wall-clock timestamps, so without a reset (b)'s `CHAT:4` record
+    // is still FRESH when (a) and (c) — same topic — run, and (a)/(c) pass only
     // because their history stubs happen to reject the routed thread. Loosen a
     // stub and (b) silently changes another test's outcome.
+    answerRouteOverrides.note({
+      chatId: CHAT,
+      enabled: true,
+      explicitThreadId: OBLIGATION_THREAD,
+      anchored: true,
+      routedThreadId: ROUTED_THREAD,
+      nowMs: Date.now(),
+    });
+    expect(answerRouteOverrides.size()).toBe(1);
+  });
+
+  it("leak guard 2/2 — the NEXT scenario still starts from an EMPTY registry", () => {
     expect(answerRouteOverrides.routedOverridesSince(CHAT, OBLIGATION_THREAD, 0)).toEqual([]);
     expect(answerRouteOverrides.size()).toBe(0);
   });
@@ -798,11 +898,12 @@ describe("obligationSweep escalate branch — nag only when the answer really is
     const DELIVERED_AT = base + 1_400;
     const { wiring, nudges } = makeWiring({
       ledger,
-      hasOutboundDeliveredSince: (chatId, sinceMs, threadId) =>
+      hasOutboundDeliveredSince: (chatId, sinceMs, threadId, untilMs) =>
         chatId === CHAT &&
         (threadId === undefined || threadId === ROUTED_THREAD) &&
         Date.now() >= DELIVERED_AT &&
-        DELIVERED_AT >= sinceMs,
+        DELIVERED_AT >= sinceMs &&
+        (untilMs == null || DELIVERED_AT <= untilMs),
     });
     answerRouteOverrides.note({
       chatId: CHAT,
@@ -828,6 +929,84 @@ describe("obligationSweep escalate branch — nag only when the answer really is
 
     expect(nudges).toEqual([]); // no nag on top of the delivered answer
     expect(ledger.isOpen(ORIGIN_E)).toBe(false); // closed silently instead
+  });
+
+  it("(f) a STARVED sweep does not pair a fresh override with a much later unrelated delivery", () => {
+    // The counterpart to (e), and the failure mode the `firstAt` anchor opens if
+    // the DELIVERY is left unbounded. Anchoring the override's freshness at
+    // `firstAt` is correct (see (e)) but it only bounds ONE end: it says the
+    // routing decision was recent WHEN THE QUESTION WAS FIRST ASKED. The history
+    // query is still read at the RE-CHECK, which the gates above this branch can
+    // starve for minutes — so an override that is legitimately fresh licenses a
+    // look at a thread across an arbitrarily long stretch of later traffic.
+    //
+    //   T+0      the model's SHORT reply to topic 47 is rerouted to thread 635.
+    //            Under 200 chars, so it is not a substantive answer and the
+    //            obligation correctly stays open.
+    //   T+0.1    first escalate decision — not answered → settle defer.
+    //            `firstAt` is pinned here for the whole episode.
+    //   T+90     an unrelated >=200-char answer to a DIFFERENT question lands in
+    //            thread 635.
+    //   T+107    the next decision that actually RUNS.
+    //
+    // Anchored at `firstAt` with an open-ended forward query, T+0's override
+    // reads fresh at T+107 and pairs with the T+90 delivery: the obligation is
+    // closed `via=reroute` and topic 47's message is never answered and never
+    // nudged. It must escalate instead. Bounding the delivery to the override's
+    // OWN window keeps (e)'s legitimate 1.4s pairing and kills this 90s one.
+    const THREAD_G = 47;
+    const ORIGIN_G = `${CHAT}:${THREAD_G}#5466`;
+    const ledger = new ObligationLedger(2);
+    const base = Date.now();
+    const UNRELATED_DELIVERED_AT = base + 90_000;
+    const { wiring, nudges } = makeWiring({
+      ledger,
+      // Only the unrelated T+90 row ever exists, and — like the real table — it
+      // is invisible until the instant it is written. Nothing was ever delivered
+      // for topic 47: not in its own thread, not in the routed one.
+      hasOutboundDeliveredSince: (chatId, sinceMs, threadId, untilMs) =>
+        chatId === CHAT &&
+        (threadId === undefined || threadId === ROUTED_THREAD) &&
+        Date.now() >= UNRELATED_DELIVERED_AT &&
+        UNRELATED_DELIVERED_AT >= sinceMs &&
+        (untilMs == null || UNRELATED_DELIVERED_AT <= untilMs),
+    });
+    answerRouteOverrides.note({
+      chatId: CHAT,
+      enabled: true,
+      explicitThreadId: THREAD_G,
+      anchored: true,
+      routedThreadId: ROUTED_THREAD,
+      nowMs: base,
+    });
+    openExhausted(ledger, base - 60_000, ORIGIN_G, THREAD_G);
+
+    const lines: string[] = [];
+    const realWrite = process.stderr.write.bind(process.stderr);
+    const realNow = Date.now;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      lines.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      Date.now = () => base + 100;
+      wiring.obligationSweep(); // decision 1 — nothing delivered yet → settle
+      expect(nudges).toEqual([]);
+      // …starved for 107s by the gates above this branch, exactly as in (e).
+      Date.now = () => base + 107_000;
+      wiring.obligationSweep();
+    } finally {
+      Date.now = realNow;
+      process.stderr.write = realWrite;
+    }
+
+    expect(nudges).toEqual([ORIGIN_G]); // topic 47's message is NOT dropped in silence
+    // …and specifically NOT via the reroute fallback pairing T+0's override with
+    // the T+90 stranger. (`nudges` alone would not distinguish a silent close
+    // from a send that has not resolved yet — the escalate send is async.)
+    expect(
+      lines.filter((l) => l.includes("closed silently") && l.includes(ORIGIN_G)),
+    ).toEqual([]);
   });
 
   it("logs the stale-override rejection so the freshness bound is measurable in production", () => {
@@ -881,11 +1060,12 @@ describe("obligationSweep escalate branch — nag only when the answer really is
       ledger,
       // Reads false until the in-flight reply is recorded, then true — in the
       // obligation's OWN topic, so no reroute record is needed.
-      hasOutboundDeliveredSince: (chatId, sinceMs, threadId) =>
+      hasOutboundDeliveredSince: (chatId, sinceMs, threadId, untilMs) =>
         answerDelivered &&
         chatId === CHAT &&
         (threadId === undefined || threadId === OBLIGATION_THREAD) &&
-        Date.now() >= sinceMs,
+        Date.now() >= sinceMs &&
+        (untilMs == null || Date.now() <= untilMs),
     });
     openExhausted(ledger, openedAt);
 

--- a/telegram-plugin/tests/escalation-staleness.test.ts
+++ b/telegram-plugin/tests/escalation-staleness.test.ts
@@ -4,21 +4,29 @@ import {
   createEscalationSettleGate,
   resolveEscalateSettleMs,
   OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT,
+  OBLIGATION_ESCALATE_SETTLE_MS_MAX,
 } from "../gateway/escalation-staleness.js";
+import {
+  createAnswerRouteOverrides,
+  answerRouteOverrides,
+} from "../gateway/answer-route-overrides.js";
 import { ObligationLedger } from "../gateway/obligation-ledger.js";
 import { createObligationWiring } from "../gateway/obligation-wiring.js";
-import type { InboundMessage } from "../gateway/ipc-protocol.js";
 
 // Regression suite for the false "⚠️ I may have missed an earlier message"
-// escalation that lands ON TOP of an answer the user already received.
+// escalation that lands ON TOP of an answer the user already received — and for
+// the opposite failure the fix must not introduce, where a genuinely unanswered
+// message is silently closed by someone else's answer.
 //
-// Two defects in the escalate branch's staleness check, both confirmed in
-// marko's gateway-supervisor.log:
+// Both defects were confirmed in marko's gateway-supervisor.log. Only ids,
+// topics and timings are reproduced here; no chat id and no message bodies.
 //
-//   1. THREAD SCOPING (2026-08-13 04:03). Obligation `<chat>:4#5462` lived in
-//      thread 4; the agent's answer (message 5494, 295 chars) was routed to
-//      thread 3 and delivered at 04:02:51.987. The thread-keyed check never saw
-//      it and the nag fired 14.2s LATER, at 04:03:06.140.
+//   1. REROUTED ANSWER (2026-08-10 06:36). Obligation `…:4#5191` lived in thread
+//      4; the model addressed its reply to thread 4 and the framework's topic
+//      authority overrode that to thread 635 — logged
+//      `EXPLICIT_OVERRIDDEN(model→4,routed→635)` at 06:36:07.921. The
+//      thread-4-keyed staleness check never saw the answer and the nag fired
+//      126 ms later at 06:36:08.047.
 //
 //   2. NO SETTLE (2026-08-10 06:36 and 07:52). The answer was still in flight at
 //      the moment the sweep decided — the reply tool had been invoked but the
@@ -26,13 +34,23 @@ import type { InboundMessage } from "../gateway/ipc-protocol.js";
 //      06:36:09.281 (1,234 ms) and decision 07:52:34.400 → delivery
 //      07:52:37.209 (2,809 ms).
 //
-// And the invariant the fix must NOT break: 2026-08-12 09:08, where the agent
-// genuinely had not answered — its real reply (5357) landed 41,331 ms after the
-// escalation decision. That obligation must still escalate.
+// And the two invariants the fix must NOT break:
+//
+//   - 2026-08-12 09:08, where the agent genuinely had not answered — its real
+//     reply landed 41,331 ms after the escalation decision. That obligation must
+//     still escalate.
+//   - 2026-08-13 04:03, where obligation `…:4#5462` (thread 4) escalated at
+//     04:03:06.140 while a 292-char answer had landed at 04:02:50.521 — but that
+//     answer was `via=origin` to turn `…:3#5480`, a DIFFERENT question in topic
+//     3, with NO override logged anywhere in the represent→escalate window.
+//     Topic 4's message was genuinely unanswered. A chat-wide "did anything long
+//     land" fallback would have closed it silently; the override-gated fallback
+//     must not.
 
 const CHAT = "-100999";
 const OBLIGATION_THREAD = 4;
-const ANSWER_THREAD = 3; // the router's `EXPLICIT_OVERRIDDEN(model→4,routed→3)` reroute
+const ROUTED_THREAD = 635; // the router's `EXPLICIT_OVERRIDDEN(model→4,routed→635)` reroute
+const UNRELATED_THREAD = 3;
 
 /**
  * Models the real history predicate: an assistant row delivered at `deliveredAt`
@@ -46,26 +64,136 @@ function historyWithAnswer(deliveredAt: number, thread: number | null) {
   };
 }
 
-describe("answeredSinceOpen — cross-topic delivered answer must stand the escalation down", () => {
-  it("counts an answer delivered to a DIFFERENT thread in the same chat (2026-08-13 04:03)", () => {
+/** A route-override registry pre-loaded with one recorded reroute. */
+function overridesWithReroute(
+  intendedThreadId: number,
+  routedThreadId: number | undefined,
+  atMs: number,
+  chatId = CHAT,
+) {
+  const reg = createAnswerRouteOverrides();
+  reg.note({
+    chatId,
+    enabled: true,
+    explicitThreadId: intendedThreadId,
+    anchored: true,
+    routedThreadId,
+    nowMs: atMs,
+  });
+  return reg;
+}
+
+const NO_OVERRIDES = createAnswerRouteOverrides();
+
+describe("answerRouteOverrides — records only genuine explicit-thread overrides", () => {
+  it("records the reroute the router logs as EXPLICIT_OVERRIDDEN", () => {
+    const reg = createAnswerRouteOverrides();
+    expect(
+      reg.note({
+        chatId: CHAT,
+        enabled: true,
+        explicitThreadId: 4,
+        anchored: true,
+        routedThreadId: 635,
+        nowMs: 1000,
+      }),
+    ).toBe(true);
+    expect(reg.routedThreadsSince(CHAT, 4, 0)).toEqual([635]);
+  });
+
+  it("maps a chat-root routing to an explicit NULL thread, never to 'any thread'", () => {
+    // 2026-08-10 07:52: `EXPLICIT_OVERRIDDEN(model→3,routed→-)`; recordOutbound
+    // writes `thread_id IS NULL` for a threadless send.
+    const reg = overridesWithReroute(3, undefined, 1000);
+    expect(reg.routedThreadsSince(CHAT, 3, 0)).toEqual([null]);
+  });
+
+  it("does NOT record when the routing agreed with the model", () => {
+    const reg = createAnswerRouteOverrides();
+    expect(
+      reg.note({
+        chatId: CHAT,
+        enabled: true,
+        explicitThreadId: 4,
+        anchored: true,
+        routedThreadId: 4,
+        nowMs: 1000,
+      }),
+    ).toBe(false);
+    expect(reg.routedThreadsSince(CHAT, 4, 0)).toEqual([]);
+  });
+
+  it("does NOT record when the model named no topic, or no anchor could override it", () => {
+    const reg = createAnswerRouteOverrides();
+    const base = { chatId: CHAT, enabled: true, routedThreadId: 635, nowMs: 1000 };
+    expect(reg.note({ ...base, explicitThreadId: undefined, anchored: true })).toBe(false);
+    expect(reg.note({ ...base, explicitThreadId: 4, anchored: false })).toBe(false);
+    expect(reg.note({ ...base, explicitThreadId: 4, anchored: true, enabled: false })).toBe(false);
+    expect(reg.size()).toBe(0);
+  });
+
+  it("scopes by chat and by intended thread", () => {
+    const reg = overridesWithReroute(4, 635, 1000);
+    expect(reg.routedThreadsSince("-100777", 4, 0)).toEqual([]);
+    expect(reg.routedThreadsSince(CHAT, 3, 0)).toEqual([]);
+  });
+
+  it("ignores an override that predates the cutoff", () => {
+    const reg = overridesWithReroute(4, 635, 1000);
+    expect(reg.routedThreadsSince(CHAT, 4, 5000)).toEqual([]);
+  });
+
+  it("bounds both the key count and the per-key history", () => {
+    const reg = createAnswerRouteOverrides(3, 2);
+    for (let i = 0; i < 20; i++) {
+      reg.note({
+        chatId: `chat-${i}`,
+        enabled: true,
+        explicitThreadId: 4,
+        anchored: true,
+        routedThreadId: 635,
+        nowMs: i,
+      });
+    }
+    expect(reg.size()).toBeLessThanOrEqual(3);
+    for (let i = 0; i < 20; i++) {
+      reg.note({
+        chatId: CHAT,
+        enabled: true,
+        explicitThreadId: 4,
+        anchored: true,
+        routedThreadId: i,
+        nowMs: i,
+      });
+    }
+    expect(reg.routedThreadsSince(CHAT, 4, 0).length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("answeredSinceOpen — a REROUTED answer stands the escalation down", () => {
+  it("counts an answer the router recorded as rerouted out of this topic (2026-08-10 06:36)", () => {
     // Pre-fix this asked history for thread 4 only, found nothing, and nagged.
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
       {
         historyEnabled: true,
-        hasOutboundDeliveredSince: historyWithAnswer(2000, ANSWER_THREAD),
+        hasOutboundDeliveredSince: historyWithAnswer(2000, ROUTED_THREAD),
+        routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, 1500),
       },
     );
-    expect(answered).toBe(true);
+    expect(answered).toEqual({ answered: true, via: "reroute", routedThreadId: ROUTED_THREAD });
   });
 
-  it("counts an answer delivered to the chat ROOT when the obligation is in a topic", () => {
-    // 2026-08-10 07:52: obligation in thread 3, answer 5232 recorded thread_id NULL.
+  it("counts an answer rerouted to the chat ROOT (2026-08-10 07:52)", () => {
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: 3 },
-      { historyEnabled: true, hasOutboundDeliveredSince: historyWithAnswer(2000, null) },
+      {
+        historyEnabled: true,
+        hasOutboundDeliveredSince: historyWithAnswer(2000, null),
+        routeOverrides: overridesWithReroute(3, undefined, 1500),
+      },
     );
-    expect(answered).toBe(true);
+    expect(answered).toEqual({ answered: true, via: "reroute", routedThreadId: null });
   });
 
   it("still counts a same-thread answer (the pre-existing behaviour is preserved)", () => {
@@ -74,20 +202,61 @@ describe("answeredSinceOpen — cross-topic delivered answer must stand the esca
       {
         historyEnabled: true,
         hasOutboundDeliveredSince: historyWithAnswer(2000, OBLIGATION_THREAD),
+        routeOverrides: NO_OVERRIDES,
       },
     );
-    expect(answered).toBe(true);
+    expect(answered).toEqual({ answered: true, via: "thread" });
   });
 
-  it("does NOT count an answer in a DIFFERENT chat (the widening is chat-scoped, not global)", () => {
+  it("does NOT count an unrelated answer in ANOTHER topic with no reroute on record (2026-08-13 04:03)", () => {
+    // The whole point of the override gate: topic 3's answer to a DIFFERENT
+    // question must not close topic 4's genuinely-unanswered obligation.
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
+      {
+        historyEnabled: true,
+        hasOutboundDeliveredSince: historyWithAnswer(2000, UNRELATED_THREAD),
+        routeOverrides: NO_OVERRIDES,
+      },
+    );
+    expect(answered).toEqual({ answered: false, via: null });
+  });
+
+  it("does NOT follow a reroute recorded for a DIFFERENT topic", () => {
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
+      {
+        historyEnabled: true,
+        hasOutboundDeliveredSince: historyWithAnswer(2000, ROUTED_THREAD),
+        // The override belongs to topic 3's answer, not topic 4's.
+        routeOverrides: overridesWithReroute(UNRELATED_THREAD, ROUTED_THREAD, 1500),
+      },
+    );
+    expect(answered.answered).toBe(false);
+  });
+
+  it("does NOT follow a reroute that PREDATES the obligation", () => {
+    const answered = answeredSinceOpen(
+      { chatId: CHAT, openedAt: 5000, threadId: OBLIGATION_THREAD },
+      {
+        historyEnabled: true,
+        hasOutboundDeliveredSince: historyWithAnswer(6000, ROUTED_THREAD),
+        routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, 1500),
+      },
+    );
+    expect(answered.answered).toBe(false);
+  });
+
+  it("does NOT count an answer in a DIFFERENT chat", () => {
     const answered = answeredSinceOpen(
       { chatId: "-100777", openedAt: 1000, threadId: OBLIGATION_THREAD },
       {
         historyEnabled: true,
-        hasOutboundDeliveredSince: historyWithAnswer(2000, ANSWER_THREAD),
+        hasOutboundDeliveredSince: historyWithAnswer(2000, ROUTED_THREAD),
+        routeOverrides: overridesWithReroute(OBLIGATION_THREAD, ROUTED_THREAD, 1500),
       },
     );
-    expect(answered).toBe(false);
+    expect(answered.answered).toBe(false);
   });
 
   it("does NOT count an answer that PREDATES the obligation", () => {
@@ -95,64 +264,81 @@ describe("answeredSinceOpen — cross-topic delivered answer must stand the esca
       { chatId: CHAT, openedAt: 5000, threadId: OBLIGATION_THREAD },
       {
         historyEnabled: true,
-        hasOutboundDeliveredSince: historyWithAnswer(2000, ANSWER_THREAD),
+        hasOutboundDeliveredSince: historyWithAnswer(2000, OBLIGATION_THREAD),
+        routeOverrides: NO_OVERRIDES,
       },
     );
-    expect(answered).toBe(false);
+    expect(answered.answered).toBe(false);
   });
 
-  it("reports false when history is unavailable (never suppresses on doubt)", () => {
+  it("reports not-answered when history is unavailable (never suppresses on doubt)", () => {
     const answered = answeredSinceOpen(
       { chatId: CHAT, openedAt: 1000, threadId: OBLIGATION_THREAD },
-      { historyEnabled: false, hasOutboundDeliveredSince: () => true },
+      {
+        historyEnabled: false,
+        hasOutboundDeliveredSince: () => true,
+        routeOverrides: NO_OVERRIDES,
+      },
     );
-    expect(answered).toBe(false);
+    expect(answered.answered).toBe(false);
   });
 });
 
 describe("createEscalationSettleGate — the nudge waits out an in-flight answer", () => {
   const ID = "-100999:4#5462";
+  const OPENED = 111;
 
   it("defers the FIRST decision and proceeds only after the settle window", () => {
     const gate = createEscalationSettleGate(8_500);
-    expect(gate.shouldDefer(ID, 0)).toBe(true); // first look — settle
-    expect(gate.shouldDefer(ID, 5_000)).toBe(true); // next 5s sweep, still settling
-    expect(gate.shouldDefer(ID, 8_499)).toBe(true);
-    expect(gate.shouldDefer(ID, 8_500)).toBe(false); // window elapsed → escalate
+    expect(gate.shouldDefer(ID, 0, OPENED)).toBe(true); // first look — settle
+    expect(gate.shouldDefer(ID, 5_000, OPENED)).toBe(true); // next 5s sweep, still settling
+    expect(gate.shouldDefer(ID, 8_499, OPENED)).toBe(true);
+    expect(gate.shouldDefer(ID, 8_500, OPENED)).toBe(false); // window elapsed → escalate
   });
 
   it("is disabled by a zero window (kill switch → pre-fix immediate escalate)", () => {
     const gate = createEscalationSettleGate(0);
-    expect(gate.shouldDefer(ID, 0)).toBe(false);
+    expect(gate.shouldDefer(ID, 0, OPENED)).toBe(false);
   });
 
   it("clear() forgets the episode so a later escalate settles afresh", () => {
     const gate = createEscalationSettleGate(8_500);
-    expect(gate.shouldDefer(ID, 0)).toBe(true);
-    expect(gate.shouldDefer(ID, 9_000)).toBe(false);
+    expect(gate.shouldDefer(ID, 0, OPENED)).toBe(true);
+    expect(gate.shouldDefer(ID, 9_000, OPENED)).toBe(false);
     gate.clear(ID);
     expect(gate.size()).toBe(0);
-    expect(gate.shouldDefer(ID, 10_000)).toBe(true); // fresh window, not stale-proceed
+    expect(gate.shouldDefer(ID, 10_000, OPENED)).toBe(true); // fresh window, not stale-proceed
+  });
+
+  it("a RE-OPENED obligation under the same origin id gets its own fresh window", () => {
+    const gate = createEscalationSettleGate(8_500);
+    expect(gate.shouldDefer(ID, 0, OPENED)).toBe(true);
+    expect(gate.shouldDefer(ID, 9_000, OPENED)).toBe(false); // episode 1 escalates
+    // Re-opened: a new openedAt. Its first decision must NOT inherit episode 1's
+    // elapsed window and skip the re-check.
+    expect(gate.shouldDefer(ID, 9_100, OPENED + 1)).toBe(true);
+    expect(gate.shouldDefer(ID, 17_599, OPENED + 1)).toBe(true);
+    expect(gate.shouldDefer(ID, 17_600, OPENED + 1)).toBe(false);
   });
 
   it("tracks obligations independently", () => {
     const gate = createEscalationSettleGate(8_500);
-    expect(gate.shouldDefer("a", 0)).toBe(true);
-    expect(gate.shouldDefer("b", 8_000)).toBe(true);
-    expect(gate.shouldDefer("a", 9_000)).toBe(false); // a's window elapsed
-    expect(gate.shouldDefer("b", 9_000)).toBe(true); // b's has not
+    expect(gate.shouldDefer("a", 0, OPENED)).toBe(true);
+    expect(gate.shouldDefer("b", 8_000, OPENED)).toBe(true);
+    expect(gate.shouldDefer("a", 9_000, OPENED)).toBe(false); // a's window elapsed
+    expect(gate.shouldDefer("b", 9_000, OPENED)).toBe(true); // b's has not
   });
 
   it("a backwards clock jump re-anchors instead of pinning the gate open forever", () => {
     const gate = createEscalationSettleGate(8_500);
-    expect(gate.shouldDefer(ID, 100_000)).toBe(true);
-    expect(gate.shouldDefer(ID, 10_000)).toBe(true); // jumped back → re-anchor
-    expect(gate.shouldDefer(ID, 18_500)).toBe(false); // one window from the new anchor
+    expect(gate.shouldDefer(ID, 100_000, OPENED)).toBe(true);
+    expect(gate.shouldDefer(ID, 10_000, OPENED)).toBe(true); // jumped back → re-anchor
+    expect(gate.shouldDefer(ID, 18_500, OPENED)).toBe(false); // one window from the new anchor
   });
 
   it("bounds its id map (a long-lived gateway cannot grow it without limit)", () => {
     const gate = createEscalationSettleGate(8_500, 4);
-    for (let i = 0; i < 50; i++) gate.shouldDefer(`id-${i}`, i);
+    for (let i = 0; i < 50; i++) gate.shouldDefer(`id-${i}`, i, OPENED);
     expect(gate.size()).toBeLessThanOrEqual(4);
   });
 });
@@ -172,11 +358,24 @@ describe("resolveEscalateSettleMs", () => {
       OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT,
     );
   });
+  it("clamps an absurd window so a config typo cannot suppress escalation for a day", () => {
+    expect(
+      resolveEscalateSettleMs({ SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS: "85000000" }),
+    ).toBe(OBLIGATION_ESCALATE_SETTLE_MS_MAX);
+    expect(
+      resolveEscalateSettleMs({ SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS: "Infinity" }),
+    ).toBe(OBLIGATION_ESCALATE_SETTLE_MS_DEFAULT); // not finite → default, not clamp
+  });
+  it("passes a deliberate in-range tuning through untouched", () => {
+    expect(resolveEscalateSettleMs({ SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS: "20000" })).toBe(
+      20_000,
+    );
+  });
 });
 
 // End-to-end through the real sweep: the assertion is the OUTCOME the user sees —
 // did the "I may have missed this" nudge go out, and was the obligation closed?
-describe("obligationSweep escalate branch — no nag on top of a delivered answer", () => {
+describe("obligationSweep escalate branch — nag only when the answer really is missing", () => {
   const ORIGIN = `${CHAT}:${OBLIGATION_THREAD}#5462`;
 
   function makeWiring(opts: {
@@ -217,27 +416,35 @@ describe("obligationSweep escalate branch — no nag on top of a delivered answe
   }
 
   /** Open an obligation whose represent ladder is already exhausted → escalate. */
-  function openExhausted(ledger: ObligationLedger, openedAt: number): void {
+  function openExhausted(ledger: ObligationLedger, openedAt: number, origin = ORIGIN): void {
     ledger.openIfAbsent({
-      originTurnId: ORIGIN,
+      originTurnId: origin,
       chatId: CHAT,
       threadId: OBLIGATION_THREAD,
       messageId: 5462,
-      text: "review lukes sales report",
+      text: "synthetic fixture question about the widget report",
       openedAt,
     });
-    ledger.markRepresented(ORIGIN);
-    ledger.markRepresented(ORIGIN); // count == max → decideAtIdle returns 'escalate'
+    ledger.markRepresented(origin);
+    ledger.markRepresented(origin); // count == max → decideAtIdle returns 'escalate'
   }
 
-  it("(b) an answer delivered to a DIFFERENT thread in the same chat suppresses the nudge", () => {
-    // 2026-08-13 04:03 reproduction. Pre-fix: the thread-4 query misses the
-    // thread-3 answer and the nag fires. Post-fix: closed silently, no nudge.
+  it("(b) an answer the router RECORDED as rerouted out of this topic suppresses the nudge", () => {
+    // 2026-08-10 06:36 reproduction. Pre-fix: the thread-4 query misses the
+    // thread-635 answer and the nag fires. Post-fix: closed silently, no nudge.
     const ledger = new ObligationLedger(2);
     const openedAt = Date.now() - 60_000;
     const { wiring, nudges } = makeWiring({
       ledger,
-      hasOutboundDeliveredSince: historyWithAnswer(Date.now() - 14_200, ANSWER_THREAD),
+      hasOutboundDeliveredSince: historyWithAnswer(Date.now() - 14_200, ROUTED_THREAD),
+    });
+    answerRouteOverrides.note({
+      chatId: CHAT,
+      enabled: true,
+      explicitThreadId: OBLIGATION_THREAD,
+      anchored: true,
+      routedThreadId: ROUTED_THREAD,
+      nowMs: Date.now() - 14_300,
     });
     openExhausted(ledger, openedAt);
 
@@ -245,6 +452,35 @@ describe("obligationSweep escalate branch — no nag on top of a delivered answe
 
     expect(nudges).toEqual([]); // the user is NOT nagged on top of their answer
     expect(ledger.isOpen(ORIGIN)).toBe(false); // closed silently
+  });
+
+  it("(d) an UNRELATED long message in another topic does NOT suppress the nudge (2026-08-13 04:03)", () => {
+    // The blocker this guard exists for. Obligation open in topic 4; a long
+    // assistant message lands in topic 3 answering a DIFFERENT question, with no
+    // reroute on record. A chat-wide fallback closes topic 4's obligation
+    // silently and the user's message is dropped with no nudge and no
+    // re-present. It must escalate instead.
+    const ledger = new ObligationLedger(2);
+    const ORIGIN_D = `${CHAT}:${OBLIGATION_THREAD}#5463`;
+    const { wiring, nudges } = makeWiring({
+      ledger,
+      // A substantive assistant row exists in topic 3 — and ONLY in topic 3.
+      hasOutboundDeliveredSince: historyWithAnswer(Date.now() - 15_000, UNRELATED_THREAD),
+    });
+    openExhausted(ledger, Date.now() - 600_000, ORIGIN_D);
+
+    const realNow = Date.now;
+    try {
+      const base = realNow();
+      for (const offset of [0, 5_000, 10_000]) {
+        Date.now = () => base + offset;
+        wiring.obligationSweep();
+      }
+    } finally {
+      Date.now = realNow;
+    }
+
+    expect(nudges).toEqual([ORIGIN_D]); // topic 4's message is NOT silently dropped
   });
 
   it("(a) an answer that lands while the first escalate decision is settling suppresses the nudge", () => {
@@ -256,9 +492,13 @@ describe("obligationSweep escalate branch — no nag on top of a delivered answe
     let answerDelivered = false;
     const { wiring, nudges } = makeWiring({
       ledger,
-      // Reads false until the in-flight reply is recorded, then true.
-      hasOutboundDeliveredSince: (chatId, sinceMs) =>
-        answerDelivered && chatId === CHAT && Date.now() >= sinceMs,
+      // Reads false until the in-flight reply is recorded, then true — in the
+      // obligation's OWN topic, so no reroute record is needed.
+      hasOutboundDeliveredSince: (chatId, sinceMs, threadId) =>
+        answerDelivered &&
+        chatId === CHAT &&
+        (threadId === undefined || threadId === OBLIGATION_THREAD) &&
+        Date.now() >= sinceMs,
     });
     openExhausted(ledger, openedAt);
 
@@ -301,23 +541,30 @@ describe("obligationSweep escalate branch — no nag on top of a delivered answe
     expect(nudges).toEqual([ORIGIN]); // the genuine escalation fires
   });
 
-  it("the settle deferral is bounded — it cannot silence a genuine escalation indefinitely", () => {
+  it("the settle deferral is real AND bounded — deferred across the window, then sent", () => {
     const ledger = new ObligationLedger(2);
     const { wiring, nudges } = makeWiring({ ledger, hasOutboundDeliveredSince: () => false });
     openExhausted(ledger, Date.now() - 600_000);
 
     const realNow = Date.now;
+    const seen: string[][] = [];
     try {
       const base = realNow();
-      // Sweep every 5s across the settle window, as the real 5s interval does.
+      // Sweep every 5s across the settle window, as the real 5s interval does,
+      // recording what the user had received after each tick.
       for (const offset of [0, 5_000, 10_000]) {
         Date.now = () => base + offset;
         wiring.obligationSweep();
+        seen.push([...nudges]);
       }
     } finally {
       Date.now = realNow;
     }
-    // Escalated within two sweep ticks of the first decision — not swallowed.
-    expect(nudges).toEqual([ORIGIN]);
+    // The deferral actually happened: nothing sent on the first two ticks, both
+    // inside the 8.5s window. (Without the gate the nudge goes out on tick 1.)
+    expect(seen[0]).toEqual([]);
+    expect(seen[1]).toEqual([]);
+    // And it is bounded: escalated on the first tick past the window.
+    expect(seen[2]).toEqual([ORIGIN]);
   });
 });

--- a/telegram-plugin/tests/escalation-staleness.test.ts
+++ b/telegram-plugin/tests/escalation-staleness.test.ts
@@ -1156,6 +1156,21 @@ describe("obligationSweep escalate branch — nag only when the answer really is
 // This drives BOTH through the REAL router (`resolveAnswerThreadId`), so the
 // routed thread is not a hand-picked constant, and asserts they agree on every
 // combination of authority / explicit topic / anchor chat.
+//
+// TWO THINGS THIS MATRIX DOES NOT PROVE, and where they are proved instead:
+//   1. That the gateway CALLS either side. Every case here re-spells
+//      `resolveAnswerThreadWithLog`'s body and notes on its OWN registry
+//      instance, so deleting `answerRouteOverrides.note(...)` from gateway.ts
+//      leaves all 64 green — see `tests/answer-route-side-effect.test.ts`, which
+//      drives the real gateway function against the real singleton.
+//   2. Individual clauses of the marker's predicate. Driving the REAL router is
+//      what makes the routed thread honest, but it also makes some combinations
+//      unreachable: with authority off (case 8) the router returns the explicit
+//      topic, and a dropped cross-chat anchor falls back to it too, so
+//      `threadId !== explicit` is never true on either arm. Dropping the
+//      `frameworkTopicAuthority` clause, or swapping the filtered anchors for
+//      the raw turns, therefore survives all 64 — both are pinned directly on
+//      the pure formatter in `gateway/reply-route-log.test.ts`.
 describe("the recorded override and the EXPLICIT_OVERRIDDEN marker cannot drift apart", () => {
   const TARGET = "-100999";
   const OTHER = "-100888";

--- a/telegram-plugin/tests/history.test.ts
+++ b/telegram-plugin/tests/history.test.ts
@@ -546,6 +546,84 @@ describe('hasOutboundDeliveredSince', () => {
       expect(hasOutboundDeliveredSince('-100', openedAt, 6, 1)).toBe(false)
     })
   })
+
+  // #4681 — the optional UPPER bound. The obligation escalate branch's reroute
+  // fallback is licensed by an `EXPLICIT_OVERRIDDEN` record, which is evidence
+  // about ONE instant; an open-ended forward query lets unrelated traffic in the
+  // routed topic, arriving arbitrarily later, read as that record's answer and
+  // close a genuinely unanswered obligation in silence.
+  describe('untilMs parameter (the reroute fallback upper bound)', () => {
+    it('omitted, the query stays open-ended forward (pre-existing behaviour)', () => {
+      const openedAt = 1_000_000 * 1000
+      recordOutbound({
+        chat_id: '-100',
+        thread_id: null,
+        message_ids: [10],
+        texts: [SUBSTANTIVE],
+        ts: 1_090_000, // 90_000s later
+      })
+      expect(hasOutboundDeliveredSince('-100', openedAt)).toBe(true)
+    })
+
+    it('excludes a row delivered AFTER the bound', () => {
+      const openedAt = 1_000_000 * 1000
+      recordOutbound({
+        chat_id: '-100',
+        thread_id: null,
+        message_ids: [10],
+        texts: [SUBSTANTIVE],
+        ts: 1_000_090, // 90s after the lower bound
+      })
+      // Inside an 18.5s window it cannot be this record's answer.
+      expect(hasOutboundDeliveredSince('-100', openedAt, undefined, 200, openedAt + 18_500)).toBe(
+        false,
+      )
+    })
+
+    it('includes a row inside the bound, and the boundary second itself', () => {
+      const openedAt = 1_000_000 * 1000
+      recordOutbound({
+        chat_id: '-100',
+        thread_id: null,
+        message_ids: [10],
+        texts: [SUBSTANTIVE],
+        ts: 1_000_018, // 18s after — inside an 18.5s window
+      })
+      expect(hasOutboundDeliveredSince('-100', openedAt, undefined, 200, openedAt + 18_500)).toBe(
+        true,
+      )
+      // The bound is CEILed to whole seconds, so a row written in the second the
+      // bound falls inside is admitted — rounding never drops a real answer.
+      expect(hasOutboundDeliveredSince('-100', openedAt, undefined, 200, openedAt + 17_600)).toBe(
+        true,
+      )
+    })
+
+    it('composes with the thread filter (parameter binding order)', () => {
+      // The `ts <= ?` placeholder is appended BEFORE `thread_id = ?`; if the two
+      // params were pushed in the wrong order the thread id would land in the
+      // timestamp comparison and this would silently misbehave.
+      const openedAt = 1_000_000 * 1000
+      recordOutbound({
+        chat_id: '-100',
+        thread_id: 5,
+        message_ids: [10],
+        texts: [SUBSTANTIVE],
+        ts: 1_000_010,
+      })
+      recordOutbound({
+        chat_id: '-100',
+        thread_id: 6,
+        message_ids: [11],
+        texts: [SUBSTANTIVE],
+        ts: 1_000_090,
+      })
+      const until = openedAt + 18_500
+      expect(hasOutboundDeliveredSince('-100', openedAt, 5, 200, until)).toBe(true)
+      expect(hasOutboundDeliveredSince('-100', openedAt, 6, 200, until)).toBe(false) // too late
+      expect(hasOutboundDeliveredSince('-100', openedAt, 6, 200)).toBe(true) // unbounded finds it
+    })
+  })
 })
 
 // Review finding H5 regression: the original PRIMARY KEY (chat_id, thread_id, message_id) does


### PR DESCRIPTION
## The failure

The obligation sweep's **escalate** branch sends a user-visible **"⚠️ I may have missed an earlier message and I'm not sure I answered it"** nudge. It is gated on a staleness check — `hasOutboundDeliveredSince(o.chatId, o.openedAt, o.threadId)` — that is supposed to stand the nudge down when the agent has, in fact, already answered. Two mechanisms let that check miss a delivered answer, and the user gets nagged on top of the answer they already received.

Evidence below is from `marko`'s `gateway-supervisor.log`. Only ids, topics and timings are reproduced — no chat id, no message bodies.

### 1. Thread scoping — the answer is delivered to another topic

The check is keyed on the obligation's `threadId`. The model can name a topic on its `reply` and have the framework's topic authority override it; the router says so in the log as `EXPLICIT_OVERRIDDEN(model→N,routed→M)`. The answer's history row then carries the routed thread M while the obligation lives under N, so a thread-N query can never see it.

**2026-08-10 06:36** (`gateway-supervisor.log:86240-86250`) — obligation `<chat>:4#5191`, thread 4:

```
06:36:07.917  ipc: tool_call tool=reply agent=marko
06:36:07.921  reply-route surface=reply … EXPLICIT_OVERRIDDEN(model→4,routed→635)
06:36:08.047  obligation escalating origin=<chat>:4#5191 attempt=1/3
06:36:09.281  [outbound] path=reply msg_id=5215 chars=748
```

The model was answering the thread-4 obligation; the answer was written under thread 635. The nag fired 126 ms after the override.

**2026-08-10 07:52** (`:87772-87781`) — obligation `<chat>:3#5200`, thread 3: same shape, `EXPLICIT_OVERRIDDEN(model→3,routed→-)` at 07:52:36.026, the answer written with `thread_id IS NULL` (chat root) while the obligation sits in thread 3.

### 2. No settle — the answer is still in flight at the decision

The check is a point-in-time read of history, and the answer is frequently still *in flight* when the sweep decides: the `reply` tool has been invoked (or is about to be) and its history row does not exist yet.

```
06:36:08.047  decision   →  06:36:09.281  delivered   (1,234 ms after)
07:52:34.400  decision   →  07:52:37.209  delivered   (2,809 ms after)
```

Note what this is *not*: widening the timestamp cutoff cannot help. The cutoff is already `openedAt`, minutes in the past, so any *recorded* row would have matched. The row is not there yet.

Both confirmed incidents carry **both** defects — the answer was rerouted **and** late relative to the decision — so neither guard alone suppresses either nag. Both are needed.

## The fix

New pure modules `telegram-plugin/gateway/escalation-staleness.ts` and `telegram-plugin/gateway/answer-route-overrides.ts`, wired into the escalate branch of `obligation-wiring.ts`:

- **`answerRouteOverrides`** — a bounded (64 keys × 8 entries, FIFO) in-memory record of the router's genuine explicit-thread overrides, written from the *existing* `explicitOverridden` predicate in `resolveAnswerThreadWithLog`. That predicate moved into the module wholesale, so the predicate itself costs `gateway.ts` nothing. The file is now **24848** lines (ratchet 24805, slack 50): this PR adds **+26** over `origin/main`'s 24822 — 5 for the test-seam comment on `resolveAnswerThreadWithLog`, the rest from the `note()` call site and its import.
- **`answeredSinceOpen(o, deps)`** — asks the obligation's **own thread** first (the pre-existing check, unchanged), then falls back to **only the thread the router recorded an answer addressed to this obligation's topic as having been routed to** — reading history from **that record's own `atMs`**, and only while the record is **fresh** (`resolveRerouteMatchWindowMs`). No fresh override on record ⇒ no second query. It keeps the escalate branch's 200-char substantive floor, so a bare ack still never stands an escalation down. It returns *how* it matched, and the sweep logs `via=thread` vs `via=reroute routed_thread=N`, so the fallback's blast radius is measurable in production.
- **`createEscalationSettleGate(settleMs)`** — the first escalate decision for an obligation is **deferred**; the nudge only goes out once the "unanswered" read has held across the settle window. Bounded by construction: the delay is exactly one window and cannot grow. Keyed on the origin turn id with `openedAt` carried as an **epoch**, so a re-opened obligation gets a fresh window rather than inheriting a stale entry, and the entry is cleared on *every* terminal (silent close, cancel, represent-branch close, escalation driven).

Kill switches, one per guard — neither disables the other. `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0` disables the settle gate and only the settle gate; `SWITCHROOM_OBLIGATION_REROUTE_MATCH_MS=0` disables the reroute fallback and only the fallback. Set BOTH for the pre-fix behaviour. (An earlier revision of this body claimed `SETTLE_MS=0` alone restored it — it did not: `resolveRerouteMatchWindowMs(0)` still returned 10s and left the fallback fully live. The fallback is the one mechanism here that can close a genuinely unanswered obligation SILENTLY, so it needed its own switch.) Both windows are **clamped** — `OBLIGATION_ESCALATE_SETTLE_MS_MAX = 60_000` and `OBLIGATION_REROUTE_MATCH_MS_MAX = 70_000` — so a fat-fingered `85000000` can neither suppress every escalation for a day nor widen the silent-close window to one.

### Why the fallback is neither chat-wide NOR cut at `openedAt`

Two weaker fallbacks were tried on this branch. Both silently drop a real message, and the same field incident kills both.

**(i) Chat-wide** — "did anything ≥200 chars land in this chat since `openedAt`" — has no relationship to the obligation beyond the chat id. In a busy forum, an obligation open in topic A is silently closed because an unrelated answer landed in topic B, and the user is never told their message was dropped. The repo already states that principle for the sibling predicate (`turn-flush-suppression.ts:44-48`, on a reply in a *different* forum topic suppressing the flush and closing the delivery obligation — "the user's real answer was dropped").

**(ii) Override-gated but cut at `openedAt`** — "an override to topic M exists, therefore accept anything ≥200 chars ever delivered in M since this obligation opened" — is the same defect wearing a gate, and it shipped in the previous revision of this branch. The override proves a reroute *happened*; it says nothing about a delivery minutes later.

The counter-example is **2026-08-13** obligation `<chat>:4#5462` — thread 4, opened 03:50:02.807, escalated 04:03:06.140:

```
03:50:02.807  obligation opened  origin=<chat>:4#5462
03:50:44.201  reply-route … EXPLICIT_OVERRIDDEN(model→4,routed→3)   via=live
03:51:43.108  reply-route … EXPLICIT_OVERRIDDEN(model→4,routed→3)   via=live
03:53:11.225  reply-route … EXPLICIT_OVERRIDDEN(model→4,routed→3)   via=live
04:02:51.987  [outbound] msg_id=5494 chars=295 thread=3   via=origin → <chat>:3#5480
04:03:06.140  obligation escalating origin=<chat>:4#5462
```

Cut at `openedAt`, the lookup returns thread 3 and matches that 295-char delivery — which answers a **different question in topic 3**, 594.8 s after the newest override. Topic 4's message was **genuinely unanswered**; pre-fix it escalates correctly, so an `openedAt` cutoff is a **regression**, not a fix. (An earlier revision of this PR reasoned about the *represent→escalate* window instead — a framing that is true of the represent window and irrelevant to the code, and it is what concealed this. The code cuts on `openedAt`, and three overrides sit inside that window.)

So the cutoff is the **override's own `atMs`**, and an override is only consulted while fresh:

- `resolveRerouteMatchWindowMs(settleMs) = settleMs + REROUTE_MATCH_GRACE_MS` = **18,500 ms** at the default.
- **Derivation.** The escalate decision that actually consults the record is the one *after* the settle gate, so a legitimate override is at most `settleMs` old (the answer was in flight when the first decision deferred) plus two 5,000 ms sweep ticks of scheduling slack.
- **Field check.** Both justifying incidents sit far inside it — 2026-08-10 06:36 override `:07.921` → delivery `:09.281` = **1.36 s**; 07:52 `:36.026` → `:37.209` = **1.18 s**. The counter-example sits far outside it — **594.8 s**, a 32× margin. Nothing observed lives in between.
- **Residual, stated plainly.** Within the window the fallback still cannot tell the rerouted answer from a second ≥200-char delivery landing in the same thread in those few seconds — the override carries no message id to tie it to one row. The window is what bounds that exposure; it is not eliminated.

So 2026-08-13 is this PR's **counter-example**, not its justification; the two 2026-08-10 incidents are the justification.

## Scope — this narrows #2472, it does not close it

This fixes the **escalate** branch only. The **re-present** branch has both the same defects and is untouched here:

- `represent-guard.ts:84-88` passes `o.threadId` at both cutoffs, so a rerouted answer is invisible to it;
- the #4341 delivery-time backstop (`represent-delivery-guard.ts:107-111`) forwards the same `threadId` and is therefore cross-topic-blind too;
- the represent branch has **no settle gate at all**.

Filed as switchroom/switchroom#4700. The CHANGELOG entry carries the same scope statement.

## Settle-window derivation

- **Lower bound (worst observed lag).** 3 × 2,809 ms = 8,427 ms, rounded up to the next 500 ms → **8,500 ms**. Real margin above the worst observed decision→delivery lag; a send can additionally sit behind per-chat send-gate pacing.
- **Sweep-tick floor.** It must span at least one 5,000 ms sweep interval, or no re-check ever runs and the gate degenerates into a pure delay. 8,500 > 5,000. ✅
- **Upper bound.** It must stay clear of the genuinely-unanswered case that *must* still escalate: 2026-08-12 09:08, where the agent's real answer landed **41,331 ms** after the decision. 8,500 ms sits **4.9× below** it.

That last case is worth recording because it was initially misread as a 58 ms race: the `sendRichMessage` at 09:08:14.466, 58 ms before the escalation, was **not** the agent's answer — that history row is `role='system'`, a permission auto-deny card. The real answer was still 41 s away. It is a genuine escalation and it keeps firing.

## Tests

`telegram-plugin/tests/escalation-staleness.test.ts` — 64 tests. The end-to-end ones drive the **real `obligationSweep`** through `createObligationWiring` and assert the outcome the user sees: did the nudge go out (`sendEscalationNudge` captures), and was the obligation closed?

- **(a)** an answer that lands while the first escalate decision is settling → no nudge, closed silently
- **(b)** an answer delivered to the thread the router **recorded this topic's answer as rerouted to**, inside the freshness window → no nudge, closed silently
- **(c)** a genuinely unanswered obligation → **still escalates** once the settle window elapses
- **(d)** the real **2026-08-13 `4#5462` shape**: three genuine `EXPLICIT_OVERRIDDEN(model→4,routed→3)` records on the registry (via `answerRouteOverrides.note`, at the incident's own 741.9/683.0/594.9 s offsets) plus an unrelated 295-char delivery in the routed thread → **still escalates**. This is the regression guard for the `openedAt` cutoff.
- plus, at the unit level: a stale override paired with a later unrelated delivery → `{answered: false, via: null}`; a *fresh* override followed from its own instant → `via: 'reroute'`; a delivery that **predates** the override it would be paired with → not answered; `resolveRerouteMatchWindowMs` bounded above the worst incident lag (2,809 ms) and below the counter-example (594,800 ms).
- and unchanged from the previous round: `answerRouteOverrides` records only genuine overrides (chat-root → `null`, FIFO bounds, earliest-in-window per routed thread); reroute scope does not leak across *chats*; history-unavailable never suppresses; the settle deferral asserted tick-by-tick (`[] , [] , [ORIGIN]`) rather than "escalates eventually"; re-open epoch; `clear()` / FIFO / backwards-clock-jump; env kill-switch parsing **and the 60 s clamp**.

**Red-then-green for this round.** The previous revision's regression guards were **vacuous** — the counter-example tests were built with `NO_OVERRIDES` and a `makeWiring` with no `note()`, so they only guarded the abandoned chat-wide fallback. Retargeted at the real shape, then mutated the fallback back to the shipped `openedAt` semantics (`const notBefore = o.openedAt; const since = o.openedAt`):

```
Tests  3 failed | 37 passed (40)

 × does NOT pair a STALE override with a later unrelated delivery (2026-08-13 04:03)
   → expected { answered: true, via: 'reroute', … } to deeply equal { answered: false, via: null }
 × does NOT accept a delivery that PREDATES the override it is paired with
   → expected true to be false
 × (d) a STALE reroute record does NOT license an unrelated later delivery (2026-08-13 04:03)
   → expected [] to deeply equal [ '-100999:44#5463' ]
```

Also still red-verified: the reroute tests fail against `origin/main`'s thread-only semantics; the bounded settle test fails with `SWITCHROOM_OBLIGATION_ESCALATE_SETTLE_MS=0`.

## Local results

```
vitest run  escalation-{bridge-gate,drive,staleness} obligation-{determinism,ledger,store,turn-end}
            represent-guard silent-end
  Test Files  9 passed (9)
       Tests  240 passed (240)

node scripts/check-gateway-line-ratchet.mjs → clean (24848, ratchet 24805, slack 50, main 24805)
node scripts/check-no-pii-secrets.mjs       → clean (3610 tracked files scanned)
node scripts/check-changelog-entry.mjs      → OK — ## Unreleased grew (origin/main...HEAD)
npx tsc --noEmit                            → clean (exit 0, zero output)
```

> The gateway line count is **24848** at this head, against a ceiling of 24855. This PR adds +26 over `origin/main` (24822) and leaves **7 lines of headroom**. The next `gateway.ts` touch will trip the ratchet; re-baselining or extracting is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




---

### Follow-up pass on head `2d346f83` (re-verification findings)

Two MAJORs and three MINORs, all of the same species as the blocker already fixed on this branch — prose asserting a guarantee the code does not implement.

- **Freshness anchor was the wrong instant.** `REROUTE_MATCH_GRACE_MS` was justified as "the sweep is the only caller, so the decision can only land on a tick boundary". A tick can be **skipped entirely**, not merely delayed, by four gates above the escalate branch: `turnInFlightForGate()` (unbounded), the background-work / session-busy defer (20 min ceiling), `OBLIGATION_ESCALATE_GRACE_MS` (45s) and `OBLIGATION_REPRESENT_GRACE_MS` (120s) — the 2026-08-13 log shows minutes-long stretches of it. Override at T, first decision T+0.1 defers, re-decision at T+107 ⇒ `notBefore = T+88.5 > T`, the fresh record is dropped and the nudge fires on top of the answer delivered at T+1.4. Fixed at the root: `EscalationSettleGate.firstAt()` is exposed and the window is measured back from the instant the decision FIRST read "unanswered"; `EscalationStalenessDeps.nowMs` is renamed `anchorMs` so the field cannot be misread.
- **Reroute fallback had no kill switch** (above).
- Negative-path telemetry: a record the bound rejects now logs `reroute record rejected age=…ms window=…ms` — previously indistinguishable from "no record", leaving the bound unmeasurable in production.
- Dropped the partial real chat id from the `escalation-staleness.ts` header (public repo; the same sentence said the chat id was deliberately not reproduced).
- `AnswerRouteOverrides.clear()` + `beforeEach` reset — the e2e scenarios wrote to the process-wide singleton with wall-clock timestamps and leaked into each other.

Red-then-green on all five. The full-revert mutation (both bounds → `openedAt`) still turns 5 tests red; mutating the anchor back to `now` reds the new skipped-tick test; removing the kill-switch guard reds its own test. Rebased onto `fd1650e7` (v0.21.10); the CHANGELOG conflict was resolved by taking main's v0.21.10 body verbatim and relocating this entry into `## Unreleased`, not by stripping markers in place.

