### PR TITLE
chore(deps): bump grammy 1.44.0 -> 1.45.1 (@grammyjs/types 3.28.0 -> 4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,18 @@ now an anomaly worth investigating, not the norm.
 
 ### Dependencies
 
+- **grammy 1.44.0 → 1.45.1** (`@grammyjs/types` 3.28.0 → 4.0.0), which brings
+  Bot API 10.2 into the type surface and unblocks the rich-message `blocks`
+  work that cannot compile without it. Both manifests move their floor to
+  `^1.45` because 4.x types only ship with grammy ≥ 1.45.0. This also
+  RE-CONVERGES the two lockfiles: `package-lock.json` was already resolving
+  grammy 1.45.1 while `bun.lock` — the one CI installs from — still pinned
+  1.44.0. The outbound payload shape is unchanged (`sendRichMessage` /
+  `editMessageText` still emit `rich_message: { markdown }`, re-verified
+  against 1.45.1 `out/core/api.js`), so `installRichMarkdownGuard` and every
+  card surface are untouched. 1.45.0 does add `duplex: "half"` to every API
+  request; a live round-trip against `api.telegram.org` on the fleet's pinned
+  Bun 1.3.13 confirms the transport still works.
 - **Claude Code CLI pinned 2.1.228 → 2.1.229** — all three lockstep locations
   move together (`docker/Dockerfile.base`, `docker/Dockerfile.hindsight`,
   `dependencies.json`), per `docs/operators/claude-cli-updates.md`. Three

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "bcryptjs": "^3.0.3",
         "chalk": "^5.4.0",
         "commander": "^13.1.0",
-        "grammy": "^1.44",
+        "grammy": "^1.45",
         "handlebars": "^4.7.8",
         "nostr-tools": "^2.24.1",
         "posthog-node": "^5.29.2",
@@ -46,7 +46,7 @@
         "@secretlint/core": "^12.2.0",
         "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
         "@xterm/headless": "^6.0.0",
-        "grammy": "^1.44",
+        "grammy": "^1.45",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-gfm": "^3.0.0",
         "micromark-extension-gfm": "^3.0.0",
@@ -168,7 +168,7 @@
 
     "@grammyjs/runner": ["@grammyjs/runner@2.0.3", "", { "dependencies": { "abort-controller": "^3.0.0" }, "peerDependencies": { "grammy": "^1.13.1" } }, "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A=="],
 
-    "@grammyjs/types": ["@grammyjs/types@3.28.0", "", {}, "sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ=="],
+    "@grammyjs/types": ["@grammyjs/types@4.0.0", "", {}, "sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
@@ -544,7 +544,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "grammy": ["grammy@1.44.0", "", { "dependencies": { "@grammyjs/types": "3.28.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A=="],
+    "grammy": ["grammy@1.45.1", "", { "dependencies": { "@grammyjs/types": "4.0.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-Y4VL/hqJMZZxwlUr5ZgM68CFu2iIeEkNLR1cY3+Ww68CIvWARDsoXFix7+31rmyC0+7L85ZI+Pq3E5JSG5+nLQ=="],
 
     "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "bcryptjs": "^3.0.3",
     "chalk": "^5.4.0",
     "commander": "^13.1.0",
-    "grammy": "^1.44",
+    "grammy": "^1.45",
     "handlebars": "^4.7.8",
     "nostr-tools": "^2.24.1",
     "posthog-node": "^5.29.2",

--- a/telegram-plugin/package.json
+++ b/telegram-plugin/package.json
@@ -31,7 +31,7 @@
     "@secretlint/core": "^12.2.0",
     "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
     "@xterm/headless": "^6.0.0",
-    "grammy": "^1.44",
+    "grammy": "^1.45",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-gfm": "^3.0.0",
     "micromark-extension-gfm": "^3.0.0",

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -251,8 +251,9 @@ export function installTgPostLogger(bot: Bot): void {
  * call site, `ctx.*` sugar, `lockedBot`, or `bot.api.raw`, so it closes the
  * whole bypass class deterministically.
  *
- * Payload shape (verified against grammy 1.44.0 `out/core/api.js`, the pinned
- * lockfile version):
+ * Payload shape (verified against grammy 1.45.1 `out/core/api.js`, the pinned
+ * lockfile version — byte-identical to the 1.44.0 shape this was originally
+ * written against, re-checked on the 1.45.1 bump):
  *   - `sendRichMessage(chat_id, rich_message, ...)` → raw payload
  *     `{ chat_id, rich_message: { markdown }, ... }`
  *   - `editMessageText(chat_id, message_id, arg, ...)` → raw payload

--- a/telegram-plugin/tests/grammy-rich-message-types.test.ts
+++ b/telegram-plugin/tests/grammy-rich-message-types.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Compile-time contract for the grammy 1.44.0 → 1.45.1 bump
+ * (`@grammyjs/types` 3.28.0 → 4.0.0).
+ *
+ * Why this file exists
+ * --------------------
+ * 4.0.0 turned `InputRichMessage` from a plain interface into a GENERIC one:
+ *
+ *   3.28.0  `export interface InputRichMessage {`            (rich.d.ts:280)
+ *   4.0.0   `export interface InputRichMessage<F> {`         (rich.d.ts:283)
+ *
+ * `F` is the file-payload type threaded through the new Bot API 10.2 `blocks`
+ * / `media` fields. Switchroom never uses either — every outbound message is
+ * the plain `{ markdown }` shape (`rich-send.ts:96`), and the plugin defines
+ * its OWN local `InputRichMessageMarkdown` (`rich-send.ts:28`) rather than
+ * importing grammy's. So the bump is only safe as long as a bare
+ * `{ markdown: string }` literal still satisfies the generic parameter at
+ * every call site.
+ *
+ * That invariant is invisible to the rest of the suite for two reasons, and
+ * both are why this test spends ~1s on a real compile instead of asserting on
+ * runtime values:
+ *
+ *   1. Every send in the regression suite is MOCKED — no mock can notice that
+ *      a payload stopped typechecking.
+ *   2. The repo's `tsc --noEmit` does NOT cover this directory. The root
+ *      `tsconfig.json` `include` is `["src/**\/*.ts", "bin/**\/*.ts",
+ *      "scripts/**\/*.ts"]` — `telegram-plugin/` is absent, so a type error
+ *      here is invisible to `npm run lint` (verified empirically: a deliberate
+ *      `const x: number = "s"` in `rich-send.ts` leaves `tsc --noEmit` at exit
+ *      0). A plain `.ts` fixture would therefore be a NO-OP as a guard.
+ *
+ * So the check has to run the compiler itself. The negative controls below are
+ * load-bearing: if the harness ever silently stopped compiling (bad fixture
+ * path, unresolved `grammy`, swallowed diagnostics), the "must fail" cases
+ * would go green and this file goes red — it cannot rot into a vacuous pass.
+ */
+import { describe, it, expect, afterAll } from 'vitest'
+import ts from 'typescript'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+// Fixtures must live INSIDE the repo tree: they `import 'grammy'`, and module
+// resolution walks up from the file to the hoisted root `node_modules`. A
+// fixture in `os.tmpdir()` would fail to resolve grammy and every case would
+// report a misleading "cannot find module" instead of the real answer.
+const fixtureDir = mkdtempSync(join(here, 'grammy-types-fixture-'))
+afterAll(() => rmSync(fixtureDir, { recursive: true, force: true }))
+
+/** Mirrors the compiler settings the plugin is actually authored against. */
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  strict: true,
+  // Matches the root tsconfig: we are asserting on OUR call shapes, not
+  // auditing grammy's own .d.ts files.
+  skipLibCheck: true,
+  noEmit: true,
+}
+
+/**
+ * Typecheck one fixture source and return its syntactic + semantic errors,
+ * formatted `TSxxxx: message`. Empty array means "compiles clean".
+ */
+function typecheck(name: string, source: string): string[] {
+  const file = resolve(fixtureDir, `${name}.ts`)
+  writeFileSync(file, source)
+  const program = ts.createProgram([file], COMPILER_OPTIONS)
+  return ts
+    .getPreEmitDiagnostics(program)
+    .filter((d) => d.file?.fileName === file.split('\\').join('/'))
+    .map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, ' ')}`)
+}
+
+describe('grammy rich-message input still accepts the plain { markdown } shape', () => {
+  it('accepts a bare { markdown } literal on sendRichMessage and editMessageText', () => {
+    expect(
+      typecheck(
+        'plain-literal',
+        `
+        import type { Bot } from 'grammy'
+        declare const bot: Bot
+        export async function send(): Promise<void> {
+          await bot.api.sendRichMessage(1, { markdown: 'hi' })
+          await bot.api.editMessageText(1, 2, { markdown: 'hi' })
+        }
+        `,
+      ),
+    ).toEqual([])
+  })
+
+  it("accepts the production helper's return type (rich-send.ts richMessage())", () => {
+    // The real seam: `richMessage()` returns the plugin's OWN local
+    // `InputRichMessageMarkdown`, which must stay structurally assignable to
+    // grammy's generic parameter. This is the assertion that would break if a
+    // future @grammyjs/types made `blocks`/`media` mandatory or constrained `F`.
+    expect(
+      typecheck(
+        'production-helper',
+        `
+        import type { Bot } from 'grammy'
+        import { richMessage } from '${join(here, '..', 'rich-send.js').split('\\').join('/')}'
+        declare const bot: Bot
+        export async function send(): Promise<void> {
+          await bot.api.sendRichMessage(1, richMessage('hi'))
+          await bot.api.editMessageText(1, 2, richMessage('hi'))
+        }
+        `,
+      ),
+    ).toEqual([])
+  })
+
+  it('still accepts a { markdown } payload through bot.api.raw', () => {
+    // `installRichMarkdownGuard` (shared/bot-runtime.ts) inspects the RAW
+    // payload `{ chat_id, rich_message: { markdown } }`, so pin that shape too.
+    expect(
+      typecheck(
+        'raw-payload',
+        `
+        import type { Bot } from 'grammy'
+        declare const bot: Bot
+        export async function send(): Promise<void> {
+          await bot.api.raw.sendRichMessage({ chat_id: 1, rich_message: { markdown: 'hi' } })
+        }
+        `,
+      ),
+    ).toEqual([])
+  })
+
+  // ── Negative controls: prove the harness has teeth ──────────────────────
+  // Without these, every assertion above would pass just as happily against a
+  // harness that had silently stopped compiling anything at all.
+
+  it('NEGATIVE CONTROL: rejects a wrongly-typed markdown field', () => {
+    const errors = typecheck(
+      'wrong-type',
+      `
+      import type { Bot } from 'grammy'
+      declare const bot: Bot
+      export async function send(): Promise<void> {
+        await bot.api.sendRichMessage(1, { markdown: 123 })
+      }
+      `,
+    )
+    expect(errors.join('\n')).toContain('TS2322')
+  })
+
+  it('NEGATIVE CONTROL: rejects an unknown field on the rich-message literal', () => {
+    const errors = typecheck(
+      'unknown-field',
+      `
+      import type { Bot } from 'grammy'
+      declare const bot: Bot
+      export async function send(): Promise<void> {
+        await bot.api.sendRichMessage(1, { markdwon: 'typo' })
+      }
+      `,
+    )
+    expect(errors.length).toBeGreaterThan(0)
+  })
+})
+
+describe('grammy supply-chain pin', () => {
+  // Assert on `bun.lock` rather than the resolved package: grammy's `exports`
+  // map deliberately hides `./package.json`, and the lockfile is the artifact
+  // CI actually installs from (`bun install --frozen-lockfile`), so it is both
+  // reachable and the more honest source of truth for what ships.
+  const lock = readFileSync(resolve(here, '..', '..', 'bun.lock'), 'utf8')
+
+  /** Pull the resolved version bun.lock pins for a package. */
+  function lockedVersion(pkg: string): string {
+    const escaped = pkg.replace('/', '\\/')
+    const m = new RegExp(`"${escaped}": \\["${escaped}@(\\d+\\.\\d+\\.\\d+)"`).exec(lock)
+    if (!m) throw new Error(`no bun.lock pin found for ${pkg}`)
+    return m[1]
+  }
+
+  // These assert a FLOOR, not an exact version: a later 1.46/5.x bump is a
+  // legitimate change and must not go red here for no substantive reason. What
+  // must never happen silently is a slide BACK below the floor — that would
+  // return @grammyjs/types to 3.28.0 and drop the Bot API 10.2 surface this
+  // bump exists to unlock, while every assertion above stayed green (the plain
+  // `{ markdown }` shape compiles under both).
+
+  it('keeps grammy at or above 1.45 (the floor that ships @grammyjs/types 4.x)', () => {
+    const [major, minor] = lockedVersion('grammy').split('.').map(Number)
+    expect(major).toBe(1)
+    expect(minor).toBeGreaterThanOrEqual(45)
+  })
+
+  it('keeps @grammyjs/types at or above the 4.x major grammy 1.45 depends on', () => {
+    const [major] = lockedVersion('@grammyjs/types').split('.').map(Number)
+    expect(major).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/telegram-plugin/tests/sent-text-capture.test.ts
+++ b/telegram-plugin/tests/sent-text-capture.test.ts
@@ -43,9 +43,9 @@ const CHAT = 5550001
 /**
  * The response Telegram actually returns for `sendRichMessage` — the body lives
  * in `rich_message.blocks`; `text` and `caption` are ABSENT. Verified against
- * `@grammyjs/types` 3.28.0 (the version `grammy@^1.44` resolves)
- * `message.d.ts:94` (`RichMessageMessage = CommonMessage &
- * MsgWith<"rich_message">`) and `:180` (`rich_message?: RichMessage`), and
+ * `@grammyjs/types` 4.0.0 (the version `grammy@^1.45` resolves)
+ * `message.d.ts:98` (`RichMessageMessage = CommonMessage &
+ * MsgWith<"rich_message">`) and `:184` (`rich_message?: RichMessage`), and
  * against the Bot API reference: `sendRichMessage` "On success, the sent
  * Message is returned", `Message.rich_message: RichMessage` "Optional. Message
  * is a rich formatted message", `RichMessage.blocks` "Content of the message".


### PR DESCRIPTION
## What

Bumps **grammy 1.44.0 → 1.45.1**, which pulls **`@grammyjs/types` 3.28.0 → 4.0.0**.

This is the enabling change for **Bot API 10.2** work: the 10.2 rich-message
`blocks` types simply do not exist in `@grammyjs/types` 3.28.0, so nothing that
uses them can compile until this lands. No 10.2 feature is adopted here — this
PR is deliberately just the dependency move plus a guard for the one invariant
it puts at risk.

## Evidence

grammy's own release notes ([grammyjs/grammY/releases](https://github.com/grammyjs/grammY/releases))
list exactly three changes across 1.45.0/1.45.1:

| PR | Change | Effect here |
|---|---|---|
| [#921](https://github.com/grammyjs/grammY/pull/921) | `feat: support Bot API 10.2` | The point of the bump — new types only. |
| [#913](https://github.com/grammyjs/grammY/pull/913) | `fix(platform): set default fetch duplex to "half" for all API requests` | Transport change; probed live, see below. |
| [#922](https://github.com/grammyjs/grammY/pull/922) / [#923](https://github.com/grammyjs/grammY/pull/923) | `narrow down ctx.subscription` / `fix bad subscription narrowing` | Not reached — switchroom has **zero** `ctx.subscription` uses. |

### The one real type break, and why it is safe

`@grammyjs/types` 4.0.0 turns `InputRichMessage` into a **generic**:

- 3.28.0 — `export interface InputRichMessage {` (`rich.d.ts:280`)
- 4.0.0 — `export interface InputRichMessage<F> {` (`rich.d.ts:283`)

`F` threads the file-payload type through the new 10.2 `blocks` / `media`
fields. Switchroom uses neither: every outbound message is the plain
`{ markdown }` shape built at `telegram-plugin/rich-send.ts:96`, against the
plugin's **own** local `InputRichMessageMarkdown` (`rich-send.ts:28`) rather
than an import of grammy's type. So the bump is safe exactly as long as a bare
`{ markdown: string }` literal still satisfies that generic — which is what
this PR's test now pins.

The outbound payload shape is **unchanged**. Re-verified against 1.45.1
`out/core/api.js:152-154` and `:1549-1558` — `sendRichMessage` and
`editMessageText` still emit `rich_message: { markdown }`, byte-identical to
1.44.0 — so `installRichMarkdownGuard`
(`telegram-plugin/shared/bot-runtime.ts`) and every card surface are untouched.

### Lockfile convergence (worth knowing)

The two lockfiles were **already divergent on main**: `package-lock.json` was
resolving grammy 1.45.1 / types 4.0.0, while `bun.lock` — the one CI actually
installs from (`bun install --frozen-lockfile`) — still pinned 1.44.0 / 3.28.0.
Only `bun.lock` moves here, which re-converges them.

Both manifests also move their floor `^1.44` → `^1.45`, because 4.x types only
ship with grammy ≥ 1.45.0; leaving `^1.44` would understate the real
requirement.

## Tests

### The transport change needed a live probe, not a mock

Red-team caught that the existing suite could not possibly catch PR #913: every
Bot API call in it is mocked, so `duplex: "half"` is never exercised. If the
runtime rejected that option, **every** outbound message from every agent would
fail at once and a green suite would have told us nothing.

So I probed it for real — a genuine round-trip to `api.telegram.org` with a
deliberately invalid token (no secret, sends nothing):

- **Bun 1.3.13 → `GrammyError 401 "Unauthorized"`.** The request was built,
  sent, and answered by Telegram: transport is healthy.
- That is the runtime that matters: the fleet pins Bun **1.3.13**
  (`docker/Dockerfile.base:226`, `dependencies.json` `runtime.bun`) and the
  gateway runs source directly under bun (`src/cli/agent.ts:211`).
- Under **Node** the same probe fails — but it fails **identically on grammy
  1.44.0**, so it is a pre-existing sandbox egress artifact of `node-fetch`,
  not a regression from this bump. Stated explicitly because the differential
  looks alarming until you run the control.

### New compile-time guard: `telegram-plugin/tests/grammy-rich-message-types.test.ts`

The `{ markdown }`-still-typechecks invariant was unguarded in **both**
directions, and the second reason is a repo-wide gap worth flagging:

1. Every send in the suite is mocked — no mock notices a type break.
2. **`tsc --noEmit` does not cover `telegram-plugin/` at all.** The root
   `tsconfig.json` `include` is `["src/**/*.ts", "bin/**/*.ts",
   "scripts/**/*.ts"]`. Verified empirically: a deliberate
   `const x: number = "s"` dropped into `rich-send.ts` leaves `npm run
   lint:tsc` at **exit 0**.

Because of (2), a plain `.ts` fixture would have been a no-op. The test instead
drives the **TypeScript compiler API in-process** (matching the existing
`import ts from 'typescript'` idiom in `format-guard-pins.test.ts`) and asserts:

- a bare `{ markdown }` literal typechecks on `sendRichMessage` **and**
  `editMessageText`;
- the production helper `richMessage()`'s return type still flows into both;
- the raw payload `{ chat_id, rich_message: { markdown } }` still typechecks
  (the shape `installRichMarkdownGuard` inspects);
- **two negative controls** — a wrongly-typed and an unknown field must FAIL to
  compile, so the harness cannot silently rot into a vacuous pass;
- a `bun.lock` floor pin (grammy ≥ 1.45, types ≥ 4). Asserted as a **floor, not
  an equality**, so a future 1.46 bump does not go red for no reason.

**Verified the test actually has teeth** (not just that it passes):

- Patching a required field into `InputRichMessage<F>` in the installed
  `.d.ts` → all 3 positive cases go **red**.
- Reverting `bun.lock` to the 1.44.0 baseline → both pin cases go **red**.

Both were restored afterwards.

### Suite results, with a baseline (the bump's actual delta is zero)

Full vitest suite on this branch:

```
 Test Files  15 failed | 1363 passed | 5 skipped (1383)
      Tests  99 failed | 23056 passed | 82 skipped (23237)
   Duration  385.10s
```

Those 99 are **not** from this bump. Re-running the *same 15 files* on
unmodified `origin/main` (`d778afb6`) against the *same* `node_modules`:

```
 Test Files  15 failed (15)
      Tests  99 failed | 172 passed | 2 skipped (273)
```

**Identical file set, identical failure count** — pre-existing, and
environmental rather than logical: this sandbox mounts `/tmp` noexec, so they
fail on `spawnSync .../pip EACCES` (`tests/deps.test.ts`, which is Python venv
setup, not npm deps), `run-hook.sh: Permission denied`, and hostd//install
harness spawns. None of the 15 imports grammy.

The tests that *do* touch grammy all pass, and I ran them on the fleet's exact
runtime rather than just under vitest:

```
$ bun test <34 telegram-plugin tests importing grammy>     # bun 1.3.13
 652 pass
 0 fail
 2841 expect() calls
Ran 652 tests across 34 files. [4.62s]
```

New guard file, verbatim:

```
 ✓ telegram-plugin/tests/grammy-rich-message-types.test.ts (7 tests)
   ✓ accepts a bare { markdown } literal on sendRichMessage and editMessageText
   ✓ accepts the production helper's return type (rich-send.ts richMessage())
   ✓ still accepts a { markdown } payload through bot.api.raw
   ✓ NEGATIVE CONTROL: rejects a wrongly-typed markdown field
   ✓ NEGATIVE CONTROL: rejects an unknown field on the rich-message literal
```

Targeted lint gates: `bun-test-imports: OK`, `test-runner-coverage: OK`,
`changelog-entry: OK`, `plugin-references: OK`.

## What I deliberately did NOT do

- **No Bot API 10.2 feature adoption.** No `blocks`, no `media`, no
  `sendRichMessageDraft` — that last one is a documented deliberate omission
  (`shared/bot-runtime.ts:263`), not a gap, and this PR does not revisit it.
- **No fix for the `telegram-plugin/` typecheck gap.** Adding it to the root
  `tsconfig` `include` is a genuinely separate, much larger change (it would
  surface pre-existing errors across the plugin) and does not belong in a
  dependency bump. Flagged here because it is the more interesting finding.
- **No mass version-comment rewrite.** I corrected only the two comments that
  asserted a now-**false current pin** (`bot-runtime.ts:254`,
  `sent-text-capture.test.ts:46`, whose cited `message.d.ts` lines also shifted
  94/180 → 98/184). The many historical "verified against 1.44.0 at time of
  writing" provenance notes are left alone rather than claiming a
  re-verification I did not perform for each.
- **No live canary send from a real agent.** Red-team asked for one in the bump
  gate; the invalid-token round-trip proves the transport, but an actual
  authenticated send from a real agent is an operator-side rollout step, not
  something to do from CI. **Recommend a staged rollout** — bounce one agent
  first and confirm one real message lands before the fleet follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
