### PR TITLE
chore: release v0.21.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.21.9 — Telegram rich-markdown guards stop destroying supported constructs, and `tg://` inline entities render
+
 ### Fixed
 
 - **Telegram `tg://` inline entities survive the render pipeline** — the Bot API
@@ -70,6 +72,11 @@ now an anomaly worth investigating, not the norm.
   card surface are untouched. 1.45.0 does add `duplex: "half"` to every API
   request; a live round-trip against `api.telegram.org` on the fleet's pinned
   Bun 1.3.13 confirms the transport still works.
+
+## v0.21.8 — UTC means UTC inside an agent container again, /tmp stops filling until the container falls over, and the stale-cooccurrence sweep finishes on a large bank
+
+### Dependencies
+
 - **Claude Code CLI pinned 2.1.228 → 2.1.229** — all three lockstep locations
   move together (`docker/Dockerfile.base`, `docker/Dockerfile.hindsight`,
   `dependencies.json`), per `docs/operators/claude-cli-updates.md`. Three


### PR DESCRIPTION
CHANGELOG-only release commit for **v0.21.9**. `package.json` is untouched (stale placeholder by design — the tag is the version source of truth).

## v0.21.9 section

Renames the `## Unreleased` staging area to `## v0.21.9 — Telegram rich-markdown guards stop destroying supported constructs, and \`tg://\` inline entities render`, carrying all three staged entries:

- `### Fixed` — `tg://` inline entities survive the render pipeline (#4683)
- `### Fixed` — rich-markdown guards no longer destroy natively-supported constructs; `**>` emission retired (#4685)
- `### Dependencies` — grammy 1.44.0 → 1.45.1 / `@grammyjs/types` 3.28.0 → 4.0.0 (#4684)

## Also: retro-labels the stranded v0.21.8 content

**v0.21.8 shipped without its Step 1 consolidation.** Tag `v0.21.8` = `d778afb6`, GitHub release published, `npm view switchroom version` = `0.21.8` — but `CHANGELOG.md` on `main` has **no `## v0.21.8` section**. Every entry from `v0.21.7..v0.21.8` (the CLI 2.1.229 bump, `### Features`, and ~35 `### Bug fixes`) was still sitting under `## Unreleased`.

`git diff v0.21.8..origin/main -- CHANGELOG.md` proves exactly three entries were added after the v0.21.8 tag — the three listed above. Renaming `## Unreleased` wholesale would have misattributed v0.21.8's entire release note to v0.21.9. So this PR inserts a `## v0.21.8 — …` header above the stranded entries, with the title copied **verbatim** from the already-published GitHub release.

Net diff: 7 added lines, two headers.

## Lint

`npm run lint`: every check passes except the leading `tsc --noEmit` / `check-plugin-references` pair, which fails in this worktree only because it borrows the shared checkout's stale `telegram-plugin/node_modules` (`@mtcute/node` type mismatch on `telegram-plugin/uat/*.ts`). Unrelated to a CHANGELOG-only diff; CI is the authority. `scripts/check-changelog-entry.mjs` and `check-agent-attribution-trailers.mjs` both pass.

[skip changelog]

Switchroom-Agent: overlord
Switchroom-Model: opus