### PR TITLE
fix(telegram): stop guards destroying wire-supported rich constructs; retire `**>` emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@ now an anomaly worth investigating, not the norm.
   link. The reply-tool path never ran the renderer and was already correct; it
   is now pinned by tests.
 
+- **Telegram rich-markdown guards no longer destroy natively-supported
+  constructs** — raw `sendRichMessage` wire probes (2026-08-13) proved
+  `<details><summary>` collapsibles, inline math `$x^2+y^2$`, footnotes
+  (`claim[^1]` + `[^1]: body`), `<sub>`/`<sup>`/`<u>`, `<aside>` pullquotes,
+  `tg://time` links and task lists are all REAL typed nodes on the Bot API
+  10.1 rich path, while the `**>` "expandable blockquote" the docs called
+  live-verified is MarkdownV2-only syntax that renders as literal `**>` text.
+  The send-time guard used to fold `<details>` into `**>` (converting a
+  supported construct into an unsupported one), backslash-escape `$math$`,
+  and delete footnote reference markers — all three conversions are deleted.
+  The renderer no longer emits `**>` anywhere: an IR `expandable` blockquote
+  (and legacy `**> ` agent input, which is still recognised and repaired)
+  degrades to a plain `>` quote, and a genuine collapsible is authored as
+  `<details>`, which now passes through the whole pipeline byte-identical.
+  Footnotes survive the parse→render path via a new verbatim `raw` IR node
+  (previously `escapeMarkdown` broke them as `\[^1\]`), and compact
+  non-currency `$…$` math spans are protected segments for every guard while
+  accidental `$5M … $10M` currency pairs are still defused (#3252). The
+  boot-injected formatting floor card, the formatting guide, the
+  native-formatting RFC, and the stale 4096-char cap claims (real rich cap:
+  `RICH_MESSAGE_MAX_CHARS = 32768`) are corrected in lockstep.
+
 ### Dependencies
 
 - **Claude Code CLI pinned 2.1.228 → 2.1.229** — all three lockstep locations

--- a/reference/rfcs/telegram-native-formatting.md
+++ b/reference/rfcs/telegram-native-formatting.md
@@ -71,16 +71,20 @@ constructs this engine cares about:
 | Bold / italic / strike / spoiler / code / link | `**b**`, `_i_`, `~~s~~`, `\|\|spoiler\|\|`, `` `code` ``, `[t](url)` |
 | Heading | bold line (Telegram has no `<h1>`–`<h6>`) |
 | Blockquote | `> …` line-prefixed |
-| **Expandable** blockquote | `**> …` (Bot API 10.1 expandable pull-quote) |
+| **Expandable** blockquote | ~~`**> …`~~ CORRECTED 2026-08-13: `**>` is MarkdownV2-only syntax; the rich markdown path renders it as literal text (wire-probed). The renderer emits a plain `> …` quote for legacy expandable input; a real collapsible is `<details><summary>…</summary>…</details>`, which passes through natively. |
 | Code block | fenced ```` ``` ```` with optional language |
 | List | `- item` / `1. item` |
 | Table | GFM pipe table (`\| col \| col \|` + `\| --- \| --- \|` separator row) |
 
 A live UAT scenario,
 [`telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts`](../../telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts),
-already confirms production Telegram renders these markdown constructs — pipe
-tables and expandable blockquotes included — correctly. The renderer's target
-is defined by what that scenario proves, not by a hypothetical HTML mapping.
+already confirms production Telegram renders these markdown constructs
+correctly. (It previously claimed the same for `**>` expandable blockquotes;
+raw wire probes on 2026-08-13 disproved that — the scenario's decode step only
+asserted a `blockquote` entity, which the plain `>` continuation lines produced
+on their own while the `**>` opener came back as literal paragraph text.) The
+renderer's target is defined by what real probes prove, not by a hypothetical
+HTML mapping.
 
 ---
 
@@ -162,7 +166,7 @@ Concretely, the corrections:
 | `code -> <code>…</code>` | `` code -> `…` `` |
 | `link -> <a href>…</a>` | `link -> [text](url)` |
 | `blockquote -> <blockquote>` | `blockquote -> > …` (line-prefixed) |
-| `expandable -> <blockquote expandable>` | `expandable -> **> …` |
+| `expandable -> <blockquote expandable>` | ~~`expandable -> **> …`~~ CORRECTED 2026-08-13: renders as a plain `> …` quote (`**>` is not rich-markdown syntax — wire-probed literal text) |
 | `code-block -> <pre><code class=…>` | fenced ```` ``` ```` + language |
 | `table -> monospaced <pre>` | GFM pipe table (Telegram renders it natively) |
 
@@ -178,9 +182,11 @@ scope for this doc-only PR, flagged for the renderer PR.)
 Telegram caps rich-message length. When rendered markdown exceeds the cap the
 renderer must split **on construct boundaries** — between blocks, list items, or
 table-with-its-own-header — never mid-construct. A table split across two
-messages must repeat its header row in the second; an expandable blockquote must
-not be cut so that its `**>` opener lands in one message and its body in
-another.
+messages must repeat its header row in the second; a blockquote must not be cut
+so that its opening `>` lines land in one message and the rest in another.
+(An earlier revision of this rule referenced the `**>` expandable opener; that
+marker is retired — wire probes 2026-08-13 showed `**>` is MarkdownV2-only and
+renders as literal text on the rich path, so the renderer no longer emits it.)
 
 **Hard rule: never truncate mid-construct.** If a single logical construct is
 itself larger than the cap and cannot be safely split (e.g. one enormous table

--- a/reference/telegram-formatting-guide.md
+++ b/reference/telegram-formatting-guide.md
@@ -50,19 +50,24 @@ You're writing for a phone screen in Telegram. Every reply renders as rich Markd
   decisive phrase inside a longer passage — rarer than bold, never stacked with it;
   fenced code blocks ALWAYS with a language
   hint (```diff, ```json, ```bash — bare fence only for non-code fixed-width output);
-  and the flagship — the **expandable blockquote** `**> first line` + `> continuation`
-  for a long quote, stack trace, or detailed aside the reader can collapse. The `**>`
-  opener must be at the line start (column 0) — never indented — or it won't parse. Use it
-  whenever a bulky supporting block would otherwise dominate the message.
+  and the flagship — the **collapsible `<details>` block**:
+  `<details><summary>Title</summary>` + body + `</details>` for a long quote, stack
+  trace, or detailed aside the reader opts into (add `open` to start expanded). Use it
+  whenever a bulky supporting block would otherwise dominate the message. Never write
+  `**> ` for a collapsible — that is MarkdownV2 syntax; this path renders it as
+  literal `**>` text.
 
-Renders wrong on this path — never emit: underline (`__x__` renders as bold),
-`^sup^`/`~sub~`, `$math$`, `<details>`, footnotes `[^1]`. Write "squared", not `x^2^`.
+Also native on this path: inline math `$x^2+y^2$`, footnotes (`claim[^1]` +
+`[^1]: note` at the end), task-list checkboxes `- [ ]`/`- [x]`, and the HTML tags
+`<sub>`/`<sup>`/`<u>`. Renders wrong — never emit: `__x__` (renders as BOLD, not
+underline — use `<u>`), or the caret/tilde shorthand `^sup^`/`~sub~` (literal noise —
+use `<sup>`/`<sub>` or words).
 
 The framework normalizes mechanics in code on every outbound message: block spacing,
 em/en dashes, and `•` bullet markers are
-rewritten deterministically; unsupported tokens (the CARET `^highlight^` form —
-`==highlight==` renders fine — plus `$math$`, `<details>`, footnotes) are repaired;
-long messages are chunked safely at 32768 chars (fences and
+rewritten deterministically; the unsupported caret `^highlight^` form is repaired
+(`==highlight==` renders fine); accidental currency `$5M and $10M` pairs are kept out
+of math mode; long messages are chunked safely at 32768 chars (fences and
 table rows never bisected); over-bolded messages get their bold stripped. Don't
 hand-tune spacing or fight it — write the content, the gateway makes typography
 consistent. Long before the cap, ask whether a wall of text is the right answer at all.
@@ -94,13 +99,16 @@ Bot API 10.1 rich messages.
 | --- | --- | --- |
 | Bold | `**text**` | The one key fact, not decoration. |
 | Italic | `*text*` or `_text_` | Light emphasis, labels, asides. |
-| Underline | — (not supported) | **`__text__` renders as BOLD**, not underline — Telegram's rich-message markdown parser reads a `__…__` run identically to `**…**` (live-verified against the Bot API, 2026-07). There is no markdown token for underline on this path; don't rely on it. |
+| Underline | `<u>text</u>` | The HTML tag renders a native underline entity (wire-verified 2026-08-13). **The markdown form `__text__` renders as BOLD**, not underline — Telegram's rich-message markdown parser reads a `__…__` run identically to `**…**` (live-verified against the Bot API, 2026-07); never rely on it for underline. |
 | Strikethrough | `~~text~~` | Retractions, "was X now Y". |
 | Spoiler | `\|\|text\|\|` | Hidden until tapped — surprises, long-answer punchlines. Live-verified: surfaces as a `spoiler` entity on the wire (2026-07). |
 | Highlight / marked | `==text==` | Live-verified: surfaces as a `marked` entity on the wire (2026-07). The `=` is an `escapeMarkdown` special, so dynamic text won't trigger it by accident. |
 | Inline code | `` `text` `` | Identifiers, tap-to-copy. Content is literal — no escaping inside. |
-| Subscript | `~text~` (single tilde) | **Falls back to literal text** in rich messages (Bot API 10.1) — the only GFM construct that doesn't render. Avoid. |
-| Superscript | `^text^` | **Falls back to literal text** in rich messages — avoid (use words, e.g. "squared"). |
+| Subscript | `<sub>text</sub>` | The HTML tag renders a native subscript entity (wire-verified 2026-08-13). The tilde shorthand `~text~` (single tilde) **falls back to literal text** — avoid it. |
+| Superscript | `<sup>text</sup>` | The HTML tag renders a native superscript entity (wire-verified 2026-08-13). The caret shorthand `^text^` **falls back to literal text** and is repaired at send time (carets stripped) — avoid it. |
+| Inline math | `$x^2+y^2$` | Renders as a native `mathematical_expression` node (wire-verified 2026-08-13). A compact `$…$` span passes through the outbound guards verbatim; accidental currency pairs (`$5M and $10M`) are still broken apart by the dollar-math guard. |
+| Footnote | `claim[^1]` + `[^1]: note` | Native footnote machinery — superscript marker, anchor, reference link, and footer (wire-verified 2026-08-13). Put definitions at the end of the message. |
+| Date/time link | `[label](tg://time?unix=…)` | Renders a native `date_time` node (wire-verified 2026-08-13). |
 | Custom emoji | Telegram premium custom-emoji entity | Premium-only; renders as a normal emoji for non-premium viewers. Don't rely on it conveying meaning. |
 | Link | `[label](https://…)` | Standard GFM link. |
 
@@ -127,9 +135,17 @@ Bot API 10.1 rich messages.
     `WORKER_STEP_INDENT` in `telegram-plugin/status-no-truncate.ts`.
   - Do **not** reach for a leading `· ` as a pseudo-indent: Telegram promotes it to a
     real list bullet, which is a block-structure line.
-- **Pull-quote / expandable blockquote** — `**> …`** (Bot API 10.1 expandable
-  blockquote). A long quote the reader can collapse/expand. The `**>` opener must be at
-  the line start (column 0) — never indented — or it won't parse.
+- **Collapsible block** — `<details><summary>Title</summary>` + body + `</details>`.
+  Renders a native typed `details` node the reader expands on tap (wire-verified
+  2026-08-13); add `open` (`<details open>`) to start expanded. This replaces the
+  retired `**> ` "expandable blockquote": `**>` is MarkdownV2-only syntax that this
+  path renders as LITERAL `**>` text (wire-verified 2026-08-13). The renderer no
+  longer emits `**>` anywhere; legacy `**> ` input is repaired into a plain `>`
+  blockquote.
+- **Pull-quote** — `<aside>…<cite>credit</cite></aside>`. Renders a native `pullquote`
+  node with a credit line (wire-verified 2026-08-13).
+- **Task list** — `- [ ] open` / `- [x] done`. Renders native checkbox list items
+  (wire-verified 2026-08-13).
 - **Section heading** — `#` … `######`. Only in a genuinely long, multi-section answer.
 - **Preformatted block** — a code fence with no language, for fixed-width non-code
   (ASCII tables, aligned columns).
@@ -138,12 +154,14 @@ Bot API 10.1 rich messages.
 - **Divider** — `---` (thematic break). Heavy horizontal rule between genuinely
   separate sections. Use sparingly.
 
-> Reach for the exotic spans (spoiler, highlight, custom emoji) only when they
+> Reach for the exotic spans (spoiler, highlight, math, custom emoji) only when they
 > genuinely serve the reader. The floor card's "why" applies: structure for the reader,
-> not the writer. Two constructs do NOT render as intended and should be avoided:
-> **sub/superscript** falls back to literal text, and **underline (`__text__`) renders
-> as bold** (Telegram's rich-message markdown has no underline token — live-verified).
-> Spoiler (`||…||`) and highlight (`==…==`) DO render correctly on this path.
+> not the writer. Two SHORTHAND forms do NOT render as intended and should be avoided:
+> the caret/tilde **sub/superscript shorthand** (`^text^` / `~text~`) falls back to
+> literal text, and **underline written as `__text__` renders as bold**. Use the HTML
+> tags instead — `<sub>`, `<sup>`, `<u>` all render natively (wire-verified
+> 2026-08-13). Spoiler (`||…||`) and highlight (`==…==`) DO render correctly on this
+> path.
 
 ### Escaping rules
 

--- a/skills/switchroom-architecture/telegram.md
+++ b/skills/switchroom-architecture/telegram.md
@@ -6,7 +6,7 @@ Switchroom ships an enhanced `switchroom-telegram` MCP plugin that replaces the 
 
 | Tool | What it does |
 |------|-------------|
-| `reply` | Send text, photos, or documents — the single final-answer tool. Chunks anything over Telegram's 4096-char limit. Supports threading, topic routing, file attachments. |
+| `reply` | Send text, photos, or documents — the single final-answer tool. Chunks anything over the 32768-char rich-message cap (4096 applies only to plain-text degradations). Supports threading, topic routing, file attachments. |
 | `react` | Add emoji reactions to messages (Telegram whitelist: 👍 👎 ❤️ 🔥 👀 🎉 etc). |
 | `edit_message` | Update a previously sent message. Edits are silent (no push notification). |
 | `delete_message` | Remove a bot-sent message (48h Telegram API limit). |
@@ -40,18 +40,20 @@ History survives process restarts and session resets.
 For long tasks you do not need to narrate progress by editing a message. The
 plugin renders an event-driven progress card (Plan → Run → Done with live tool
 bullets, elapsed time, and status emoji) for free while the turn is in-flight.
-Send the final answer once, with `reply` — it chunks anything over Telegram's
-4096-char limit. For an explicit mid-turn check-in use `progress_update`.
+Send the final answer once, with `reply` — it chunks anything over the
+32768-char rich-message cap (4096 applies only to plain-text degradations).
+For an explicit mid-turn check-in use `progress_update`.
 
 ## Formatting
 
-Markdown is auto-converted to Telegram HTML:
-- `**bold**` → `<b>bold</b>`
-- `` `code` `` → `<code>code</code>`
-- ` ```blocks``` ` → `<pre><code>...</code></pre>`
-- Smart chunking preserves tag balance across Telegram's 4096-char limit
-
-Formats: `html` (default), `markdownv2`, `text`
+Every outbound message is sent as raw GFM markdown via the Bot API 10.1
+rich-message path (`sendRichMessage` / `editMessageText({ markdown })`) —
+Telegram parses the markdown server-side. There is no markdown→HTML
+conversion and no `parse_mode` on this path. Smart chunking
+(`splitMarkdownChunks`) splits anything over the 32768-char rich cap without
+bisecting code fences or table rows; bodies that degrade to plain text fall
+back to the legacy 4096-char cap. See
+`reference/telegram-formatting-guide.md` for the full vocabulary.
 
 ## Access control
 

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -294,7 +294,7 @@ The `switchroom-telegram` plugin is an enhanced fork of the official Telegram MC
 
 | Tool | Purpose |
 |---|---|
-| `reply` | Send a text/photo message — the single final-answer tool; chunks anything over Telegram's 4096-char limit. Optional `reply_to` for threaded quotes |
+| `reply` | Send a text/photo message — the single final-answer tool; chunks anything over the 32768-char rich-message cap (4096 applies only to plain-text degradations). Optional `reply_to` for threaded quotes |
 | `react` | Emoji reaction on an inbound or outbound message |
 | `edit_message` | Modify an earlier bot message's text |
 | `delete_message` | Remove an earlier bot message |

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -554,19 +554,24 @@ You're writing for a phone screen in Telegram. Every reply renders as rich Markd
   decisive phrase inside a longer passage — rarer than bold, never stacked with it;
   fenced code blocks ALWAYS with a language
   hint (\`\`\`diff, \`\`\`json, \`\`\`bash — bare fence only for non-code fixed-width output);
-  and the flagship — the **expandable blockquote** \`**> first line\` + \`> continuation\`
-  for a long quote, stack trace, or detailed aside the reader can collapse. The \`**>\`
-  opener must be at the line start (column 0) — never indented — or it won't parse. Use it
-  whenever a bulky supporting block would otherwise dominate the message.
+  and the flagship — the **collapsible \`<details>\` block**:
+  \`<details><summary>Title</summary>\` + body + \`</details>\` for a long quote, stack
+  trace, or detailed aside the reader opts into (add \`open\` to start expanded). Use it
+  whenever a bulky supporting block would otherwise dominate the message. Never write
+  \`**> \` for a collapsible — that is MarkdownV2 syntax; this path renders it as
+  literal \`**>\` text.
 
-Renders wrong on this path — never emit: underline (\`__x__\` renders as bold),
-\`^sup^\`/\`~sub~\`, \`$math$\`, \`<details>\`, footnotes \`[^1]\`. Write "squared", not \`x^2^\`.
+Also native on this path: inline math \`$x^2+y^2$\`, footnotes (\`claim[^1]\` +
+\`[^1]: note\` at the end), task-list checkboxes \`- [ ]\`/\`- [x]\`, and the HTML tags
+\`<sub>\`/\`<sup>\`/\`<u>\`. Renders wrong — never emit: \`__x__\` (renders as BOLD, not
+underline — use \`<u>\`), or the caret/tilde shorthand \`^sup^\`/\`~sub~\` (literal noise —
+use \`<sup>\`/\`<sub>\` or words).
 
 The framework normalizes mechanics in code on every outbound message: block spacing,
 em/en dashes, and \`\u2022\` bullet markers are
-rewritten deterministically; unsupported tokens (the CARET \`^highlight^\` form —
-\`==highlight==\` renders fine — plus \`$math$\`, \`<details>\`, footnotes) are repaired;
-long messages are chunked safely at 32768 chars (fences and
+rewritten deterministically; the unsupported caret \`^highlight^\` form is repaired
+(\`==highlight==\` renders fine); accidental currency \`$5M and $10M\` pairs are kept out
+of math mode; long messages are chunked safely at 32768 chars (fences and
 table rows never bisected); over-bolded messages get their bold stripped. Don't
 hand-tune spacing or fight it — write the content, the gateway makes typography
 consistent. Long before the cap, ask whether a wall of text is the right answer at all.

--- a/telegram-plugin/README.md
+++ b/telegram-plugin/README.md
@@ -204,7 +204,9 @@ For long tasks the model does **not** need to narrate progress or drive a
 streaming message itself. The plugin renders an event-driven progress card
 (Plan → Run → Done with live tool bullets, elapsed time, and status emoji)
 for free while the turn is in-flight. Send the final answer once, with
-`reply` — it chunks anything over Telegram's 4096-char limit. (The retired
+`reply` — it chunks anything over the rich-message wire cap of 32768 chars
+(`RICH_MESSAGE_MAX_CHARS` in `format.ts`; the legacy 4096 cap applies only to
+plain-text degradations). (The retired
 `stream_reply` tool was a redundant, worse alias of `reply`; the internal
 progress-card streaming that drove it is preserved and is what renders the
 live card.)

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -735,9 +735,12 @@ export function normalizePunctuation(text: string): string {
   // The dash rewrite runs per line so blockquote lines can be exempted:
   // `>` blockquotes are reserved for VERBATIM quoted text, and rewriting an
   // author's ` — ` to `, ` inside a quotation would corrupt what they quoted.
-  // The expandable-blockquote opener `**>` is a blockquote line too even though
-  // isBlockquoteLine (which keys on a leading `>`) doesn't catch the `**`
-  // prefix, so exempt it explicitly. Code spans and link hrefs stay masked
+  // A line opening with the LEGACY `**>` expandable-quote marker is a
+  // blockquote line too (the render path no longer emits `**>` — it is
+  // MarkdownV2-only syntax, see render.ts renderBlockquote — but legacy agent
+  // output still contains it and parse.ts repairs it into a real quote), so
+  // exempt it explicitly even though isBlockquoteLine (which keys on a leading
+  // `>`) doesn't catch the `**` prefix. Code spans and link hrefs stay masked
   // throughout, so their dashes are already protected on every line.
   const rewriteDashes = (line: string): string =>
     line

--- a/telegram-plugin/render/code-segments.ts
+++ b/telegram-plugin/render/code-segments.ts
@@ -73,6 +73,13 @@ export function splitCodeSegments(text: string): Segment[] {
 //   • bare autolinked URLs — `http(s)://…` and `www.…` runs Telegram auto-links.
 //   • GFM table rows — a table's structural pipes / empty cells (`|a||b|`) must
 //     survive; escaping inside a real table row corrupts the table.
+//   • inline-math `$…$` spans — Telegram's rich GFM parser typesets a `$…$`
+//     pair as a real mathematical_expression node (wire-verified 2026-08-13).
+//     A COMPACT span (whitespace-free inner run that is not a bare currency
+//     amount, e.g. `$x^2+y^2$`) is intentional math and must reach the wire
+//     byte-identical: no guard may escape its `$`, `^`, `_`, `*`, or `+`.
+//     Currency-shaped inners (`$5M-$`) are NOT protected, so the dollar-math
+//     guard still breaks accidental `$5M … $10M` currency pairs (#3252).
 // Everything else is prose and stays fully guarded. This is the sibling of the
 // code-span skip: a PROTECTED segment (`code: true`) is emitted verbatim.
 //
@@ -92,6 +99,19 @@ function isTableDelimiterRow(line: string): boolean {
 function isTableCandidateLine(line: string): boolean {
   return /^\s*\|/.test(line);
 }
+
+/** A compact `$…$` inline-math pair: opening `$`, a whitespace-free inner run
+ *  with no nested `$`, closing `$`. Anchored — tested at the scanner's current
+ *  position only. */
+const COMPACT_MATH_PAIR = /^\$([^\s$]+)\$/;
+
+/** A currency-shaped inner run: digits plus amount punctuation and magnitude
+ *  suffix letters only (`5M-`, `0.5`, `10,000`, `5+`). Such a run between two
+ *  `$` is a pair of ADJACENT currency amounts (`$5M-$10M`), not math — it must
+ *  stay guardable so the dollar-math guard can break the accidental pair. A
+ *  run containing any other character (`x^2+y^2`, `\alpha`, `a_b`) is treated
+ *  as intentional math and protected. */
+const CURRENCY_SHAPED_INNER = /^[0-9.,+\-kKmMbB]+$/;
 
 /** Find the [start, end) char ranges (relative to `text`) of GFM table blocks —
  *  maximal runs of 2+ consecutive `|`-leading lines that contain a delimiter
@@ -185,6 +205,19 @@ function splitProseProtected(text: string): Segment[] {
         continue;
       }
     }
+    // 4. Compact inline-math pair `$…$` — a supported Telegram construct
+    //    (mathematical_expression, wire-verified 2026-08-13) that must reach
+    //    the wire verbatim. Currency-shaped inners are NOT math (they are two
+    //    adjacent amounts like `$5M-$10M`) and stay guardable.
+    if (ch === "$") {
+      const m = COMPACT_MATH_PAIR.exec(text.slice(i));
+      if (m && !CURRENCY_SHAPED_INNER.test(m[1])) {
+        const end = i + m[0].length;
+        pushProtected(i, end);
+        i = end;
+        continue;
+      }
+    }
     i++;
   }
   if (plainStart < text.length) out.push({ code: false, text: text.slice(plainStart) });
@@ -193,10 +226,11 @@ function splitProseProtected(text: string): Segment[] {
 
 /** Split rendered markdown into prose / protected segments where a PROTECTED
  *  (`code: true`) segment is any content a guard must emit verbatim: code spans,
- *  fenced code blocks, markdown link destinations, bare autolinks, and GFM
- *  table rows. This is the link/table-aware superset of `splitCodeSegments` that
- *  all four #3252 guards route through. Prose segments (`code: false`) remain
- *  guardable (including a link's `[label]` text). Deterministic, linear-time. */
+ *  fenced code blocks, markdown link destinations, bare autolinks, GFM table
+ *  rows, and compact `$…$` inline-math spans. This is the link/table/math-aware
+ *  superset of `splitCodeSegments` that all the #3252 guards route through.
+ *  Prose segments (`code: false`) remain guardable (including a link's
+ *  `[label]` text). Deterministic, linear-time. */
 export function splitProtectedSegments(text: string): Segment[] {
   const out: Segment[] = [];
   for (const seg of splitCodeSegments(text)) {

--- a/telegram-plugin/render/dollar-math-guard.ts
+++ b/telegram-plugin/render/dollar-math-guard.ts
@@ -29,6 +29,20 @@
 // a `$…$` pair if only the leading-`$digit` token is escaped — so we escape the
 // lot once the currency signal + 2-dollar threshold are met.
 //
+// ── INTENTIONAL math is exempt (wire-verified 2026-08-13) ─────────────────
+// Telegram's rich path renders a `$…$` pair as a native mathematical_expression
+// node, and intentional math (`$x^2+y^2$`) must reach the wire byte-identical —
+// an escaped `\$x^2+y^2\$` destroys a SUPPORTED construct. The discrimination
+// lives in `splitProtectedSegments` (code-segments.ts): a COMPACT math span
+// (whitespace-free inner, not currency-shaped) is a protected segment, so this
+// guard neither counts its `$`s toward the 2+ threshold nor escapes them.
+// Currency amounts always sit next to whitespace/prose (`$5M and $10M`) or have
+// a digits-and-punctuation-only inner (`$5M-$10M`), so #3252-class accidental
+// pairs remain fully guarded. Known residual: a SPACED math span (`$a + b$`)
+// is indistinguishable from currency prose and is not exempted — it is escaped
+// when the message also carries a currency signal, rendering as literal text
+// (legible, not broken).
+//
 // Idempotent (F5): the escape uses a negative-lookbehind (`(?<!\\)\$`) so an
 // already-escaped `\$` is never doubled to `\\$`. Running the guard twice (e.g.
 // the streaming path renders then this wrapper re-wraps) is a strict no-op the
@@ -100,7 +114,8 @@ const UNESCAPED_DOLLAR = /(?<!\\)\$/g;
  * them is digit-adjacent (a currency signal). When armed, EVERY unescaped prose
  * `$` is backslash-escaped so no two `$` can pair into a math span — this is
  * what closes the F3 trailing-`$` / `$.50` false-negatives. Code spans / fenced
- * blocks are never touched. Idempotent (F5) and deterministic.
+ * blocks AND compact intentional-math `$…$` spans (protected segments, see
+ * code-segments.ts) are never touched. Idempotent (F5) and deterministic.
  */
 export function guardDollarMath(text: string): string {
   if (!text.includes("$")) return text;

--- a/telegram-plugin/render/ir.ts
+++ b/telegram-plugin/render/ir.ts
@@ -31,11 +31,20 @@
 //     code      -> `` `…` ``
 //     link      -> `[…](…)`
 //     tg-entity -> `![…](tg://…)`  (Bot API date_time / custom-emoji entity)
+//     raw       -> source bytes verbatim (never escaped) — footnote markers
+//                  `[^1]` and definition lines `[^1]: …`, which Telegram's
+//                  rich parser renders natively and escapeMarkdown would break
 //
 //   Block
 //     paragraph      -> children joined; blocks separated by "\n\n"
 //     heading        -> `#`…`######` line
-//     blockquote     -> `> …` (expandable === true -> `**> …` expandable blockquote)
+//     blockquote     -> `> …` on every line. `expandable === true` records that
+//                       the SOURCE carried the legacy `**> ` marker, but it is
+//                       NOT a distinct wire style: `**>` is MarkdownV2-only
+//                       syntax that the rich markdown path renders as literal
+//                       text (wire-verified 2026-08-13), so the renderer
+//                       degrades it to a plain quote. Authors wanting a real
+//                       collapsible use `<details><summary>…</summary>…</details>`.
 //     code-block     -> ```` ```lang … ``` ````
 //     list           -> line-per-item with `-`/`1.` markers
 //     thematic-break -> `---` thematic break
@@ -134,6 +143,16 @@ export interface TgEntityNode extends Pos {
   href: string;
 }
 
+/** Verbatim wire passthrough: the node's SOURCE bytes are already the exact
+ *  syntax Telegram's rich parser expects, so the renderer must emit them
+ *  unescaped (escapeMarkdown would corrupt them). Used for GFM footnote
+ *  reference markers (`[^1]`) and footnote definition lines (`[^1]: …`) —
+ *  both natively supported on the rich path (wire-verified 2026-08-13). */
+export interface RawNode extends Pos {
+  type: "raw";
+  text: string;
+}
+
 export type Inline =
   | PlainNode
   | BoldNode
@@ -144,7 +163,8 @@ export type Inline =
   | HighlightNode
   | CodeNode
   | LinkNode
-  | TgEntityNode;
+  | TgEntityNode
+  | RawNode;
 
 // ---------------------------------------------------------------------------
 // Block nodes
@@ -165,7 +185,11 @@ export interface HeadingNode extends Pos {
 export interface BlockquoteNode extends Pos {
   type: "blockquote";
   children: Block[];
-  /** Telegram <blockquote expandable>. Always false in Increment 1 — see parse.ts. */
+  /** True when the source carried the LEGACY switchroom `**> ` expandable
+   *  marker (see parse.ts markExpandableQuotes). Records authoring intent
+   *  only: `**>` is MarkdownV2 syntax with no rich-markdown equivalent
+   *  (wire-verified 2026-08-13), so the renderer emits a plain `> ` quote
+   *  either way. */
   expandable: boolean;
 }
 

--- a/telegram-plugin/render/parse.ts
+++ b/telegram-plugin/render/parse.ts
@@ -37,12 +37,18 @@
 //   own reading of the delimiters.
 //
 // Blockquote expandable handling:
-//   The IR carries `expandable: boolean` for Telegram's expandable blockquote
-//   (Bot API 10.1). GFM has no expandable marker; the switchroom render path
-//   emits `**> ` on the FIRST line of an expandable quote (`render.ts` /
-//   `reference/telegram-formatting-guide.md`). micromark does NOT understand
-//   `**> ` as a blockquote — the leading `**` makes the line a paragraph with
-//   an unclosed strong-emphasis run — so this module pre-transforms each
+//   The IR carries `expandable: boolean` for the LEGACY switchroom `**> `
+//   expandable-quote encoding. `**>` was believed to be the Bot API 10.1
+//   expandable-blockquote marker; wire probes (2026-08-13) proved it is
+//   MarkdownV2-only syntax that the rich markdown path renders as LITERAL
+//   `**>` text, so `render.ts` no longer emits it — an expandable node renders
+//   as a plain `> ` quote. Recognition here is kept as INPUT REPAIR: agent
+//   output (and Hindsight memories) trained on the old floor card still
+//   contains `**> ` quotes, and without this rewrite such a line would reach
+//   the wire as a broken literal-`**>` paragraph. micromark does NOT
+//   understand `**> ` as a blockquote — the leading `**` makes the line a
+//   paragraph with an unclosed strong-emphasis run — so this module
+//   pre-transforms each
 //   `**>` marker into a plain `  >` marker of IDENTICAL length (`**` → two
 //   spaces) before handing the text to mdast. Length preservation keeps every
 //   UTF-16 source offset (and therefore the never-lose-text round-trip
@@ -90,10 +96,12 @@ function slice(source: string, node: MdastNode): string {
   return source.slice(start, end);
 }
 
-/** The Bot API 10.1 expandable-blockquote marker: `**>` at the very start of
- *  a line (column 0). This is exactly what the render path emits
- *  (`render.ts` writes `**> ` on the first line of an expandable quote; see
- *  `reference/telegram-formatting-guide.md`). Matching only at column 0 keeps
+/** The LEGACY switchroom expandable-blockquote marker: `**>` at the very
+ *  start of a line (column 0). The render path no longer emits it (it is
+ *  MarkdownV2-only syntax, not rich markdown — see `render.ts`
+ *  renderBlockquote), but it is still RECOGNISED on input so a legacy `**> `
+ *  line is repaired into a real blockquote instead of shipping as literal
+ *  `**>` text. Matching only at column 0 keeps
  *  the length-preserving rewrite (`**` → two spaces) inside CommonMark's
  *  3-space blockquote-indent budget — allowing leading indent here would push
  *  the rewritten `  >` past 3 spaces and turn it into an indented code block. */
@@ -202,8 +210,16 @@ function foldInline(node: PhrasingContent, source: string): Inline {
       }
       return { type: "plain", text: slice(source, node), ...pos(node) };
     }
-    // Not in the palette (break, non-`tg:` image, html, footnoteReference, …):
-    // keep the raw source text so no content is lost.
+    // GFM footnote reference marker (`[^1]`): natively supported by Telegram's
+    // rich markdown path (wire-verified 2026-08-13 — renders as the full
+    // superscript + anchor + reference_link machinery). The source bytes ARE
+    // the wire syntax, so fold to a `raw` node the renderer emits verbatim;
+    // a `plain` node would be escapeMarkdown'd (`\[^1\]`) and break the
+    // construct on the wire.
+    case "footnoteReference":
+      return { type: "raw", text: slice(source, node), ...pos(node) };
+    // Not in the palette (break, non-`tg:` image, html, …): keep the raw
+    // source text so no content is lost.
     default:
       return { type: "plain", text: slice(source, node), ...pos(node) };
   }
@@ -364,8 +380,19 @@ function foldBlock(
         ...pos(node),
       };
     }
-    // Not in the palette (html, definition, footnoteDefinition, …): degrade to
-    // a paragraph carrying the raw source slice so no content is dropped.
+    // GFM footnote DEFINITION (`[^1]: body`): natively supported on the wire
+    // (2026-08-13 probe — pairs with the reference marker into footer/anchor
+    // nodes). Emit the raw source slice VERBATIM via a `raw` inline: a `plain`
+    // fold would escapeMarkdown the `[`/`]` (`\[^1\]: body`) and orphan the
+    // reference.
+    case "footnoteDefinition":
+      return {
+        type: "paragraph",
+        children: [{ type: "raw", text: slice(source, node), ...pos(node) }],
+        ...pos(node),
+      };
+    // Not in the palette (html, definition, …): degrade to a paragraph
+    // carrying the raw source slice so no content is dropped.
     default:
       return {
         type: "paragraph",

--- a/telegram-plugin/render/render.ts
+++ b/telegram-plugin/render/render.ts
@@ -16,10 +16,11 @@
 // "HTML" }`. There is no HTML anywhere on the current outbound path (see
 // `reference/telegram-formatting-guide.md`). This renderer therefore targets
 // the ACTUAL contract: GFM markdown with the Bot API 10.1 extensions
-// documented in the formatting guide (expandable blockquote via `**> `,
-// spoiler via `||…||`, GFM pipe tables, etc). This module is NOT wired into
-// the live send path yet — that is a later increment, per the RFC's phased
-// rollout (rich rendering stays gated off by default until then).
+// documented in the formatting guide (spoiler via `||…||`, GFM pipe tables,
+// `<details>` collapsibles passed through as HTML, etc). NOTE: `**> ` is NOT
+// part of that contract — it is MarkdownV2-only syntax the rich path renders
+// as literal text (wire-verified 2026-08-13); this renderer no longer emits
+// it anywhere (see renderBlockquote).
 //
 // Round-trip note: `parse.ts` folds inline text (`PlainNode.text`,
 // `CodeNode.text`, `code-block` `text`, link `href`) into DECODED strings —
@@ -111,6 +112,13 @@ function renderInline(node: Inline, ctx: InlineCtx = {}): string {
       // `escapeLinkHref` treatment a link's does (a no-op for the paren-free
       // `tg:` URLs in practice, load-bearing if one ever carries a `)`).
       return `![${escapeMarkdown(collapseLabelBreaks(node.label))}](${escapeLinkHref(node.href)})`;
+    case "raw":
+      // Verbatim wire passthrough — the source bytes ARE the wire syntax
+      // (footnote reference markers `[^1]` / definition lines `[^1]: …`,
+      // which Telegram's rich parser renders natively; escapeMarkdown would
+      // escape their `[`/`]` and break the construct — the exact bug this
+      // node type exists to prevent).
+      return node.text;
     default: {
       // Exhaustiveness guard — the IR union is closed; a new variant must be
       // handled above rather than silently dropped.
@@ -138,17 +146,20 @@ function prefixLines(text: string, prefix: string): string {
 
 function renderBlockquote(node: BlockquoteNode): string {
   const inner = renderBlocks(node.children);
-  // Bot API 10.1 expandable blockquote: `**> ` on the first quoted line.
-  // Plain blockquote: `> ` on every line.
-  if (node.expandable) {
-    const lines = inner.split("\n");
-    return lines
-      .map((line, i) => {
-        const marker = i === 0 ? "**> " : "> ";
-        return line.length > 0 ? `${marker}${line}` : marker.trimEnd();
-      })
-      .join("\n");
-  }
+  // Always a plain `> ` blockquote — including for `expandable: true` nodes.
+  //
+  // This renderer USED to emit `**> ` on the first line of an expandable
+  // quote, believing it to be the Bot API 10.1 expandable-blockquote marker.
+  // That belief was falsified by raw sendRichMessage wire probes (2026-08-13):
+  // `**>` is MarkdownV2 syntax; the rich markdown path renders it as a LITERAL
+  // `**> …` paragraph followed by a detached plain quote. The `expandable`
+  // flag is retained on the IR (parse.ts still repairs legacy `**>` input into
+  // a real blockquote instead of letting the literal `**>` reach the wire),
+  // but it is NOT a distinct wire style — the faithful degradation is a plain
+  // quote, which shows the full content. An author who wants a genuine
+  // collapsible writes `<details><summary>…</summary>…</details>`, which the
+  // rich path renders natively (typed `details` node, wire-verified) and which
+  // passes through this pipeline verbatim.
   return prefixLines(inner, "> ");
 }
 
@@ -323,6 +334,9 @@ export const SUPPORTED_INLINE = [
   // entities in Telegram's Rich Markdown grammar. Emitted verbatim (label and
   // href re-escaped); any OTHER image url stays a `plain` node.
   "tg-entity",
+  // Verbatim passthrough for constructs whose SOURCE bytes are the wire syntax
+  // (footnote markers/definitions). Never escaped, never rewritten.
+  "raw",
 ] as const;
 
 export const SUPPORTED_BLOCK = [

--- a/telegram-plugin/render/unsupported-token-guard.ts
+++ b/telegram-plugin/render/unsupported-token-guard.ts
@@ -3,44 +3,55 @@
 //
 // ── Root cause ───────────────────────────────────────────────────────────
 // Assistant replies are composed by a model that habitually emits constructs
-// from OTHER surfaces (GitHub / Obsidian / LaTeX): caret highlight/superscript
-// `^…^`, footnote markers `[^1]`, and HTML `<details><summary>` collapsibles.
-// None of these are part of Telegram's rich markdown; they degrade to literal
-// carets, stray `[^1]`, and raw `<details>` tags on the reader's screen — the
-// worst kind of consistency failure (a broken glyph in chat). The resident
-// floor card tells the model not to emit them, but prompt discipline is not a
-// guarantee. This guard makes the repair deterministic at send time.
+// from OTHER surfaces (GitHub / Obsidian / LaTeX). Most of them turn out to be
+// natively supported by Telegram's rich markdown path (wire-verified
+// 2026-08-13 by sending raw `sendRichMessage` probes and reading back the
+// echoed `rich_message.blocks`):
+//   • `<details open><summary>S</summary>…</details>` → a real typed
+//     `details` node (native collapsible) — SUPPORTED, must pass through.
+//   • `$x^2+y^2$` → a `mathematical_expression` node — SUPPORTED (and
+//     protected from the sibling guards via `splitProtectedSegments`'s
+//     compact-math-span rule; see code-segments.ts).
+//   • footnotes `claim[^1]` + `[^1]: body` → full superscript/anchor/
+//     reference_link/footer machinery — SUPPORTED, must pass through.
+//   • `<sub>`/`<sup>`/`<u>`, `<aside>…<cite>…</cite></aside>`, `tg://time`
+//     links, `- [ ]` task lists — all SUPPORTED, never touched here.
+// (An earlier revision of this guard "repaired" `<details>` into a `**> `
+// expandable blockquote and deleted footnote reference markers. Both repairs
+// were built on a false belief: `**>` is MarkdownV2 syntax that the rich
+// markdown path renders as LITERAL `**>` paragraph text — the probe proved the
+// conversion turned a SUPPORTED construct into an UNSUPPORTED one. That logic
+// is deleted, not gated.)
+//
+// What genuinely does NOT render and still needs repair: the caret
+// highlight/superscript shorthand `^…^`. Telegram's rich markdown has no caret
+// syntax — the carets render literally on the reader's screen. The resident
+// floor card tells the model to use `<sup>…</sup>` instead, but prompt
+// discipline is not a guarantee; this guard makes the repair deterministic at
+// send time.
 //
 // ── What it repairs (deterministic, pure string transform) ─────────────────
-//   • `<details><summary>Title</summary>body</details>` → a Telegram EXPANDABLE
-//     blockquote (`**> Title` first line + `> …` continuation) — the native
-//     equivalent of a collapsible. `<details>` without a `<summary>` folds the
-//     whole body into an expandable blockquote. Any orphan `<details>` /
-//     `</details>` / `<summary>` tags left over are stripped.
-//   • `^highlight^` / `x^2^` caret pairs → the inner text, carets removed
-//     (Telegram has no highlight/superscript; the carets render literally).
-//   • Footnote reference markers `[^id]` → removed (Telegram has no footnotes).
-//     A footnote DEFINITION line `[^id]: …` is left alone (the `]:` lookahead).
+//   • `^highlight^` / `x^2^` caret pairs → the inner text, carets removed.
 //
 // ── What it deliberately does NOT touch ────────────────────────────────────
-//   • `$…$` math: already neutralised deterministically upstream by
-//     `guardDollarMath` (it backslash-escapes `$` so the pair can never typeset
-//     as math — the reader sees literal `$`). Re-processing `$` here would
-//     double-process and risk corrupting currency prose, so this guard leaves
-//     `$` untouched by design. Math repair is COVERED, just in the sibling guard.
+//   • `$…$` math: a compact math span is PROTECTED upstream (a `code: true`
+//     segment from `splitProtectedSegments`), and accidental currency `$` is
+//     owned by `guardDollarMath` (disjoint char set).
 //   • `~sub~` tilde pairs: the strikethrough/tilde trigger is owned by
 //     `guardAccidentalInlinePairs` (disjoint char set). This guard never
 //     inspects or inserts `~`.
 //   • `__underline__`: renders as BOLD in Telegram — legible, not broken — so it
 //     is left as-is (the floor card asks the model to avoid it, but there is no
 //     glyph-level failure to repair).
+//   • footnote markers `[^id]` / definitions `[^id]: …`: natively supported,
+//     pass through verbatim. (The caret regex below can never touch them: the
+//     `]` / `:` break the alphanumeric-only inner run.)
 //
-// Code spans / fenced blocks / link destinations / table rows are emitted
-// verbatim (shared `splitProtectedSegments`). A strict no-op for any body
-// without one of these tokens, and idempotent (running twice is a no-op the
-// second time — a repaired blockquote contains no `<details>`, a stripped caret
-// pair contains no `^`). Safe to compose once per send alongside the #3252
-// accidental-formatting guards.
+// Code spans / fenced blocks / link destinations / math spans / table rows are
+// emitted verbatim (shared `splitProtectedSegments`). A strict no-op for any
+// body without a caret pair, and idempotent (a stripped caret pair contains no
+// `^`). Safe to compose once per send alongside the #3252 accidental-formatting
+// guards.
 
 import { splitProtectedSegments } from "./code-segments.js";
 
@@ -56,69 +67,23 @@ import { splitProtectedSegments } from "./code-segments.js";
  *  permissive inner run the first two carets of `a^2+b^2=c^2` pair up (`^2+b^`)
  *  and get stripped, mangling the math; requiring the inner run to be pure
  *  alphanumerics means `^2+b^` never matches (the `+` breaks the run), so
- *  `a^2+b^2=c^2`, `2^8`, and `x^n` all pass through untouched. */
+ *  `a^2+b^2=c^2`, `2^8`, and `x^n` all pass through untouched. It also keeps
+ *  the guard off footnote markers `[^1]` (the `]` breaks the run). */
 const CARET_PAIR = /\^([A-Za-z0-9]+)\^/g;
-
-/** Footnote reference marker `[^id]` where the id is a short alphanumeric run
- *  (`[^1]`, `[^note]`, `[^ref]`) NOT immediately followed by `:` (which would
- *  make it a footnote DEFINITION line we leave intact). Removed entirely.
- *  Requiring the id to be 1–10 ALPHANUMERIC chars keeps this off regex-ish
- *  literals like `[^/]`, `[^\s]`, `[^-a-z]`, whose bodies contain punctuation
- *  and so never match. In-prose subscript-ish `array[^i]` outside a code span
- *  is a rare theoretical false positive (an `i` id matches); code spans are
- *  masked upstream by splitProtectedSegments so real code is safe, and prose
- *  that writes a literal `[^i]` reads as footnote noise anyway. */
-const FOOTNOTE_MARKER = /\[\^[A-Za-z0-9]{1,10}\](?!:)/g;
-
-/** `<details>…</details>` with an optional leading `<summary>…</summary>`.
- *  Dot-all via `[\s\S]`; non-greedy so adjacent blocks don't merge. */
-const DETAILS_BLOCK =
-  /<details[^>]*>\s*(?:<summary[^>]*>([\s\S]*?)<\/summary>)?([\s\S]*?)<\/details>/gi;
-
-/** Orphan collapsible tags left after DETAILS_BLOCK (malformed / unpaired). */
-const ORPHAN_TAGS = /<\/?(?:details|summary)[^>]*>/gi;
-
-/** Fold `title` + `body` into a Telegram expandable blockquote: the first
- *  emitted line carries the `**> ` marker (switchroom's expandable-blockquote
- *  encoding — see parse.ts), every subsequent line a plain `> `. */
-function toExpandableBlockquote(title: string, body: string): string {
-  const lines: string[] = [];
-  const t = title.trim();
-  if (t) lines.push(t);
-  for (const raw of body.split("\n")) {
-    const line = raw.trimEnd();
-    // Collapse leading/trailing blank lines but keep interior structure.
-    if (line.trim() === "" && lines.length === 0) continue;
-    lines.push(line);
-  }
-  // Trim trailing blanks.
-  while (lines.length > 0 && lines[lines.length - 1].trim() === "") lines.pop();
-  if (lines.length === 0) return "";
-  return lines
-    .map((line, i) => (i === 0 ? `**> ${line}` : `> ${line}`))
-    .join("\n");
-}
 
 /** Repair unsupported tokens in a single PROSE segment. */
 function repairProse(text: string): string {
-  let out = text;
-  out = out.replace(DETAILS_BLOCK, (_m, summary: string | undefined, body: string) =>
-    toExpandableBlockquote(summary ?? "", body ?? ""),
-  );
-  out = out.replace(ORPHAN_TAGS, "");
-  out = out.replace(CARET_PAIR, (_m, inner: string) => inner);
-  out = out.replace(FOOTNOTE_MARKER, "");
-  return out;
+  return text.replace(CARET_PAIR, (_m, inner: string) => inner);
 }
 
 /**
- * Neutralise Telegram-unrenderable tokens (`<details>`, `^…^`, `[^1]`) on the
- * FINAL rendered rich-markdown string. Code / links / tables are verbatim.
+ * Neutralise Telegram-unrenderable caret pairs (`^…^`) on the FINAL rendered
+ * rich-markdown string. Code / links / math spans / tables are verbatim.
  * Deterministic, idempotent, and a strict no-op absent any target token.
  */
 export function guardUnsupportedTokens(text: string): string {
-  // Cheap pre-check: nothing to do unless a target trigger char is present.
-  if (!/[\^]|<details|<\/details|<summary/i.test(text)) return text;
+  // Cheap pre-check: nothing to do unless a caret is present at all.
+  if (!text.includes("^")) return text;
   return splitProtectedSegments(text)
     .map((seg) => (seg.code ? seg.text : repairProse(seg.text)))
     .join("");

--- a/telegram-plugin/rich-send.ts
+++ b/telegram-plugin/rich-send.ts
@@ -54,16 +54,31 @@ export interface InputRichMessageMarkdown {
  * guards is disjoint in the characters it inspects AND the characters it
  * inserts (`\_ \* \> \. \~ \=\= \|\|` vs `\$`), so no other insertion can
  * create or destroy a signal for a sibling. Verified by composition tests.
+ *
+ * Intentional inline math (`$x^2+y^2$`, a native Telegram construct) is
+ * PROTECTED from every sub-guard: `splitProtectedSegments` treats a compact
+ * non-currency `$…$` span like a code span (see code-segments.ts), so the
+ * dollar guard neither counts nor escapes its `$` and the emphasis/caret
+ * guards never rewrite its interior.
  */
 export function guardAccidentalFormatting(markdown: string): string {
   let out = markdown
-  // Repair Telegram-unrenderable tokens FIRST: `<details>` folds into a `**> `
-  // expandable blockquote whose `> `-with-space lines are invisible to the
-  // block-construct guard (which only escapes space-LESS `>digit`/`>=`), and
-  // `**> ` is the exact marker switchroom's own render path emits — so the
-  // downstream emphasis/block guards treat it identically to a native
-  // expandable quote. Caret/footnote removal inserts no trigger char for any
-  // sibling guard, so this pass neither creates nor destroys their signals.
+  // Repair Telegram-unrenderable tokens FIRST. This pass now strips ONLY caret
+  // pairs (`^x^` → `x`): removing a `^` inserts no trigger char for any
+  // sibling guard, so it neither creates nor destroys their signals.
+  //
+  // What this pass deliberately NO LONGER does (wire-verified 2026-08-13 by
+  // raw `sendRichMessage` probes): it used to fold `<details>` into a `**> `
+  // "expandable blockquote" and delete footnote markers `[^1]`. Both beliefs
+  // were false — `<details><summary>` and footnotes are NATIVE rich-markdown
+  // constructs (typed `details` / footnote nodes on the wire), while `**>` is
+  // MarkdownV2-only syntax the rich path renders as LITERAL `**>` text. The
+  // conversion destroyed a supported construct to emit an unsupported one, so
+  // it is deleted. `<details>`, footnotes, `<sub>`/`<sup>`/`<u>`, `<aside>`,
+  // `tg://` links and task lists all pass through every guard untouched: none
+  // of `< > [ ] : /` is a trigger char for the emphasis / heading /
+  // block-construct / inline-pair / dollar guards ('composition' tests cover
+  // this interaction).
   out = guardUnsupportedTokens(out)
   out = guardAccidentalEmphasis(out)
   out = guardAccidentalHeading(out)

--- a/telegram-plugin/telegraph.ts
+++ b/telegram-plugin/telegraph.ts
@@ -193,10 +193,12 @@ export async function createTelegraphPage(
 }
 
 /**
- * A blockquote line: a plain `> ` marker OR the expandable-blockquote opener
- * `**> ` (Bot API 10.1 syntax the switchroom render path emits on the first
- * line of an expandable quote — see `render/render.ts` and
- * `reference/telegram-formatting-guide.md`). Telegra.ph has no collapsible
+ * A blockquote line: a plain `> ` marker OR the LEGACY expandable-blockquote
+ * opener `**> ` (a switchroom encoding once believed to be Bot API 10.1
+ * syntax; wire probes 2026-08-13 showed the rich path renders `**>` as
+ * literal text, so `render/render.ts` no longer emits it — but legacy agent
+ * output still contains it and it must be tolerated on input here).
+ * Telegra.ph has no collapsible
  * blockquote tag, so an expandable quote degrades to a normal `<blockquote>`;
  * the `**` prefix must still be recognised and stripped here, else the
  * unterminated `**` renders as literal `**>` text and the `>` continuation

--- a/telegram-plugin/tests/render/dollar-math-guard.test.ts
+++ b/telegram-plugin/tests/render/dollar-math-guard.test.ts
@@ -160,3 +160,46 @@ describe("guardDollarMath — link / table awareness (findings 1 & 3)", () => {
     expect(out).not.toMatch(/(?<!\\)\$/);
   });
 });
+
+describe("guardDollarMath — intentional math spans are exempt (wire-verified 2026-08-13)", () => {
+  it("never escapes a compact `$…$` math span", () => {
+    // Telegram renders `$x^2+y^2$` as a native mathematical_expression node;
+    // escaping it destroys a SUPPORTED construct. On the pre-fix guard this
+    // input came back as `inline \$x^2+y^2\$ done`.
+    const s = "inline $x^2+y^2$ done";
+    expect(guardDollarMath(s)).toBe(s);
+  });
+
+  it("math span dollars do not count toward the 2+ arming threshold", () => {
+    // Only ONE prose `$` outside the math span → can never pair → untouched.
+    const s = "solve $x^2+y^2$ for the $BUDGET case";
+    expect(guardDollarMath(s)).toBe(s);
+  });
+
+  it("still escapes currency in the SAME message as an exempt math span", () => {
+    const out = guardDollarMath("sum $x^2+y^2$ costs $5 and $10");
+    expect(out).toContain("$x^2+y^2$");
+    expect(out).toContain("\\$5");
+    expect(out).toContain("\\$10");
+  });
+
+  it("a currency-shaped compact pair (`$5M-$10M`) is NOT treated as math", () => {
+    // The `$5M-$` inner run is digits/magnitude punctuation only — two
+    // adjacent amounts, the exact #3252 accident. Must still be escaped.
+    const out = guardDollarMath("the range is $5M-$10M this year");
+    expect(out).not.toMatch(/(?<!\\)\$/);
+  });
+
+  it("spaced `$…$` spans are NOT exempt (indistinguishable from currency prose)", () => {
+    // Documented residual: `$a + b$` cannot be told apart from two stray
+    // currency signs, so when a currency signal arms the guard it is escaped
+    // (renders as literal text — legible, not broken).
+    const out = guardDollarMath("we know $a + b$ plus $5 fees");
+    expect(out).not.toMatch(/(?<!\\)\$/);
+  });
+
+  it("is idempotent with a math span present", () => {
+    const once = guardDollarMath("sum $x^2+y^2$ costs $5 and $10");
+    expect(guardDollarMath(once)).toBe(once);
+  });
+});

--- a/telegram-plugin/tests/render/guard-composition.test.ts
+++ b/telegram-plugin/tests/render/guard-composition.test.ts
@@ -135,4 +135,106 @@ describe("guardAccidentalFormatting composition (#3252)", () => {
     // And re-wrapping (streaming re-render) is byte-stable.
     expect(richMessage(wire.markdown).markdown).toBe(wire.markdown);
   });
+
+  // ── Wire-verified NATIVE constructs survive the FULL pipeline ────────────
+  // Raw sendRichMessage probes (2026-08-13) proved Telegram's rich markdown
+  // path natively renders `<details>`, `$…$` inline math, and footnotes. The
+  // pre-fix pipeline destroyed all three (details → the unsupported `**>`
+  // marker, `$x^2+y^2$` → `\$x^2+y^2\$`, `[^n1]` deleted) — each assertion
+  // below FAILS on that pipeline.
+  describe("native constructs pass through the full composed guard", () => {
+    it("<details open><summary> block survives byte-identical", () => {
+      const src = "<details open><summary>S</summary>\n\nbody\n\n</details>";
+      expect(guardAccidentalFormatting(src)).toBe(src);
+      expect(richMessage(src).markdown).toBe(src);
+    });
+
+    it("compact $math$ span survives byte-identical", () => {
+      const src = "inline $x^2+y^2$ done";
+      expect(guardAccidentalFormatting(src)).toBe(src);
+    });
+
+    it("footnote reference + definition survive byte-identical", () => {
+      const src = "claim[^n1]\n\n[^n1]: body";
+      expect(guardAccidentalFormatting(src)).toBe(src);
+    });
+
+    it("`**>` is never emitted for any input the pipeline repairs", () => {
+      const out = guardAccidentalFormatting(
+        "<details><summary>T</summary>\nbody\n</details>",
+      );
+      expect(out).not.toContain("**>");
+    });
+  });
+
+  // ── Guard-interaction cases for the now-passing-through constructs ───────
+  // Removing the old token conversions changes what the sibling guards see (a
+  // surviving `$`, a surviving `<`). These prove the emphasis / heading /
+  // block-construct / inline-pair / dollar guards do not mangle the natives,
+  // while their own repairs still fire in the SAME message.
+  describe("native constructs vs sibling guards (interaction)", () => {
+    it("math span is exempt while surrounding currency is still broken apart", () => {
+      const src = "sum $x^2+y^2$ costs $5 and $10 total";
+      const out = guardAccidentalFormatting(src);
+      // The math span reaches the wire byte-identical…
+      expect(out).toContain("$x^2+y^2$");
+      // …while the accidental currency pair is still defused (#3252).
+      expect(out).toContain("\$5");
+      expect(out).toContain("\$10");
+    });
+
+    it("currency-shaped adjacent amounts are NOT mistaken for math", () => {
+      // `$5M-$10M` has a whitespace-free `$…$` pair (`$5M-$`) — the currency
+      // shape must keep it guardable, else #3252 regresses.
+      const out = guardAccidentalFormatting("range is $5M-$10M this year");
+      expect(out).not.toMatch(/(?<!\\)\$/);
+    });
+
+    it("math span interior is protected from the emphasis and caret guards", () => {
+      // `a_b*c` inside math would trip the intra-word `_`/`*` escapes, and
+      // `^2y^` is an alphanumeric caret pair the token guard would strip —
+      // both must stay verbatim inside the protected span. The `_`/`*`
+      // OUTSIDE the span are still guarded — note the protected span's
+      // delimiters do NOT count toward the 2+ pairing threshold, so the
+      // prose needs its own pairable signals (`2*3 and 4*5`).
+      const src = "$a_b*c$ and file_name_here times 2*3 and 4*5";
+      const out = guardAccidentalFormatting(src);
+      expect(out).toContain("$a_b*c$");
+      expect(out).toContain("file\\_name\\_here");
+      expect(out).toContain("2\\*3");
+      expect(out).toContain("4\\*5");
+      expect(guardAccidentalFormatting("inline $x^2y^2$ done")).toBe(
+        "inline $x^2y^2$ done",
+      );
+    });
+
+    it("<details> lines are invisible to the line-start and heading guards", () => {
+      // A details block whose body carries genuine accidental signals: the
+      // guards must fire on the BODY prose without touching the tags.
+      const src =
+        "<details open><summary>Stats</summary>\n\n>2x growth and #1 priority\n\n</details>";
+      const out = guardAccidentalFormatting(src);
+      expect(out).toContain("<details open><summary>Stats</summary>");
+      expect(out).toContain("</details>");
+      // Line-start `>2x` and glued `#1` are still repaired inside the body.
+      expect(out).toContain("\>2x");
+      expect(out).toContain("\#1");
+    });
+
+    it("footnote markers survive alongside a firing dollar guard", () => {
+      const src = "cost[^1] was $5 then $9\n\n[^1]: the note";
+      const out = guardAccidentalFormatting(src);
+      expect(out).toContain("cost[^1]");
+      expect(out).toContain("[^1]: the note");
+      expect(out).toContain("\$5");
+      expect(out).toContain("\$9");
+    });
+
+    it("the whole composition stays idempotent with natives present", () => {
+      const src =
+        "claim[^1] and $x^2+y^2$ in <details><summary>T</summary>\nb\n</details> with $5 and $10\n\n[^1]: n";
+      const once = guardAccidentalFormatting(src);
+      expect(guardAccidentalFormatting(once)).toBe(once);
+    });
+  });
 });

--- a/telegram-plugin/tests/render/parse.test.ts
+++ b/telegram-plugin/tests/render/parse.test.ts
@@ -336,7 +336,7 @@ describe("parse: nested lists", () => {
   });
 });
 
-describe("expandable blockquote (Bot API 10.1 `**>` marker)", () => {
+describe("expandable blockquote (LEGACY switchroom `**>` marker — input repair only)", () => {
   it("parses a single-line `**>` quote into an expandable blockquote", () => {
     const md = "**> a collapsible line";
     const doc = parse(md);
@@ -374,10 +374,10 @@ describe("expandable blockquote (Bot API 10.1 `**>` marker)", () => {
   });
 
   it("only recognises the marker at column 0 (leading indent is not expandable)", () => {
-    // The renderer only ever emits `**>` at column 0; a leading-indented
-    // variant is deliberately NOT treated as an expandable quote (matching it
-    // would push the length-preserving rewrite past the 3-space blockquote
-    // budget into indented-code-block territory).
+    // The legacy encoding only ever placed `**>` at column 0; a
+    // leading-indented variant is deliberately NOT treated as an expandable
+    // quote (matching it would push the length-preserving rewrite past the
+    // 3-space blockquote budget into indented-code-block territory).
     const md = "   **> indented";
     const doc = parse(md);
     const bq = doc.blocks[0] as any;
@@ -389,5 +389,30 @@ describe("expandable blockquote (Bot API 10.1 `**>` marker)", () => {
     // line start.
     const doc = parse("**bold** > not a quote");
     expect(doc.blocks[0].type).toBe("paragraph");
+  });
+});
+
+describe("footnotes fold to verbatim `raw` nodes (native Telegram construct)", () => {
+  it("a footnote reference marker folds to a raw inline carrying its source bytes", () => {
+    // GFM only recognises a reference when a matching definition exists in
+    // the document (a lone `[^n1]` is ordinary text).
+    const doc = parse("claim[^n1] more\n\n[^n1]: body");
+    const para = doc.blocks[0] as Extract<Block, { type: "paragraph" }>;
+    const raw = para.children.find((c: Inline) => c.type === "raw") as
+      | Extract<Inline, { type: "raw" }>
+      | undefined;
+    expect(raw).toBeDefined();
+    expect(raw!.text).toBe("[^n1]");
+  });
+
+  it("a footnote definition folds to a paragraph with one raw inline (verbatim slice)", () => {
+    const doc = parse("[^n1]: body text");
+    const para = doc.blocks[0] as Extract<Block, { type: "paragraph" }>;
+    expect(para.type).toBe("paragraph");
+    expect(para.children).toHaveLength(1);
+    expect(para.children[0].type).toBe("raw");
+    expect((para.children[0] as Extract<Inline, { type: "raw" }>).text).toBe(
+      "[^n1]: body text",
+    );
   });
 });

--- a/telegram-plugin/tests/render/render.test.ts
+++ b/telegram-plugin/tests/render/render.test.ts
@@ -195,7 +195,10 @@ describe("render: block palette", () => {
   it("plain blockquote", () => {
     expect(render(parse("> quoted line"))).toBe("> quoted line");
   });
-  it("expandable blockquote uses **> on the first line", () => {
+  it("expandable IR flag renders as a PLAIN quote — the retired `**>` marker is never emitted", () => {
+    // `**>` is MarkdownV2-only syntax; the rich markdown path renders it as
+    // LITERAL `**>` text (wire-proved 2026-08-13 via raw sendRichMessage
+    // probes), so the renderer degrades an expandable node to a plain quote.
     const doc: Document = {
       blocks: [
         {
@@ -214,9 +217,10 @@ describe("render: block palette", () => {
         },
       ],
     };
-    expect(render(doc)).toBe("**> hidden gem");
+    expect(render(doc)).toBe("> hidden gem");
+    expect(render(doc)).not.toContain("**>");
   });
-  it("multi-line expandable blockquote continues with a plain > marker", () => {
+  it("multi-line expandable blockquote renders every line with a plain > marker", () => {
     const doc: Document = {
       blocks: [
         {
@@ -242,8 +246,9 @@ describe("render: block palette", () => {
       ],
     };
     const out = render(doc);
+    expect(out).not.toContain("**>");
     const lines = out.split("\n");
-    expect(lines[0]).toBe("**> line one");
+    expect(lines[0]).toBe("> line one");
     for (const line of lines.slice(1)) {
       expect(line.startsWith("> ") || line === ">").toBe(true);
     }

--- a/telegram-plugin/tests/render/rich-render.test.ts
+++ b/telegram-plugin/tests/render/rich-render.test.ts
@@ -5,6 +5,7 @@ import {
   renderOutbound,
   maybeRenderOutbound,
 } from "../../render/rich-render.js";
+import { guardAccidentalFormatting } from "../../rich-send.js";
 
 describe("parseRichRenderEnabled", () => {
   it("defaults ON when unset (escape hatch, not opt-in)", () => {
@@ -52,8 +53,10 @@ describe("maybeRenderOutbound", () => {
   it("default (env unset) routes through parse -> renderSafe", () => {
     const r = maybeRenderOutbound("**> collapsible", {} as NodeJS.ProcessEnv);
     expect(r.mode).toBe("markdown");
-    // The expandable blockquote round-trips back to the `**> ` marker.
-    expect(r.text).toContain("**> ");
+    // The legacy expandable marker is REPAIRED to a plain quote: `**>` is
+    // MarkdownV2-only syntax the rich path renders as literal text
+    // (wire-proved 2026-08-13), so the renderer must never re-emit it.
+    expect(r.text).toBe("> collapsible");
   });
 
   it("default preserves plain prose through the round-trip", () => {
@@ -84,15 +87,53 @@ describe("maybeRenderOutbound", () => {
       SWITCHROOM_RICH_RENDER: "maybe",
     } as NodeJS.ProcessEnv);
     expect(r.mode).toBe("markdown");
-    expect(r.text).toContain("**> ");
+    expect(r.text).toBe("> collapsible");
   });
 });
 
 describe("renderOutbound (flag-independent)", () => {
-  it("renders an expandable blockquote round-trip end to end", () => {
+  it("repairs a legacy `**>` quote to a plain quote end to end", () => {
     const r = renderOutbound("**> hidden line one\n> hidden line two");
     expect(r.mode).toBe("markdown");
-    expect(r.text.split("\n")[0]).toMatch(/^\*\*> /);
+    // One coherent quote, no retired marker: on the pre-fix renderer the
+    // first line came back as `**> hidden line one`, which Telegram rendered
+    // as LITERAL `**>` paragraph text (wire-proved 2026-08-13).
+    expect(r.text).not.toContain("**>");
+    expect(r.text.split("\n")[0]).toBe("> hidden line one");
+    expect(r.text).toContain("> hidden line two");
+  });
+
+  it("passes native constructs through: <details>, $math$, footnotes", () => {
+    // Wire-verified natives (2026-08-13) must survive parse -> renderSafe
+    // BYTE-IDENTICAL. On the pre-fix pipeline the footnote case failed:
+    // escapeMarkdown turned `[^n1]` into `\[^n1\]`, breaking the construct.
+    const details =
+      "<details open><summary>S</summary>\n\nbody\n\n</details>";
+    expect(renderOutbound(details).text).toBe(details);
+
+    const math = "inline $x^2+y^2$ done";
+    expect(renderOutbound(math).text).toBe(math);
+
+    const footnotes = "claim[^n1] more\n\n[^n1]: body text";
+    expect(renderOutbound(footnotes).text).toBe(footnotes);
+  });
+
+  it("a tg:// inline entity and a footnote survive TOGETHER in one message", () => {
+    // Cross-feature composition (#4683 x #4685): the `tg-entity` fold (mdast
+    // image position) and the footnote `raw` fold (footnoteReference /
+    // footnoteDefinition) land in the SAME foldInline/foldBlock walk — this
+    // pins that neither eats the other. On #4683 alone the footnote came back
+    // as `claim\[^n1\]`; on #4685 alone (pre-rebase) the entity came back as
+    // `!\[now\](tg://time?unix\=…)` literal text.
+    const combined =
+      "meet at ![now](tg://time?unix=1755000000&format=wDT) as promised[^n1]\n\n[^n1]: agreed yesterday";
+    expect(renderOutbound(combined).text).toBe(combined);
+
+    // Same pair inside ONE paragraph plus the guard seam on top: the composed
+    // wire body (renderOutbound then the richMessage guard, i.e. the full
+    // streamed send path) is still byte-identical.
+    const guarded = guardAccidentalFormatting(renderOutbound(combined).text);
+    expect(guarded).toBe(combined);
   });
 
   it("falls back to plain mode for oversized atomic content", () => {

--- a/telegram-plugin/tests/render/unsupported-token-guard.test.ts
+++ b/telegram-plugin/tests/render/unsupported-token-guard.test.ts
@@ -3,43 +3,60 @@ import { guardUnsupportedTokens } from "../../render/unsupported-token-guard.js"
 import { richMessage } from "../../rich-send.js";
 
 describe("guardUnsupportedTokens — deterministic send-time repair", () => {
-  it("folds <details><summary> into a Telegram expandable blockquote", () => {
+  // ── Natively-supported constructs pass through BYTE-IDENTICAL ────────────
+  // Wire-verified 2026-08-13: raw sendRichMessage probes showed `<details>`,
+  // footnotes, `<sub>`/`<sup>`/`<u>`, `<aside>`, `tg://time` and task lists
+  // all parse into real typed nodes on Telegram's rich markdown path. An
+  // earlier revision of this guard "repaired" `<details>` into a `**> `
+  // expandable blockquote (MarkdownV2-only syntax that renders as LITERAL
+  // `**>` text on this path) and deleted footnote markers — both conversions
+  // destroyed supported constructs and are deleted. These tests would FAIL on
+  // the old guard.
+  it("passes a <details><summary> block through untouched (native construct)", () => {
     const input =
-      "Here is the trace:\n<details><summary>Stack trace</summary>\nline 1\nline 2\n</details>\ndone";
-    const out = guardUnsupportedTokens(input);
-    // Anti-tautology: the raw HTML tags MUST be gone from the wire body.
-    expect(out).not.toContain("<details>");
-    expect(out).not.toContain("</details>");
-    expect(out).not.toContain("<summary>");
-    // Summary becomes the expandable-blockquote first line (`**> ` marker).
-    expect(out).toContain("**> Stack trace");
-    // Body lines become plain `> ` continuation lines.
-    expect(out).toContain("> line 1");
-    expect(out).toContain("> line 2");
+      "Here is the trace:\n<details open><summary>Stack trace</summary>\n\nline 1\nline 2\n\n</details>\ndone";
+    expect(guardUnsupportedTokens(input)).toBe(input);
   });
 
-  it("folds a <details> without a <summary> into an expandable blockquote", () => {
-    const out = guardUnsupportedTokens("<details>hidden body text</details>");
-    expect(out).not.toContain("<details");
-    expect(out).toContain("**> hidden body text");
+  it("passes a <details> without a <summary> through untouched", () => {
+    const input = "<details>hidden body text</details>";
+    expect(guardUnsupportedTokens(input)).toBe(input);
   });
 
+  it("never converts <details> into the retired `**>` marker", () => {
+    const out = guardUnsupportedTokens(
+      "<details><summary>More</summary>\nbody\n</details>",
+    );
+    expect(out).not.toContain("**>");
+    expect(out).toContain("<details>");
+  });
+
+  it("keeps footnote reference markers AND definition lines (native construct)", () => {
+    expect(guardUnsupportedTokens("see the note[^1] here")).toBe(
+      "see the note[^1] here",
+    );
+    expect(guardUnsupportedTokens("[^1]: the definition")).toBe(
+      "[^1]: the definition",
+    );
+    // Alphanumeric ids too — the pair renders as real footnote machinery.
+    expect(guardUnsupportedTokens("claim[^note] holds\n\n[^note]: body")).toBe(
+      "claim[^note] holds\n\n[^note]: body",
+    );
+  });
+
+  it("passes <sub>/<sup>/<u>/<aside> HTML tags through untouched", () => {
+    const input =
+      "H<sub>2</sub>O and x<sup>2</sup> and <u>under</u>\n<aside>pull\n<cite>credit</cite></aside>";
+    expect(guardUnsupportedTokens(input)).toBe(input);
+  });
+
+  // ── The one genuinely-unsupported token: caret pairs ─────────────────────
   it("strips caret highlight / superscript pairs to their inner text", () => {
     expect(guardUnsupportedTokens("energy is x^2^ joules")).toBe(
       "energy is x2 joules",
     );
     expect(guardUnsupportedTokens("a ^highlighted^ word")).toBe(
       "a highlighted word",
-    );
-  });
-
-  it("removes footnote reference markers but keeps definition lines", () => {
-    expect(guardUnsupportedTokens("see the note[^1] here")).toBe(
-      "see the note here",
-    );
-    // A `[^1]:` definition line is left intact (the negative lookahead).
-    expect(guardUnsupportedTokens("[^1]: the definition")).toBe(
-      "[^1]: the definition",
     );
   });
 
@@ -71,27 +88,18 @@ describe("guardUnsupportedTokens — deterministic send-time repair", () => {
     expect(guardUnsupportedTokens("x^2^ metres")).toBe("x2 metres");
   });
 
-  it("repairs alphanumeric footnote markers, not just numeric", () => {
-    // POLISH-4: widened from digits-only so `[^note]`/`[^ref]` no longer ship
-    // as literal bracket noise. Each would survive UNTOUCHED on origin/main.
-    expect(guardUnsupportedTokens("see the note[^note] here")).toBe(
-      "see the note here",
-    );
-    expect(guardUnsupportedTokens("as shown[^ref] above")).toBe(
-      "as shown above",
-    );
-    expect(guardUnsupportedTokens("point[^fn1] made")).toBe("point made");
-    // A single-letter id is a footnote too.
-    expect(guardUnsupportedTokens("claim[^a] holds")).toBe("claim holds");
-    // Definition lines with an alphanumeric id are still left intact (`(?!:)`).
-    expect(guardUnsupportedTokens("[^note]: the definition")).toBe(
-      "[^note]: the definition",
-    );
+  it("never strips carets inside a $…$ math span (protected segment)", () => {
+    // `$x^2y^2$` contains an alphanumeric-only caret pair (`^2y^`) that the
+    // caret regex WOULD strip in bare prose — but the compact math span is a
+    // protected segment (code-segments.ts), so the wire bytes survive intact
+    // for Telegram to typeset as a mathematical_expression node.
+    const math = "inline $x^2y^2$ done";
+    expect(guardUnsupportedTokens(math)).toBe(math);
   });
 
   it("leaves regex-literal negated char classes intact", () => {
-    // Real negated char classes contain punctuation / ranges / escapes, so the
-    // alphanumeric-only id requirement excludes them — these stay verbatim.
+    // The guard no longer touches `[^…]` at all (footnotes are supported),
+    // so every negated-char-class shape survives verbatim.
     expect(guardUnsupportedTokens("use [^/] to match")).toBe(
       "use [^/] to match",
     );
@@ -99,20 +107,11 @@ describe("guardUnsupportedTokens — deterministic send-time repair", () => {
       "strip [^a-z] chars",
     );
     expect(guardUnsupportedTokens('match [^"] here')).toBe('match [^"] here');
-    // Accepted tradeoff (task POLISH-4): a PURE-alphanumeric negated class in
-    // BARE prose like `array[^index]` is now treated as a footnote and stripped.
-    // This is rare — regex/index literals in real prose live in code spans,
-    // which splitProtectedSegments masks (see code-span test below).
-    expect(guardUnsupportedTokens("array[^index] lookup")).toBe("array lookup");
-    // …but inside a code span the same literal is untouched.
+    expect(guardUnsupportedTokens("array[^index] lookup")).toBe(
+      "array[^index] lookup",
+    );
     expect(guardUnsupportedTokens("`array[^index]` lookup")).toBe(
       "`array[^index]` lookup",
-    );
-  });
-
-  it("repairs a real numeric footnote marker", () => {
-    expect(guardUnsupportedTokens("see the note[^1] here")).toBe(
-      "see the note here",
     );
   });
 
@@ -139,18 +138,19 @@ describe("guardUnsupportedTokens — deterministic send-time repair", () => {
     expect(guardUnsupportedTokens(once)).toBe(once);
   });
 
-  it("OUTCOME: the composed richMessage wire body has unsupported tokens repaired", () => {
-    // End-to-end through the real send-path composition. This is the
-    // anti-tautology anchor: without guardUnsupportedTokens wired into
-    // guardAccidentalFormatting, the raw `<details>` / `^` / `[^1]` tokens would
-    // reach the wire and this assertion would FAIL.
+  it("OUTCOME: the composed richMessage wire body preserves supported constructs and repairs carets", () => {
+    // End-to-end through the real send-path composition (the FULL
+    // guardAccidentalFormatting pipeline). This is the anti-tautology anchor:
+    // on the pre-fix pipeline, `<details>` was folded into the unsupported
+    // `**>` marker and `[^1]` was deleted — every assertion below would FAIL.
     const { markdown } = richMessage(
-      "note[^1]\n<details><summary>More</summary>\ndetail line\n</details>\nx^2^",
+      "note[^1]\n<details><summary>More</summary>\ndetail line\n</details>\nx^2^\n\n[^1]: the note",
     );
-    expect(markdown).not.toContain("<details>");
-    expect(markdown).not.toContain("[^1]");
-    expect(markdown).toContain("**> More");
-    expect(markdown).toContain("> detail line");
-    expect(markdown).toContain("x2");
+    expect(markdown).toContain("<details><summary>More</summary>");
+    expect(markdown).toContain("</details>");
+    expect(markdown).toContain("note[^1]");
+    expect(markdown).toContain("[^1]: the note");
+    expect(markdown).not.toContain("**>");
+    expect(markdown).toContain("x2"); // caret pair repaired
   });
 });

--- a/telegram-plugin/tests/telegraph.test.ts
+++ b/telegram-plugin/tests/telegraph.test.ts
@@ -165,7 +165,7 @@ describe('markdownToTelegraphNodes — block elements', () => {
   })
 
   it('folds an expandable `**>` quote into one blockquote, marker stripped', () => {
-    // The Bot API 10.1 expandable-blockquote syntax: `**>` opener on the first
+    // The LEGACY switchroom expandable-quote encoding: `**>` opener on the first
     // line, `>` continuation lines. Telegra.ph has no collapsible-blockquote
     // tag, so it degrades to a normal blockquote — but the `**>` marker MUST be
     // recognised. Before the fix the `**>` line became a paragraph with literal

--- a/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
@@ -271,13 +271,16 @@ function kindsPresent(msg: ObservedMessage): Set<string> {
 );
 
 // ---------------------------------------------------------------------------
-// Rich-render wiring proof — expandable / collapsible content round-trip.
+// Rich-render wiring proof — legacy `**> ` quote repair round-trip.
 //
 // This is the piece the unit suite CANNOT prove: that a REAL markdown reply
-// carrying the Bot API 10.1 expandable-blockquote marker (`**> `) flows
+// carrying the LEGACY switchroom expandable-quote marker (`**> `) flows
 // through the live send path — parse.ts (marker -> IR `expandable: true`) ->
-// render.ts (IR -> `**> ` markdown) -> renderSafe -> sendRichMessage — and
-// that Telegram actually parses it back to a blockquote entity on the wire.
+// render.ts (IR -> plain `> ` markdown; `**>` is MarkdownV2-only and renders
+// as literal text on the rich path, wire-proved 2026-08-13, so the renderer
+// no longer emits it) -> renderSafe -> sendRichMessage — and that Telegram
+// parses the repaired output back to a blockquote entity with NO literal
+// `**>` glyphs reaching the reader.
 //
 // Runs ONLY when the rich-render flag is on in this process (see
 // RICH_RENDER_ON) AND the driver creds are present; self-skips green
@@ -299,7 +302,7 @@ const EXPANDABLE_SAMPLE = [
   "uat: expandable/collapsible content round-trips through the live renderer",
   () => {
     it(
-      "a `**>` reply parses -> renders -> sends -> decodes as a blockquote entity",
+      "a legacy `**>` reply is repaired to a plain quote and decodes as a blockquote entity",
       async () => {
         const sc = await spinUp({ agent: AGENT });
         try {
@@ -318,9 +321,9 @@ const EXPANDABLE_SAMPLE = [
           ).not.toBe("\x01");
           expect(reply.text).toContain(EXP_MARKER);
 
-          // The collapsible construct must survive as a real blockquote entity
-          // on the wire — proof the parse->render->send path produced valid
-          // Bot API 10.1 markdown, not stray `**>` literal text.
+          // The legacy quote must survive as a real blockquote entity on the
+          // wire — proof the parse->render->send path repaired the `**>` line
+          // into the quote instead of shipping stray literal text.
           const present = kindsPresent(reply);
           expect(
             [...present],
@@ -330,6 +333,12 @@ const EXPANDABLE_SAMPLE = [
 
           // The quoted body text must round-trip (content never lost).
           expect(reply.text).toContain("first hidden line");
+
+          // And the retired marker must never reach the reader as literal
+          // glyphs — the exact failure mode of the pre-repair renderer
+          // (Telegram rendered the `**> ` opener as a literal `**>` paragraph
+          // while the `> ` continuation lines formed a detached quote).
+          expect(reply.text).not.toContain("**>");
 
           console.info(
             "[uat] expandable round-trip entity structure: " +

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -4090,11 +4090,19 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(startSh).toContain("chunked safely at 32768 chars");
     expect(startSh).toContain("Every reply renders as rich Markdown");
     // The thickened card promotes the flagship rich constructs resident so the
-    // model reaches for them without loading anything: expandable blockquotes,
-    // fenced-code language hints, and the "renders wrong — never emit" anti-list.
-    expect(startSh).toContain("expandable blockquote");
+    // model reaches for them without loading anything: the collapsible
+    // `<details>` block (which replaced the falsified `**>` "expandable
+    // blockquote" — wire probes 2026-08-13 showed `**>` renders as literal
+    // text on the rich path), fenced-code language hints, and the "renders
+    // wrong — never emit" anti-list.
+    expect(startSh).toContain("collapsible \`<details>\` block");
+    expect(startSh).not.toContain("expandable blockquote");
     expect(startSh).toContain("fenced code blocks ALWAYS with a language");
-    expect(startSh).toContain("never emit: underline");
+    expect(startSh).toContain("never emit: \`__x__\`");
+    // Wire-verified natives are taught as SUPPORTED, not forbidden.
+    expect(startSh).toContain("inline math \`$x^2+y^2$\`");
+    expect(startSh).toContain("footnotes (\`claim[^1]\`");
+    expect(startSh).toContain("task-list checkboxes");
     // Full Bot API 10.1 surface folded resident (the on-demand skill is gone,
     // so the card must carry EVERY construct with its when-to-use guidance):
     // italic, strikethrough, spoiler, ordered/nested lists, divider.
@@ -4109,7 +4117,7 @@ describe("scaffoldAgent with global defaults cascade", () => {
     // unambiguous that only the CARET ^...^ form is repaired away, so no agent
     // misreads "^highlight^ is repaired" as "highlighting never works".
     expect(startSh).toContain("`==highlight==` to marker-pen the one");
-    expect(startSh).toContain("the CARET `^highlight^` form");
+    expect(startSh).toContain("the unsupported caret `^highlight^` form");
     expect(startSh).toContain("`==highlight==` renders fine");
     // The on-demand telegram-formatting skill was deleted (its guidance is now
     // resident + deterministically repaired at send time). The card must carry


### PR DESCRIPTION
## Wire evidence (the justification)

Raw `sendRichMessage` probes were sent directly to the live Telegram Bot API on 2026-08-13, bypassing the switchroom pipeline, and the echoed `rich_message.blocks` were read back:

**SUPPORTED by the rich markdown path** (parsed into real typed nodes):
- `<details open><summary>S</summary>…</details>` → `{"type":"details","summary":"S","blocks":[…],"is_open":true}`
- `$x^2+y^2$` → `{"type":"mathematical_expression","expression":"x^2+y^2"}`
- footnotes `claim[^n1]` + `[^n1]: body` → full `superscript` + `anchor` + `reference_link` + `footer` machinery
- `<sub>` / `<sup>` / `<u>` → `subscript` / `superscript` / `underline`
- `<aside>…<cite>x</cite></aside>` → `{"type":"pullquote","text":…,"credit":"x"}`
- `tg://time` → `{"type":"date_time",…}`
- `- [ ]` / `- [x]` → list items with `has_checkbox` / `is_checked`

**NOT supported:** the `**>` "expandable blockquote". The probe came back as a LITERAL paragraph `{"type":"paragraph","text":"**> PROBE A2 first"}` followed by a plain non-expandable `blockquote` for the subsequent `>` lines. `**>` is MarkdownV2 syntax, not rich markdown — the docs' "flagship, live-verified" claim was false (the old UAT only asserted a `blockquote` entity, which the plain `>` continuation lines produced on their own).

Running the identical strings through our own send path confirmed the damage: `guardAccidentalFormatting` folded `<details>` into `**>` (converting a SUPPORTED construct into an UNSUPPORTED one), escaped `$math$` to `\$…\$`, and deleted footnote reference markers. Additionally (found during this fix), the parse→render reply path broke footnotes on its own: `escapeMarkdown` emitted `claim\[^n1\]`.

## Changes

- **`render/unsupported-token-guard.ts`** — the `<details>`→`**>` fold, orphan-tag strip, and footnote-marker deletion are DELETED (not flag-gated). Only the genuinely-unsupported caret `^x^` shorthand is still repaired.
- **`render/code-segments.ts`** — compact non-currency `$…$` math spans are protected segments, so no guard touches their interior (`$`, `^`, `_`, `*`), while accidental `$5M and $10M` currency pairs remain fully defused (#3252). Currency-shaped inners (`$5M-$10M`) are deliberately NOT protected.
- **`render/render.ts`** — `renderBlockquote` never emits `**>`. The IR `expandable: true` flag now renders as a **plain `>` blockquote** (design call, see below). `parse.ts` keeps recognising legacy `**> ` input and repairs it into a real quote (agents' Hindsight memories still emit it).
- **`render/parse.ts` / `render/ir.ts`** — new verbatim `raw` inline node; `footnoteReference` / `footnoteDefinition` fold to it so footnotes survive the parse→render path byte-identical.
- **`rich-send.ts`** — the falsified justification comment is rewritten to state the wire truth.
- **Docs, same PR:** floor card in `src/agents/scaffold.ts` (fleet-wide via `--append-system-prompt`) + `reference/telegram-formatting-guide.md` (verbatim-synced, verified programmatically), `reference/rfcs/telegram-native-formatting.md` (dated corrections at the spec-table row, IR-mapping row, chunking rule, and the false live-verification claim), stale 4096-cap claims in `telegram-plugin/README.md`, `skills/switchroom-cli/SKILL.md`, `skills/switchroom-architecture/telegram.md` (real rich cap: `RICH_MESSAGE_MAX_CHARS = 32768` in `format.ts`; 4096 is the plain-degrade cap). `<aside>`, `tg://time`, and task lists are now documented in the guide's depth reference.

## Design call: `expandable: true` renders as a plain `>` quote, not `<details>`

Argued, not silent: the legacy `**>` encoding carries **no summary**, so any `<details>` mapping must invent one by splitting rendered markdown mid-block — reintroducing the mid-construct-cut hazard `renderSafe` exists to prevent. A plain quote keeps the author's QUOTE semantics, shows full content (no information loss), and matches how `telegraph.ts` already degrades the marker. Authors who want a real collapsible now write `<details><summary>…</summary>…</details>` directly (the floor card teaches exactly that), and it passes through the entire pipeline byte-identical.

Before/after for legacy input `**> line one\n> line two`:
- before (wire): literal `**> line one` paragraph + detached quote of `line two`
- after (wire): one plain blockquote `> line one\n> line two`

## Tests (assert the rendered tree / final wire string)

- Natives survive the FULL `guardAccidentalFormatting` pipeline byte-identical (`<details open>…`, `inline $x^2+y^2$ done`, `claim[^n1]…[^n1]: body`) — each FAILS on the pre-fix pipeline.
- `**>` never emitted: renderer unit tests, `renderOutbound` end-to-end, guard pipeline, and the live UAT scenario now asserts `not.toContain("**>")` on the decoded reply.
- Guard-interaction coverage: math exempt while same-message currency is escaped; currency-shaped `$5M-$10M` NOT mistaken for math; math interior protected from emphasis/caret guards while prose signals still fire; `<details>` body prose still guarded (`\>2x`, `\#1`) with tags untouched; footnotes alongside a firing dollar guard; composition idempotency with natives present.
- Footnote `raw`-node folding asserted at the parse layer; parse→render byte-identity asserted at the rich-render layer.

## Test results

- `vitest run telegram-plugin/tests` — **551 files, 9141 passed, 3 skipped, 0 failed**
- `vitest run tests/ src/` — 134 failures, ALL pre-existing sandbox/environment failures: the identical 21-file set fails **identically (133 tests) on pristine `origin/main`** in the same environment (symlink/docker/git-hook dependent tests). Zero failures attributable to this branch.
- `npm run lint` — exit 0 (includes `check-plugin-references` strict tsc over the plugin source and the changelog-entry gate).

## Known residuals / deliberately left undone

- **Spaced math spans** (`$a + b$`) are indistinguishable from currency prose and are still escaped when a currency signal arms the dollar guard (renders as legible literal text). Documented in `dollar-math-guard.ts` and covered by a test.
- **Digit-only math** (`$2+2$`) is currency-shaped by definition and stays guardable — same legible-literal outcome.
- `<details>` blocks in a >32k-char message can still be bisected by the length chunker (`splitMarkdownChunks` protects fences/table rows only) — pre-existing limitation class, out of scope.
- The floor card teaches `<details>` (collapsed default) but only the `<details open>` variant was wire-probed; a probe of the bare `<details>` form would settle the default state empirically.
- The caret/tilde shorthand (`^sup^`/`~sub~`) and `__x__` warnings are left standing per instruction — those forms were not wire-probed.
- CHANGELOG historical entries mentioning `**>` are left as historical record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)