### PR TITLE
fix(telegram): let tg:// inline entities survive the render pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Fixed
+
+- **Telegram `tg://` inline entities survive the render pipeline** — the Bot API
+  "Rich Markdown style" grammar carries two inline entities in mdast IMAGE
+  position: `![22:45 tomorrow](tg://time?unix=…&format=…)` (the `date_time`
+  entity, Bot API 9.5; `RichTextDateTime` in 10.1) and `![](tg://emoji?id=…)`.
+  Both were DEAD on the streamed send path: `render/parse.ts` demoted every
+  mdast `image` node to plain text and `render/render.ts` then
+  `escapeMarkdown`'d it, shipping `!\[22:45 tomorrow\](tg://time?unix\=…)` as
+  literal characters. Those two documented hrefs now fold into a `tg-entity` IR
+  node and render back byte-exact (label re-escaped as prose, so a `]` inside it
+  can't close the label early; href through `escapeLinkHref`). Every OTHER image
+  url — notably the http(s) MEDIA forms, which Telegram accepts only as a
+  separate block — keeps the existing demote-to-literal behaviour.
+  `splitMarkdownChunks`' inline-span back-off now covers the leading `!`, so a
+  cap-straddling entity can no longer be cut into a stray `!` plus an ordinary
+  link. The reply-tool path never ran the renderer and was already correct; it
+  is now pinned by tests.
+
 ### Dependencies
 
 - **Claude Code CLI pinned 2.1.228 → 2.1.229** — all three lockstep locations

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -1414,7 +1414,12 @@ const INLINE_SPAN_PATTERNS: readonly RegExp[] = [
   /\*\*[^*\n]+\*\*/g, // bold
   /__[^_\n]+__/g, // underline
   /(?<![\w*])_[^_\n]+_(?![\w*])/g, // italic (snake_case-guarded)
-  /\[[^\]\n]*\]\([^)\n]*\)/g, // link [label](href)
+  // link `[label](href)` — and, via the optional leading `!`, Telegram's
+  // inline-entity form `![22:45 tomorrow](tg://time?unix=…&format=…)` /
+  // `![](tg://emoji?id=…)`. Without the `!?` the protected span would start at
+  // the `[`, so a cut could land in the one-character gap and strand the `!`
+  // on the previous chunk — silently demoting a date_time entity to a link.
+  /!?\[[^\]\n]*\]\([^)\n]*\)/g,
   /~~[^~\n]+~~/g, // strikethrough
   /\|\|[^|\n]+\|\|/g, // spoiler
 ]

--- a/telegram-plugin/render/ir.ts
+++ b/telegram-plugin/render/ir.ts
@@ -30,6 +30,7 @@
 //     highlight -> `==…==`  (Bot API 10.1 marked entity)
 //     code      -> `` `…` ``
 //     link      -> `[…](…)`
+//     tg-entity -> `![…](tg://…)`  (Bot API date_time / custom-emoji entity)
 //
 //   Block
 //     paragraph      -> children joined; blocks separated by "\n\n"
@@ -109,6 +110,30 @@ export interface LinkNode extends Pos {
   children: Inline[];
 }
 
+/** A Telegram rich-markdown INLINE entity written in mdast IMAGE position.
+ *  The "Rich Markdown style" grammar (https://core.telegram.org/bots/api,
+ *  quoted in `reference/telegram-formatting-guide.md`) lists exactly two:
+ *
+ *    ![](tg://emoji?id=5368324170671202286)                  custom emoji
+ *    ![22:45 tomorrow](tg://time?unix=1647531900&format=wDT) date_time
+ *
+ *  (the `date_time` MessageEntity is Bot API 9.5, March 1 2026; the rich-message
+ *  `RichTextDateTime` class is 10.1, June 11 2026 — both in the Bot API
+ *  changelog.) `parse.ts` folds ONLY those two `tg:` hrefs into this node;
+ *  every other image url keeps the historical demote-to-`plain` fallback,
+ *  because an http(s) `![](…)` is a Telegram MEDIA block — "Media can be
+ *  specified only as a separate block" (same doc) — not an inline entity, and
+ *  switchroom does not emit media blocks.
+ *
+ *  `label` is the DECODED alternative text (mdast `image.alt`, empty for the
+ *  emoji form); `href` is the `tg:` URL. Both are re-escaped on render, same
+ *  as `LinkNode`. */
+export interface TgEntityNode extends Pos {
+  type: "tg-entity";
+  label: string;
+  href: string;
+}
+
 export type Inline =
   | PlainNode
   | BoldNode
@@ -118,7 +143,8 @@ export type Inline =
   | SpoilerNode
   | HighlightNode
   | CodeNode
-  | LinkNode;
+  | LinkNode
+  | TgEntityNode;
 
 // ---------------------------------------------------------------------------
 // Block nodes

--- a/telegram-plugin/render/parse.ts
+++ b/telegram-plugin/render/parse.ts
@@ -99,6 +99,24 @@ function slice(source: string, node: MdastNode): string {
  *  the rewritten `  >` past 3 spaces and turn it into an indented code block. */
 const EXPANDABLE_MARKER_RE = /^\*\*>/;
 
+/** The `tg:` hrefs Telegram's "Rich Markdown style" grammar accepts in IMAGE
+ *  position — `![label](tg://…)`. Exactly two are documented
+ *  (https://core.telegram.org/bots/api): `tg://emoji?id=…` (custom emoji) and
+ *  `tg://time?unix=…[&format=…]` (the `date_time` entity). Deliberately an
+ *  ALLOWLIST rather than a bare `tg:` scheme test: an undocumented `tg://…` in
+ *  image position is not known-good syntax, and demoting it to literal text
+ *  (the historical behaviour) is safer than shipping a construct Telegram may
+ *  parse-reject. */
+const TG_INLINE_ENTITY_HREFS = ["tg://emoji", "tg://time"] as const;
+
+/** True when an mdast `image` url is one of the documented inline `tg:`
+ *  entities. Scheme/host comparison is case-insensitive (URLs are), but the
+ *  ORIGINAL href is what gets re-emitted — we never rewrite the author's bytes. */
+function isTgInlineEntityHref(href: string): boolean {
+  const h = href.toLowerCase();
+  return TG_INLINE_ENTITY_HREFS.some((base) => h === base || h.startsWith(`${base}?`));
+}
+
 /** Pre-transform expandable-blockquote markers so mdast can parse them as
  *  ordinary blockquotes, WITHOUT shifting any source offset. Each line that
  *  opens with `**>` has its two `*` characters replaced by two spaces
@@ -170,8 +188,22 @@ function foldInline(node: PhrasingContent, source: string): Inline {
         children: foldInlineChildren(node, source),
         ...pos(node),
       };
-    // Not in the palette (break, image, html, footnoteReference, …): keep the
-    // raw source text so no content is lost.
+    case "image": {
+      // GFM's image syntax doubles as Telegram's INLINE-entity syntax:
+      // `![22:45 tomorrow](tg://time?unix=…&format=…)` (date_time) and
+      // `![](tg://emoji?id=…)` (custom emoji). Fold those two into a
+      // `tg-entity` node so the renderer re-emits the construct verbatim
+      // instead of escaping the brackets to literal text. Every OTHER image
+      // url — notably the http(s) MEDIA forms, which Telegram accepts only as
+      // a SEPARATE block — falls through to the demote-to-`plain` default
+      // below, unchanged.
+      if (isTgInlineEntityHref(node.url)) {
+        return { type: "tg-entity", label: node.alt ?? "", href: node.url, ...pos(node) };
+      }
+      return { type: "plain", text: slice(source, node), ...pos(node) };
+    }
+    // Not in the palette (break, non-`tg:` image, html, footnoteReference, …):
+    // keep the raw source text so no content is lost.
     default:
       return { type: "plain", text: slice(source, node), ...pos(node) };
   }

--- a/telegram-plugin/render/render.ts
+++ b/telegram-plugin/render/render.ts
@@ -59,6 +59,14 @@ interface InlineCtx {
   inTableCell?: boolean;
 }
 
+/** Collapse any whitespace run containing a newline down to a single space.
+ *  Used for a `tg-entity` label: `![` … `]` must stay on ONE line or the
+ *  construct is not an entity any more. mdast decodes a soft line break inside
+ *  the alt text to a literal `\n`, which is exactly the case this flattens. */
+function collapseLabelBreaks(label: string): string {
+  return label.replace(/[ \t]*\r?\n[ \t\r\n]*/g, " ");
+}
+
 function renderInline(node: Inline, ctx: InlineCtx = {}): string {
   switch (node.type) {
     case "plain":
@@ -91,6 +99,18 @@ function renderInline(node: Inline, ctx: InlineCtx = {}): string {
       // Escape the href so a literal `)` in the URL can't terminate the
       // destination early and break the link (F3).
       return `[${renderInlineChildren(node.children, ctx)}](${escapeLinkHref(node.href)})`;
+    case "tg-entity":
+      // `![label](tg://time?unix=…&format=…)` / `![](tg://emoji?id=…)`.
+      // The label is PROSE (the alternative text Telegram shows when it can't
+      // render the entity), so it is escaped exactly like a `plain` node —
+      // without that, a label containing `]` or a formatting delimiter
+      // (`![see [22:45]](tg://time?…)`) closes the label early and smuggles
+      // raw bracket syntax past the renderer. A newline inside the label would
+      // split the construct across lines, so runs of whitespace spanning one
+      // are collapsed to a single space first. The href gets the same
+      // `escapeLinkHref` treatment a link's does (a no-op for the paren-free
+      // `tg:` URLs in practice, load-bearing if one ever carries a `)`).
+      return `![${escapeMarkdown(collapseLabelBreaks(node.label))}](${escapeLinkHref(node.href)})`;
     default: {
       // Exhaustiveness guard — the IR union is closed; a new variant must be
       // handled above rather than silently dropped.
@@ -299,6 +319,10 @@ export const SUPPORTED_INLINE = [
   "highlight",
   "code",
   "link",
+  // `![…](tg://time?…)` / `![…](tg://emoji?id=…)` — the two inline `tg:`
+  // entities in Telegram's Rich Markdown grammar. Emitted verbatim (label and
+  // href re-escaped); any OTHER image url stays a `plain` node.
+  "tg-entity",
 ] as const;
 
 export const SUPPORTED_BLOCK = [

--- a/telegram-plugin/tests/render/tg-entity.test.ts
+++ b/telegram-plugin/tests/render/tg-entity.test.ts
@@ -1,0 +1,242 @@
+// Telegram inline `tg:` entities in mdast IMAGE position survive the whole
+// outbound pipeline.
+//
+// Bot API grammar (https://core.telegram.org/bots/api, "Rich Markdown style"):
+//
+//   ![](tg://emoji?id=5368324170671202286)                    custom emoji
+//   ![22:45 tomorrow](tg://time?unix=1647531900&format=wDT)   date_time
+//
+// (the `date_time` MessageEntity landed in Bot API 9.5, 2026-03-01; the
+// rich-message `RichTextDateTime` class in 10.1, 2026-06-11 — Bot API
+// changelog.) grammy 1.44.0 speaks 10.1, so the wire has accepted this since
+// #2669 — but the RENDER path escaped the brackets to literal text, so the
+// syntax was dead on the streamed send path.
+//
+// Two DISTINCT outbound surfaces are pinned here, because they do not share a
+// pipeline:
+//   - the STREAMED path (stream-controller.ts:272) → `renderOutboundChunks` →
+//     `parse → renderSafe`. This is the surface the escaping bug lived on.
+//   - the REPLY-TOOL path (outbound-send-path.ts) → `computeReplyChunks` →
+//     `richMessage()`, which NEVER runs the renderer — only the
+//     accidental-formatting guards. It was already correct; these tests pin it
+//     so a future guard can't silently start eating the syntax.
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../render/parse.js";
+import { renderSafe, SUPPORTED_INLINE } from "../../render/render.js";
+import { renderOutboundChunks } from "../../render/rich-render.js";
+import { guardAccidentalFormatting, richMessage } from "../../rich-send.js";
+import { computeReplyChunks } from "../../gateway/outbound-send-path.js";
+import { splitMarkdownChunks, RICH_MESSAGE_MAX_CHARS } from "../../format.js";
+import type { Inline } from "../../render/ir.js";
+
+/** The doc's own date_time example, verbatim. */
+const DATE_TIME = "![22:45 tomorrow](tg://time?unix=1647531900&format=wDT)";
+/** The doc's own custom-emoji example, verbatim (empty label). */
+const EMOJI = "![](tg://emoji?id=5368324170671202286)";
+
+/** parse → renderSafe, the streamed path's core. */
+const roundTrip = (md: string): string => renderSafe(parse(md), md).text;
+
+/** Flatten every inline node in the rendered IR of `md`. */
+function inlines(md: string): Inline[] {
+  const out: Inline[] = [];
+  const walk = (n: Inline): void => {
+    out.push(n);
+    for (const c of (n as { children?: Inline[] }).children ?? []) walk(c);
+  };
+  for (const b of parse(md).blocks) {
+    for (const n of (b as { children?: Inline[] }).children ?? []) walk(n);
+  }
+  return out;
+}
+
+describe("tg:// inline entities: parse → renderSafe round-trip", () => {
+  // THE bug this PR fixes: at HEAD the image node demoted to `plain` and
+  // `escapeMarkdown` backslash-escaped `[`, `]` and `=`, shipping
+  // `!\[22:45 tomorrow\](tg://time?unix\=…&format\=wDT)` — literal text, no
+  // entity. Byte-exact preservation is the whole contract.
+  it("preserves a date_time entity byte-exact", () => {
+    const body = `Meeting at ${DATE_TIME} sharp.`;
+    expect(roundTrip(body)).toBe(body);
+  });
+
+  it("preserves the empty-label custom-emoji entity byte-exact", () => {
+    expect(roundTrip(`hi ${EMOJI} there`)).toBe(`hi ${EMOJI} there`);
+  });
+
+  it("preserves a date_time entity with no `format` parameter", () => {
+    const body = "![22:45 tomorrow](tg://time?unix=1647531900)";
+    expect(roundTrip(body)).toBe(body);
+  });
+
+  it("folds the entity into a `tg-entity` IR node, not `plain`", () => {
+    const node = inlines(`x ${DATE_TIME}`).find((n) => n.type === "tg-entity");
+    expect(node).toMatchObject({
+      type: "tg-entity",
+      label: "22:45 tomorrow",
+      href: "tg://time?unix=1647531900&format=wDT",
+    });
+  });
+
+  it("survives inside a blockquote, a heading, a list item and a table cell", () => {
+    for (const body of [
+      `> when: ${DATE_TIME}`,
+      `## Due ${DATE_TIME}`,
+      `- due ${DATE_TIME}`,
+      `| when | who |\n| --- | --- |\n| ${DATE_TIME} | me |`,
+    ]) {
+      expect(roundTrip(body)).toContain(DATE_TIME);
+    }
+  });
+
+  it("matches the `tg:` href case-insensitively (URL schemes are)", () => {
+    const body = "![t](TG://Time?unix=1647531900)";
+    // Folded as an entity, and the author's ORIGINAL bytes are re-emitted —
+    // the parser never rewrites the href.
+    expect(inlines(body).some((n) => n.type === "tg-entity")).toBe(true);
+    expect(roundTrip(body)).toBe(body);
+  });
+
+  it("lists `tg-entity` in the renderer's construct allowlist", () => {
+    expect(SUPPORTED_INLINE).toContain("tg-entity");
+  });
+});
+
+describe("tg:// inline entities: label escaping (no bracket breakout)", () => {
+  // A model-authored label carrying `]` would close the label early and
+  // smuggle raw bracket syntax past the renderer if the label were re-emitted
+  // undecorated. It is prose, so it gets `escapeMarkdown` exactly like a
+  // `plain` node.
+  it("escapes brackets in the label instead of letting them close it early", () => {
+    const out = roundTrip("![see [22:45]](tg://time?unix=1&format=t)");
+    expect(out).toBe("![see \\[22:45\\]](tg://time?unix=1&format=t)");
+    // No BARE `]` before the destination — the only unescaped one closes the label.
+    expect(out.slice(0, out.indexOf("](")).includes("\\]")).toBe(true);
+  });
+
+  it("escapes emphasis delimiters in the label", () => {
+    expect(roundTrip("![a*b_c~d](tg://time?unix=1&format=t)")).toBe(
+      "![a\\*b\\_c\\~d](tg://time?unix=1&format=t)",
+    );
+  });
+
+  it("collapses a soft line break in the label so the construct stays on one line", () => {
+    const out = roundTrip("![22:45\ntomorrow](tg://time?unix=1&format=t)");
+    expect(out).toBe("![22:45 tomorrow](tg://time?unix=1&format=t)");
+    expect(out).not.toContain("\n");
+  });
+});
+
+describe("tg:// inline entities: no regression of the image demotion", () => {
+  // Deliberate, unchanged: an http(s) `![](…)` is a Telegram MEDIA block —
+  // "Media can be specified only as a separate block" (Rich Markdown style) —
+  // not an inline entity, and switchroom emits no media blocks. It keeps
+  // degrading to escaped literal text.
+  it("still degrades an http(s) image link to escaped plain text", () => {
+    expect(roundTrip("![alt](https://x.example/y.png)")).toBe(
+      "!\\[alt\\](https://x.example/y.png)",
+    );
+  });
+
+  it("still degrades an UNDOCUMENTED tg:// image href to escaped plain text", () => {
+    // The allowlist is deliberate: only `tg://time` and `tg://emoji` are
+    // documented in image position, so anything else stays literal rather than
+    // shipping syntax Telegram may parse-reject.
+    expect(roundTrip("![t](tg://photo?id=1)")).toBe("!\\[t\\](tg://photo?id\\=1)");
+    expect(roundTrip("![t](tg://user?id=1)")).toBe("!\\[t\\](tg://user?id\\=1)");
+  });
+
+  it("leaves an ordinary `[label](tg://user?id=…)` mention link alone", () => {
+    const body = "ping [Ken](tg://user?id=123456789)";
+    expect(roundTrip(body)).toBe(body);
+  });
+});
+
+describe("tg:// inline entities: code context stays literal", () => {
+  it("keeps the syntax verbatim inside an inline code span", () => {
+    const body = "use `![22:45](tg://time?unix=1&format=t)` for that";
+    expect(roundTrip(body)).toBe(body);
+    // and it is a `code` node, NOT a folded entity
+    expect(inlines(body).some((n) => n.type === "tg-entity")).toBe(false);
+  });
+
+  it("keeps the syntax verbatim inside a fenced code block", () => {
+    const body = "```\n![22:45](tg://time?unix=1&format=t)\n```";
+    expect(roundTrip(body)).toBe(body);
+    expect(inlines(body).some((n) => n.type === "tg-entity")).toBe(false);
+  });
+});
+
+describe("tg:// inline entities: the accidental-formatting guards are a no-op", () => {
+  // `guardAccidentalFormatting` is the universal seam (installed as a grammy
+  // API transformer in shared/bot-runtime.ts), so it runs over EVERY outbound
+  // body — rendered or hand-built card alike. Its documented trigger set
+  // (`_ * > . ~ == || $ #`) does not intersect this syntax, but nothing
+  // asserted that until now.
+  const bodies = [
+    `Meeting at ${DATE_TIME} sharp.`,
+    `${DATE_TIME} at the very start of the line`,
+    EMOJI,
+    `- due ${DATE_TIME}\n- and ${DATE_TIME}`,
+    `> when: ${DATE_TIME}`,
+    `| when |\n| --- |\n| ${DATE_TIME} |`,
+    "![see \\[22:45\\]](tg://time?unix=1&format=t)",
+  ];
+
+  it("leaves every tg:// entity body byte-identical", () => {
+    for (const body of bodies) expect(guardAccidentalFormatting(body)).toBe(body);
+  });
+
+  it("is idempotent over the rendered form too", () => {
+    for (const body of bodies) {
+      const rendered = roundTrip(body);
+      expect(guardAccidentalFormatting(rendered)).toBe(rendered);
+    }
+  });
+});
+
+describe("tg:// inline entities: live outbound seams", () => {
+  it("survives the STREAMED seam (renderOutboundChunks)", () => {
+    const body = `Standup starts ${DATE_TIME}.`;
+    const pieces = renderOutboundChunks(body);
+    expect(pieces).toHaveLength(1);
+    expect(pieces[0].mode).toBe("markdown");
+    expect(pieces[0].text).toBe(body);
+  });
+
+  it("survives the REPLY-TOOL seam (computeReplyChunks → richMessage)", () => {
+    // This surface never touches the renderer — it is guards-only. Pinned so a
+    // future guard cannot start escaping the syntax unnoticed.
+    const body = `Standup starts ${DATE_TIME}.`;
+    const chunks = computeReplyChunks({
+      effectiveText: body,
+      literalText: false,
+      limit: RICH_MESSAGE_MAX_CHARS,
+      chunkMode: "length",
+    });
+    expect(chunks.map((c) => richMessage(c).markdown).join("")).toContain(DATE_TIME);
+  });
+});
+
+describe("tg:// inline entities: chunk boundaries never bisect the construct", () => {
+  // `INLINE_SPAN_PATTERNS`' link pattern used to start at the `[`, leaving the
+  // leading `!` outside the protected span: a cut inside the construct
+  // retreated only to the `[`, stranding `!` on the previous chunk and
+  // silently demoting a date_time entity to an ordinary link.
+  it("keeps a cap-straddling date_time entity whole in one chunk", () => {
+    const body = `${"x".repeat(80)} ${DATE_TIME}`;
+    const chunks = splitMarkdownChunks(body, 110);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Exactly one chunk carries the entity, whole.
+    expect(chunks.filter((c) => c.includes(DATE_TIME))).toHaveLength(1);
+    // And no chunk ends on the stranded `!`.
+    for (const c of chunks) expect(c.endsWith("!")).toBe(false);
+  });
+
+  it("still keeps an ordinary link whole (unchanged behaviour)", () => {
+    const link = "[a fairly long link label here](https://example.com/some/path)";
+    const chunks = splitMarkdownChunks(`${"x".repeat(80)} ${link}`, 110);
+    expect(chunks.filter((c) => c.includes(link))).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What / why

Telegram's Bot API **"Rich Markdown style"** grammar — the mode switchroom
actually sends in (`sendRichMessage` with `{ markdown }`, `telegram-plugin/rich-send.ts:27`)
— carries two INLINE entities written in mdast **image** position. Quoted
verbatim from <https://core.telegram.org/bots/api> ("Rich Markdown style"):

```
![](tg://emoji?id=5368324170671202286)
![22:45 tomorrow](tg://time?unix=1647531900&format=wDT)
```

Versions, precisely (Bot API changelog, <https://core.telegram.org/bots/api-changelog>):

- `date_time` **MessageEntity** — **Bot API 9.5**, 2026-03-01: *"Added the
  MessageEntity type “date_time”…"*
- `RichTextDateTime` (the rich-message class) — **Bot API 10.1**, 2026-06-11:
  *"Added the classes RichTextBold, … RichTextDateTime, …"*

`bun.lock` pins `grammy@1.44.0`, whose release notes say *"feat: support Bot
API 10.1"*, so the **wire** has accepted this since #2669.

**The syntax was nevertheless dead on the streamed send path.** Verified by
running the real pipeline at `origin/main`:

| stage | at `origin/main` |
|---|---|
| `parse()` | `render/parse.ts:174` (old `default:` arm) folded the mdast `image` into a `plain` node holding the raw slice |
| `renderSafe()` | `render/render.ts:65` → `escapeMarkdown` (`format.ts:66-68` escapes `` \ ` * _ ~ = [ ] | ``) |
| result | `Meeting at !\[22:45 tomorrow\](tg://time?unix\=1647531900&format\=wDT) sharp.` — literal characters, no entity |

## Which surface this actually fixes (read this before QA'ing it)

The renderer is **not** on every outbound path. `renderOutboundChunks` is
imported by exactly one module — `telegram-plugin/stream-controller.ts:28`,
used at `:272`. So:

- **STREAMED drafts / streamed replies** (`stream-reply-handler.ts`,
  `pty-partial-handler.ts` → `stream-controller.ts:272` → `renderOutboundChunks`
  → `parse → renderSafe`) — **this is the broken surface, and what this PR
  fixes.**
- **The `reply` MCP tool** (`gateway/outbound-send-path.ts:1625` →
  `computeReplyChunks` → `splitMarkdownChunks` → `richMessage()`) **never runs
  the renderer.** It was already correct: `guardAccidentalFormatting`'s trigger
  characters (`_ * > . ~ == || $ #`) don't intersect this syntax. Nothing
  asserted that; now something does.
- **Hand-built cards** likewise bypass the renderer (`render/line-start-guard.ts:56-58`).

If you sanity-check this by sending a `tg://time` span through the reply tool,
you are testing the surface that was **already** working — not this PR.

## What changed

1. **`render/parse.ts`** — a `case "image"` arm folds an image whose url is one of
   two **allowlisted** hrefs (`tg://emoji`, `tg://time`; matched
   case-insensitively, since URL schemes are) into a new `tg-entity` IR node.
   Deliberately an allowlist rather than a bare `tg:` scheme test — an
   undocumented `tg://…` in image position isn't known-good syntax, and
   demoting it to literal text is safer than shipping something Telegram may
   parse-reject.
2. **`render/ir.ts`** — the `TgEntityNode { label, href }` variant.
3. **`render/render.ts`** — renders `![label](href)`.
   - The **label is escaped** with `escapeMarkdown`. Without that, a
     model-authored `![see [22:45]](tg://time?…)` closes the label early and
     smuggles raw bracket syntax past the renderer. (This is the hole the
     design's own risk item scoped only to the href.)
   - A **soft line break** inside the label is collapsed to a space so the
     construct can't split across lines.
   - The href goes through `escapeLinkHref`, same as `link` — a no-op for
     paren-free `tg:` URLs, load-bearing if one ever carries a `)`.
   - `tg-entity` added to `SUPPORTED_INLINE`.
4. **`format.ts`** — `INLINE_SPAN_PATTERNS`' link pattern widened
   `[label](href)` → `!?[label](href)`. Without the `!` the protected span
   started one character late, so a **cap-straddling** entity got cut into a
   stray `!` on chunk N and a plain link on chunk N+1. This also protects the
   `reply`-tool path, which uses `splitMarkdownChunks` directly.

**Unchanged by design:** every other image url still demotes to escaped literal
text. An http(s) `![](…)` is a Telegram **media block** — *"Media can be
specified only as a separate block"* (same doc) — not an inline entity, and
switchroom emits no media blocks.

## Tested

`telegram-plugin/tests/render/tg-entity.test.ts` — 21 tests, all green:

```
 ✓ telegram-plugin/tests/render/tg-entity.test.ts (21 tests) 45ms
   Test Files  1 passed (1)
        Tests  21 passed (21)
```

Each fix was **verified red** by breaking it and re-running:

| break | result |
|---|---|
| `parse.ts` stops folding `tg:` images (i.e. `origin/main`'s behaviour) | **10 failed** / 11 passed |
| `format.ts` link pattern back to `[…](…)` without `!?` | **1 failed** / 20 passed |
| label rendered without `escapeMarkdown` | **2 failed** / 19 passed |
| label rendered without the line-break collapse | **1 failed** / 20 passed |

Coverage: byte-exact round-trip of the doc's own `date_time` and custom-emoji
examples; the entity inside a blockquote / heading / list item / table cell;
label bracket + emphasis escaping; soft-line-break collapse; **no regression**
of the http(s) image demotion or of an undocumented `tg://photo`;
`[label](tg://user?id=…)` mention links untouched; the syntax staying literal
inside an inline code span and a fenced block; `guardAccidentalFormatting`
byte-identical (and idempotent over the rendered form) across seven bodies;
the **streamed** seam (`renderOutboundChunks`) and the **reply-tool** seam
(`computeReplyChunks → richMessage`) each pinned separately; and a
cap-straddling entity landing whole in exactly one chunk.

Wider runs, locally:

```
$ ./node_modules/.bin/vitest run telegram-plugin/tests/
 Test Files  552 passed (552)
      Tests  9142 passed | 3 skipped (9145)

$ npm run lint
… check-changelog-entry: OK — ## Unreleased grew (origin/main...HEAD).
… check-agent-attribution-trailers: OK — 1 commit(s), 1 machine-authored and attributed.
(exit 0)
```

## Deliberately NOT done

- **No live-wire verification.** I have not sent a `tg://time` span to Telegram
  and watched it render. Everything above is doc + local-pipeline evidence.
- **No agent-facing adoption.** `reference/telegram-formatting-guide.md`'s
  vocabulary table is untouched, so no agent starts emitting `tg://time` off
  the back of this PR. Advertising the construct there would assert wire
  behaviour I haven't verified. That belongs in the adoption PR, after a live
  check.
- **No `tg://photo`** or other speculative schemes — only the two hrefs the
  Rich Markdown grammar actually documents in image position.
- **No media-block support.** Out of scope and a separate-block construct.
- **A `|` inside a link/entity HREF still tears a GFM table row** —
  `escapeLinkHref` doesn't escape `|`. Pre-existing and identical for the
  existing `link` node; not introduced or widened here.
- **`INLINE_OPENER_AT_HEAD`** (`format.ts`, used only by
  `truncateMarkdownSafe`'s opener-drop repair) was left alone — the chunker now
  retreats past the whole `![`, so the next chunk's head is a complete
  construct, not a stranded opener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
