### PR TITLE
fix(fleet-health): detectors must check an alarm's outcome, not just match it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,98 @@ now an anomaly worth investigating, not the norm.
   reinstated spread form still PASSES under Bun — the guard asserted nothing
   in the shipping runtime.
 
+- **fleet-health: a detector must check an alarm's OUTCOME, not just match
+  it.** Two Layer-0 rules matched an alarm and never asked how it ended, so the
+  nightly ledger booked working safety mechanisms as failures.
+  `represent-escalation` was the bare substring `/obligation escalation/`, which
+  five emitter lines carry — including the per-attempt retry line and
+  `obligation-wiring.ts`'s `deferred — bridge down` line, i.e. the guard
+  deliberately *not* escalating while the Telegram bridge is down. Three of 11
+  live hits were that suppression path, all for the same obligation. It now
+  anchors on the two mutually-exclusive TERMINAL outcomes (`delivered + closed`,
+  `PERMANENTLY undeliverable`), the same attempt-vs-outcome fix #3931 made for
+  `reply-delivery-failure`. `orphaned-db-handle` matched the deleted-inode sweep
+  alarm without checking whether the paired recovery followed; an alarm whose
+  own sweep tick reopened `history.db` and left no lane un-recovered is now
+  `orphaned-db-handle-recovered` (drift, severity 1) instead of a severity-3
+  silent-data-loss incident. `registry.db`, an unowned handle, a FAILED reopen,
+  or a tick the detector cannot see in full all keep severity 3 — every
+  narrowing fails *toward* the alarm.
+
+- **fleet-health: gateway findings count affected turns, and a change of
+  counting unit can no longer auto-close a live GitHub issue.** Matched gateway
+  lines sharing an `origin=` turn id now fold into one finding, so ledger
+  `frequency` counts distinct affected turns rather than log lines (`gw_hits`
+  stays a raw line count for the digest). That is a change of *ruler*, and the
+  ledger's count-drop self-verify closes an issue when the number falls: an open
+  `duplicate-delivery-represent` issue at frequency 8 across 3 turns would have
+  collapsed to 3 on the first scan after merge, flipped to
+  `resolved-pending-verify`, and had the sensor comment "Verified count-drop …
+  Closed by the Fleet Health sensor." on a still-broken issue. Each issue now
+  records the `counting_unit` its frequency was measured in, and the writer
+  holds an issue's status for exactly one scan when that unit changes — a real
+  close is delayed by one scan, never suppressed, and reopening still works.
+
+- **fleet-health: the orphaned-DB verdict no longer depends on when the scan
+  ran, and a reclassified issue no longer claims a fix nobody made.** The
+  recovered/unrecovered split used a 12-line lookahead to find its tick
+  boundary, but sweeps are five minutes apart, so the identical alarm+reopen
+  pair booked severity 1 while it sat at the log tail and severity 3 once
+  ordinary traffic accumulated behind it. The two verdicts carry different
+  signatures, so a flip moved the finding to a different dedup_key and emptied
+  the old one — which the writer reads as a drop to zero, closing a live
+  severity-3 issue with "Verified count-drop … Closed by the Fleet Health
+  sensor." The same lookahead also downgraded a real `registry.db` alarm to
+  informational whenever its lane line fell outside the window. The verdict is
+  now derived from the tick's content — the alarm line names every affected
+  lane, and the first sweep line after it is that tick's history-lane outcome —
+  so it no longer moves with log GROWTH. Truncation is a separate problem and
+  is handled separately (next entry): reading the alarm's lane list is only
+  sound if that list is COMPLETE, which the first cut of this fix did not
+  check. Alongside it: a close caused
+  by findings re-sorting into a sibling signature is recorded as
+  `close_reason: "reclassified"` and commented as such rather than as a
+  verified count-drop; an issue whose defect reappears after closing is now
+  reopened on GitHub instead of staying shut forever; the count-drop arm tests
+  `count < prior.frequency` so an issue held across a counting-unit change can
+  still close (previously it could only ever leave the board at zero, i.e.
+  stale-open however much of it got fixed); and the gateway-signal list that
+  drives the counting-unit guard is built from a `Record<GatewaySignal, true>`
+  so a new derived signal is a compile error rather than a signal silently
+  counted in the wrong unit.
+
+- **fleet-health: a TRUNCATED orphaned-DB alarm can no longer launder silent
+  data loss down to informational.** Deriving the verdict from the alarm line's
+  lane list (previous entry) traded position-dependence for total dependence on
+  that one line arriving intact, which is the same bug class on a different
+  path. The emitter writes `DETECTED <n>` and then exactly one `fd=<n> <target>`
+  pair per orphan, so count and list are 1:1 by construction — but the
+  classifier read the pairs and ignored the count. A short or interleaved
+  `write()` on the supervisor's stderr for an alarm line over `PIPE_BUF` —
+  reachable precisely when many handles are orphaned, i.e. the worst incident —
+  drops the tail of the list, and a surviving `history.db` pair then booked
+  severity 1 on a tick that also lost `registry.db`. The sharp case is that the
+  intact `registry.db … rows written since the last checkpoint are LOST.` line
+  was sitting right there in the log and the classifier never looked at it,
+  because it only ever read the FIRST sweep line after the alarm and the
+  registry lane is emitted after the history lane. Severity 1 migrates the
+  finding's `dedup_key`, empties the severity-3 key, and drives close-on-zero —
+  a real unrecoverable loss closed as fixed. Two guards now: the lane list is
+  cross-checked against the alarm's own count and an incomplete list fails
+  toward the alarm; and a registry/unowned lane line anywhere between an alarm
+  and the NEXT alarm vetoes a recovery outright, restoring the veto the first
+  cut deleted without restoring its line-count window (the scan is bounded by
+  the log's content, so no position-dependence returns). The sticky
+  closed-history and FAILED-reopen lines are deliberately NOT vetoes: both also
+  fire from the no-alarm retry path, so vetoing on them would let a later,
+  unrelated tick flip an earlier recovered verdict — the exact dependence the
+  previous entry removed. Also: the `Record<GatewaySignal, true>` exhaustiveness
+  guard's test was tautological — every runtime view of that set is derived from
+  the same constant, so it passed against the very hand-written array it was
+  filed about; it now asserts against an independently written list, with `tsc`
+  named as the real guarantee. And the RFC now states the ledger reopen path's
+  one-scan durability window, which was true in code and documented nowhere.
+
 ## v0.21.10 — the Telegram render pipeline stops deleting prose and corrupting fenced code, and TTS stops failing on long messages
 
 ### Bug fixes
@@ -203,61 +295,6 @@ now an anomaly worth investigating, not the norm.
   unguaranteeable markup is — which beats a 400 that degrades the whole
   message to plain text. Also locks in the blank-line-separated expandable
   shape, the majority corpus shape, which worked but had no test.
-
-- **fleet-health: a detector must check an alarm's OUTCOME, not just match
-  it.** Two Layer-0 rules matched an alarm and never asked how it ended, so the
-  nightly ledger booked working safety mechanisms as failures.
-  `represent-escalation` was the bare substring `/obligation escalation/`, which
-  five emitter lines carry — including the per-attempt retry line and
-  `obligation-wiring.ts`'s `deferred — bridge down` line, i.e. the guard
-  deliberately *not* escalating while the Telegram bridge is down. Three of 11
-  live hits were that suppression path, all for the same obligation. It now
-  anchors on the two mutually-exclusive TERMINAL outcomes (`delivered + closed`,
-  `PERMANENTLY undeliverable`), the same attempt-vs-outcome fix #3931 made for
-  `reply-delivery-failure`. `orphaned-db-handle` matched the deleted-inode sweep
-  alarm without checking whether the paired recovery followed; an alarm whose
-  own sweep tick reopened `history.db` and left no lane un-recovered is now
-  `orphaned-db-handle-recovered` (drift, severity 1) instead of a severity-3
-  silent-data-loss incident. `registry.db`, an unowned handle, a FAILED reopen,
-  or a tick the detector cannot see in full all keep severity 3 — every
-  narrowing fails *toward* the alarm.
-- **fleet-health: gateway findings count affected turns, and a change of
-  counting unit can no longer auto-close a live GitHub issue.** Matched gateway
-  lines sharing an `origin=` turn id now fold into one finding, so ledger
-  `frequency` counts distinct affected turns rather than log lines (`gw_hits`
-  stays a raw line count for the digest). That is a change of *ruler*, and the
-  ledger's count-drop self-verify closes an issue when the number falls: an open
-  `duplicate-delivery-represent` issue at frequency 8 across 3 turns would have
-  collapsed to 3 on the first scan after merge, flipped to
-  `resolved-pending-verify`, and had the sensor comment "Verified count-drop …
-  Closed by the Fleet Health sensor." on a still-broken issue. Each issue now
-  records the `counting_unit` its frequency was measured in, and the writer
-  holds an issue's status for exactly one scan when that unit changes — a real
-  close is delayed by one scan, never suppressed, and reopening still works.
-- **fleet-health: the orphaned-DB verdict no longer depends on when the scan
-  ran, and a reclassified issue no longer claims a fix nobody made.** The
-  recovered/unrecovered split used a 12-line lookahead to find its tick
-  boundary, but sweeps are five minutes apart, so the identical alarm+reopen
-  pair booked severity 1 while it sat at the log tail and severity 3 once
-  ordinary traffic accumulated behind it. The two verdicts carry different
-  signatures, so a flip moved the finding to a different dedup_key and emptied
-  the old one — which the writer reads as a drop to zero, closing a live
-  severity-3 issue with "Verified count-drop … Closed by the Fleet Health
-  sensor." The same lookahead also downgraded a real `registry.db` alarm to
-  informational whenever its lane line fell outside the window. The verdict is
-  now derived from the tick's content — the alarm line names every affected
-  lane, and the first sweep line after it is that tick's history-lane outcome —
-  so it is stable under log growth and truncation. Alongside it: a close caused
-  by findings re-sorting into a sibling signature is recorded as
-  `close_reason: "reclassified"` and commented as such rather than as a
-  verified count-drop; an issue whose defect reappears after closing is now
-  reopened on GitHub instead of staying shut forever; the count-drop arm tests
-  `count < prior.frequency` so an issue held across a counting-unit change can
-  still close (previously it could only ever leave the board at zero, i.e.
-  stale-open however much of it got fixed); and the gateway-signal list that
-  drives the counting-unit guard is built from a `Record<GatewaySignal, true>`
-  so a new derived signal is a compile error rather than a signal silently
-  counted in the wrong unit.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -980,6 +980,7 @@ now an anomaly worth investigating, not the norm.
   `Intl`, since Node's ICU reports a correct UTC even on a corrupted host and
   would mask exactly this defect.
 - **gateway: never evict an approval outcome while anything else is droppable**
+- **fleet-health: detectors must check an alarm's outcome, not just match it**
 
 ## v0.21.7 — a Fable-pinned agent boots on Fable, a cron edit stops failing on its first try, and the merge queue stops ejecting innocent PRs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,37 @@ now an anomaly worth investigating, not the norm.
   message to plain text. Also locks in the blank-line-separated expandable
   shape, the majority corpus shape, which worked but had no test.
 
+- **fleet-health: a detector must check an alarm's OUTCOME, not just match
+  it.** Two Layer-0 rules matched an alarm and never asked how it ended, so the
+  nightly ledger booked working safety mechanisms as failures.
+  `represent-escalation` was the bare substring `/obligation escalation/`, which
+  five emitter lines carry — including the per-attempt retry line and
+  `obligation-wiring.ts`'s `deferred — bridge down` line, i.e. the guard
+  deliberately *not* escalating while the Telegram bridge is down. Three of 11
+  live hits were that suppression path, all for the same obligation. It now
+  anchors on the two mutually-exclusive TERMINAL outcomes (`delivered + closed`,
+  `PERMANENTLY undeliverable`), the same attempt-vs-outcome fix #3931 made for
+  `reply-delivery-failure`. `orphaned-db-handle` matched the deleted-inode sweep
+  alarm without checking whether the paired recovery followed; an alarm whose
+  own sweep tick reopened `history.db` and left no lane un-recovered is now
+  `orphaned-db-handle-recovered` (drift, severity 1) instead of a severity-3
+  silent-data-loss incident. `registry.db`, an unowned handle, a FAILED reopen,
+  or a tick the detector cannot see in full all keep severity 3 — every
+  narrowing fails *toward* the alarm.
+- **fleet-health: gateway findings count affected turns, and a change of
+  counting unit can no longer auto-close a live GitHub issue.** Matched gateway
+  lines sharing an `origin=` turn id now fold into one finding, so ledger
+  `frequency` counts distinct affected turns rather than log lines (`gw_hits`
+  stays a raw line count for the digest). That is a change of *ruler*, and the
+  ledger's count-drop self-verify closes an issue when the number falls: an open
+  `duplicate-delivery-represent` issue at frequency 8 across 3 turns would have
+  collapsed to 3 on the first scan after merge, flipped to
+  `resolved-pending-verify`, and had the sensor comment "Verified count-drop …
+  Closed by the Fleet Health sensor." on a still-broken issue. Each issue now
+  records the `counting_unit` its frequency was measured in, and the writer
+  holds an issue's status for exactly one scan when that unit changes — a real
+  close is delayed by one scan, never suppressed, and reopening still works.
+
 ### Features
 
 - **voice: flag-gated raw-markdown speech capture (PR-0)** — `SWITCHROOM_SPEECH_CAPTURE=1`
@@ -980,7 +1011,6 @@ now an anomaly worth investigating, not the norm.
   `Intl`, since Node's ICU reports a correct UTC even on a corrupted host and
   would mask exactly this defect.
 - **gateway: never evict an approval outcome while anything else is droppable**
-- **fleet-health: detectors must check an alarm's outcome, not just match it**
 
 ## v0.21.7 — a Fable-pinned agent boots on Fable, a cron edit stops failing on its first try, and the merge queue stops ejecting innocent PRs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,30 @@ now an anomaly worth investigating, not the norm.
   records the `counting_unit` its frequency was measured in, and the writer
   holds an issue's status for exactly one scan when that unit changes — a real
   close is delayed by one scan, never suppressed, and reopening still works.
+- **fleet-health: the orphaned-DB verdict no longer depends on when the scan
+  ran, and a reclassified issue no longer claims a fix nobody made.** The
+  recovered/unrecovered split used a 12-line lookahead to find its tick
+  boundary, but sweeps are five minutes apart, so the identical alarm+reopen
+  pair booked severity 1 while it sat at the log tail and severity 3 once
+  ordinary traffic accumulated behind it. The two verdicts carry different
+  signatures, so a flip moved the finding to a different dedup_key and emptied
+  the old one — which the writer reads as a drop to zero, closing a live
+  severity-3 issue with "Verified count-drop … Closed by the Fleet Health
+  sensor." The same lookahead also downgraded a real `registry.db` alarm to
+  informational whenever its lane line fell outside the window. The verdict is
+  now derived from the tick's content — the alarm line names every affected
+  lane, and the first sweep line after it is that tick's history-lane outcome —
+  so it is stable under log growth and truncation. Alongside it: a close caused
+  by findings re-sorting into a sibling signature is recorded as
+  `close_reason: "reclassified"` and commented as such rather than as a
+  verified count-drop; an issue whose defect reappears after closing is now
+  reopened on GitHub instead of staying shut forever; the count-drop arm tests
+  `count < prior.frequency` so an issue held across a counting-unit change can
+  still close (previously it could only ever leave the board at zero, i.e.
+  stale-open however much of it got fixed); and the gateway-signal list that
+  drives the counting-unit guard is built from a `Record<GatewaySignal, true>`
+  so a new derived signal is a compile error rather than a signal silently
+  counted in the wrong unit.
 
 ### Features
 

--- a/docs/fleet-health.md
+++ b/docs/fleet-health.md
@@ -110,7 +110,7 @@ The model-free sensor's explicit, documented mapping (source of truth:
 | `killed-incomplete-turn` (status ∉ complete/no_reply) | missed-trigger | 3 | `steer-or-queue-mid-flight` |
 | `represent-escalation` (`obligation escalation delivered + closed` / `PERMANENTLY undeliverable` — terminal outcomes only; a per-attempt retry and the `deferred — bridge down` suppression line are not escalations) | drift | 1 | `feel-like-a-colleague` |
 | `orphaned-db-handle` (`orphaned-db-sweep DETECTED …` with a lane left un-recovered) | success-theater | 3 | `survive-reboots-and-real-life` |
-| `orphaned-db-handle-recovered` (same alarm, but the tick reopened `history.db` and left no lane un-recovered) | drift | 1 | `survive-reboots-and-real-life` |
+| `orphaned-db-handle-recovered` (same alarm, but the alarm names only `history.db*` targets and the tick's next sweep line is the reopen-succeeded one) | drift | 1 | `survive-reboots-and-real-life` |
 
 Tuned L0 constants (load-bearing; ported verbatim from the validated reference
 detector): `HANG_MS = 360000`, `HANG_MAXTOOLS = 2`, `synthetic-` turn ids

--- a/docs/fleet-health.md
+++ b/docs/fleet-health.md
@@ -108,7 +108,9 @@ The model-free sensor's explicit, documented mapping (source of truth:
 | `reply-delivery-failure` (`sendRichMessage … status=err` — terminal only; a retried attempt logs `status=retry`, #3931) | success-theater | 3 | `talk-to-agents-from-anywhere` |
 | `hang-long-stalled` (>6 min AND ≤2 tools) | partial | 2 | `steer-or-queue-mid-flight` |
 | `killed-incomplete-turn` (status ∉ complete/no_reply) | missed-trigger | 3 | `steer-or-queue-mid-flight` |
-| `represent-escalation` (`obligation escalation`) | drift | 1 | `feel-like-a-colleague` |
+| `represent-escalation` (`obligation escalation delivered + closed` / `PERMANENTLY undeliverable` — terminal outcomes only; a per-attempt retry and the `deferred — bridge down` suppression line are not escalations) | drift | 1 | `feel-like-a-colleague` |
+| `orphaned-db-handle` (`orphaned-db-sweep DETECTED …` with a lane left un-recovered) | success-theater | 3 | `survive-reboots-and-real-life` |
+| `orphaned-db-handle-recovered` (same alarm, but the tick reopened `history.db` and left no lane un-recovered) | drift | 1 | `survive-reboots-and-real-life` |
 
 Tuned L0 constants (load-bearing; ported verbatim from the validated reference
 detector): `HANG_MS = 360000`, `HANG_MAXTOOLS = 2`, `synthetic-` turn ids

--- a/reference/rfcs/fleet-health.md
+++ b/reference/rfcs/fleet-health.md
@@ -427,6 +427,22 @@ same `origin=` turn id fold into a single finding for that signal, so ledger
 `frequency` counts distinct affected turns. Lines with no origin id keep
 one-finding-per-line.
 
+**A change of counting UNIT is not a count-drop.** `frequency` is a count, and
+the count-drop self-verify below closes an issue when it falls — so changing
+what an occurrence *is* makes every open issue on that signal look fixed, with
+nothing fixed. Each issue therefore records the `counting_unit` its `frequency`
+was measured in (`log-line` or `gateway-event`; absent means the legacy
+`log-line`). When the unit differs from the prior ledger's, the writer holds the
+issue's status for exactly one scan instead of advancing it toward closure. The
+issue is rewritten carrying the new unit, so the next scan compares like with
+like and a genuine drop still closes it — a real close is delayed by one scan,
+never suppressed. Reopening is still allowed: a count above the threshold cannot
+produce a false "fixed" claim. Without this the fold above would have flipped
+every live gateway issue to `resolved-pending-verify` on the first post-merge
+scan and had `gh-sync` comment "Verified count-drop … Closed by the Fleet Health
+sensor." on issues nobody touched — the board lying, which is the one failure
+this ledger exists to prevent.
+
 The dedup key is `<job_spec>:<signature>` (one GitHub issue per key).
 
 ### Priority score (as implemented)

--- a/reference/rfcs/fleet-health.md
+++ b/reference/rfcs/fleet-health.md
@@ -475,6 +475,19 @@ runs `gh issue reopen` — `gh issue edit` refreshes a closed issue's body witho
 reopening it, so without that the board would say "fixed" forever while the
 sensor found the defect every night.
 
+**The reopen path is a one-scan window.** The close-on-zero loop only carries a
+prior key forward when its status is `open` or `resolved-pending-verify`
+(`ledger.ts:283-287`), so a `closed` issue that stays quiet is dropped from the
+ledger on the very NEXT scan and its `gh_issue` number goes with it. A defect
+that returns on the immediately following scan is reopened on the original
+thread; one that returns two or more scans later has nothing left to reopen and
+falls through to `gh-sync`'s create path, filing a FRESH issue for the same
+`dedup_key`. That is deliberate — the alternative is an unbounded tombstone list
+of every key ever closed — and it costs continuity, not correctness: the board
+never claims "fixed" while the defect is live either way. It is stated here
+because the window is invisible in the code, and a change to it silently changes
+which incidents keep their history.
+
 The dedup key is `<job_spec>:<signature>` (one GitHub issue per key).
 
 ### Priority score (as implemented)

--- a/reference/rfcs/fleet-health.md
+++ b/reference/rfcs/fleet-health.md
@@ -422,6 +422,17 @@ lane left un-recovered, is emitted as `orphaned-db-handle-recovered` (drift, sev
 handle, or a FAILED reopen behind stays `orphaned-db-handle` at sev 3 — that is
 genuine silent loss.
 
+**The verdict is derived from the tick's CONTENT, never from how many lines
+follow it.** Which lanes a tick hit is stated by the alarm line itself (it
+interpolates every orphaned fd's target), and `history.db*` is the only lane
+with an in-process recovery; whether that lane recovered is stated by the first
+`orphaned-db-sweep` line after the alarm, which the emitter logs with no `await`
+in between. A line-count lookahead would instead make the answer depend on when
+the scan ran — the same alarm+reopen pair reading sev 1 at the log tail and sev
+3 once ordinary traffic accumulated behind it — and because the two verdicts
+carry different signatures, a flip would migrate the finding between dedup_keys
+and empty the old one, which the writer reads as a fix-to-zero.
+
 A gateway finding is one EVENT, not one log line: matched lines carrying the
 same `origin=` turn id fold into a single finding for that signal, so ledger
 `frequency` counts distinct affected turns. Lines with no origin id keep
@@ -442,6 +453,27 @@ every live gateway issue to `resolved-pending-verify` on the first post-merge
 scan and had `gh-sync` comment "Verified count-drop … Closed by the Fleet Health
 sensor." on issues nobody touched — the board lying, which is the one failure
 this ledger exists to prevent.
+
+"Never suppressed" is only true because the count-drop arm tests `count <
+prior.frequency`, not `prior.frequency > RESOLVED_THRESHOLD`. The hold REWRITES
+`frequency` to the post-fold count, so an issue held at 3 carries a prior
+frequency of 3 from then on and would never satisfy `> 3` again — under that
+test a held issue could only ever leave the board through the zero path, i.e.
+stale-open on GitHub however much of it got fixed.
+
+**A key emptied by RECLASSIFICATION is not a verified fix either.** The unit
+guard compares a prior issue with this scan's issue under the SAME dedup_key,
+but findings that re-sort into a sibling signature (`orphaned-db-handle` →
+`orphaned-db-handle-recovered`, `silent-no-op-candidate` →
+`flush-recovered-turn`) EMPTY the old key and fill the sibling's, which reads as
+a drop to zero. Zero occurrences really is zero, so the issue does close — but
+the writer records `close_reason: "reclassified"` (naming the sibling keys the
+evidence moved to) and `gh-sync` posts that instead of a "Verified count-drop"
+claim nobody earned. And because any close can turn out to be premature, an
+issue whose defect reappears after closing is marked `reopened` and `gh-sync`
+runs `gh issue reopen` — `gh issue edit` refreshes a closed issue's body without
+reopening it, so without that the board would say "fixed" forever while the
+sensor found the defect every night.
 
 The dedup key is `<job_spec>:<signature>` (one GitHub issue per key).
 

--- a/reference/rfcs/fleet-health.md
+++ b/reference/rfcs/fleet-health.md
@@ -405,10 +405,27 @@ the 23 `reference/jobs/*.md`) and a taxonomy class + severity:
 | `killed-incomplete-turn` | missed-trigger | 3 | `steer-or-queue-mid-flight` | the turn was abandoned incomplete while in progress |
 | `represent-escalation` | drift | 1 | `feel-like-a-colleague` | the gateway had to nudge on the agent's behalf — UX-friction, informational (does not alone open a sev-3 issue) |
 
-Note: `represent-escalation` (`/obligation escalation/`) is an added sev-1
-*informational* signal beyond the two precise delivery signatures — it flags
-UX-friction, not a delivery failure, and does not alone open a sev-3 issue, so
-it is not scope creep on the delivery-signature detection.
+Note: `represent-escalation` is an added sev-1 *informational* signal beyond the
+two precise delivery signatures — it flags UX-friction, not a delivery failure,
+and does not alone open a sev-3 issue, so it is not scope creep on the
+delivery-signature detection. Its signature matches the two TERMINAL escalation
+outcomes only (`delivered + closed`, `PERMANENTLY undeliverable`), for the same
+attempt-vs-outcome reason as `reply-delivery-failure` (#3931): the bare
+`/obligation escalation/` substring also matched the per-attempt retry line and
+the `deferred — bridge down` SUPPRESSION line, so the guard *declining* to
+escalate while the bridge was down was booked as a failure.
+
+`orphaned-db-handle` splits on recovery rather than on attempt: an alarm whose
+sweep tick also logged `reopened history.db — writes are durable again`, with no
+lane left un-recovered, is emitted as `orphaned-db-handle-recovered` (drift, sev
+1, `survive-reboots-and-real-life`). A tick that left `registry.db`, an unowned
+handle, or a FAILED reopen behind stays `orphaned-db-handle` at sev 3 — that is
+genuine silent loss.
+
+A gateway finding is one EVENT, not one log line: matched lines carrying the
+same `origin=` turn id fold into a single finding for that signal, so ledger
+`frequency` counts distinct affected turns. Lines with no origin id keep
+one-finding-per-line.
 
 The dedup key is `<job_spec>:<signature>` (one GitHub issue per key).
 

--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -351,6 +351,48 @@ describe("#4680 — a working guard is not a failure", () => {
       expect(severityOf(log)).toEqual([3]);
     });
 
+    // The tick's lane ordering is load-bearing and lives in a DIFFERENT file:
+    // `orphaned-db-sweep.ts` logs the history lane (and therefore the reopen
+    // line, since `attemptHistoryReopen` is synchronous) at :219-229 BEFORE
+    // the registry lane at :231-238. So the line that VETOES a "recovered"
+    // verdict is exactly the one an added `await`, or another subsystem's
+    // interleaved output, pushes past the lookahead cap. Without the
+    // tick-boundary requirement this silently downgrades real `registry.db`
+    // data loss from severity 3 to severity 1 — and no adjacent-lines fixture
+    // above would notice.
+    it("stays severity 3 when the registry lane is pushed past the lookahead cap", () => {
+      const filler = Array.from(
+        { length: 14 },
+        (_, i) => `2026-08-12T03:00:0${i % 10}Z telegram gateway: unrelated chatter #${i}`,
+      );
+      const log = [
+        detect(2, "/state/registry.db"),
+        reopened,
+        ...filler,
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep found an orphaned" +
+          " registry.db handle. An in-process reopen is NOT safe here — the turnsDb handle" +
+          " is captured by value into long-lived wiring, so closing it would leave those" +
+          " consumers on a closed handle. RESTART the gateway to recover; subagent/turn" +
+          " rows written since the last checkpoint are LOST.",
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    // The conservative rule must not swallow the ordinary recovered case: an
+    // alarm + reopen followed by a short quiet tail still ends at EOF inside
+    // the window, so the whole tick IS visible.
+    it("still books severity 1 when the whole tick is visible", () => {
+      const log = [
+        detect(1, "/state/history.db"),
+        reopened,
+        ...Array.from(
+          { length: 3 },
+          (_, i) => `2026-08-12T03:00:0${i}Z telegram gateway: unrelated chatter #${i}`,
+        ),
+      ].join("\n");
+      expect(severityOf(log)).toEqual([1]);
+    });
+
     it("a LATER tick's recovery does not launder an earlier unrecovered alarm", () => {
       const log = [detect(1, "/state/history.db"), detect(1, "/state/history.db"), reopened]
         .join("\n");
@@ -382,6 +424,21 @@ describe("#4680 — a working guard is not a failure", () => {
       expect(findings).toHaveLength(1);
       expect(findings[0]?.ts).toBe("2026-08-12T04:01:00Z");
       expect(findings[0]?.log_pointer).toBe("logs/carrie/gateway-supervisor.log:2");
+    });
+
+    // `log_pointer` is the line the operator greps to check the `ts` the ledger
+    // windowed and ranked on. If a newest line with an unparseable timestamp
+    // advanced the pointer while `ts` fell back to an earlier line, the finding
+    // would claim line 2 as evidence for a timestamp that only line 1 carries.
+    it("does not advance the pointer past the line its `ts` came from", () => {
+      const log = [
+        `2026-08-12T04:00:00Z gateway: represent duplicate-send origin=${ORIGIN}`,
+        `gateway: represent duplicate-send origin=${ORIGIN}`, // no ISO prefix
+      ].join("\n");
+      const { findings } = detectGatewayFindings("carrie", log);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.ts).toBe("2026-08-12T04:00:00Z");
+      expect(findings[0]?.log_pointer).toBe("logs/carrie/gateway-supervisor.log:1");
     });
 
     it("keeps DISTINCT origins as distinct findings", () => {

--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -7,8 +7,10 @@ import {
   extractTs,
   HANG_MS,
   SILENT_NOOP_FLOOR_TS,
+  GATEWAY_SIGNAL_NAMES,
 } from "./detect.js";
-import { mapSignal } from "./mapping.js";
+import type { L0Signal } from "./detect.js";
+import { mapSignal, countingUnitFor } from "./mapping.js";
 import { ROUTE_FIELD_SHIP_TS } from "../../telegram-plugin/gateway/turn-record-status.js";
 
 /**
@@ -397,6 +399,109 @@ describe("#4680 — a working guard is not a failure", () => {
       const log = [detect(1, "/state/history.db"), detect(1, "/state/history.db"), reopened]
         .join("\n");
       expect(severityOf(log)).toEqual([3, 1]);
+    });
+
+    /**
+     * #4682 B1 — the verdict must be a property of the TICK, not of how much
+     * log happened to follow it. A line-count lookahead cap makes it the
+     * latter: the exact same alarm+reopen pair books severity 1 while it sits
+     * at the log tail and severity 3 once ordinary traffic pushes the (absent)
+     * tick boundary out of the window. Sweeps are 5 minutes apart, so in a live
+     * log the next alarm is essentially never within a dozen lines — the
+     * verdict would then depend on WHEN the scan ran, and a signal that flips
+     * with the clock migrates its findings between two dedup_keys and drives
+     * the ledger's close-on-zero path on a defect nobody fixed.
+     */
+    it("books the same severity for one tick no matter how much traffic follows", () => {
+      const tick = [detect(1, "/state/history.db"), reopened];
+      for (const trailing of [0, 1, 5, 11, 12, 13, 60]) {
+        const log = [
+          ...tick,
+          ...Array.from(
+            { length: trailing },
+            (_, i) => `2026-08-12T03:05:00Z telegram gateway: unrelated chatter #${i}`,
+          ),
+        ].join("\n");
+        expect(severityOf(log), `${trailing} trailing lines`).toEqual([1]);
+      }
+    });
+
+    /**
+     * #4682 B1 — the same property in the severity-3 direction. The registry
+     * lane has no in-process recovery, so an alarm naming `registry.db` is
+     * silent data loss whether or not its lane line survived into the scanned
+     * window. The DETECTED line itself interpolates every orphaned target
+     * (`orphaned-db-sweep.ts:213-217`), so the affected LANES are knowable from
+     * the alarm alone and no lookahead may be allowed to overrule it.
+     */
+    it("keeps severity 3 for a registry.db alarm whose lane line is absent", () => {
+      // A truncated log tail: the alarm and the history reopen survive, the
+      // registry lane line does not. Trusting the missing veto line downgrades
+      // real, unrecoverable `registry.db` loss to informational.
+      const log = [detect(2, "/state/registry.db"), reopened].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    it("keeps severity 3 for an unowned-lane alarm whose lane line is absent", () => {
+      const log = [detect(2, "/state/grants.db"), reopened].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    it("keeps severity 3 when the alarm names history AND registry", () => {
+      const log = [
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep DETECTED 2 deleted-inode" +
+          " DB handle(s): fd=13 /state/history.db (deleted), fd=14 /state/registry.db" +
+          " (deleted) — another process unlinked these files while we held them open.",
+        reopened,
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    it("keeps severity 3 when the alarm's target list cannot be parsed", () => {
+      // Fail toward the alarm: an emitter format change must never silently
+      // downgrade a data-loss record.
+      const log = [
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep DETECTED 1 deleted-inode" +
+          " DB handle(s): <redacted>",
+        reopened,
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    it("treats history.db-wal alongside history.db as the history lane", () => {
+      const log = [
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep DETECTED 2 deleted-inode" +
+          " DB handle(s): fd=13 /state/history.db (deleted), fd=14 /state/history.db-wal" +
+          " (deleted) — another process unlinked these files while we held them open.",
+        reopened,
+      ].join("\n");
+      expect(severityOf(log)).toEqual([1]);
+    });
+  });
+
+  /**
+   * #4682 M2 — `countingUnitFor` decides whether the ledger's count-drop
+   * self-verify may compare two scans at all, and it reads a list of gateway
+   * signal names. A hand-written list can silently omit a new signal, handing
+   * that signal a `log-line` unit it was never counted in. The list is now
+   * derived from a `Record<GatewaySignal, true>` so tsc rejects an omission at
+   * compile time; this test asserts the observable consequence — every signal
+   * `detectGatewayFindings` can actually emit is counted in `gateway-event` —
+   * enumerated from the detector's own `gw_hits` record rather than from the
+   * list under test, so the two cannot drift silently.
+   */
+  describe("every emittable gateway signal carries the gateway-event unit", () => {
+    it("agrees with the detector's own gw_hits keys", () => {
+      const { gw_hits } = detectGatewayFindings("alpha", "");
+      const emittable = Object.keys(gw_hits).sort();
+      expect(emittable.length).toBeGreaterThan(0);
+      for (const signal of emittable) {
+        expect(
+          countingUnitFor(signal as L0Signal),
+          `${signal} must be counted in gateway-event`,
+        ).toBe("gateway-event");
+      }
+      expect([...GATEWAY_SIGNAL_NAMES].sort()).toEqual(emittable);
     });
   });
 

--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -8,6 +8,7 @@ import {
   HANG_MS,
   SILENT_NOOP_FLOOR_TS,
 } from "./detect.js";
+import { mapSignal } from "./mapping.js";
 import { ROUTE_FIELD_SHIP_TS } from "../../telegram-plugin/gateway/turn-record-status.js";
 
 /**
@@ -173,7 +174,9 @@ describe("detectGatewayFindings", () => {
     `2026-07-02T21:03:00Z gateway: represent duplicate-send tid=${CHAT}:_#42`,
     `2026-07-02T21:04:00Z gateway: tg-post method=getUpdates status=err timeout`,
     `2026-07-02T21:05:00Z gateway: tg-post method=sendRichMessage tid=${CHAT}:_#43 status=err`,
-    `2026-07-02T21:06:00Z gateway: obligation escalation tid=${CHAT}:_#44`,
+    // The literal terminal line `escalation-drive.ts:62` emits.
+    `2026-07-02T21:06:00Z telegram gateway: obligation escalation delivered + closed` +
+      ` origin=${CHAT}:_#44`,
   ].join("\n");
 
   it("counts represent-duplicate and reply-delivery-failure, ignores getUpdates blip", () => {
@@ -216,6 +219,186 @@ describe("detectGatewayFindings", () => {
         " detection is DISABLED until it exists and is readable.",
     ].join("\n");
     expect(detectGatewayFindings("alpha", quiet).gw_hits["orphaned-db-handle"]).toBe(0);
+  });
+});
+
+/**
+ * #4680 — two detector rules matched an ALARM without checking its OUTCOME, so
+ * the nightly ledger booked working safety mechanisms as failures. Every fixture
+ * below is the literal line its emitter writes; a fixture that drifts from the
+ * emitter is the failure mode these rules already had once.
+ */
+describe("#4680 — a working guard is not a failure", () => {
+  const ORIGIN = `${CHAT}:_#2198`;
+
+  describe("represent-escalation matches the terminal OUTCOME, not every attempt", () => {
+    // `obligation-wiring.ts:303` — the guard deliberately NOT escalating while
+    // the Telegram bridge is down. This is the suppression path working.
+    const suppressed =
+      `2026-08-12T02:00:00Z telegram gateway: obligation escalation deferred — bridge down` +
+      ` (nudge waits for reconnect) origin=${ORIGIN}`;
+    // `escalation-drive.ts:72` — one line per ATTEMPT, below the retry policy.
+    const retrying =
+      `2026-08-12T02:05:00Z telegram gateway: obligation escalation send failed (attempt 1/3),` +
+      ` retrying next sweep origin=${ORIGIN}: Error: 429`;
+    // `escalation-drive.ts:62` / `:68` — the two mutually-exclusive terminals.
+    const delivered =
+      `2026-08-12T02:10:00Z telegram gateway: obligation escalation delivered + closed` +
+      ` origin=${ORIGIN}`;
+    const undeliverable =
+      `2026-08-12T02:15:00Z telegram gateway: obligation escalation PERMANENTLY undeliverable` +
+      ` after 3 attempts — closing best-effort origin=${ORIGIN}: Error: 403`;
+
+    it("does NOT flag the bridge-down SUPPRESSION line", () => {
+      const { gw_hits, findings } = detectGatewayFindings("carrie", suppressed);
+      expect(gw_hits["represent-escalation"]).toBe(0);
+      expect(findings).toHaveLength(0);
+    });
+
+    it("does NOT flag a retry attempt (the nudge has not resolved yet)", () => {
+      expect(
+        detectGatewayFindings("carrie", retrying).gw_hits["represent-escalation"],
+      ).toBe(0);
+    });
+
+    it("DOES flag a delivered escalation", () => {
+      const { gw_hits, findings } = detectGatewayFindings("carrie", delivered);
+      expect(gw_hits["represent-escalation"]).toBe(1);
+      expect(findings[0]?.turn_id).toBe(ORIGIN);
+    });
+
+    it("DOES flag a permanently-undeliverable escalation", () => {
+      expect(
+        detectGatewayFindings("carrie", undeliverable).gw_hits["represent-escalation"],
+      ).toBe(1);
+    });
+
+    // The live shape: one obligation, four matching lines, of which exactly one
+    // is an escalation that happened. Before the fix this booked 4 findings.
+    it("books ONE finding for one obligation's full retry-then-deliver history", () => {
+      const log = [suppressed, retrying, retrying, delivered].join("\n");
+      const { findings } = detectGatewayFindings("carrie", log);
+      const esc = findings.filter((f) => f.signal === "represent-escalation");
+      expect(esc).toHaveLength(1);
+      expect(esc[0]?.ts).toBe("2026-08-12T02:10:00Z");
+    });
+  });
+
+  describe("orphaned-db-handle splits on whether the sweep RECOVERED", () => {
+    const detect = (n: number, target: string) =>
+      `2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep DETECTED ${n} deleted-inode` +
+      ` DB handle(s): fd=13 ${target} (deleted) — another process unlinked these files while` +
+      ` we held them open; every row written since the last checkpoint is LOST and further` +
+      ` writes would be lost too.`;
+    const reopened =
+      "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep reopened history.db —" +
+      " writes are durable again (proved by the post-reopen writer self-check); rows" +
+      " written since the last checkpoint are NOT recoverable.";
+
+    /** Severity is what the ledger acts on, so assert THAT, not the signal name. */
+    const severityOf = (log: string): number[] =>
+      detectGatewayFindings("overlord", log).findings.map(
+        (f) => mapSignal(f.signal).severity,
+      );
+
+    it("DETECT + reopen in the same tick is NOT a severity-3 record", () => {
+      const log = [detect(1, "/state/history.db"), reopened].join("\n");
+      expect(severityOf(log)).toEqual([1]);
+      const { gw_hits } = detectGatewayFindings("overlord", log);
+      expect(gw_hits["orphaned-db-handle"]).toBe(0);
+      expect(gw_hits["orphaned-db-handle-recovered"]).toBe(1);
+      // Still reported — the pre-reopen rows really are gone.
+      expect(detectGatewayFindings("overlord", log).findings).toHaveLength(1);
+    });
+
+    it("DETECT with no recovery line STAYS severity 3", () => {
+      expect(severityOf(detect(1, "/state/history.db"))).toEqual([3]);
+    });
+
+    it("a FAILED reopen stays severity 3", () => {
+      const log = [
+        detect(1, "/state/history.db"),
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep FAILED to reopen" +
+          " history.db: EACCES — history writes are NOT durable; RESTART the gateway.",
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    it("registry.db stays severity 3 even when history recovers in the same tick", () => {
+      // The registry lane has NO in-process recovery — reopening history does
+      // not make those rows durable, so the tick is not recovered.
+      const log = [
+        detect(2, "/state/registry.db"),
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep found an orphaned" +
+          " registry.db handle. An in-process reopen is NOT safe here — the turnsDb handle" +
+          " is captured by value into long-lived wiring, so closing it would leave those" +
+          " consumers on a closed handle. RESTART the gateway to recover; subagent/turn" +
+          " rows written since the last checkpoint are LOST.",
+        reopened,
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    it("an unowned lane stays severity 3 even alongside a history reopen", () => {
+      const log = [
+        detect(2, "/state/grants.db"),
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep found orphaned handle(s)" +
+          " on grants.db, which no recovery lane owns — the gateway cannot reopen them in" +
+          " place. RESTART the gateway to recover; rows written to those files since the" +
+          " last checkpoint are LOST.",
+        reopened,
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    it("a LATER tick's recovery does not launder an earlier unrecovered alarm", () => {
+      const log = [detect(1, "/state/history.db"), detect(1, "/state/history.db"), reopened]
+        .join("\n");
+      expect(severityOf(log)).toEqual([3, 1]);
+    });
+  });
+
+  describe("gateway findings dedup by event identity, not by log line", () => {
+    it("folds repeated lines for the same origin into one finding", () => {
+      const log = [
+        `2026-08-12T04:00:00Z gateway: represent duplicate-send origin=${ORIGIN}`,
+        `2026-08-12T04:01:00Z gateway: represent duplicate-send origin=${ORIGIN}`,
+      ].join("\n");
+      const { findings, gw_hits } = detectGatewayFindings("carrie", log);
+      expect(findings).toHaveLength(1);
+      // gw_hits stays the RAW line count — it is the digest's noise readout.
+      expect(gw_hits["duplicate-delivery-represent"]).toBe(2);
+    });
+
+    // `buildLedger` windows AND ranks on `Finding.ts`, so a folded event that
+    // kept the FIRST line's timestamp could age a still-happening cluster out
+    // of the scan window entirely.
+    it("carries the NEWEST line's timestamp and pointer, not the first's", () => {
+      const log = [
+        `2026-07-01T04:00:00Z gateway: represent duplicate-send origin=${ORIGIN}`,
+        `2026-08-12T04:01:00Z gateway: represent duplicate-send origin=${ORIGIN}`,
+      ].join("\n");
+      const { findings } = detectGatewayFindings("carrie", log);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.ts).toBe("2026-08-12T04:01:00Z");
+      expect(findings[0]?.log_pointer).toBe("logs/carrie/gateway-supervisor.log:2");
+    });
+
+    it("keeps DISTINCT origins as distinct findings", () => {
+      const log = [
+        `2026-08-12T04:00:00Z gateway: represent duplicate-send origin=${CHAT}:_#1`,
+        `2026-08-12T04:01:00Z gateway: represent duplicate-send origin=${CHAT}:_#2`,
+      ].join("\n");
+      expect(detectGatewayFindings("carrie", log).findings).toHaveLength(2);
+    });
+
+    it("keeps one-finding-per-line when the line carries NO origin id", () => {
+      const log = [
+        "2026-08-12T04:00:00Z gateway: represent duplicate-send",
+        "2026-08-12T04:01:00Z gateway: represent duplicate-send",
+      ].join("\n");
+      expect(detectGatewayFindings("carrie", log).findings).toHaveLength(2);
+    });
   });
 });
 
@@ -295,7 +478,12 @@ describe("scanAgent escalation decision", () => {
   });
 
   it("does NOT escalate on a represent-escalation alone", () => {
-    const res = scanAgent("alpha", turn(1, {}), "gateway: obligation escalation");
+    const res = scanAgent(
+      "alpha",
+      turn(1, {}),
+      `telegram gateway: obligation escalation delivered + closed origin=${CHAT}:_#44`,
+    );
+    expect(res.gw_hits["represent-escalation"]).toBe(1);
     expect(res.escalate).toBe(false);
   });
 

--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -468,6 +468,139 @@ describe("#4680 — a working guard is not a failure", () => {
       expect(severityOf(log)).toEqual([3]);
     });
 
+    /**
+     * #4682 B1 follow-up — a PARTIALLY parseable target list must fail toward
+     * the alarm too. The emitter writes `DETECTED <n>` and then exactly one
+     * `fd=<n> <target>` pair per orphan (`orphaned-db-sweep.ts:211-217`), so
+     * the count and the pair list are 1:1 by construction. Reading only the
+     * pairs makes the verdict depend on the alarm line arriving INTACT: a
+     * short/interleaved `write()` on the supervisor's stderr for an alarm line
+     * over `PIPE_BUF` — reachable exactly when many fds are orphaned, i.e. the
+     * worst incident — truncates the list, and the surviving `history.db` pair
+     * then launders a real `registry.db` loss down to severity 1. Cross-checking
+     * the count makes the truncation visible from the alarm line alone.
+     */
+    it("keeps severity 3 when the alarm declares more handles than it lists", () => {
+      const log = [
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep DETECTED 2 deleted-inode" +
+          " DB handle(s): fd=13 /state/history.db",
+        reopened,
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    /**
+     * The sharp case. The emitter logs the history lane BEFORE the registry
+     * lane (`orphaned-db-sweep.ts:219-238`), so the registry veto line lands
+     * AFTER the reopen line. If a truncated alarm hid `registry.db` from the
+     * lane list, a verdict that reads ONLY the first sweep line after the alarm
+     * never sees the intact `registry.db … rows written since the last
+     * checkpoint are LOST.` line sitting right there in the log, and books
+     * severity 1 on unrecoverable loss.
+     */
+    it("keeps severity 3 when a registry lane line follows the reopen line", () => {
+      const log = [
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep DETECTED 2 deleted-inode" +
+          " DB handle(s): fd=13 /state/history.db",
+        reopened,
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep found an orphaned" +
+          " registry.db handle. An in-process reopen is NOT safe here — the turnsDb handle" +
+          " is captured by value into long-lived wiring, so closing it would leave those" +
+          " consumers on a closed handle. RESTART the gateway to recover; subagent/turn" +
+          " rows written since the last checkpoint are LOST.",
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    it("keeps severity 3 when an unowned lane line follows the reopen line", () => {
+      const log = [
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep DETECTED 2 deleted-inode" +
+          " DB handle(s): fd=13 /state/history.db",
+        reopened,
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep found orphaned handle(s)" +
+          " on grants.db, which no recovery lane owns — the gateway cannot reopen them in" +
+          " place. RESTART the gateway to recover; rows written to those files since the" +
+          " last checkpoint are LOST.",
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    /**
+     * Isolates the VETO from the count cross-check: this alarm is entirely
+     * self-consistent (`DETECTED 1` / one `fd=` pair / history lane), so the
+     * count check passes it and only a lane-line veto can keep the severity.
+     * Today's emitter cannot produce this shape — the registry line is emitted
+     * only for a name in the alarm's own list (`orphaned-db-sweep.ts:231-238`)
+     * — which is the point: this is the standing guarantee that an intact
+     * "rows … are LOST" line in the tick is never overruled by whatever the
+     * alarm line happens to say, so an emitter change cannot re-open the
+     * downgrade path a second time.
+     */
+    it("an intact registry lane line vetoes recovery even on a consistent alarm", () => {
+      const log = [
+        detect(1, "/state/history.db"),
+        reopened,
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep found an orphaned" +
+          " registry.db handle. An in-process reopen is NOT safe here — RESTART the" +
+          " gateway to recover; subagent/turn rows written since the last checkpoint" +
+          " are LOST.",
+      ].join("\n");
+      expect(severityOf(log)).toEqual([3]);
+    });
+
+    /**
+     * The count cross-check is a COMPLETENESS test, not a lane test: a full,
+     * self-consistent multi-handle history-only alarm still books severity 1.
+     */
+    it("still books severity 1 for a complete multi-handle history alarm", () => {
+      const log = [
+        "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep DETECTED 2 deleted-inode" +
+          " DB handle(s): fd=13 /state/history.db (deleted), fd=14 /state/history.db-wal" +
+          " (deleted) — another process unlinked these files while we held them open.",
+        reopened,
+      ].join("\n");
+      expect(severityOf(log)).toEqual([1]);
+    });
+
+    /**
+     * The veto must stay a property of THIS tick. A later tick's own alarm ends
+     * the scan, so its lane lines can never be charged to an earlier, genuinely
+     * recovered one — otherwise the veto would reintroduce exactly the
+     * log-growth dependence #4682 B1 removed.
+     */
+    it("a LATER tick's registry lane does not re-arm an earlier recovered alarm", () => {
+      const log = [
+        detect(1, "/state/history.db"),
+        reopened,
+        detect(1, "/state/registry.db"),
+        "2026-08-12T03:05:00Z telegram gateway: orphaned-db-sweep found an orphaned" +
+          " registry.db handle. An in-process reopen is NOT safe here — RESTART the" +
+          " gateway to recover; subagent/turn rows written since the last checkpoint" +
+          " are LOST.",
+      ].join("\n");
+      expect(severityOf(log)).toEqual([1, 3]);
+    });
+
+    /**
+     * The two lane lines the veto deliberately does NOT carry: the sticky
+     * closed-history line and a FAILED reopen both also fire from the
+     * no-DETECTED retry path (`orphaned-db-sweep.ts:253-264`), so vetoing on
+     * them would let a later, unrelated tick flip an earlier recovered alarm —
+     * log-growth dependence again. This tick's OWN failed reopen is already
+     * caught by the first-sweep-line rule (asserted above), so nothing is lost.
+     */
+    it("a later tick's sticky history failure does not re-arm a recovered alarm", () => {
+      const log = [
+        detect(1, "/state/history.db"),
+        reopened,
+        "2026-08-12T03:05:00Z telegram gateway: orphaned-db-sweep history.db is CLOSED and" +
+          " a previous reopen failed (EACCES) — every history read and write is dead and" +
+          " no fd evidence remains. Retrying the reopen; RESTART the gateway if this keeps" +
+          " repeating.",
+      ].join("\n");
+      expect(severityOf(log)).toEqual([1]);
+    });
+
     it("treats history.db-wal alongside history.db as the history lane", () => {
       const log = [
         "2026-08-12T03:00:00Z telegram gateway: orphaned-db-sweep DETECTED 2 deleted-inode" +
@@ -483,25 +616,46 @@ describe("#4680 — a working guard is not a failure", () => {
    * #4682 M2 — `countingUnitFor` decides whether the ledger's count-drop
    * self-verify may compare two scans at all, and it reads a list of gateway
    * signal names. A hand-written list can silently omit a new signal, handing
-   * that signal a `log-line` unit it was never counted in. The list is now
-   * derived from a `Record<GatewaySignal, true>` so tsc rejects an omission at
-   * compile time; this test asserts the observable consequence — every signal
-   * `detectGatewayFindings` can actually emit is counted in `gateway-event` —
-   * enumerated from the detector's own `gw_hits` record rather than from the
-   * list under test, so the two cannot drift silently.
+   * that signal a `log-line` unit it was never counted in.
+   *
+   * The EXHAUSTIVENESS guarantee is `tsc`, not this test: `GATEWAY_SIGNAL_NAMES`
+   * is derived from a `Record<GatewaySignal, true>`, so omitting a member is a
+   * compile error (verified: `detect.ts:251`, TS2741). A runtime test cannot
+   * add to that, because every runtime view of the set — `gw_hits`,
+   * `GATEWAY_SIGNAL_NAMES`, `countingUnitFor`'s `GATEWAY_SIGNAL_SET` — is
+   * derived from that same constant, so comparing them to each other is a
+   * tautology that passes even against the hand-written array this was filed
+   * about (measured).
+   *
+   * What this test IS: a tripwire against an INDEPENDENTLY written list. Adding
+   * a gateway signal turns it red here, which is the prompt to confirm the new
+   * signal's ledger counting unit deliberately rather than inherit one. Keep
+   * the literal hand-written — deriving it from the source under test is
+   * exactly what made the previous version vacuous.
    */
   describe("every emittable gateway signal carries the gateway-event unit", () => {
-    it("agrees with the detector's own gw_hits keys", () => {
-      const { gw_hits } = detectGatewayFindings("alpha", "");
-      const emittable = Object.keys(gw_hits).sort();
-      expect(emittable.length).toBeGreaterThan(0);
-      for (const signal of emittable) {
+    const EXPECTED_GATEWAY_SIGNALS = [
+      "duplicate-delivery-represent",
+      "orphaned-db-handle",
+      "orphaned-db-handle-recovered",
+      "reply-delivery-failure",
+      "represent-escalation",
+    ] as const;
+
+    it("is exactly the set this test was written against", () => {
+      expect([...GATEWAY_SIGNAL_NAMES].sort()).toEqual([...EXPECTED_GATEWAY_SIGNALS]);
+      expect(Object.keys(detectGatewayFindings("alpha", "").gw_hits).sort()).toEqual([
+        ...EXPECTED_GATEWAY_SIGNALS,
+      ]);
+    });
+
+    it("counts every one of them in gateway-event, not log-line", () => {
+      for (const signal of EXPECTED_GATEWAY_SIGNALS) {
         expect(
           countingUnitFor(signal as L0Signal),
           `${signal} must be counted in gateway-event`,
         ).toBe("gateway-event");
       }
-      expect([...GATEWAY_SIGNAL_NAMES].sort()).toEqual(emittable);
     });
   });
 

--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -438,12 +438,12 @@ describe("#4680 — a working guard is not a failure", () => {
       // A truncated log tail: the alarm and the history reopen survive, the
       // registry lane line does not. Trusting the missing veto line downgrades
       // real, unrecoverable `registry.db` loss to informational.
-      const log = [detect(2, "/state/registry.db"), reopened].join("\n");
+      const log = [detect(1, "/state/registry.db"), reopened].join("\n");
       expect(severityOf(log)).toEqual([3]);
     });
 
     it("keeps severity 3 for an unowned-lane alarm whose lane line is absent", () => {
-      const log = [detect(2, "/state/grants.db"), reopened].join("\n");
+      const log = [detect(1, "/state/grants.db"), reopened].join("\n");
       expect(severityOf(log)).toEqual([3]);
     });
 

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -104,7 +104,15 @@ export type GatewaySignal =
   // them. `history.db` self-heals in process; `registry.db` and anything else
   // needs a restart — either way a human has to be told, which is what this
   // signal is for. See `telegram-plugin/gateway/orphaned-db-sweep.ts`.
-  | "orphaned-db-handle";
+  | "orphaned-db-handle"
+  // The same alarm, but the sweep's OWN recovery landed in the same tick: the
+  // `history.db` lane reopened and proved the handle durable again, and no
+  // lane in that tick was left un-recovered. The rows written before the
+  // reopen are still lost, so this stays a reportable event — but the
+  // mechanism designed to catch it WORKED, which is not a severity-3
+  // data-loss incident. Informational counterpart of `orphaned-db-handle`,
+  // exactly as `flush-recovered-turn` is to `silent-no-op-candidate`.
+  | "orphaned-db-handle-recovered";
 
 /** Signals from the standalone config/state sensors — NOT derived from an
  *  agent's turns.jsonl or gateway log. Each sensor reads a hard artifact
@@ -186,9 +194,34 @@ export interface AgentScanResult {
  * incidental: it pins the match to the exact token `err`, so no future
  * `err<suffix>` tier can silently re-enter this signal.
  */
-export const GATEWAY_SIGNATURES: Record<GatewaySignal, RegExp> = {
+/** The gateway signals matched by a single log LINE. `orphaned-db-handle-recovered`
+ *  is deliberately absent: it is not a line signature but a RECLASSIFICATION of
+ *  the `orphaned-db-handle` alarm decided by the lines that follow it within the
+ *  same sweep tick (see `classifyOrphanedDbTick`). */
+export type LineMatchedGatewaySignal = Exclude<
+  GatewaySignal,
+  "orphaned-db-handle-recovered"
+>;
+
+export const GATEWAY_SIGNATURES: Record<LineMatchedGatewaySignal, RegExp> = {
   "duplicate-delivery-represent": /represent duplicate-send/,
-  "represent-escalation": /obligation escalation/,
+  // #4680 — same attempt-vs-OUTCOME rule as `reply-delivery-failure` above.
+  // Four emitter lines carry the literal `obligation escalation`, and a bare
+  // substring match counted all four:
+  //   escalation-drive.ts:62  delivered + closed         ← terminal outcome
+  //   escalation-drive.ts:68  PERMANENTLY undeliverable  ← terminal outcome
+  //   escalation-drive.ts:72  send failed … retrying next sweep  ← an ATTEMPT
+  //   obligation-wiring.ts:303 deferred — bridge down    ← the SUPPRESSION path
+  // The last one is the guard deliberately NOT escalating while the Telegram
+  // bridge is down, i.e. the safety mechanism WORKING; counting it reported a
+  // healthy suppression as a failure. The retry line is the #3931 shape exactly:
+  // one line per attempt, so a nudge that landed on attempt 3 used to book three
+  // findings for one obligation. Anchoring on the two mutually-exclusive
+  // TERMINAL lines yields exactly one hit per escalated obligation, and keeps
+  // the permanently-undeliverable case (a real escalation that never reached the
+  // operator) in the ledger rather than dropping coverage.
+  "represent-escalation":
+    /obligation escalation (?:delivered \+ closed|PERMANENTLY undeliverable)/,
   "reply-delivery-failure": /tg-post method=sendRichMessage[^\n]*status=err(?![a-z])/,
   // Anchored on the sweep's DETECTED line, which is emitted once per tick per
   // incident for EVERY lane (history, registry, unowned) — so the registry
@@ -197,6 +230,59 @@ export const GATEWAY_SIGNATURES: Record<GatewaySignal, RegExp> = {
   // lanes are added, and one signal per incident is the right escalation rate.
   "orphaned-db-handle": /orphaned-db-sweep DETECTED \d+ deleted-inode DB handle/,
 };
+
+/** The sweep's in-process recovery line, logged by `attemptHistoryReopen` the
+ *  moment the reopened `history.db` handle passes its post-reopen writer
+ *  self-check (`orphaned-db-sweep.ts:279`). `reopened` is the first-detection
+ *  verb; `recovered` is the sticky-failure retry verb, which fires on a tick
+ *  with no DETECTED line at all and so never pairs with an alarm here. */
+const ORPHANED_DB_RECOVERED_RE =
+  /orphaned-db-sweep reopened history\.db — writes are durable again/;
+
+/**
+ * Lines that say a lane in THIS tick was left un-recovered — each one is real,
+ * unrecovered data loss and must keep the severity-3 alarm even if the history
+ * lane reopened alongside it. Verbatim from `orphaned-db-sweep.ts`:
+ * registry.db (:233), the unowned lane (:247), history-with-no-reopen-wired
+ * (:225), the sticky closed-history lane (:260) and a failed reopen (:285).
+ */
+const ORPHANED_DB_UNRECOVERED_RE =
+  /orphaned-db-sweep (?:found an orphaned registry\.db handle|found orphaned handle\(s\) on |found an orphaned history\.db handle but no reopen|history\.db is CLOSED and a previous reopen failed|FAILED to reopen history\.db)/;
+
+/** Upper bound on the lookahead for a tick's follow-up lines. One tick emits at
+ *  most a handful (alarm + up to three lane lines + the recovery line); the cap
+ *  keeps a truncated or interleaved log from scanning the whole file. */
+const ORPHANED_DB_TICK_LOOKAHEAD = 12;
+
+/**
+ * Decide whether an `orphaned-db-sweep DETECTED` alarm at `alarmIdx` was
+ * RECOVERED inside its own sweep tick.
+ *
+ * `runOrphanedDbSweepTick` logs the alarm and every lane line synchronously,
+ * with no `await` between them, so a tick's lines are contiguous. The window
+ * therefore runs from the alarm to the next DETECTED line (the next tick's
+ * alarm) or `ORPHANED_DB_TICK_LOOKAHEAD` lines, whichever comes first.
+ *
+ * Recovered means BOTH: the reopen-succeeded line landed, AND no lane in the
+ * tick reported itself un-recovered. `registry.db` has no in-process recovery
+ * at all, so a tick that reopened history while registry stayed orphaned is
+ * still severity-3 silent loss.
+ */
+export function classifyOrphanedDbTick(
+  lines: readonly string[],
+  alarmIdx: number,
+): "recovered" | "unrecovered" {
+  let recovered = false;
+  const end = Math.min(lines.length, alarmIdx + 1 + ORPHANED_DB_TICK_LOOKAHEAD);
+  for (let j = alarmIdx + 1; j < end; j++) {
+    const line = lines[j];
+    if (!line) continue;
+    if (GATEWAY_SIGNATURES["orphaned-db-handle"].test(line)) break; // next tick
+    if (ORPHANED_DB_UNRECOVERED_RE.test(line)) return "unrecovered";
+    if (ORPHANED_DB_RECOVERED_RE.test(line)) recovered = true;
+  }
+  return recovered ? "recovered" : "unrecovered";
+}
 
 /** Parse `turns.jsonl` text into records, silently skipping malformed lines
  *  (a corrupt line must never crash the scan — RFC: defensive).
@@ -394,8 +480,26 @@ export function detectTurnFindings(
 
 /**
  * Run the precise gateway signatures over one agent's gateway log text. Returns
- * both the per-signature hit counts and one Finding per matched line (so the
- * ledger gets real log pointers). `logName` is only used to build the pointer.
+ * the per-signature hit counts and the findings the ledger aggregates (with real
+ * log pointers). `logName` is only used to build the pointer.
+ *
+ * A finding is one EVENT, not one log line. Where a matched line carries an
+ * `origin=`/`tid=` origin-turn id, every line for that (signal, origin) pair
+ * folds into ONE finding: the ledger's `frequency` then counts distinct
+ * affected turns, which is what its priority scoring means by "how often".
+ * Lines with no origin id keep their old one-finding-per-line behaviour — there
+ * is no identity to fold on, and guessing one would merge unrelated events.
+ *
+ * The folded finding carries the NEWEST line's timestamp and pointer, not the
+ * first's. A gateway log is append-ordered, and `buildLedger` both windows
+ * (`withinWindow`) and ranks (`recencyFactor`) on `Finding.ts` — pinning the
+ * oldest line would let a cluster that is still happening age out of the scan
+ * window, which is the "the board lies" failure this detector exists to
+ * prevent. The pointer moves with it, so the operator lands on live evidence.
+ *
+ * `gw_hits` stays a RAW line count on purpose: it is the digest's
+ * signature-frequency readout and the input to the escalate decision, and both
+ * want "how noisy was the log", not "how many distinct turns".
  */
 export function detectGatewayFindings(
   agent: string,
@@ -408,23 +512,49 @@ export function detectGatewayFindings(
     "represent-escalation": 0,
     "reply-delivery-failure": 0,
     "orphaned-db-handle": 0,
+    "orphaned-db-handle-recovered": 0,
   };
   const lines = logText.split("\n");
+  /** (signal, origin) → index of that event's finding in `findings`. */
+  const eventIndex = new Map<string, number>();
   for (const [name, re] of Object.entries(GATEWAY_SIGNATURES) as [
-    GatewaySignal,
+    LineMatchedGatewaySignal,
     RegExp,
   ][]) {
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       if (!line) continue;
       if (re.test(line)) {
-        gw_hits[name] += 1;
+        // The orphaned-DB alarm splits on what the REST of its sweep tick did:
+        // an in-process reopen that proved the handle durable again is the
+        // mechanism working, not a severity-3 data-loss incident.
+        const signal: GatewaySignal =
+          name === "orphaned-db-handle" &&
+          classifyOrphanedDbTick(lines, i) === "recovered"
+            ? "orphaned-db-handle-recovered"
+            : name;
+        gw_hits[signal] += 1;
+        const origin = extractTurnId(line);
+        const pointer = `${logName}:${i + 1}`;
+        const ts = extractTs(line);
+        if (origin !== null) {
+          const eventKey = `${signal}|${origin}`;
+          const at = eventIndex.get(eventKey);
+          if (at !== undefined) {
+            // Same event, later line: advance the evidence to the newest one
+            // rather than booking a second occurrence.
+            const prev = findings[at]!;
+            findings[at] = { ...prev, log_pointer: pointer, ts: ts ?? prev.ts };
+            continue;
+          }
+          eventIndex.set(eventKey, findings.length);
+        }
         findings.push({
-          signal: name,
+          signal,
           agent,
-          turn_id: extractTurnId(line) ?? `${agent}:gw#${i + 1}`,
-          log_pointer: `${logName}:${i + 1}`,
-          ts: extractTs(line),
+          turn_id: origin ?? `${agent}:gw#${i + 1}`,
+          log_pointer: pointer,
+          ts,
         });
       }
     }

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -231,6 +231,20 @@ export const GATEWAY_SIGNATURES: Record<LineMatchedGatewaySignal, RegExp> = {
   "orphaned-db-handle": /orphaned-db-sweep DETECTED \d+ deleted-inode DB handle/,
 };
 
+/**
+ * Every signal `detectGatewaySignals` can emit — the line-matched ones plus the
+ * `orphaned-db-handle-recovered` split it derives. #4680 rule 3 folds these
+ * findings by event identity (the `origin=` turn id) instead of one per log
+ * line, so this list is also the authoritative set of signals whose ledger
+ * COUNTING UNIT is `gateway-event` (see `countingUnitFor` in `mapping.ts`).
+ * Single-sourced here so a new gateway signal cannot be added to the detector
+ * and silently miss the ledger's counting-unit guard.
+ */
+export const GATEWAY_SIGNAL_NAMES: readonly GatewaySignal[] = [
+  ...(Object.keys(GATEWAY_SIGNATURES) as LineMatchedGatewaySignal[]),
+  "orphaned-db-handle-recovered",
+];
+
 /** The sweep's in-process recovery line, logged by `attemptHistoryReopen` the
  *  moment the reopened `history.db` handle passes its post-reopen writer
  *  self-check (`orphaned-db-sweep.ts:279`). `reopened` is the first-detection
@@ -267,21 +281,41 @@ const ORPHANED_DB_TICK_LOOKAHEAD = 12;
  * tick reported itself un-recovered. `registry.db` has no in-process recovery
  * at all, so a tick that reopened history while registry stayed orphaned is
  * still severity-3 silent loss.
+ *
+ * The lookahead cap is a safety valve, NOT a tick boundary, and the ordering
+ * makes that distinction load-bearing: `runOrphanedDbSweepTick` logs the
+ * history lane (and therefore the reopen-succeeded line, since
+ * `attemptHistoryReopen` is synchronous) at :219-229 BEFORE the registry lane
+ * at :231-238 and the unowned lane at :242-251. So the lines that veto a
+ * "recovered" verdict are exactly the ones an interleaved or truncated log
+ * pushes out of the window. If the scan runs out of window without reaching a
+ * tick boundary — the next tick's DETECTED alarm, or EOF — we have NOT seen
+ * the whole tick and cannot prove no lane was left un-recovered, so we fail
+ * toward the alarm and report `unrecovered` (severity 3). Without this, an
+ * emitter that grew an `await` between the lanes, or 12 interleaved lines from
+ * another gateway subsystem, would silently downgrade a real `registry.db`
+ * data loss from severity 3 to severity 1.
  */
 export function classifyOrphanedDbTick(
   lines: readonly string[],
   alarmIdx: number,
 ): "recovered" | "unrecovered" {
   let recovered = false;
-  const end = Math.min(lines.length, alarmIdx + 1 + ORPHANED_DB_TICK_LOOKAHEAD);
+  const cap = alarmIdx + 1 + ORPHANED_DB_TICK_LOOKAHEAD;
+  const end = Math.min(lines.length, cap);
+  // EOF inside the window means the log simply ended: the whole tick is visible.
+  let sawTickBoundary = lines.length <= cap;
   for (let j = alarmIdx + 1; j < end; j++) {
     const line = lines[j];
     if (!line) continue;
-    if (GATEWAY_SIGNATURES["orphaned-db-handle"].test(line)) break; // next tick
+    if (GATEWAY_SIGNATURES["orphaned-db-handle"].test(line)) {
+      sawTickBoundary = true; // next tick's alarm — this tick is fully seen
+      break;
+    }
     if (ORPHANED_DB_UNRECOVERED_RE.test(line)) return "unrecovered";
     if (ORPHANED_DB_RECOVERED_RE.test(line)) recovered = true;
   }
-  return recovered ? "recovered" : "unrecovered";
+  return recovered && sawTickBoundary ? "recovered" : "unrecovered";
 }
 
 /** Parse `turns.jsonl` text into records, silently skipping malformed lines
@@ -542,9 +576,15 @@ export function detectGatewayFindings(
           const at = eventIndex.get(eventKey);
           if (at !== undefined) {
             // Same event, later line: advance the evidence to the newest one
-            // rather than booking a second occurrence.
+            // rather than booking a second occurrence. `log_pointer` and `ts`
+            // move together or not at all — a newest line with no parseable
+            // timestamp must not leave a pointer at line N describing evidence
+            // whose `ts` came from an earlier line, because `withinWindow` and
+            // `buildLedger`'s recency then age on a `ts` the pointer disowns.
             const prev = findings[at]!;
-            findings[at] = { ...prev, log_pointer: pointer, ts: ts ?? prev.ts };
+            if (ts !== null || prev.ts === null) {
+              findings[at] = { ...prev, log_pointer: pointer, ts };
+            }
             continue;
           }
           eventIndex.set(eventKey, findings.length);

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -232,18 +232,41 @@ export const GATEWAY_SIGNATURES: Record<LineMatchedGatewaySignal, RegExp> = {
 };
 
 /**
- * Every signal `detectGatewaySignals` can emit — the line-matched ones plus the
- * `orphaned-db-handle-recovered` split it derives. #4680 rule 3 folds these
- * findings by event identity (the `origin=` turn id) instead of one per log
- * line, so this list is also the authoritative set of signals whose ledger
- * COUNTING UNIT is `gateway-event` (see `countingUnitFor` in `mapping.ts`).
- * Single-sourced here so a new gateway signal cannot be added to the detector
- * and silently miss the ledger's counting-unit guard.
+ * Every signal `detectGatewayFindings` can emit — the line-matched ones plus
+ * the splits it derives. #4680 rule 3 folds these findings by event identity
+ * (the `origin=` turn id) instead of one per log line, so this is also the
+ * authoritative set of signals whose ledger COUNTING UNIT is `gateway-event`
+ * (see `countingUnitFor` in `mapping.ts`).
+ *
+ * #4682 M2 — this is a `Record<GatewaySignal, true>`, not a list, and that is
+ * load-bearing. A hand-written array satisfies `readonly GatewaySignal[]` while
+ * MISSING a member, and nothing else in the codebase would object: a DERIVED
+ * signal (one excluded from `LineMatchedGatewaySignal`, as
+ * `orphaned-db-handle-recovered` is) needs no `GATEWAY_SIGNATURES` entry, so
+ * tsc stays green and `countingUnitFor` silently hands the new signal the
+ * `log-line` unit it was never counted in — re-arming the exact false
+ * "Verified count-drop" auto-close the guard exists to stop. A `Record` keyed
+ * by the union makes an omission a compile error.
  */
-export const GATEWAY_SIGNAL_NAMES: readonly GatewaySignal[] = [
-  ...(Object.keys(GATEWAY_SIGNATURES) as LineMatchedGatewaySignal[]),
-  "orphaned-db-handle-recovered",
-];
+const GATEWAY_SIGNAL_MEMBERS: Record<GatewaySignal, true> = {
+  "duplicate-delivery-represent": true,
+  "represent-escalation": true,
+  "reply-delivery-failure": true,
+  "orphaned-db-handle": true,
+  "orphaned-db-handle-recovered": true,
+};
+
+export const GATEWAY_SIGNAL_NAMES: readonly GatewaySignal[] = Object.keys(
+  GATEWAY_SIGNAL_MEMBERS,
+) as GatewaySignal[];
+
+/** Zeroed `gw_hits` accumulator — derived from the same exhaustive record, so a
+ *  new gateway signal cannot be counted under a key that does not exist. */
+function emptyGwHits(): Record<GatewaySignal, number> {
+  const out = {} as Record<GatewaySignal, number>;
+  for (const name of GATEWAY_SIGNAL_NAMES) out[name] = 0;
+  return out;
+}
 
 /** The sweep's in-process recovery line, logged by `attemptHistoryReopen` the
  *  moment the reopened `history.db` handle passes its post-reopen writer
@@ -253,69 +276,79 @@ export const GATEWAY_SIGNAL_NAMES: readonly GatewaySignal[] = [
 const ORPHANED_DB_RECOVERED_RE =
   /orphaned-db-sweep reopened history\.db — writes are durable again/;
 
-/**
- * Lines that say a lane in THIS tick was left un-recovered — each one is real,
- * unrecovered data loss and must keep the severity-3 alarm even if the history
- * lane reopened alongside it. Verbatim from `orphaned-db-sweep.ts`:
- * registry.db (:233), the unowned lane (:247), history-with-no-reopen-wired
- * (:225), the sticky closed-history lane (:260) and a failed reopen (:285).
- */
-const ORPHANED_DB_UNRECOVERED_RE =
-  /orphaned-db-sweep (?:found an orphaned registry\.db handle|found orphaned handle\(s\) on |found an orphaned history\.db handle but no reopen|history\.db is CLOSED and a previous reopen failed|FAILED to reopen history\.db)/;
+/** Any `orphaned-db-sweep` line. The emitter logs an alarm and every lane line
+ *  for one tick synchronously (`runOrphanedDbSweepTick`, no `await` between
+ *  :210 and :251), so the FIRST sweep line after an alarm is that alarm's own
+ *  tick reporting its history lane. This is the tick boundary — a property of
+ *  the log's CONTENT, not of how many lines happen to follow. */
+const ORPHANED_DB_SWEEP_LINE_RE = /orphaned-db-sweep /;
 
-/** Upper bound on the lookahead for a tick's follow-up lines. One tick emits at
- *  most a handful (alarm + up to three lane lines + the recovery line); the cap
- *  keeps a truncated or interleaved log from scanning the whole file. */
-const ORPHANED_DB_TICK_LOOKAHEAD = 12;
+/** Each `fd=<n> <target>` pair the DETECTED line interpolates
+ *  (`orphaned-db-sweep.ts:213-214`). The target may carry a trailing
+ *  ` (deleted)`, which `\S+` naturally stops before. */
+const ORPHANED_DB_ALARM_TARGET_RE = /\bfd=\d+ (\S+)/g;
+
+/**
+ * The lanes an alarm line names, as basenames. Returns `null` when the line
+ * carries no parseable target at all — an emitter format change must fail
+ * toward the alarm, never silently downgrade a data-loss record.
+ */
+function orphanedDbAlarmLanes(alarmLine: string): string[] | null {
+  const names: string[] = [];
+  for (const m of alarmLine.matchAll(ORPHANED_DB_ALARM_TARGET_RE)) {
+    const target = m[1]!;
+    names.push(target.slice(target.lastIndexOf("/") + 1));
+  }
+  return names.length > 0 ? names : null;
+}
 
 /**
  * Decide whether an `orphaned-db-sweep DETECTED` alarm at `alarmIdx` was
  * RECOVERED inside its own sweep tick.
  *
- * `runOrphanedDbSweepTick` logs the alarm and every lane line synchronously,
- * with no `await` between them, so a tick's lines are contiguous. The window
- * therefore runs from the alarm to the next DETECTED line (the next tick's
- * alarm) or `ORPHANED_DB_TICK_LOOKAHEAD` lines, whichever comes first.
+ * #4682 B1 — the verdict is derived from the tick's CONTENT, never from how
+ * many lines follow it. The previous line-count lookahead made the answer
+ * position-dependent: the identical alarm+reopen pair classified `recovered`
+ * while it sat at the log tail and `unrecovered` once twelve lines of ordinary
+ * traffic had accumulated behind it. Sweeps are five minutes apart, so the next
+ * alarm is essentially never inside a dozen lines and the verdict effectively
+ * tracked WHEN the scan ran. That is fatal downstream: the two verdicts carry
+ * different signatures, so a flip migrates the finding between dedup_keys and
+ * empties the old one, which the ledger reads as a fix-to-zero.
  *
- * Recovered means BOTH: the reopen-succeeded line landed, AND no lane in the
- * tick reported itself un-recovered. `registry.db` has no in-process recovery
- * at all, so a tick that reopened history while registry stayed orphaned is
- * still severity-3 silent loss.
+ * Two content-derived facts settle it:
  *
- * The lookahead cap is a safety valve, NOT a tick boundary, and the ordering
- * makes that distinction load-bearing: `runOrphanedDbSweepTick` logs the
- * history lane (and therefore the reopen-succeeded line, since
- * `attemptHistoryReopen` is synchronous) at :219-229 BEFORE the registry lane
- * at :231-238 and the unowned lane at :242-251. So the lines that veto a
- * "recovered" verdict are exactly the ones an interleaved or truncated log
- * pushes out of the window. If the scan runs out of window without reaching a
- * tick boundary — the next tick's DETECTED alarm, or EOF — we have NOT seen
- * the whole tick and cannot prove no lane was left un-recovered, so we fail
- * toward the alarm and report `unrecovered` (severity 3). Without this, an
- * emitter that grew an `await` between the lanes, or 12 interleaved lines from
- * another gateway subsystem, would silently downgrade a real `registry.db`
- * data loss from severity 3 to severity 1.
+ * 1. WHICH LANES the tick hit is stated by the alarm line itself — it
+ *    interpolates every orphaned fd's target (`orphaned-db-sweep.ts:213-217`).
+ *    `history.db*` (including `-wal`/`-shm`, matching the emitter's own
+ *    `startsWith('history.db')` lane test at :219) is the only lane with an
+ *    in-process recovery. An alarm naming `registry.db` or an unowned file is
+ *    unrecoverable silent loss, full stop — no lookahead may overrule it, and
+ *    crucially a truncated log that lost the lane line can no longer launder it
+ *    down to severity 1.
+ * 2. WHETHER the history lane recovered is stated by the first `orphaned-db-sweep`
+ *    line after the alarm. The emitter reaches its history lane with no `await`
+ *    after the alarm and always logs exactly one of: reopened-and-proved-durable,
+ *    no-reopen-wired, or FAILED-to-reopen. Only the first is a recovery; anything
+ *    else — including running out of log — keeps the alarm.
  */
 export function classifyOrphanedDbTick(
   lines: readonly string[],
   alarmIdx: number,
 ): "recovered" | "unrecovered" {
-  let recovered = false;
-  const cap = alarmIdx + 1 + ORPHANED_DB_TICK_LOOKAHEAD;
-  const end = Math.min(lines.length, cap);
-  // EOF inside the window means the log simply ended: the whole tick is visible.
-  let sawTickBoundary = lines.length <= cap;
-  for (let j = alarmIdx + 1; j < end; j++) {
-    const line = lines[j];
-    if (!line) continue;
-    if (GATEWAY_SIGNATURES["orphaned-db-handle"].test(line)) {
-      sawTickBoundary = true; // next tick's alarm — this tick is fully seen
-      break;
-    }
-    if (ORPHANED_DB_UNRECOVERED_RE.test(line)) return "unrecovered";
-    if (ORPHANED_DB_RECOVERED_RE.test(line)) recovered = true;
+  const lanes = orphanedDbAlarmLanes(lines[alarmIdx] ?? "");
+  // Unparseable target list, or any lane without an in-process recovery.
+  if (lanes === null || !lanes.every((n) => n.startsWith("history.db"))) {
+    return "unrecovered";
   }
-  return recovered && sawTickBoundary ? "recovered" : "unrecovered";
+  for (let j = alarmIdx + 1; j < lines.length; j++) {
+    const line = lines[j];
+    if (!line || !ORPHANED_DB_SWEEP_LINE_RE.test(line)) continue;
+    // The first sweep line after the alarm IS this tick's history-lane verdict.
+    return ORPHANED_DB_RECOVERED_RE.test(line) ? "recovered" : "unrecovered";
+  }
+  // The log ended before the lane reported: we cannot prove a recovery.
+  return "unrecovered";
 }
 
 /** Parse `turns.jsonl` text into records, silently skipping malformed lines
@@ -541,13 +574,7 @@ export function detectGatewayFindings(
   logName = `logs/${agent}/gateway-supervisor.log`,
 ): { findings: Finding[]; gw_hits: Record<GatewaySignal, number> } {
   const findings: Finding[] = [];
-  const gw_hits: Record<GatewaySignal, number> = {
-    "duplicate-delivery-represent": 0,
-    "represent-escalation": 0,
-    "reply-delivery-failure": 0,
-    "orphaned-db-handle": 0,
-    "orphaned-db-handle-recovered": 0,
-  };
+  const gw_hits = emptyGwHits();
   const lines = logText.split("\n");
   /** (signal, origin) → index of that event's finding in `findings`. */
   const eventIndex = new Map<string, number>();

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -288,10 +288,28 @@ const ORPHANED_DB_SWEEP_LINE_RE = /orphaned-db-sweep /;
  *  ` (deleted)`, which `\S+` naturally stops before. */
 const ORPHANED_DB_ALARM_TARGET_RE = /\bfd=\d+ (\S+)/g;
 
+/** The handle COUNT the alarm declares — the same `\d+` the
+ *  `orphaned-db-handle` signature already requires, so it is present on every
+ *  line that reaches here. `orphaned-db-sweep.ts:211-217` writes
+ *  `DETECTED ${orphans.length}` and then exactly one `fd=` pair per orphan, so
+ *  count and pair list are 1:1 BY CONSTRUCTION and any inequality means the
+ *  list we are reading is not the list the emitter wrote. */
+const ORPHANED_DB_ALARM_COUNT_RE = /DETECTED (\d+) deleted-inode DB handle/;
+
 /**
- * The lanes an alarm line names, as basenames. Returns `null` when the line
- * carries no parseable target at all — an emitter format change must fail
- * toward the alarm, never silently downgrade a data-loss record.
+ * The lanes an alarm line names, as basenames. Returns `null` when the line's
+ * target list is not provably COMPLETE — either nothing parsed at all, or fewer
+ * pairs parsed than the line's own count declares. An emitter format change, a
+ * truncated line, or an interleaved write must fail toward the alarm, never
+ * silently downgrade a data-loss record.
+ *
+ * #4682 B1 follow-up — reading the pairs and ignoring the count made the
+ * verdict depend on the alarm line arriving INTACT. A short `write()` on the
+ * supervisor's stderr for an alarm line over `PIPE_BUF` (reachable precisely
+ * when many fds are orphaned — the worst incident) drops the tail of the list,
+ * and a surviving `history.db` pair then launders a real `registry.db` loss
+ * down to severity 1. The count is at the HEAD of the line, so it survives
+ * exactly the truncations that eat the list.
  */
 function orphanedDbAlarmLanes(alarmLine: string): string[] | null {
   const names: string[] = [];
@@ -299,8 +317,28 @@ function orphanedDbAlarmLanes(alarmLine: string): string[] | null {
     const target = m[1]!;
     names.push(target.slice(target.lastIndexOf("/") + 1));
   }
-  return names.length > 0 ? names : null;
+  if (names.length === 0) return null;
+  const declared = ORPHANED_DB_ALARM_COUNT_RE.exec(alarmLine)?.[1];
+  if (declared === undefined || names.length !== Number(declared)) return null;
+  return names;
 }
+
+/**
+ * Lane lines that state, in this tick, that a lane was left UN-recovered. They
+ * veto a `recovered` verdict no matter what the alarm line's own list said.
+ *
+ * Deliberately only the two lanes the emitter logs AFTER the history lane and
+ * ONLY from inside an alarm's own `orphans.length > 0` block: registry
+ * (`orphaned-db-sweep.ts:231-238`) and unowned (`:242-251`). The sticky
+ * closed-history line (`:255-264`) and `FAILED to reopen` (`:285`) are
+ * excluded on purpose — both also fire from the retry path on a tick with NO
+ * DETECTED line, so vetoing on them would let a LATER, unrelated tick flip an
+ * earlier recovered alarm, which is the log-growth dependence #4682 B1 removed.
+ * This tick's own failed reopen is already caught by the first-sweep-line rule
+ * below, so nothing is lost by excluding them.
+ */
+const ORPHANED_DB_LANE_VETO_RE =
+  /orphaned-db-sweep found (?:an orphaned registry\.db handle|orphaned handle\(s\) on )/;
 
 /**
  * Decide whether an `orphaned-db-sweep DETECTED` alarm at `alarmIdx` was
@@ -318,37 +356,52 @@ function orphanedDbAlarmLanes(alarmLine: string): string[] | null {
  *
  * Two content-derived facts settle it:
  *
- * 1. WHICH LANES the tick hit is stated by the alarm line itself — it
- *    interpolates every orphaned fd's target (`orphaned-db-sweep.ts:213-217`).
- *    `history.db*` (including `-wal`/`-shm`, matching the emitter's own
- *    `startsWith('history.db')` lane test at :219) is the only lane with an
- *    in-process recovery. An alarm naming `registry.db` or an unowned file is
- *    unrecoverable silent loss, full stop — no lookahead may overrule it, and
- *    crucially a truncated log that lost the lane line can no longer launder it
- *    down to severity 1.
+ * 1. WHICH LANES the tick hit is stated by the alarm line itself — it declares
+ *    a handle COUNT and then interpolates one `fd=` pair per orphaned target
+ *    (`orphaned-db-sweep.ts:211-217`). `history.db*` (including `-wal`/`-shm`,
+ *    matching the emitter's own `startsWith('history.db')` lane test at :219)
+ *    is the only lane with an in-process recovery. An alarm naming
+ *    `registry.db` or an unowned file is unrecoverable silent loss, full stop.
+ *    Count and pair list are 1:1 by construction, so `orphanedDbAlarmLanes`
+ *    cross-checks them and refuses to answer from a list it cannot prove
+ *    COMPLETE — a truncated alarm can no longer launder a hidden `registry.db`
+ *    down to severity 1 on the strength of a surviving `history.db` pair.
  * 2. WHETHER the history lane recovered is stated by the first `orphaned-db-sweep`
  *    line after the alarm. The emitter reaches its history lane with no `await`
  *    after the alarm and always logs exactly one of: reopened-and-proved-durable,
  *    no-reopen-wired, or FAILED-to-reopen. Only the first is a recovery; anything
  *    else — including running out of log — keeps the alarm.
+ * 3. Belt and braces: any registry/unowned lane line between this alarm and the
+ *    NEXT alarm vetoes a recovery outright (`ORPHANED_DB_LANE_VETO_RE`). Those
+ *    lines are emitted only from inside an alarm's own block, so the scan window
+ *    is bounded by the log's CONTENT (the next DETECTED line, or EOF) and never
+ *    by a line count — no position-dependence is reintroduced. It exists so an
+ *    intact "rows … are LOST" line in the tick is never overruled by whatever
+ *    the alarm line happens to say, whatever the emitter's format becomes.
  */
 export function classifyOrphanedDbTick(
   lines: readonly string[],
   alarmIdx: number,
 ): "recovered" | "unrecovered" {
   const lanes = orphanedDbAlarmLanes(lines[alarmIdx] ?? "");
-  // Unparseable target list, or any lane without an in-process recovery.
+  // Incomplete target list, or any lane without an in-process recovery.
   if (lanes === null || !lanes.every((n) => n.startsWith("history.db"))) {
     return "unrecovered";
   }
+  let verdict: "recovered" | "unrecovered" | null = null;
   for (let j = alarmIdx + 1; j < lines.length; j++) {
     const line = lines[j];
     if (!line || !ORPHANED_DB_SWEEP_LINE_RE.test(line)) continue;
+    // The next alarm ends this tick — its lane lines are not ours to read.
+    if (GATEWAY_SIGNATURES["orphaned-db-handle"].test(line)) break;
+    // An un-recovered lane anywhere in THIS tick settles it, alarm line or not.
+    if (ORPHANED_DB_LANE_VETO_RE.test(line)) return "unrecovered";
     // The first sweep line after the alarm IS this tick's history-lane verdict.
-    return ORPHANED_DB_RECOVERED_RE.test(line) ? "recovered" : "unrecovered";
+    verdict ??= ORPHANED_DB_RECOVERED_RE.test(line) ? "recovered" : "unrecovered";
+    if (verdict === "unrecovered") return "unrecovered";
   }
-  // The log ended before the lane reported: we cannot prove a recovery.
-  return "unrecovered";
+  // `null` — the log ended before the lane reported: we cannot prove a recovery.
+  return verdict ?? "unrecovered";
 }
 
 /** Parse `turns.jsonl` text into records, silently skipping malformed lines

--- a/src/fleet-health/gh-sync.test.ts
+++ b/src/fleet-health/gh-sync.test.ts
@@ -196,3 +196,86 @@ describe("#4680 — no GitHub issue auto-closes across a counting-unit change", 
     expect(finalIssue.gh_issue).toBe(1841);
   });
 });
+
+/**
+ * #4682 B1 — the GitHub-facing half. The counting-unit guard cannot see a
+ * finding that reclassifies into a SIBLING signature, because that empties the
+ * old dedup_key rather than shrinking it. The old key then takes the
+ * close-on-zero path and `gh-sync` comments "Verified count-drop … Closed by
+ * the Fleet Health sensor." — a fix claim nobody earned — and, with no reopen
+ * path, that close is permanent.
+ */
+describe("#4682 — gh-sync tells the truth about WHY an issue closed", () => {
+  const NOW = new Date("2026-07-03T00:00:00Z");
+
+  const dbFinding = (signal: Finding["signal"], seq: number): Finding => ({
+    signal,
+    agent: "alpha",
+    turn_id: `alpha:gw#${seq}`,
+    log_pointer: `logs/alpha/gateway-supervisor.log:${seq}`,
+    ts: "2026-07-02T21:03:00Z",
+  });
+
+  const issueFor = (led: FleetHealthLedger, key: string) =>
+    led.records.flatMap((r) => r.issues).find((i) => i.dedup_key.endsWith(key))!;
+
+  it("does not claim a verified count-drop when the finding was reclassified", () => {
+    const prior = buildLedger([dbFinding("orphaned-db-handle", 1)], { now: NOW });
+    issueFor(prior, "deleted-inode-writes").gh_issue = 909;
+    const next = buildLedger([dbFinding("orphaned-db-handle-recovered", 1)], {
+      now: NOW,
+      prior,
+    });
+
+    const { deps, calls } = fakeDeps();
+    syncLedgerIssues(next, "switchroom/switchroom", deps);
+    const close = calls.find((c) => c[0] === "issue" && c[1] === "close")!;
+    expect(close).toBeDefined();
+    expect(close).toContain("909");
+    const comment = close[close.indexOf("--comment") + 1];
+    expect(comment).not.toMatch(/Verified count-drop/);
+    expect(comment).toMatch(/reclassified/i);
+    expect(comment).toMatch(/orphaned-db-handle:recovered-in-tick/);
+  });
+
+  it("still claims a verified count-drop on a genuine drop to zero", () => {
+    const prior = buildLedger([dbFinding("orphaned-db-handle", 1)], { now: NOW });
+    issueFor(prior, "deleted-inode-writes").gh_issue = 909;
+    const next = buildLedger([], { now: NOW, prior });
+
+    const { deps, calls } = fakeDeps();
+    syncLedgerIssues(next, "switchroom/switchroom", deps);
+    const close = calls.find((c) => c[0] === "issue" && c[1] === "close")!;
+    expect(close[close.indexOf("--comment") + 1]).toMatch(/Verified count-drop/);
+  });
+
+  it("reopens a closed issue whose defect came back", () => {
+    const prior = buildLedger([dbFinding("orphaned-db-handle", 1)], { now: NOW });
+    issueFor(prior, "deleted-inode-writes").gh_issue = 909;
+    const closed = buildLedger([], { now: NOW, prior });
+    const back = buildLedger([dbFinding("orphaned-db-handle", 2)], {
+      now: NOW,
+      prior: closed,
+    });
+
+    const { deps, calls } = fakeDeps();
+    syncLedgerIssues(back, "switchroom/switchroom", deps);
+    const reopen = calls.find((c) => c[0] === "issue" && c[1] === "reopen");
+    expect(reopen).toBeDefined();
+    expect(reopen).toContain("909");
+    // …and it must not also be closed in the same pass.
+    expect(calls.filter((c) => c[0] === "issue" && c[1] === "close")).toEqual([]);
+  });
+
+  it("does not reopen an issue that was already open", () => {
+    const prior = buildLedger([dbFinding("orphaned-db-handle", 1)], { now: NOW });
+    issueFor(prior, "deleted-inode-writes").gh_issue = 909;
+    const still = buildLedger([dbFinding("orphaned-db-handle", 2)], {
+      now: NOW,
+      prior,
+    });
+    const { deps, calls } = fakeDeps();
+    syncLedgerIssues(still, "switchroom/switchroom", deps);
+    expect(calls.filter((c) => c[0] === "issue" && c[1] === "reopen")).toEqual([]);
+  });
+});

--- a/src/fleet-health/gh-sync.test.ts
+++ b/src/fleet-health/gh-sync.test.ts
@@ -136,3 +136,63 @@ describe("gh-sync (no network — injected deps)", () => {
     expect(closeCall).toBeDefined();
   });
 });
+
+/**
+ * #4680 — the end-to-end consequence the counting-unit guard exists to stop.
+ * Rule 3 of that PR folds gateway findings by affected turn instead of by log
+ * line, which shrinks every open gateway issue's `frequency` with nothing
+ * fixed. Two scans is all it takes for the naive count-drop rule to run
+ * `gh issue close` and comment "Verified count-drop … Closed by the Fleet
+ * Health sensor." on a live, still-broken issue.
+ */
+describe("#4680 — no GitHub issue auto-closes across a counting-unit change", () => {
+  const NOW = new Date("2026-07-03T00:00:00Z");
+
+  it("runs no `gh issue close` on either scan after the fold changes the unit", () => {
+    // Pre-#4680 on-disk ledger: 8 duplicate-send LOG LINES across 3 turns,
+    // tracked as GH #1841. Written before `counting_unit` existed.
+    const prior: FleetHealthLedger = buildLedger(
+      [1, 1, 1, 2, 2, 2, 3, 3].map((t) => dup("clerk", t)),
+      { now: NOW },
+    );
+    for (const rec of prior.records) {
+      for (const iss of rec.issues) {
+        delete (iss as { counting_unit?: unknown }).counting_unit;
+        iss.gh_issue = 1841;
+      }
+    }
+    const key = dedupKeyFor(dup("clerk", 1));
+    const priorIssue = prior.records
+      .flatMap((r) => r.issues)
+      .find((i) => i.dedup_key === key)!;
+    expect(priorIssue.frequency).toBe(8);
+    expect(priorIssue.status).toBe("open");
+
+    // The SAME three broken turns, now folded to one finding each. Nothing was
+    // fixed; only the ruler changed.
+    const scan1 = buildLedger([1, 2, 3].map((t) => dup("clerk", t)), {
+      now: NOW,
+      prior,
+    });
+    const scan2 = buildLedger([1, 2, 3].map((t) => dup("clerk", t)), {
+      now: NOW,
+      prior: scan1,
+    });
+
+    const closeCalls: string[][] = [];
+    for (const led of [scan1, scan2]) {
+      const { deps, calls } = fakeDeps();
+      syncLedgerIssues(led, "switchroom/switchroom", deps);
+      closeCalls.push(
+        ...calls.filter((c) => c[0] === "issue" && c[1] === "close"),
+      );
+    }
+    expect(closeCalls).toEqual([]);
+
+    const finalIssue = scan2.records
+      .flatMap((r) => r.issues)
+      .find((i) => i.dedup_key === key)!;
+    expect(finalIssue.status).toBe("open");
+    expect(finalIssue.gh_issue).toBe(1841);
+  });
+});

--- a/src/fleet-health/gh-sync.ts
+++ b/src/fleet-health/gh-sync.ts
@@ -131,18 +131,48 @@ function syncIssue(
     deps.log(`fleet-health: gh issue edit #${num} failed: ${upd.stderr}`);
   }
 
-  if (iss.status === "closed") {
-    const c = deps.run([
+  // #4682 B1 — a CLOSED GitHub issue whose defect came back. `gh issue edit`
+  // above refreshed its body and left it closed, so without an explicit reopen
+  // the board would keep saying "fixed" while the sensor finds the defect every
+  // night — a permanent lie, and the one failure this ledger exists to prevent.
+  if (iss.reopened) {
+    const r = deps.run([
       "issue",
-      "close",
+      "reopen",
       num,
       "-R",
       repo,
       "--comment",
-      `Verified count-drop (frequency ${iss.frequency} ≤ resolved threshold). Closed by the Fleet Health sensor.`,
+      `Reopened by the Fleet Health sensor: this defect is back (frequency ${iss.frequency}` +
+        ` in the current scan window). The earlier close was not a durable fix.`,
     ]);
-    if (c.ok) deps.log(`fleet-health: closed GH #${num} (count-drop) for ${iss.dedup_key}`);
-    else deps.log(`fleet-health: gh issue close #${num} failed: ${c.stderr}`);
+    if (r.ok) deps.log(`fleet-health: reopened GH #${num} for ${iss.dedup_key}`);
+    else deps.log(`fleet-health: gh issue reopen #${num} failed: ${r.stderr}`);
+    return;
+  }
+
+  if (iss.status === "closed") {
+    // WHY it closed decides what we are allowed to claim. `reclassified` means
+    // the findings moved to a SIBLING signature — the same alarm re-sorted by
+    // its outcome — so the count is genuinely zero here but nobody fixed
+    // anything. Saying "Verified count-drop" there is the success-theater
+    // inversion this sensor exists to catch, so the comment names the
+    // reclassification and points at where the evidence went instead.
+    const reclassified = iss.close_reason === "reclassified";
+    const comment = reclassified
+      ? `No occurrences in the current scan window because these findings were` +
+        ` RECLASSIFIED into ${(iss.reclassified_into ?? []).join(", ")} — the same` +
+        ` detected condition re-sorted by its outcome. This is NOT a verified fix;` +
+        ` the evidence now lives on the sibling issue. Closed by the Fleet Health sensor.`
+      : `Verified count-drop (frequency ${iss.frequency} ≤ resolved threshold).` +
+        ` Closed by the Fleet Health sensor.`;
+    const c = deps.run(["issue", "close", num, "-R", repo, "--comment", comment]);
+    if (c.ok) {
+      deps.log(
+        `fleet-health: closed GH #${num} (${reclassified ? "reclassified" : "count-drop"})` +
+          ` for ${iss.dedup_key}`,
+      );
+    } else deps.log(`fleet-health: gh issue close #${num} failed: ${c.stderr}`);
   }
 }
 

--- a/src/fleet-health/ledger.test.ts
+++ b/src/fleet-health/ledger.test.ts
@@ -432,3 +432,154 @@ describe("#4680 — a change of counting UNIT is not a count-drop", () => {
     expect(issueOn(after, DELIVERY).status).toBe("closed");
   });
 });
+
+/**
+ * #4682 — the counting-unit guard's two blind spots.
+ *
+ * M1: the guard rewrites `frequency` to the POST-fold count, and the
+ * count-drop arm required `prior.frequency > RESOLVED_THRESHOLD`. A folded
+ * count of 3 never satisfies that again, so a held issue could only ever leave
+ * the board through the zero path — stale-open forever, not "delayed one
+ * scan".
+ *
+ * B1: the guard only sees a prior issue under the SAME dedup_key. A finding
+ * that reclassifies into a sibling signature (`orphaned-db-handle` →
+ * `orphaned-db-handle-recovered`) empties its old key entirely, which reads as
+ * a fix-to-zero and drives the close-on-zero path — the same false "Verified
+ * count-drop" claim the unit guard exists to prevent, on a key the guard
+ * cannot see.
+ */
+describe("#4682 — the guard's blind spots", () => {
+  const NOW = new Date("2026-07-03T00:00:00Z");
+  const DELIVERY = "talk-to-agents-from-anywhere";
+  const DB_JOB = "survive-reboots-and-real-life";
+
+  const issueFor = (led: ReturnType<typeof buildLedger>, key: string) =>
+    led.records.flatMap((r) => r.issues).find((i) => i.dedup_key.endsWith(key));
+
+  function legacyLedger(findings: Finding[], ghIssue?: number) {
+    const led = buildLedger(findings, { now: NOW });
+    for (const rec of led.records) {
+      for (const iss of rec.issues) {
+        delete (iss as { counting_unit?: unknown }).counting_unit;
+        if (ghIssue !== undefined) iss.gh_issue = ghIssue;
+      }
+    }
+    return led;
+  }
+
+  it("M1: a held issue still closes when its folded count genuinely drops", () => {
+    // Pre-#4680: 8 duplicate-send log lines across 3 turns, GH #4242.
+    const legacy = legacyLedger(
+      [1, 1, 1, 2, 2, 2, 3, 3].map((t, i) =>
+        dupFinding("clerk", t, `2026-07-02T21:0${i}:00Z`),
+      ),
+      4242,
+    );
+    // Scan 1 — the ruler changes, 8 log lines fold to 3 turns. Held open.
+    const held = buildLedger([1, 2, 3].map((t) => dupFinding("clerk", t)), {
+      now: NOW,
+      prior: legacy,
+    });
+    const heldIssue = held.records.find((r) => r.job_spec === DELIVERY)!.issues[0];
+    expect(heldIssue.status).toBe("open");
+    expect(heldIssue.frequency).toBe(3);
+
+    // Scan 2 — someone actually fixes two of the three turns. Same ruler on
+    // both sides now, and the count really dropped. The board must be able to
+    // say so: this is the "delayed one scan, never suppressed" promise.
+    const dropped = buildLedger([dupFinding("clerk", 1)], { now: NOW, prior: held });
+    const droppedIssue = dropped.records.find((r) => r.job_spec === DELIVERY)!.issues[0];
+    expect(droppedIssue.frequency).toBe(1);
+    expect(droppedIssue.status).toBe("resolved-pending-verify");
+
+    // Scan 3 — verified, closed.
+    const verified = buildLedger([dupFinding("clerk", 1)], { now: NOW, prior: dropped });
+    expect(
+      verified.records.find((r) => r.job_spec === DELIVERY)!.issues[0].status,
+    ).toBe("closed");
+  });
+
+  it("M1: a count that does NOT drop is never laundered into pending-verify", () => {
+    const legacy = legacyLedger(
+      [1, 1, 1, 2, 2, 2, 3, 3].map((t, i) =>
+        dupFinding("clerk", t, `2026-07-02T21:0${i}:00Z`),
+      ),
+      4242,
+    );
+    const held = buildLedger([1, 2, 3].map((t) => dupFinding("clerk", t)), {
+      now: NOW,
+      prior: legacy,
+    });
+    // Same three broken turns, forever. Nothing dropped, so nothing closes.
+    let led = held;
+    for (let scan = 0; scan < 3; scan++) {
+      led = buildLedger([1, 2, 3].map((t) => dupFinding("clerk", t)), {
+        now: NOW,
+        prior: led,
+      });
+      expect(led.records.find((r) => r.job_spec === DELIVERY)!.issues[0].status).toBe(
+        "open",
+      );
+    }
+  });
+
+  const dbFinding = (signal: Finding["signal"], seq: number): Finding => ({
+    signal,
+    agent: "alpha",
+    turn_id: `alpha:gw#${seq}`,
+    log_pointer: `logs/alpha/gateway-supervisor.log:${seq}`,
+    ts: "2026-07-02T21:03:00Z",
+  });
+
+  it("B1: a reclassification into a sibling signature is not a verified fix", () => {
+    const prior = buildLedger([dbFinding("orphaned-db-handle", 1)], { now: NOW });
+    const priorIssue = issueFor(prior, "deleted-inode-writes")!;
+    priorIssue.gh_issue = 909;
+    expect(priorIssue.status).toBe("open");
+
+    // The SAME sweep tick, now sorted into the recovered sibling. Nothing was
+    // fixed; the alarm was re-filed.
+    const next = buildLedger([dbFinding("orphaned-db-handle-recovered", 1)], {
+      now: NOW,
+      prior,
+    });
+    const migrated = issueFor(next, "deleted-inode-writes")!;
+    expect(migrated.frequency).toBe(0);
+    expect(migrated.gh_issue).toBe(909);
+    // It IS closed — zero occurrences is zero occurrences — but the ledger must
+    // record WHY, so gh-sync cannot claim a count-drop nobody earned.
+    expect(migrated.status).toBe("closed");
+    expect(migrated.close_reason).toBe("reclassified");
+    // …and the sibling is on the board carrying the evidence.
+    expect(issueFor(next, "recovered-in-tick")!.frequency).toBe(1);
+  });
+
+  it("B1: a genuine drop to zero is still marked as a count-drop", () => {
+    const prior = buildLedger([dbFinding("orphaned-db-handle", 1)], { now: NOW });
+    issueFor(prior, "deleted-inode-writes")!.gh_issue = 909;
+    // No findings at all this scan — the sweep stopped firing.
+    const next = buildLedger([], { now: NOW, prior });
+    const closed = issueFor(next, "deleted-inode-writes")!;
+    expect(closed.status).toBe("closed");
+    expect(closed.close_reason).toBe("count-drop");
+  });
+
+  it("B1: an issue that comes back after closing is marked for reopening", () => {
+    const prior = buildLedger([dbFinding("orphaned-db-handle", 1)], { now: NOW });
+    issueFor(prior, "deleted-inode-writes")!.gh_issue = 909;
+    const closed = buildLedger([], { now: NOW, prior });
+    expect(issueFor(closed, "deleted-inode-writes")!.status).toBe("closed");
+
+    // It regresses. A closed GitHub issue that never reopens is the board
+    // lying permanently, which is the one thing this ledger exists to prevent.
+    const back = buildLedger([dbFinding("orphaned-db-handle", 2)], {
+      now: NOW,
+      prior: closed,
+    });
+    const reborn = issueFor(back, "deleted-inode-writes")!;
+    expect(reborn.status).toBe("open");
+    expect(reborn.gh_issue).toBe(909);
+    expect(reborn.reopened).toBe(true);
+  });
+});

--- a/src/fleet-health/ledger.test.ts
+++ b/src/fleet-health/ledger.test.ts
@@ -309,3 +309,126 @@ describe("runScan (I/O) — defensive over a synthetic fleet tree", () => {
     }
   });
 });
+
+/**
+ * #4680 — the counting-UNIT guard.
+ *
+ * `frequency` is a count, and `buildLedger`'s self-verify closes an issue when
+ * the count DROPS. Rule 3 of this PR changes what a gateway finding counts:
+ * one per affected turn instead of one per matching log line. That makes every
+ * open gateway issue's frequency fall on the first scan after merge with
+ * nothing fixed — and the drop is indistinguishable from a real fix unless the
+ * ledger records the ruler alongside the number. Left unguarded, a live
+ * `duplicate-delivery-represent` issue flips to `resolved-pending-verify`,
+ * closes on the next scan, and `gh-sync` comments "Verified count-drop …" on a
+ * still-broken GitHub issue.
+ */
+describe("#4680 — a change of counting UNIT is not a count-drop", () => {
+  const NOW = new Date("2026-07-03T00:00:00Z");
+  const DELIVERY = "talk-to-agents-from-anywhere";
+  const KILLED_JOB = "steer-or-queue-mid-flight";
+
+  /** A ledger exactly as a PRE-#4680 scan wrote it to disk: counts are log
+   *  lines and no `counting_unit` field exists on any issue. */
+  function legacyLedger(findings: Finding[], ghIssue?: number) {
+    const led = buildLedger(findings, { now: NOW });
+    for (const rec of led.records) {
+      for (const iss of rec.issues) {
+        delete (iss as { counting_unit?: unknown }).counting_unit;
+        if (ghIssue !== undefined) iss.gh_issue = ghIssue;
+      }
+    }
+    return led;
+  }
+
+  const issueOn = (led: ReturnType<typeof buildLedger>, job: string) =>
+    led.records.find((r) => r.job_spec === job)!.issues[0];
+
+  it("holds a live gateway issue OPEN when the fold shrinks its frequency", () => {
+    // Pre-#4680 on-disk state: 8 duplicate-send log lines across 3 turns.
+    const prior = legacyLedger(
+      [1, 1, 1, 2, 2, 2, 3, 3].map((turn, i) => dupFinding("clerk", turn, `2026-07-02T21:0${i}:00Z`)),
+      4242,
+    );
+    expect(issueOn(prior, DELIVERY).frequency).toBe(8);
+    expect(issueOn(prior, DELIVERY).status).toBe("open");
+
+    // First post-merge scan: the SAME three broken turns, now folded to one
+    // finding each. 3 <= RESOLVED_THRESHOLD, so the naive rule fires.
+    const next = buildLedger(
+      [1, 2, 3].map((t) => dupFinding("clerk", t, "2026-07-02T21:30:00Z")),
+      { now: NOW, prior },
+    );
+    const iss = issueOn(next, DELIVERY);
+    expect(iss.frequency).toBe(3);
+    expect(iss.gh_issue).toBe(4242);
+    // The defect is unchanged, so the board must still say so.
+    expect(iss.status).toBe("open");
+    // …and the new ruler is recorded, so the NEXT scan compares like with like.
+    expect(iss.counting_unit).toBe("gateway-event");
+  });
+
+  it("still closes on a genuine drop the scan AFTER the unit change settles", () => {
+    const legacy = legacyLedger(
+      Array.from({ length: 20 }, (_, i) => dupFinding("clerk", i)),
+      4242,
+    );
+    // Scan 1 — unit changes; held open despite the low count.
+    const scan1 = buildLedger([dupFinding("clerk", 1)], { now: NOW, prior: legacy });
+    expect(issueOn(scan1, DELIVERY).status).toBe("open");
+    // Scan 2 — same unit on both sides now. Prior frequency is 1, which is not
+    // above the threshold, so the count-drop arm cannot fire; the guard must
+    // not have laundered a close either. A real regression back up and down is
+    // what re-arms it, which is the honest semantics.
+    const scan2 = buildLedger([dupFinding("clerk", 1)], { now: NOW, prior: scan1 });
+    expect(issueOn(scan2, DELIVERY).status).toBe("open");
+
+    // A real fix, measured in the SAME unit both times, still closes.
+    const busy = buildLedger(
+      Array.from({ length: 20 }, (_, i) => dupFinding("clerk", i)),
+      { now: NOW, prior: scan2 },
+    );
+    expect(issueOn(busy, DELIVERY).frequency).toBe(20);
+    const fixed = buildLedger([dupFinding("clerk", 1)], { now: NOW, prior: busy });
+    expect(issueOn(fixed, DELIVERY).status).toBe("resolved-pending-verify");
+    const verified = buildLedger([dupFinding("clerk", 1)], { now: NOW, prior: fixed });
+    expect(issueOn(verified, DELIVERY).status).toBe("closed");
+  });
+
+  it("does not delay a signal whose unit did NOT change", () => {
+    // `killed-incomplete-turn` is a turns.jsonl signal — the gateway fold never
+    // touched it, so its legacy `log-line` unit still matches and the ordinary
+    // count-drop must fire on the very first scan.
+    const legacy = legacyLedger(
+      Array.from({ length: 20 }, (_, i) =>
+        killedFinding("clerk", i, "2026-07-02T21:03:00Z"),
+      ),
+      777,
+    );
+    const next = buildLedger(
+      [killedFinding("clerk", 99, "2026-07-02T21:03:00Z")],
+      { now: NOW, prior: legacy },
+    );
+    const iss = issueOn(next, KILLED_JOB);
+    expect(iss.status).toBe("resolved-pending-verify");
+    expect(iss.counting_unit).toBe("log-line");
+  });
+
+  it("never advances a pending-verify gateway issue to closed across the change", () => {
+    const legacy = legacyLedger(
+      Array.from({ length: 20 }, (_, i) => dupFinding("clerk", i)),
+      4242,
+    );
+    // Pre-#4680: the issue had already dropped and was awaiting verification.
+    const pending = legacyLedger([dupFinding("clerk", 1)], 4242);
+    issueOn(pending, DELIVERY).status = "resolved-pending-verify";
+    expect(issueOn(legacy, DELIVERY).frequency).toBe(20);
+
+    const next = buildLedger([dupFinding("clerk", 1)], { now: NOW, prior: pending });
+    // Held, not closed: the verification scan must be measured in the same unit
+    // as the drop it is verifying.
+    expect(issueOn(next, DELIVERY).status).toBe("resolved-pending-verify");
+    const after = buildLedger([dupFinding("clerk", 1)], { now: NOW, prior: next });
+    expect(issueOn(after, DELIVERY).status).toBe("closed");
+  });
+});

--- a/src/fleet-health/ledger.test.ts
+++ b/src/fleet-health/ledger.test.ts
@@ -582,4 +582,41 @@ describe("#4682 — the guard's blind spots", () => {
     expect(reborn.gh_issue).toBe(909);
     expect(reborn.reopened).toBe(true);
   });
+
+  /**
+   * #4682 M2 — pins the DURABILITY WINDOW of the reopen path above, because the
+   * RFC now states it as a contract (`reference/rfcs/fleet-health.md`, "the
+   * reopen path is a one-scan window"). `buildLedger`'s close-on-zero loop only
+   * carries a prior key forward when its status is `open` or
+   * `resolved-pending-verify` (`ledger.ts:283-287`), so a `closed` issue with
+   * no findings is DROPPED on the very next scan and its `gh_issue` number goes
+   * with it. A defect returning two or more scans later therefore cannot
+   * reopen — it falls through to `gh-sync`'s create path and files a fresh
+   * issue. That is deliberate (an unbounded tombstone list is its own problem)
+   * but it is not obvious from the code, and a silent change to the window
+   * would change which incidents keep their thread.
+   */
+  it("B1: the reopen window is exactly one scan — then the GH number is gone", () => {
+    const prior = buildLedger([dbFinding("orphaned-db-handle", 1)], { now: NOW });
+    issueFor(prior, "deleted-inode-writes")!.gh_issue = 909;
+
+    // Scan 2: no findings — closed, but the number is still carried.
+    const scan2 = buildLedger([], { now: NOW, prior });
+    expect(issueFor(scan2, "deleted-inode-writes")!.gh_issue).toBe(909);
+
+    // Scan 3: still clean — the key is dropped from the ledger entirely.
+    const scan3 = buildLedger([], { now: NOW, prior: scan2 });
+    expect(issueFor(scan3, "deleted-inode-writes")).toBeUndefined();
+
+    // Scan 4: the defect is back, but there is nothing left to reopen. It is a
+    // fresh issue as far as gh-sync is concerned.
+    const scan4 = buildLedger([dbFinding("orphaned-db-handle", 2)], {
+      now: NOW,
+      prior: scan3,
+    });
+    const refiled = issueFor(scan4, "deleted-inode-writes")!;
+    expect(refiled.status).toBe("open");
+    expect(refiled.gh_issue).toBeUndefined();
+    expect(refiled.reopened).toBeUndefined();
+  });
 });

--- a/src/fleet-health/ledger.ts
+++ b/src/fleet-health/ledger.ts
@@ -14,6 +14,7 @@ import type {
   FleetHealthRecord,
   FleetHealthIssue,
   FleetHealthOccurrence,
+  FleetHealthCountingUnit,
 } from "../web/fleet-health-read.js";
 import type { Finding } from "./detect.js";
 import {
@@ -21,6 +22,8 @@ import {
   mapSignal,
   dedupKeyFor,
   issuePriority,
+  countingUnitFor,
+  LEGACY_COUNTING_UNIT,
 } from "./mapping.js";
 
 /** Below this occurrence count, a previously-open issue is considered fixed —
@@ -40,6 +43,9 @@ export interface PriorIssueState {
   job_spec: string;
   failure_mode: FleetHealthIssue["failure_mode"];
   severity: number;
+  /** The unit `frequency` above was counted in. A ledger written before #4680
+   *  carries no field, which means the legacy one-per-log-line unit. */
+  counting_unit: FleetHealthCountingUnit;
 }
 
 export function indexPriorIssues(
@@ -56,6 +62,7 @@ export function indexPriorIssues(
         job_spec: rec.job_spec,
         failure_mode: iss.failure_mode,
         severity: iss.severity,
+        counting_unit: iss.counting_unit ?? LEGACY_COUNTING_UNIT,
       });
     }
   }
@@ -73,6 +80,8 @@ interface Agg {
   /** Authoritative frequency — every finding for this key. Tracked during the
    *  single aggregation pass to avoid an O(findings × aggs) re-filter later. */
   count: number;
+  /** The unit `count` is measured in — see `countingUnitFor`. */
+  counting_unit: FleetHealthCountingUnit;
 }
 
 function newer(a: string | null, b: string | null): string | null {
@@ -174,6 +183,7 @@ export function buildLedger(
         reach: new Set(),
         newest: null,
         count: 0,
+        counting_unit: countingUnitFor(f.signal),
       };
       aggs.set(key, agg);
     }
@@ -198,9 +208,32 @@ export function buildLedger(
     // single aggregation pass above; occurrences are capped-at-50 samples).
     const count = agg.count;
     const prior = priorIdx.get(agg.dedup_key);
+    // #4680 — did the RULER change under this issue since the prior scan?
+    // `frequency` is a count in `counting_unit`, and the self-verify below
+    // compares this scan's count against the prior ledger's. When the unit
+    // changes (the gateway fold switched from one-per-log-line to one-per
+    // affected-turn), the number falls with NOTHING fixed: a live
+    // `duplicate-delivery-represent` issue at frequency 8 over 3 turns lands
+    // at 3 on the very next scan. Honouring that as a count-drop flips it to
+    // `resolved-pending-verify`, closes it the scan after, and has `gh-sync`
+    // post "Verified count-drop … Closed by the Fleet Health sensor." on a
+    // still-broken issue — the board lying, which is the one failure this
+    // ledger exists to prevent.
+    const unitChanged = prior !== undefined && prior.counting_unit !== agg.counting_unit;
 
     let status: FleetHealthIssue["status"] = "open";
-    if (count <= RESOLVED_THRESHOLD && prior && prior.frequency > RESOLVED_THRESHOLD) {
+    if (unitChanged) {
+      // Hold state for exactly one scan: never advance toward closure across a
+      // unit change. The issue is rewritten below carrying the NEW unit, so the
+      // next scan compares like with like and a genuine drop still closes it —
+      // this delays a real close by one scan, it does not suppress it. Reopening
+      // is still allowed (a count above the threshold clears pending-verify),
+      // because that direction cannot produce a false "fixed" claim.
+      status =
+        count <= RESOLVED_THRESHOLD && prior.status === "resolved-pending-verify"
+          ? "resolved-pending-verify"
+          : "open";
+    } else if (count <= RESOLVED_THRESHOLD && prior && prior.frequency > RESOLVED_THRESHOLD) {
       // count dropped after a fix → pending verification.
       status = "resolved-pending-verify";
     } else if (prior?.status === "resolved-pending-verify" && count <= RESOLVED_THRESHOLD) {
@@ -217,6 +250,7 @@ export function buildLedger(
       occurrences: agg.occurrences,
       ...(prior?.gh_issue !== undefined ? { gh_issue: prior.gh_issue } : {}),
       status,
+      counting_unit: agg.counting_unit,
     };
     const list = byJob.get(agg.job_spec) ?? [];
     list.push(issue);
@@ -243,6 +277,11 @@ export function buildLedger(
       occurrences: [],
       ...(prior.gh_issue !== undefined ? { gh_issue: prior.gh_issue } : {}),
       status: "closed",
+      // Not subject to the unit guard: zero findings means the artifact is
+      // genuinely absent from the window. Folding a non-empty finding set can
+      // shrink a count but can never empty it, so a unit change cannot
+      // manufacture this path.
+      counting_unit: prior.counting_unit,
     };
     const list = byJob.get(prior.job_spec) ?? [];
     list.push(issue);

--- a/src/fleet-health/ledger.ts
+++ b/src/fleet-health/ledger.ts
@@ -24,6 +24,7 @@ import {
   issuePriority,
   countingUnitFor,
   LEGACY_COUNTING_UNIT,
+  siblingDedupKeys,
 } from "./mapping.js";
 
 /** Below this occurrence count, a previously-open issue is considered fixed —
@@ -233,12 +234,30 @@ export function buildLedger(
         count <= RESOLVED_THRESHOLD && prior.status === "resolved-pending-verify"
           ? "resolved-pending-verify"
           : "open";
-    } else if (count <= RESOLVED_THRESHOLD && prior && prior.frequency > RESOLVED_THRESHOLD) {
-      // count dropped after a fix → pending verification.
-      status = "resolved-pending-verify";
     } else if (prior?.status === "resolved-pending-verify" && count <= RESOLVED_THRESHOLD) {
+      // The drop held for a second scan in the same unit → verified, close it.
       status = "closed";
+    } else if (prior && count <= RESOLVED_THRESHOLD && count < prior.frequency) {
+      // The count DROPPED to at/below the resolved threshold → pending
+      // verification.
+      //
+      // #4682 M1 — the test is `count < prior.frequency`, NOT
+      // `prior.frequency > RESOLVED_THRESHOLD`. The two are equivalent for an
+      // issue that was never held, but the unit guard above rewrites
+      // `frequency` to the POST-fold count: an issue held at 3 carries a prior
+      // frequency of 3 from then on, which never satisfies `> 3` again. Under
+      // the old test such an issue could only ever leave the board through the
+      // zero path — stale-open on GitHub however much of it got fixed, the
+      // opposite of the "delayed one scan, never suppressed" guarantee the
+      // guard was written to keep.
+      status = "resolved-pending-verify";
     }
+
+    // #4682 B1 — a closed GitHub issue whose defect is back in the scan needs
+    // an explicit reopen: `gh issue edit` refreshes the body of a CLOSED issue
+    // and leaves it closed, so without this the board states "fixed" forever
+    // while the sensor keeps finding the defect every night.
+    const reopened = prior?.status === "closed" && status !== "closed";
 
     const issue: FleetHealthIssue = {
       dedup_key: agg.dedup_key,
@@ -250,6 +269,7 @@ export function buildLedger(
       occurrences: agg.occurrences,
       ...(prior?.gh_issue !== undefined ? { gh_issue: prior.gh_issue } : {}),
       status,
+      ...(reopened ? { reopened: true as const } : {}),
       counting_unit: agg.counting_unit,
     };
     const list = byJob.get(agg.job_spec) ?? [];
@@ -258,15 +278,23 @@ export function buildLedger(
   }
 
   // Close-on-zero: a dedup_key that was open (or pending-verify) in the prior
-  // ledger but produced NO findings this scan has no agg above — the fix drove
-  // its count to zero. Synthesize a zero-frequency `closed` issue carrying the
-  // prior GH issue number so gh-sync runs `gh issue close`. This is the common
-  // success path, not an edge case: without it the issue leaks open forever.
+  // ledger but produced NO findings this scan has no agg above. Synthesize a
+  // zero-frequency `closed` issue carrying the prior GH issue number so gh-sync
+  // runs `gh issue close`. This is the common success path, not an edge case:
+  // without it the issue leaks open forever.
   for (const [dedup_key, prior] of priorIdx) {
     if (aggs.has(dedup_key)) continue;
     if (prior.status !== "open" && prior.status !== "resolved-pending-verify") {
       continue;
     }
+    // WHY the count is zero is not always "someone fixed it". #4682 B1 — a
+    // finding that RECLASSIFIED into a sibling signature (the same alarm sorted
+    // by its outcome: `orphaned-db-handle` → `orphaned-db-handle-recovered`)
+    // empties this key and fills the sibling's. Zero is still zero, so the
+    // close is correct — but the claim gh-sync attaches to it must not be
+    // "Verified count-drop", which asserts a fix nobody made. `close_reason`
+    // carries the distinction to `syncIssue`.
+    const migratedTo = siblingDedupKeys(dedup_key).filter((k) => aggs.has(k));
     const issue: FleetHealthIssue = {
       dedup_key,
       failure_mode: prior.failure_mode,
@@ -277,10 +305,12 @@ export function buildLedger(
       occurrences: [],
       ...(prior.gh_issue !== undefined ? { gh_issue: prior.gh_issue } : {}),
       status: "closed",
-      // Not subject to the unit guard: zero findings means the artifact is
-      // genuinely absent from the window. Folding a non-empty finding set can
-      // shrink a count but can never empty it, so a unit change cannot
-      // manufacture this path.
+      close_reason: migratedTo.length > 0 ? "reclassified" : "count-drop",
+      ...(migratedTo.length > 0 ? { reclassified_into: migratedTo.sort() } : {}),
+      // The counting-unit guard does not apply here: a unit change re-measures
+      // a non-empty finding set, which can shrink a count but never empty it.
+      // Reclassification is the path that CAN empty it, and `close_reason`
+      // above — not the unit guard — is what keeps that honest.
       counting_unit: prior.counting_unit,
     };
     const list = byJob.get(prior.job_spec) ?? [];

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -11,8 +11,12 @@
  * scoring is arithmetic, exactly as the RFC specifies.
  */
 
-import type { FleetHealthFailureMode } from "../web/fleet-health-read.js";
+import type {
+  FleetHealthCountingUnit,
+  FleetHealthFailureMode,
+} from "../web/fleet-health-read.js";
 import type { L0Signal, Finding } from "./detect.js";
+import { GATEWAY_SIGNAL_NAMES } from "./detect.js";
 
 /** How one L0 signal classifies: its failure mode, severity (1-3), the job
  *  spec it maps to, and the stable dedup-key signature fragment. */
@@ -243,6 +247,29 @@ export const ALL_JOB_SPECS: readonly string[] = [
 
 export function mapSignal(signal: L0Signal): SignalMapping {
   return SIGNAL_MAP[signal];
+}
+
+const GATEWAY_SIGNAL_SET: ReadonlySet<string> = new Set(GATEWAY_SIGNAL_NAMES);
+
+/** The unit every issue written before #4680 was counted in. A prior ledger
+ *  carries no `counting_unit` field, so this is what its absence means. */
+export const LEGACY_COUNTING_UNIT: FleetHealthCountingUnit = "log-line";
+
+/**
+ * The unit this signal's ledger `frequency` counts in.
+ *
+ * #4680 rule 3 folds gateway findings by event identity (the `origin=` turn
+ * id), so a gateway signal's frequency counts distinct affected turns, not
+ * matching log lines. Every other signal is still one finding per artifact.
+ *
+ * This exists so `buildLedger` can tell a genuine count DROP (someone fixed
+ * the defect) from a change of RULER (the same defect, measured differently).
+ * The two are indistinguishable from the number alone, and conflating them
+ * makes the sensor post "Verified count-drop" on a live GitHub issue nobody
+ * touched — the exact success-theater inversion the ledger exists to catch.
+ */
+export function countingUnitFor(signal: L0Signal): FleetHealthCountingUnit {
+  return GATEWAY_SIGNAL_SET.has(signal) ? "gateway-event" : "log-line";
 }
 
 /** The stable dedup key for a finding: `<job_spec>:<signature>`. One GitHub

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -99,6 +99,22 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
     job_spec: "survive-reboots-and-real-life",
     signature: "orphaned-db-handle:deleted-inode-writes",
   },
+  "orphaned-db-handle-recovered": {
+    // #4680 — the same alarm, but the sweep reopened `history.db` in the same
+    // tick and proved the new handle durable (the 2026-08-12 occurrence
+    // recovered in 20ms), with no lane left un-recovered. The rows written
+    // before the reopen are still gone, so the operator is still told — but a
+    // guard that fired and self-healed is not the silent-loss incident severity
+    // 3 describes, and booking it as one is exactly the success-theater
+    // inversion this ledger exists to avoid. severity 1, informational: the
+    // same split `flush-recovered-turn` makes against `silent-no-op-candidate`.
+    // Anything left un-recovered in the tick (registry.db, an unowned handle, a
+    // FAILED reopen) stays `orphaned-db-handle` at severity 3.
+    failure_mode: "drift",
+    severity: 1,
+    job_spec: "survive-reboots-and-real-life",
+    signature: "orphaned-db-handle:recovered-in-tick",
+  },
   "hang-long-stalled": {
     failure_mode: "partial",
     severity: 2,

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -258,9 +258,13 @@ export const LEGACY_COUNTING_UNIT: FleetHealthCountingUnit = "log-line";
 /**
  * The unit this signal's ledger `frequency` counts in.
  *
- * #4680 rule 3 folds gateway findings by event identity (the `origin=` turn
- * id), so a gateway signal's frequency counts distinct affected turns, not
- * matching log lines. Every other signal is still one finding per artifact.
+ * #4680 rule 3 folds gateway findings by event identity, so a gateway signal's
+ * frequency counts distinct affected TURNS wherever the log line carries an
+ * `origin=`/`tid=` turn id, and falls back to one finding per line where it
+ * does not (`detectGatewayFindings`). `gateway-event` names that folded unit —
+ * it is not a promise that every line was folded, only that the count is NOT
+ * comparable with a pre-#4680 `log-line` count. Every non-gateway signal is one
+ * finding per artifact.
  *
  * This exists so `buildLedger` can tell a genuine count DROP (someone fixed
  * the defect) from a change of RULER (the same defect, measured differently).
@@ -270,6 +274,47 @@ export const LEGACY_COUNTING_UNIT: FleetHealthCountingUnit = "log-line";
  */
 export function countingUnitFor(signal: L0Signal): FleetHealthCountingUnit {
   return GATEWAY_SIGNAL_SET.has(signal) ? "gateway-event" : "log-line";
+}
+
+/**
+ * Signals that are RECLASSIFICATIONS of one another: the same detected
+ * artifact, sorted into a different severity by its OUTCOME. A finding can move
+ * between the members of a group when the detector's classifier changes, or
+ * when a real occurrence's outcome differs from the last one's.
+ *
+ * #4682 B1 — this is what the counting-unit guard cannot see. That guard
+ * compares a prior issue with THIS scan's issue under the SAME dedup_key, but
+ * a reclassification does not shrink a key's count: it EMPTIES the key and
+ * fills a sibling. The old key then falls to `buildLedger`'s close-on-zero
+ * path, which is otherwise the honest "someone fixed it" path, and gh-sync
+ * comments "Verified count-drop … Closed by the Fleet Health sensor." on a
+ * defect that was merely re-filed. Zero occurrences really is zero, so the
+ * close itself is correct — the CLAIM attached to it is not.
+ */
+const RECLASSIFICATION_GROUPS: readonly (readonly L0Signal[])[] = [
+  ["orphaned-db-handle", "orphaned-db-handle-recovered"],
+  ["silent-no-op-candidate", "flush-recovered-turn"],
+];
+
+/** dedup_key → the dedup_keys its findings can reclassify into. Derived from
+ *  `SIGNALS` via `mapSignal`, so a signature or job-spec edit cannot leave a
+ *  stale hand-written key behind. */
+const SIBLING_DEDUP_KEYS: ReadonlyMap<string, readonly string[]> = (() => {
+  const m = new Map<string, string[]>();
+  for (const group of RECLASSIFICATION_GROUPS) {
+    const keys = group.map((s) => {
+      const map = mapSignal(s);
+      return `${map.job_spec}:${map.signature}`;
+    });
+    for (const key of keys) m.set(key, keys.filter((k) => k !== key));
+  }
+  return m;
+})();
+
+/** The dedup_keys `key`'s findings can reclassify into. Empty for a signal
+ *  with no sibling. */
+export function siblingDedupKeys(key: string): readonly string[] {
+  return SIBLING_DEDUP_KEYS.get(key) ?? [];
 }
 
 /** The stable dedup key for a finding: `<job_spec>:<signature>`. One GitHub

--- a/src/web/fleet-health-read.ts
+++ b/src/web/fleet-health-read.ts
@@ -47,6 +47,13 @@ export type FleetHealthIssueStatus =
   | "resolved-pending-verify"
   | "closed";
 
+/** The unit `frequency` counts in. `log-line` is one occurrence per matching
+ *  log line; `gateway-event` is one occurrence per distinct affected turn (the
+ *  #4680 gateway fold). The ledger's count-drop self-verify may only compare
+ *  two scans measured in the SAME unit — see `countingUnitFor` in
+ *  `src/fleet-health/mapping.ts` and the guard in `buildLedger`. */
+export type FleetHealthCountingUnit = "log-line" | "gateway-event";
+
 export interface FleetHealthIssue {
   /** Stable de-dup key — one GitHub issue per key, updated not re-created. */
   dedup_key: string;
@@ -64,6 +71,9 @@ export interface FleetHealthIssue {
   /** Linked GitHub issue number (identify + resolve system-of-record). */
   gh_issue?: number;
   status: FleetHealthIssueStatus;
+  /** The unit `frequency` was counted in on the scan that wrote this issue.
+   *  Absent on a ledger written before #4680, which means `log-line`. */
+  counting_unit?: FleetHealthCountingUnit;
 }
 
 /** One persistent record per job spec (23 of them). */

--- a/src/web/fleet-health-read.ts
+++ b/src/web/fleet-health-read.ts
@@ -71,6 +71,20 @@ export interface FleetHealthIssue {
   /** Linked GitHub issue number (identify + resolve system-of-record). */
   gh_issue?: number;
   status: FleetHealthIssueStatus;
+  /** WHY this issue closed (`status: "closed"` only; absent otherwise and on a
+   *  ledger written before #4682). `count-drop` is the honest success path —
+   *  the defect stopped appearing. `reclassified` means the findings moved to a
+   *  SIBLING signature (the same alarm re-sorted by its outcome) and nothing
+   *  was fixed, so gh-sync must not claim a verified count-drop. */
+  close_reason?: "count-drop" | "reclassified";
+  /** The sibling dedup_keys this issue's findings moved into. Present only
+   *  alongside `close_reason: "reclassified"`, so the close comment can name
+   *  where the evidence went. */
+  reclassified_into?: string[];
+  /** Set when a previously CLOSED issue's defect reappeared in this scan.
+   *  `gh issue edit` refreshes a closed issue's body without reopening it, so
+   *  gh-sync needs the explicit signal to run `gh issue reopen`. */
+  reopened?: true;
   /** The unit `frequency` was counted in on the scan that wrote this issue.
    *  Absent on a ledger written before #4680, which means `log-line`. */
   counting_unit?: FleetHealthCountingUnit;

--- a/telegram-plugin/tests/orphaned-db-sweep.test.ts
+++ b/telegram-plugin/tests/orphaned-db-sweep.test.ts
@@ -106,7 +106,13 @@ import {
   runOrphanedDbSweepTick,
   startOrphanedDbSweep,
 } from '../gateway/orphaned-db-sweep.js'
-import { GATEWAY_SIGNATURES } from '../../src/fleet-health/detect.js'
+import { GATEWAY_SIGNATURES, detectGatewayFindings } from '../../src/fleet-health/detect.js'
+import { mapSignal } from '../../src/fleet-health/mapping.js'
+
+/** Severity the fleet-health ledger would book for a real sweep log. */
+function ledgerSeverities(log: string): number[] {
+  return detectGatewayFindings('uat', log).findings.map((f) => mapSignal(f.signal).severity)
+}
 
 /**
  * `/proc/self/fd` is Linux-only. Without this guard every detection test would
@@ -294,6 +300,13 @@ describe.skipIf(!onLinux)('orphaned-db-sweep — history.db recovery', () => {
     // alarm has no consumer.
     expect(GATEWAY_SIGNATURES['orphaned-db-handle'].test(log)).toBe(true)
 
+    // #4680 — but this tick RECOVERED: the reopen landed in the same tick and
+    // the writer self-check proved the handle durable. The ledger must book
+    // that as the informational lane, not a severity-3 silent-loss incident.
+    // Asserted against the REAL sweep output, so a wording change in either the
+    // emitter or the detector fails here instead of drifting silently.
+    expect(ledgerSeverities(log)).toEqual([1])
+
     // 7. THE FIX, half one: the deleted-inode handles are actually GONE. A
     //    close that leaves un-finalized statements behind leaves them open
     //    (measured), so this is the assertion that pins the hard close.
@@ -439,6 +452,9 @@ describe.skipIf(!onLinux)('orphaned-db-sweep — registry.db and unowned lanes',
       expect(log).toContain('registry.db')
       expect(log).toContain('RESTART')
       expect(GATEWAY_SIGNATURES['orphaned-db-handle'].test(log)).toBe(true)
+      // #4680 — the registry lane has NO in-process recovery, so it stays the
+      // severity-3 alarm. This is the half of the split that must not be lost.
+      expect(ledgerSeverities(log)).toEqual([3])
 
       // Detection ONLY: the raw handle is left alone, so its consumers (the
       // by-value `turnsDb` captures in gateway.ts) are never handed a closed DB.


### PR DESCRIPTION
## Summary

Two Layer-0 fleet-health detector rules matched an **alarm** without checking its
**outcome**, so the nightly ledger booked a working safety mechanism as a
failure. Both are the same single concern and are fixed together.

## Why — the false-positive evidence

**`represent-escalation`** was the bare substring `/obligation escalation/`.
Five emitter lines carry that literal, and only two are terminal escalation
outcomes:

| line | what it is |
|---|---|
| `escalation-drive.ts:62` `delivered + closed` | terminal outcome — the nudge landed |
| `escalation-drive.ts:68` `PERMANENTLY undeliverable` | terminal outcome — the nudge never landed |
| `escalation-drive.ts:59` `obligation escalation send timed out` | the watchdog's deadline message — not its own log line, but it is interpolated into `:68`/`:72` as `${err}`, so it reaches the log carrying the literal a second time on the same line |
| `escalation-drive.ts:72` `send failed … retrying next sweep` | one line per **attempt**, below the retry policy |
| `obligation-wiring.ts:303` `deferred — bridge down` | the **suppression** path: the guard deliberately NOT escalating while the Telegram bridge is down |

Of 11 post-2026-08-08 hits in the live ledger, **3 were suppression lines** —
the guard working — and all 3 were the *same* obligation (`…#2198`) counted
repeatedly. This is the identical attempt-vs-outcome defect fixed for
`reply-delivery-failure` in #3931, and the fix follows that precedent: anchor on
the two mutually-exclusive TERMINAL lines, so one escalated obligation yields
exactly one hit. `PERMANENTLY undeliverable` is kept deliberately — it is a real
escalation that never reached the operator, and dropping it would be a coverage
regression, not a false-positive fix.

**`orphaned-db-handle`** matched the sweep's `DETECTED … deleted-inode DB
handle` alarm and never checked whether the paired recovery followed. The single
2026-08-12 occurrence recovered in 20 ms
(`logs/overlord/gateway-supervisor.log:297583-297584`: DETECT, then
`reopened history.db — writes are durable again`) and was still booked as a
severity-3 silent-data-loss incident.

## The fix

- `src/fleet-health/detect.ts` — `represent-escalation` is now
  `/obligation escalation (?:delivered \+ closed|PERMANENTLY undeliverable)/`.
- `src/fleet-health/detect.ts` — new `classifyOrphanedDbTick()`: an alarm whose
  own sweep tick also logged the reopen-succeeded line, **and left no lane
  un-recovered**, is emitted as `orphaned-db-handle-recovered`
  (drift, **sev 1**, `survive-reboots-and-real-life`) instead of
  `orphaned-db-handle` (success-theater, sev 3). The `registry.db` lane (no
  in-process recovery), unowned handles, a no-reopen-wired history lane and a
  `FAILED to reopen` all keep sev 3 — those are genuine data loss. The split is
  the same one `flush-recovered-turn` already makes against
  `silent-no-op-candidate`, so it needs no new ledger concept.
- `src/fleet-health/detect.ts` — **rule 3**: gateway findings dedup by *event
  identity* (the `origin=` turn id) instead of by log line, so ledger
  `frequency` counts distinct affected turns. A folded event carries the
  **newest** line's ts/pointer (`buildLedger` both windows and ranks on
  `Finding.ts`; keeping the oldest could age a still-live cluster out of the
  scan window). Lines with no origin id keep one-finding-per-line. `gw_hits`
  stays a raw line count — it is the digest's noise readout and the escalate
  input.
- `src/fleet-health/mapping.ts`, `docs/fleet-health.md`,
  `reference/rfcs/fleet-health.md` — the new signal and both rules documented.

## Test plan

`src/fleet-health/detect.test.ts` — new `#4680` block, all asserting outcomes
(severity / finding count), with every fixture the literal line its emitter
writes:

- the bridge-down **suppression** line yields zero findings; a retry attempt
  yields zero; `delivered + closed` and `PERMANENTLY undeliverable` each yield
  one; one obligation's suppression + 2 retries + delivery books **one** finding
  dated at the delivery.
- DETECT + reopen in one tick → severity `[1]`; DETECT alone → `[3]`; FAILED
  reopen → `[3]`; registry.db or an unowned lane alongside a history reopen →
  `[3]`; a later tick's recovery does not launder an earlier alarm (`[3, 1]`).
- dedup: repeated lines for one origin fold to one finding carrying the newest
  ts + pointer; distinct origins stay distinct; origin-less lines stay
  per-line.

`telegram-plugin/tests/orphaned-db-sweep.test.ts` — the incident-reproducing bun
test now asserts the ledger severity of its **real** sweep output (`[1]` for the
recovered history lane, `[3]` for the registry lane), so emitter and detector
cannot drift apart silently.

**Falsified**: with the three changes reverted one at a time, 6 of the new tests
fail (3 escalation, 2 orphaned-db, 1 dedup); with the fix, `vitest run
src/fleet-health` 126 pass, `bun test telegram-plugin/tests/orphaned-db-sweep.test.ts`
20 pass, `vitest run src/fleet-health src/web src/cli/fleet-health` 685 pass,
`npm run lint` green.

## Risk

The two detector narrowings are low and one-directional: strictly fewer sev-3
records and no new ones, and both fail *toward* the alarm — a truncated log, an
interleaved tick or an unrecognised lane line keeps severity 3.

**Rule 3 is the one with real blast radius, and it needed a guard.** It changes
the counting UNIT for *every* gateway signal, including `duplicate-delivery-represent` and `reply-delivery-failure`, which this PR does not otherwise touch.
Finding count is the ledger's `frequency` (`ledger.ts`), `frequency` falling
below `RESOLVED_THRESHOLD` drives the count-drop transition, and that drives
`gh-sync.ts` posting *"Verified count-drop (frequency N ≤ resolved threshold).
Closed by the Fleet Health sensor."* So an open `duplicate-delivery-represent`
issue at frequency 8 across 3 affected turns would collapse to 3 on the first
scan after merge, flip to `resolved-pending-verify`, close on the next scan, and
post that comment on a live issue nobody fixed — the exact board-lies inversion
this detector exists to prevent.

Fixed by recording the `counting_unit` each `frequency` was measured in
(`log-line` | `gateway-event`; absent on a pre-#4680 ledger means `log-line`)
and holding an issue's status for exactly ONE scan when the unit differs from
the prior ledger's. The issue is rewritten carrying the new unit, so the next
scan compares like with like: a real close is delayed by one scan, never
suppressed; reopening is still allowed (that direction cannot manufacture a
false "fixed"); signals whose unit did not change still self-verify on the first
scan. Covered by `gh-sync.test.ts` (asserts zero `gh issue close` invocations
across two scans over the unit change; without the guard it asserts-fails
holding the literal *"Verified count-drop (frequency 3 …)"* argv) and four
`ledger.test.ts` cases.

## Review round 2 — three blind spots in the guard above (`f29ae618b`)

Each was reproduced against the branch as pushed before anything was changed.

**B1 (blocker) — the recovered/unrecovered split's own verdict was
position-dependent, and the guard could not see the resulting migration.**
`classifyOrphanedDbTick` found its tick boundary with a 12-line lookahead, but
sweeps are 5 minutes apart, so the boundary is essentially never within a dozen
lines and the verdict tracked *when the scan ran*: `[ALARM, REOPEN]` classified
`recovered`; the same pair with 12 lines of ordinary traffic behind it
classified `unrecovered`, flipping at exactly 12. The two verdicts carry
different signatures, so a flip migrates the finding to a sibling `dedup_key`
and **empties** the old one. The counting-unit guard only fires when a prior
exists for the *same* key, so that reads as a fix-to-zero, takes `buildLedger`'s
close-on-zero path, and has `gh-sync` comment *"Verified count-drop … Closed by
the Fleet Health sensor."* on a live severity-3 issue — permanently, because
`gh-sync` had no reopen path at all. The same lookahead separately downgraded a
genuine `registry.db` alarm to severity 1 whenever its lane line fell outside
the window; a truncated log tail was enough.

The verdict is now derived from the tick's **content**, with no line-count cap
anywhere. The alarm line interpolates every orphaned fd's target
(`orphaned-db-sweep.ts:213-217`), so which lanes the tick hit is stated by the
alarm itself and `history.db*` is the only lane with an in-process recovery;
whether that lane recovered is stated by the first `orphaned-db-sweep` line
after the alarm, which the emitter logs with no `await` in between. An
unparseable target list fails toward the alarm.

Rather than *suppressing* the close on migration, the close is made honest —
zero occurrences really is zero, so holding the key open forever would be its
own board lie ("still happening" when it is not), while the sibling issue is
separately on the board carrying the evidence. So: a key emptied by
reclassification closes with `close_reason: "reclassified"` naming the sibling
keys, and `gh-sync` posts that instead of a count-drop claim; and any close that
turns out premature is now recoverable — an issue whose defect reappears is
marked `reopened` and `gh-sync` runs `gh issue reopen`, because `gh issue edit`
refreshes a closed issue's body without reopening it.

**M1 (major) — "delayed one scan, never suppressed" was false as written.** The
guard rewrites `frequency` to the post-fold count, and the count-drop arm
required `prior.frequency > RESOLVED_THRESHOLD`, which a folded count of 3 never
satisfies again: such an issue could only ever leave the board through the zero
path, i.e. stale-open on GitHub however much of it got fixed. The arm now tests
`count < prior.frequency`, which is equivalent for an issue that was never held.
The comment, the RFC and the CHANGELOG are corrected too — the claim is now true
of the code.

**M2 (major) — `GATEWAY_SIGNAL_NAMES` was a hand-written array.** A *derived*
gateway signal (one excluded from `LineMatchedGatewaySignal`, as
`orphaned-db-handle-recovered` is) needs no `GATEWAY_SIGNATURES` entry, so
omitting it from the array produced **zero** non-test `tsc` errors while
`countingUnitFor` silently handed it the `log-line` unit — re-arming the exact
false auto-close. The list is derived from a `Record<GatewaySignal, true>`; the
same probe now fails at `detect.ts:252`.

Two nits also addressed: the close-on-zero "cannot manufacture this path"
comment (reclassification does reach it) and the `countingUnitFor` doc (only
lines carrying an `origin=`/`tid=` are folded).

Every new test was proved red against the unfixed branch first — the trailing
-traffic case at exactly 12 lines, the four lane-line-absent severity cases, the
`close_reason` / `reopened` cases, and the two `gh-sync` comment assertions.
`vitest run src/fleet-health src/web src/cli/fleet-health` 710 pass, `bun test
telegram-plugin/tests/orphaned-db-sweep.test.ts` 20 pass, `tsc --noEmit` clean,
`npm run lint` green.

One smaller behaviour note: `gw_hits["orphaned-db-handle"]` no longer counts
recovered ticks (they are counted under the new key) — it feeds the digest only,
not `escalate`.

(The round-1 body claimed a `recovered` verdict was only honoured once the scan
reached a tick boundary — next `DETECTED` alarm or EOF, within 12 lines. That
lookahead is what B1 above removed; the sentence is superseded and no line-count
cap remains in the classifier.)

## Scope

Rule 3 (the gateway finding-fold) stays bundled rather than splitting into its
own PR. It is the only change here with blast radius beyond the two named
signals, so the split is a fair question — but the counting-unit guard above and
the fold are only correct *together*. Landing the fold first exposes every open
gateway issue to one scan of false auto-closes; landing the guard first ships
dead code guarding a unit change that has not happened. Two PRs would therefore
have to merge in a fixed order with a nightly cron firing in between, which is a
worse risk than one reviewed diff. The fold also carries the ledger half of this
PR's central claim — that one escalated obligation books one hit — which is only
end-to-end true once `frequency` counts events.

## Job spec

`reference/jobs/fleet-stays-healthy.md` — the ledger is only useful if a
priority-1 entry is a real problem. Also `survive-reboots-and-real-life`
(the orphaned-DB lane) and `feel-like-a-colleague` (the escalation lane).



