### PR TITLE
fix(voice): TTS unit-suffix regex hotfix — decimal lookbehind + M case-sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,28 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
-- **voice: unit-suffix regex lookbehind + case-sensitivity hotfix**
+- **voice: unit-suffix regex lookbehind + case-sensitivity hotfix** — the
+  number+unit-suffix regex shared by both TTS normalization passes
+  (`telegram-plugin/voice-normalize-text.ts`, `telegram-plugin/tts-normalize.ts`)
+  had three live defects on every outbound voice message. (1) No lookbehind
+  on the digit group: `\b` re-anchored between a decimal point/thousands
+  comma and the following digits, so `0.17s` → `"0.seventeen seconds"` and
+  `1,500s` → `"1,five hundred seconds"`, splitting the number apart. (2) The
+  whole unit alternation ran case-insensitively, so a bare capital letter —
+  money shorthand (`5M`), a memory size (`4G`/`12G`/`97G`), a product name
+  (`4080S`) — matched a single-letter unit it was never meant to and got
+  read as a wrong duration/distance/mass. Fixed by adding a
+  `(?<![\d.,])` lookbehind and splitting the unit alternation so
+  multi-letter units (`ms`, `GB`, …) stay case-insensitive while
+  single-letter units (`s`, `m`, `h`, `d`, `g`) are matched
+  case-sensitively, lowercase-only, in a second pass. **Known, deliberate
+  trade-off (disclosed, not fixed here):** a decimal- or comma-glued
+  number+unit token (`27.5s`, `89.5g`, `1,500s`) is now left completely
+  unexpanded — the unit goes unspoken — rather than mangled; corpus-measured,
+  samples carrying an unspoken digit-adjacent unit go 65 → 121 (60 samples
+  change, every one trading a wrong reading for a silently-skipped one).
+  Correctly expanding a decimal/comma-glued number is out of scope for this
+  narrow hotfix and is left for a follow-up.
 
 ## v0.21.9 — Telegram rich-markdown guards stop destroying supported constructs, and `tg://` inline entities render
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ now an anomaly worth investigating, not the norm.
   trade-off (disclosed, not fixed here):** a decimal- or comma-glued
   number+unit token (`27.5s`, `89.5g`, `1,500s`) is now left completely
   unexpanded — the unit goes unspoken — rather than mangled; corpus-measured,
-  samples carrying an unspoken digit-adjacent unit go 65 → 121 (60 samples
+  samples carrying an unspoken digit-adjacent unit go 65 → 122 (61 samples
   change, every one trading a wrong reading for a silently-skipped one).
   Correctly expanding a decimal/comma-glued number is out of scope for this
   narrow hotfix and is left for a follow-up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **voice: unit-suffix regex lookbehind + case-sensitivity hotfix**
+
 ## v0.21.9 — Telegram rich-markdown guards stop destroying supported constructs, and `tg://` inline entities render
 
 ### Fixed

--- a/telegram-plugin/tests/tts-normalize.test.ts
+++ b/telegram-plugin/tests/tts-normalize.test.ts
@@ -185,17 +185,50 @@ describe('numbers', () => {
     )
   })
 
-  // Regression: unit-suffix lookbehind + case sensitivity (prod corpus,
-  // ~250/1679 samples). A decimal seconds value like "0.17s" was matched by
-  // \b re-anchoring between the "." and the following digits, so "17s" alone
-  // got read as "seventeen seconds" and split the decimal apart; and the /i
-  // flag let a bare capital "M" (money shorthand, "$5M") match the "m"
-  // (metre/minute) unit alternative.
+  // Regression: unit-suffix lookbehind + case sensitivity. Corpus in
+  // /tmp/claude-0/tts/corpus.json (1,679 samples of ALREADY-NORMALIZED
+  // production output, not raw input): 146 samples already carry the
+  // shipped mangle artifact this fix removes, 52 carry an unfixed decimal/
+  // comma+unit token (see the "known gap" test below), and 60 samples
+  // change under this fix. A decimal seconds value like "0.17s" was matched
+  // by \b re-anchoring between the "." and the following digits, so "17s"
+  // alone got read as "seventeen seconds" and split the decimal apart; and
+  // the /i flag let a bare capital letter (money shorthand "5M", a memory
+  // size "4G", a product name "4080S") match a single-letter unit
+  // alternative it was never meant to.
   test('decimal seconds survive intact — no mid-decimal unit match', () => {
     expect(normalizeForTts('latency was 0.17s')).toBe('latency was 0.17s')
     expect(normalizeForTts('took 1.5s to load')).toBe('took 1.5s to load')
     expect(normalizeForTts('waited 2.25s')).toBe('waited 2.25s')
     expect(normalizeForTts('under 0.9s')).toBe('under 0.9s')
+  })
+
+  // KNOWN GAP (disclosed, not fixed in this hotfix — see the comment above
+  // the unit-suffix regex in tts-normalize.ts): a decimal- or comma-glued
+  // number+unit token is now left completely unexpanded (unit unspoken)
+  // rather than mangled. This is a real, measured trade-off — corpus
+  // samples carrying an unspoken digit-adjacent unit go 65 → 121 (60
+  // samples change, every one gaining an unspoken unit) — pinned here as
+  // the baseline a future decimal-expansion pass should move.
+  test('KNOWN GAP: decimal/comma-glued number+unit is left unexpanded, not mangled', () => {
+    expect(normalizeForTts('free: 13.0 GB')).toBe('free: 13.0 GB')
+    expect(normalizeForTts('weighs 89.5g')).toBe('weighs 89.5g')
+    expect(normalizeForTts('ran for 27.5 s')).toBe('ran for 27.5 s')
+    expect(normalizeForTts('paused 9.5 min')).toBe('paused 9.5 min')
+    expect(normalizeForTts('spread over 0.7-0.8 m')).toBe('spread over 0.7-0.8 m')
+  })
+
+  // MINOR: comma leak — same defect class as the decimal lookbehind, closed
+  // in the same lookbehind by also excluding `,`. Before this: "1,500s" →
+  // "1,five hundred seconds", "12,000s" → "12,zero seconds", "1,024MB" →
+  // "1,twenty-four megabytes". The lookbehind is adjacency-only so an
+  // ordinary sentence comma ("wait, 5s") still expands correctly — only a
+  // digit glued directly to the comma is blocked.
+  test('comma-glued numbers are left unmangled; a sentence comma still expands', () => {
+    expect(normalizeForTts('rate limited: 1,500s')).toBe('rate limited: 1,500s')
+    expect(normalizeForTts('timeout after 12,000s')).toBe('timeout after 12,000s')
+    expect(normalizeForTts('buffer is 1,024MB')).toBe('buffer is 1,024MB')
+    expect(normalizeForTts('wait, 5s')).toBe('wait, five seconds')
   })
 
   test('whole-number seconds still expand: 90s → ninety seconds', () => {
@@ -213,8 +246,13 @@ describe('numbers', () => {
     expect(normalizeForTts('Revenue was 5M this year')).toBe(
       'Revenue was 5M this year',
     )
-    expect(normalizeForTts('raised $5M in the round')).not.toContain('minutes')
-    expect(normalizeForTts('raised $5M in the round')).not.toContain('metres')
+    // Pre-existing quirk, not introduced or fixed here: the currency regex
+    // consumes "$5" before the unit pass ever sees the dangling "M", so this
+    // never read as "minutes" even on unpatched main — pin the ACTUAL output
+    // instead of an assertion that can't fail in either direction.
+    expect(normalizeForTts('raised $5M in the round')).toBe(
+      'raised five dollarsM in the round',
+    )
   })
 
   test('HTTP-status-shaped input adjacent to a capital letter is not read as a duration', () => {
@@ -222,6 +260,43 @@ describe('numbers', () => {
       'a 503M error occurred',
     )
     expect(normalizeForTts('status 503M')).toBe('status 503M')
+  })
+
+  // Corpus wins from the case-sensitivity split (22 samples improved, 14 of
+  // them "G" memory sizes wrongly read as GRAMS, plus an RTX "4080S" wrongly
+  // read as a duration). These already passed after the original fix but
+  // were previously unpinned.
+  test('single-letter units case-split: bare capitals stay untouched (was misread pre-fix)', () => {
+    expect(normalizeForTts('done in 5S')).toBe('done in 5S')
+    expect(normalizeForTts('wait 3H')).toBe('wait 3H')
+    expect(normalizeForTts('ships in 10D')).toBe('ships in 10D')
+    expect(normalizeForTts('needs 2G')).toBe('needs 2G')
+    expect(normalizeForTts('ran 16 M')).toBe('ran 16 M')
+  })
+
+  test('memory-size "G" no longer read as grams (corpus: 4G/12G/97G)', () => {
+    expect(normalizeForTts('upgrade to 4G')).toBe('upgrade to 4G')
+    expect(normalizeForTts('needs 12G')).toBe('needs 12G')
+    expect(normalizeForTts('disk has 97G')).toBe('disk has 97G')
+  })
+
+  test('product name "4080S" (RTX 4080 Super) not read as a duration', () => {
+    expect(normalizeForTts('bought a 4080S')).toBe('bought a 4080S')
+  })
+})
+
+describe('composed pipeline: normalizeForTts(normalizeForSpeech(x))', () => {
+  // Fleet-critical, previously unguarded: production always composes pass 1
+  // (voice-normalize-text.ts, NO \s? between number and unit, "m" → minute)
+  // with pass 2 (tts-normalize.ts, optional \s?, "m" → metre). The
+  // minute-vs-metre reading is an EMERGENT property of that composition, not
+  // a property either pass exhibits alone.
+  test('glued "5m" reads as minutes (pass 1 claims it first, no space)', () => {
+    expect(normalizeForTts(normalizeForSpeech('run 5m'))).toBe('run five minutes')
+  })
+
+  test('spaced "16 m" reads as metres (pass 1 has no \\s?, so pass 2 claims it)', () => {
+    expect(normalizeForTts(normalizeForSpeech('ran 16 m'))).toBe('ran sixteen metres')
   })
 })
 

--- a/telegram-plugin/tests/tts-normalize.test.ts
+++ b/telegram-plugin/tests/tts-normalize.test.ts
@@ -184,6 +184,45 @@ describe('numbers', () => {
       'rename class5 and my5thing',
     )
   })
+
+  // Regression: unit-suffix lookbehind + case sensitivity (prod corpus,
+  // ~250/1679 samples). A decimal seconds value like "0.17s" was matched by
+  // \b re-anchoring between the "." and the following digits, so "17s" alone
+  // got read as "seventeen seconds" and split the decimal apart; and the /i
+  // flag let a bare capital "M" (money shorthand, "$5M") match the "m"
+  // (metre/minute) unit alternative.
+  test('decimal seconds survive intact — no mid-decimal unit match', () => {
+    expect(normalizeForTts('latency was 0.17s')).toBe('latency was 0.17s')
+    expect(normalizeForTts('took 1.5s to load')).toBe('took 1.5s to load')
+    expect(normalizeForTts('waited 2.25s')).toBe('waited 2.25s')
+    expect(normalizeForTts('under 0.9s')).toBe('under 0.9s')
+  })
+
+  test('whole-number seconds still expand: 90s → ninety seconds', () => {
+    expect(normalizeForTts('done in 90s')).toBe('done in ninety seconds')
+  })
+
+  test('units unaffected by the case-sensitivity fix: 500ms, 5MB, 2GB, 16 m', () => {
+    expect(normalizeForTts('took 500ms')).toBe('took five hundred milliseconds')
+    expect(normalizeForTts('file is 5MB')).toBe('file is five megabytes')
+    expect(normalizeForTts('disk has 2GB')).toBe('disk has two gigabytes')
+    expect(normalizeForTts('ran 16 m')).toBe('ran sixteen metres')
+  })
+
+  test('bare capital M never reads as minutes/metres (money shorthand, corpus)', () => {
+    expect(normalizeForTts('Revenue was 5M this year')).toBe(
+      'Revenue was 5M this year',
+    )
+    expect(normalizeForTts('raised $5M in the round')).not.toContain('minutes')
+    expect(normalizeForTts('raised $5M in the round')).not.toContain('metres')
+  })
+
+  test('HTTP-status-shaped input adjacent to a capital letter is not read as a duration', () => {
+    expect(normalizeForTts('a 503M error occurred')).toBe(
+      'a 503M error occurred',
+    )
+    expect(normalizeForTts('status 503M')).toBe('status 503M')
+  })
 })
 
 describe('URLs', () => {

--- a/telegram-plugin/tests/tts-normalize.test.ts
+++ b/telegram-plugin/tests/tts-normalize.test.ts
@@ -188,8 +188,8 @@ describe('numbers', () => {
   // Regression: unit-suffix lookbehind + case sensitivity. Corpus in
   // /tmp/claude-0/tts/corpus.json (1,679 samples of ALREADY-NORMALIZED
   // production output, not raw input): 146 samples already carry the
-  // shipped mangle artifact this fix removes, 52 carry an unfixed decimal/
-  // comma+unit token (see the "known gap" test below), and 60 samples
+  // shipped mangle artifact this fix removes, 53 carry an unfixed decimal/
+  // comma+unit token (see the "known gap" test below), and 61 samples
   // change under this fix. A decimal seconds value like "0.17s" was matched
   // by \b re-anchoring between the "." and the following digits, so "17s"
   // alone got read as "seventeen seconds" and split the decimal apart; and
@@ -207,7 +207,7 @@ describe('numbers', () => {
   // the unit-suffix regex in tts-normalize.ts): a decimal- or comma-glued
   // number+unit token is now left completely unexpanded (unit unspoken)
   // rather than mangled. This is a real, measured trade-off — corpus
-  // samples carrying an unspoken digit-adjacent unit go 65 → 121 (60
+  // samples carrying an unspoken digit-adjacent unit go 65 → 122 (61
   // samples change, every one gaining an unspoken unit) — pinned here as
   // the baseline a future decimal-expansion pass should move.
   test('KNOWN GAP: decimal/comma-glued number+unit is left unexpanded, not mangled', () => {

--- a/telegram-plugin/tests/voice-normalize-text.test.ts
+++ b/telegram-plugin/tests/voice-normalize-text.test.ts
@@ -197,8 +197,8 @@ describe('normalizeForSpeech — numbers, units & symbols', () => {
   // Regression: unit-suffix lookbehind + case sensitivity. Corpus in
   // /tmp/claude-0/tts/corpus.json (1,679 samples of ALREADY-NORMALIZED
   // production output, not raw input): 146 samples already carry the
-  // shipped mangle artifact this fix removes, 52 carry an unfixed decimal/
-  // comma+unit token (see the "known gap" test below), and 60 samples
+  // shipped mangle artifact this fix removes, 53 carry an unfixed decimal/
+  // comma+unit token (see the "known gap" test below), and 61 samples
   // change under this fix. A decimal seconds value like "0.17s" was matched
   // by \b re-anchoring between the "." and the following digits, so "17s"
   // alone got read as "seventeen seconds" and split the decimal apart; and
@@ -216,7 +216,7 @@ describe('normalizeForSpeech — numbers, units & symbols', () => {
   // the unit-suffix regex in voice-normalize-text.ts): a decimal- or
   // comma-glued number+unit token is now left completely unexpanded (unit
   // unspoken) rather than mangled. Measured: samples carrying an unspoken
-  // digit-adjacent unit go 65 → 121 across the corpus (60 samples change,
+  // digit-adjacent unit go 65 → 122 across the corpus (61 samples change,
   // every one gaining an unspoken unit) — pinned here as the baseline a
   // future decimal-expansion pass should move.
   it('KNOWN GAP: decimal/comma-glued number+unit is left unexpanded, not mangled', () => {

--- a/telegram-plugin/tests/voice-normalize-text.test.ts
+++ b/telegram-plugin/tests/voice-normalize-text.test.ts
@@ -194,17 +194,49 @@ describe('normalizeForSpeech — numbers, units & symbols', () => {
     expect(normalizeForSpeech('class5 room')).toBe('class5 room')
   })
 
-  // Regression: unit-suffix lookbehind + case sensitivity (prod corpus,
-  // ~250/1679 samples). A decimal seconds value like "0.17s" was matched by
-  // \b re-anchoring between the "." and the following digits, so "17s" alone
-  // got read as "seventeen seconds" and split the decimal apart; and the /i
-  // flag let a bare capital "M" (money shorthand, "$5M") match the "m"
-  // (minute) unit alternative.
+  // Regression: unit-suffix lookbehind + case sensitivity. Corpus in
+  // /tmp/claude-0/tts/corpus.json (1,679 samples of ALREADY-NORMALIZED
+  // production output, not raw input): 146 samples already carry the
+  // shipped mangle artifact this fix removes, 52 carry an unfixed decimal/
+  // comma+unit token (see the "known gap" test below), and 60 samples
+  // change under this fix. A decimal seconds value like "0.17s" was matched
+  // by \b re-anchoring between the "." and the following digits, so "17s"
+  // alone got read as "seventeen seconds" and split the decimal apart; and
+  // the /i flag let a bare capital letter (money shorthand "5M", a memory
+  // size "4G", a product name "4080S") match a single-letter unit
+  // alternative it was never meant to.
   it('decimal seconds survive intact — no mid-decimal unit match', () => {
     expect(normalizeForSpeech('latency was 0.17s')).toBe('latency was 0.17s')
     expect(normalizeForSpeech('took 1.5s to load')).toBe('took 1.5s to load')
     expect(normalizeForSpeech('waited 2.25s')).toBe('waited 2.25s')
     expect(normalizeForSpeech('under 0.9s')).toBe('under 0.9s')
+  })
+
+  // KNOWN GAP (disclosed, not fixed in this hotfix — see the comment above
+  // the unit-suffix regex in voice-normalize-text.ts): a decimal- or
+  // comma-glued number+unit token is now left completely unexpanded (unit
+  // unspoken) rather than mangled. Measured: samples carrying an unspoken
+  // digit-adjacent unit go 65 → 121 across the corpus (60 samples change,
+  // every one gaining an unspoken unit) — pinned here as the baseline a
+  // future decimal-expansion pass should move.
+  it('KNOWN GAP: decimal/comma-glued number+unit is left unexpanded, not mangled', () => {
+    expect(normalizeForSpeech('free: 13.0 GB')).toBe('free: 13.0 GB')
+    expect(normalizeForSpeech('weighs 89.5g')).toBe('weighs 89.5g')
+    expect(normalizeForSpeech('ran for 27.5 s')).toBe('ran for 27.5 s')
+    expect(normalizeForSpeech('paused 9.5 min')).toBe('paused 9.5 min')
+  })
+
+  // MINOR: comma leak — same defect class as the decimal lookbehind, closed
+  // in the same lookbehind by also excluding `,`. Before this: "1,500s" →
+  // "1,five hundred seconds", "12,000s" → "12,zero seconds", "1,024MB" →
+  // "1,twenty-four megabytes". The lookbehind is adjacency-only so an
+  // ordinary sentence comma ("wait, 5s") still expands correctly — only a
+  // digit glued directly to the comma is blocked.
+  it('comma-glued numbers are left unmangled; a sentence comma still expands', () => {
+    expect(normalizeForSpeech('rate limited: 1,500s')).toBe('rate limited: 1,500s')
+    expect(normalizeForSpeech('timeout after 12,000s')).toBe('timeout after 12,000s')
+    expect(normalizeForSpeech('buffer is 1,024MB')).toBe('buffer is 1,024MB')
+    expect(normalizeForSpeech('wait, 5s')).toBe('wait, five seconds')
   })
 
   it('whole-number seconds still expand: 90s → ninety seconds', () => {
@@ -222,7 +254,13 @@ describe('normalizeForSpeech — numbers, units & symbols', () => {
     expect(normalizeForSpeech('Revenue was 5M this year')).toBe(
       'Revenue was 5M this year',
     )
-    expect(normalizeForSpeech('raised $5M in the round')).not.toContain('minutes')
+    // Pre-existing quirk, not introduced or fixed here: the currency regex
+    // consumes "$5" before the unit pass ever sees the dangling "M", so this
+    // never read as "minutes" even on unpatched main — pin the ACTUAL output
+    // instead of an assertion that can't fail in either direction.
+    expect(normalizeForSpeech('raised $5M in the round')).toBe(
+      'raised five dollarsM in the round',
+    )
   })
 
   it('HTTP-status-shaped input adjacent to a capital letter is not read as a duration', () => {
@@ -230,6 +268,19 @@ describe('normalizeForSpeech — numbers, units & symbols', () => {
       'a 503M error occurred',
     )
     expect(normalizeForSpeech('status 503M')).toBe('status 503M')
+  })
+
+  // Corpus wins from the case-sensitivity split (22 samples improved fleet-
+  // wide across both passes, 14 of them "G" memory sizes wrongly read via
+  // pass 2 as GRAMS, plus an RTX "4080S" wrongly read as a duration).
+  // Pass 1 has no "g" in its own UNIT_MAP, so these were already inert here
+  // pre-fix; pinned to lock in the no-op and guard the composed pipeline
+  // (see tts-normalize.test.ts for the pass-2 "grams"/"4080S" regression).
+  it('single-letter units case-split: bare capitals stay untouched', () => {
+    expect(normalizeForSpeech('done in 5S')).toBe('done in 5S')
+    expect(normalizeForSpeech('wait 3H')).toBe('wait 3H')
+    expect(normalizeForSpeech('ships in 10D')).toBe('ships in 10D')
+    expect(normalizeForSpeech('bought a 4080S')).toBe('bought a 4080S')
   })
 })
 

--- a/telegram-plugin/tests/voice-normalize-text.test.ts
+++ b/telegram-plugin/tests/voice-normalize-text.test.ts
@@ -193,6 +193,44 @@ describe('normalizeForSpeech — numbers, units & symbols', () => {
     expect(normalizeForSpeech('my5thing works')).toBe('my5thing works')
     expect(normalizeForSpeech('class5 room')).toBe('class5 room')
   })
+
+  // Regression: unit-suffix lookbehind + case sensitivity (prod corpus,
+  // ~250/1679 samples). A decimal seconds value like "0.17s" was matched by
+  // \b re-anchoring between the "." and the following digits, so "17s" alone
+  // got read as "seventeen seconds" and split the decimal apart; and the /i
+  // flag let a bare capital "M" (money shorthand, "$5M") match the "m"
+  // (minute) unit alternative.
+  it('decimal seconds survive intact — no mid-decimal unit match', () => {
+    expect(normalizeForSpeech('latency was 0.17s')).toBe('latency was 0.17s')
+    expect(normalizeForSpeech('took 1.5s to load')).toBe('took 1.5s to load')
+    expect(normalizeForSpeech('waited 2.25s')).toBe('waited 2.25s')
+    expect(normalizeForSpeech('under 0.9s')).toBe('under 0.9s')
+  })
+
+  it('whole-number seconds still expand: 90s → ninety seconds', () => {
+    expect(normalizeForSpeech('done in 90s')).toBe('done in ninety seconds')
+  })
+
+  it('units unaffected by the case-sensitivity fix: 500ms, 5MB, 2GB', () => {
+    expect(normalizeForSpeech('took 500ms')).toBe('took five hundred milliseconds')
+    expect(normalizeForSpeech('a 5MB image')).toBe('a five megabytes image')
+    expect(normalizeForSpeech('a 2GB dump')).toBe('a two gigabytes dump')
+    expect(normalizeForSpeech('run 5m')).toBe('run five minutes')
+  })
+
+  it('bare capital M never reads as minutes (money shorthand, corpus)', () => {
+    expect(normalizeForSpeech('Revenue was 5M this year')).toBe(
+      'Revenue was 5M this year',
+    )
+    expect(normalizeForSpeech('raised $5M in the round')).not.toContain('minutes')
+  })
+
+  it('HTTP-status-shaped input adjacent to a capital letter is not read as a duration', () => {
+    expect(normalizeForSpeech('a 503M error occurred')).toBe(
+      'a 503M error occurred',
+    )
+    expect(normalizeForSpeech('status 503M')).toBe('status 503M')
+  })
 })
 
 describe('normalizeForSpeech — abbreviations (phase 2)', () => {

--- a/telegram-plugin/tts-normalize.ts
+++ b/telegram-plugin/tts-normalize.ts
@@ -350,16 +350,31 @@ export function normalizeForTts(text: string): string {
 
   // -- Number + unit suffix glued to the number (500ms, 5km, 10GB). Only a
   //    known unit bounded by a non-letter, so identifiers never match.
+  //    The leading `(?<![\d.])` lookbehind is load-bearing: without it `\b`
+  //    is satisfied between a decimal point and the following digits (the
+  //    boundary in "0.17s" sits between "." and "1"), so "17s" inside
+  //    "0.17s" would match on its own and mangle the decimal. Multi-letter
+  //    units (ms, GB, …) stay case-insensitive since `5MB`/`500ms` must
+  //    keep working regardless of case; single-letter units (s, m, h, d, g)
+  //    are matched case-sensitively lowercase-only in a second pass — the
+  //    single letter "M" is one keystroke from meaning "million" in prose
+  //    ("$5M", "Revenue was 5M") and must never fall through to "minutes"
+  //    just because the whole alternation ran under /i.
+  const unitReplacer = (m: string, num: string, unitRaw: string): string => {
+    const unit = UNIT_MAP[unitRaw.toLowerCase()]
+    if (!unit) return m
+    const n = Number(num)
+    const w = numberToWords(n)
+    if (!w) return m
+    return `${w} ${n === 1 ? unit.s : unit.p}`
+  }
   s = s.replace(
-    /\b(\d{1,9})\s?(ms|sec|min|km|cm|mm|kg|kb|mb|gb|tb|ghz|mhz|hr|mi|s|m|h|d|g)(?![a-z])/gi,
-    (m, num: string, unitRaw: string) => {
-      const unit = UNIT_MAP[unitRaw.toLowerCase()]
-      if (!unit) return m
-      const n = Number(num)
-      const w = numberToWords(n)
-      if (!w) return m
-      return `${w} ${n === 1 ? unit.s : unit.p}`
-    },
+    /(?<![\d.])\b(\d{1,9})\s?(ms|sec|min|km|cm|mm|kg|kb|mb|gb|tb|ghz|mhz|hr|mi)(?![a-zA-Z])/gi,
+    unitReplacer,
+  )
+  s = s.replace(
+    /(?<![\d.])\b(\d{1,9})\s?(s|m|h|d|g)(?![a-zA-Z])/g,
+    unitReplacer,
   )
 
   // -- Symbols in prose.

--- a/telegram-plugin/tts-normalize.ts
+++ b/telegram-plugin/tts-normalize.ts
@@ -370,7 +370,7 @@ export function normalizeForTts(text: string): string {
   //    (27.5s, 1,500s, 89.5g, 0.7-0.8m) is now left completely UNEXPANDED —
   //    the unit goes unspoken — rather than mangled the way it was before.
   //    Corpus-measured: samples carrying a digit-adjacent unspoken unit go
-  //    65 → 121 (60 samples change under this fix, every one gaining an
+  //    65 → 122 (61 samples change under this fix, every one gaining an
   //    unspoken unit). Correctly expanding a decimal/comma-glued number is
   //    explicitly out of scope for this narrow hotfix — see the pinning
   //    tests below (13.0 GB / 89.5g / 27.5 s) marking the baseline for a

--- a/telegram-plugin/tts-normalize.ts
+++ b/telegram-plugin/tts-normalize.ts
@@ -350,16 +350,39 @@ export function normalizeForTts(text: string): string {
 
   // -- Number + unit suffix glued to the number (500ms, 5km, 10GB). Only a
   //    known unit bounded by a non-letter, so identifiers never match.
-  //    The leading `(?<![\d.])` lookbehind is load-bearing: without it `\b`
-  //    is satisfied between a decimal point and the following digits (the
-  //    boundary in "0.17s" sits between "." and "1"), so "17s" inside
-  //    "0.17s" would match on its own and mangle the decimal. Multi-letter
-  //    units (ms, GB, …) stay case-insensitive since `5MB`/`500ms` must
-  //    keep working regardless of case; single-letter units (s, m, h, d, g)
-  //    are matched case-sensitively lowercase-only in a second pass — the
-  //    single letter "M" is one keystroke from meaning "million" in prose
-  //    ("$5M", "Revenue was 5M") and must never fall through to "minutes"
-  //    just because the whole alternation ran under /i.
+  //
+  //    The leading `(?<![\d.,])` lookbehind is load-bearing: without it
+  //    `\b` is satisfied between a decimal point (or thousands comma) and
+  //    the digits that follow, so "17s" inside "0.17s" — or "500s" inside
+  //    "1,500s" — would match on its own and mangle the number ("0.17s" →
+  //    "0.seventeen seconds"; "1,500s" → "1,five hundred seconds"). Excludes
+  //    both `.` and `,` so a glued decimal/thousands-separated number is
+  //    never re-anchored on. Multi-letter units (ms, GB, …) stay
+  //    case-insensitive since `5MB`/`500ms` must keep working regardless of
+  //    case; single-letter units (s, m, h, d, g) are matched
+  //    case-sensitively lowercase-only in a second pass — the single letter
+  //    "M" is one keystroke from meaning "million" in prose ("$5M",
+  //    "Revenue was 5M") and must never fall through to "minutes" just
+  //    because the whole alternation ran under /i.
+  //
+  //    KNOWN GAP, disclosed deliberately (2026-08, hotfix for #2760-derived
+  //    corpus regression): a decimal- or comma-glued number with a unit
+  //    (27.5s, 1,500s, 89.5g, 0.7-0.8m) is now left completely UNEXPANDED —
+  //    the unit goes unspoken — rather than mangled the way it was before.
+  //    Corpus-measured: samples carrying a digit-adjacent unspoken unit go
+  //    65 → 121 (60 samples change under this fix, every one gaining an
+  //    unspoken unit). Correctly expanding a decimal/comma-glued number is
+  //    explicitly out of scope for this narrow hotfix — see the pinning
+  //    tests below (13.0 GB / 89.5g / 27.5 s) marking the baseline for a
+  //    follow-up decimal-expansion pass.
+  //
+  //    ASYMMETRY WITH pass 1 (voice-normalize-text.ts), pre-existing and
+  //    NOT introduced by this fix: this pass allows an optional space
+  //    (`\s?`) between the number and the unit and maps `m` to METRE; pass
+  //    1 has no `\s?` and maps `m` to MINUTE. That accident is exactly what
+  //    makes "5m" (no space) come out of pass 1 as minutes and "16 m"
+  //    (space) come out of pass 2 as metres in the composed pipeline —
+  //    pinned by the composed-pipeline test in the test suite.
   const unitReplacer = (m: string, num: string, unitRaw: string): string => {
     const unit = UNIT_MAP[unitRaw.toLowerCase()]
     if (!unit) return m
@@ -369,11 +392,11 @@ export function normalizeForTts(text: string): string {
     return `${w} ${n === 1 ? unit.s : unit.p}`
   }
   s = s.replace(
-    /(?<![\d.])\b(\d{1,9})\s?(ms|sec|min|km|cm|mm|kg|kb|mb|gb|tb|ghz|mhz|hr|mi)(?![a-zA-Z])/gi,
+    /(?<![\d.,])\b(\d{1,9})\s?(ms|sec|min|km|cm|mm|kg|kb|mb|gb|tb|ghz|mhz|hr|mi)(?![a-zA-Z])/gi,
     unitReplacer,
   )
   s = s.replace(
-    /(?<![\d.])\b(\d{1,9})\s?(s|m|h|d|g)(?![a-zA-Z])/g,
+    /(?<![\d.,])\b(\d{1,9})\s?(s|m|h|d|g)(?![a-zA-Z])/g,
     unitReplacer,
   )
 

--- a/telegram-plugin/voice-normalize-text.ts
+++ b/telegram-plugin/voice-normalize-text.ts
@@ -561,16 +561,40 @@ export function normalizeForSpeech(input: string): string {
   //     Number + unit suffix → "<number> <unit>" (e.g. 500ms, 2h, 10KB).
   //     Only when the suffix is a known unit glued directly to the number and
   //     bounded by a non-letter (so "my5thing" / "class5" are never touched).
-  //     The leading `(?<![\d.])` lookbehind is load-bearing: without it `\b`
-  //     is satisfied between a decimal point and the following digits (the
-  //     boundary in "0.17s" sits between "." and "1"), so "17s" inside
-  //     "0.17s" would match on its own and mangle the decimal. Multi-letter
-  //     units (ms, GB, …) stay case-insensitive since `5MB`/`500ms` must
-  //     keep working regardless of case; single-letter units (s, m, h, d)
-  //     are matched case-sensitively lowercase-only in a second pass — the
-  //     single letter "M" is one keystroke from meaning "million" in prose
-  //     ("$5M", "Revenue was 5M") and must never fall through to "minutes"
-  //     just because the whole alternation ran under /i.
+  //
+  //     The leading `(?<![\d.,])` lookbehind is load-bearing: without it
+  //     `\b` is satisfied between a decimal point (or thousands comma) and
+  //     the digits that follow, so "17s" inside "0.17s" — or "500s" inside
+  //     "1,500s" — would match on its own and mangle the number ("0.17s" →
+  //     "0.seventeen seconds"; "1,500s" → "1,five hundred seconds"). Excludes
+  //     both `.` and `,` so a glued decimal/thousands-separated number is
+  //     never re-anchored on. Multi-letter units (ms, GB, …) stay
+  //     case-insensitive since `5MB`/`500ms` must keep working regardless of
+  //     case; single-letter units (s, m, h, d) are matched case-sensitively
+  //     lowercase-only in a second pass — the single letter "M" is one
+  //     keystroke from meaning "million" in prose ("$5M", "Revenue was 5M")
+  //     and must never fall through to "minutes" just because the whole
+  //     alternation ran under /i.
+  //
+  //     KNOWN GAP, disclosed deliberately (2026-08, hotfix for a corpus
+  //     regression): a decimal- or comma-glued number with a unit (27.5s,
+  //     1,500s, 89.5g, 0.7-0.8m) is now left completely UNEXPANDED — the
+  //     unit goes unspoken — rather than mangled the way it was before.
+  //     Corpus-measured: samples carrying a digit-adjacent unspoken unit go
+  //     65 → 121 (60 samples change under this fix, every one gaining an
+  //     unspoken unit). Correctly expanding a decimal/comma-glued number is
+  //     explicitly out of scope for this narrow hotfix — see the pinning
+  //     tests below (13.0 GB / 89.5g / 27.5 s) marking the baseline for a
+  //     follow-up decimal-expansion pass.
+  //
+  //     ASYMMETRY WITH pass 2 (tts-normalize.ts), pre-existing and NOT
+  //     introduced by this fix: this pass has NO optional space between the
+  //     number and the unit (unlike pass 2's `\s?`) and maps `m` to MINUTE;
+  //     pass 2 maps `m` to METRE. That accident is exactly what makes "5m"
+  //     (no space) come out of THIS pass as minutes and "16 m" (space) fall
+  //     through untouched here but come out of pass 2 as metres in the
+  //     composed pipeline — pinned by the composed-pipeline test in the
+  //     tts-normalize test suite.
   const unitReplacer = (m: string, num: string, unitRaw: string): string => {
     const unit = UNIT_MAP[unitRaw.toLowerCase()]
     if (!unit) return m
@@ -580,11 +604,11 @@ export function normalizeForSpeech(input: string): string {
     return `${w} ${n === 1 ? unit.s : unit.p}`
   }
   s = s.replace(
-    /(?<![\d.])\b(\d{1,9})(ms|sec|min|kb|mb|gb|tb|hr)(?![a-zA-Z])/gi,
+    /(?<![\d.,])\b(\d{1,9})(ms|sec|min|kb|mb|gb|tb|hr)(?![a-zA-Z])/gi,
     unitReplacer,
   )
   s = s.replace(
-    /(?<![\d.])\b(\d{1,9})(s|m|h|d)(?![a-zA-Z])/g,
+    /(?<![\d.,])\b(\d{1,9})(s|m|h|d)(?![a-zA-Z])/g,
     unitReplacer,
   )
   //     Symbols between tokens: standalone & → and, + → plus, = → equals.

--- a/telegram-plugin/voice-normalize-text.ts
+++ b/telegram-plugin/voice-normalize-text.ts
@@ -561,16 +561,31 @@ export function normalizeForSpeech(input: string): string {
   //     Number + unit suffix → "<number> <unit>" (e.g. 500ms, 2h, 10KB).
   //     Only when the suffix is a known unit glued directly to the number and
   //     bounded by a non-letter (so "my5thing" / "class5" are never touched).
+  //     The leading `(?<![\d.])` lookbehind is load-bearing: without it `\b`
+  //     is satisfied between a decimal point and the following digits (the
+  //     boundary in "0.17s" sits between "." and "1"), so "17s" inside
+  //     "0.17s" would match on its own and mangle the decimal. Multi-letter
+  //     units (ms, GB, …) stay case-insensitive since `5MB`/`500ms` must
+  //     keep working regardless of case; single-letter units (s, m, h, d)
+  //     are matched case-sensitively lowercase-only in a second pass — the
+  //     single letter "M" is one keystroke from meaning "million" in prose
+  //     ("$5M", "Revenue was 5M") and must never fall through to "minutes"
+  //     just because the whole alternation ran under /i.
+  const unitReplacer = (m: string, num: string, unitRaw: string): string => {
+    const unit = UNIT_MAP[unitRaw.toLowerCase()]
+    if (!unit) return m
+    const n = Number(num)
+    const w = numberToWords(n)
+    if (!w) return m
+    return `${w} ${n === 1 ? unit.s : unit.p}`
+  }
   s = s.replace(
-    /\b(\d{1,9})(ms|sec|min|kb|mb|gb|tb|hr|s|m|h|d)(?![a-z])/gi,
-    (m, num, unitRaw) => {
-      const unit = UNIT_MAP[unitRaw.toLowerCase()]
-      if (!unit) return m
-      const n = Number(num)
-      const w = numberToWords(n)
-      if (!w) return m
-      return `${w} ${n === 1 ? unit.s : unit.p}`
-    },
+    /(?<![\d.])\b(\d{1,9})(ms|sec|min|kb|mb|gb|tb|hr)(?![a-zA-Z])/gi,
+    unitReplacer,
+  )
+  s = s.replace(
+    /(?<![\d.])\b(\d{1,9})(s|m|h|d)(?![a-zA-Z])/g,
+    unitReplacer,
   )
   //     Symbols between tokens: standalone & → and, + → plus, = → equals.
   s = s.replace(/(\S)\s*\+\s*(\S)/g, '$1 plus $2')

--- a/telegram-plugin/voice-normalize-text.ts
+++ b/telegram-plugin/voice-normalize-text.ts
@@ -581,7 +581,7 @@ export function normalizeForSpeech(input: string): string {
   //     1,500s, 89.5g, 0.7-0.8m) is now left completely UNEXPANDED — the
   //     unit goes unspoken — rather than mangled the way it was before.
   //     Corpus-measured: samples carrying a digit-adjacent unspoken unit go
-  //     65 → 121 (60 samples change under this fix, every one gaining an
+  //     65 → 122 (61 samples change under this fix, every one gaining an
   //     unspoken unit). Correctly expanding a decimal/comma-glued number is
   //     explicitly out of scope for this narrow hotfix — see the pinning
   //     tests below (13.0 GB / 89.5g / 27.5 s) marking the baseline for a


### PR DESCRIPTION
## Summary

Two live production defects in the number+unit-suffix regex, present identically in **both** TTS normalization passes (`telegram-plugin/voice-normalize-text.ts` pass 1, `telegram-plugin/tts-normalize.ts` pass 2). Both passes run on every outbound voice message today — pass 1 has no kill switch, and pass 2's `SWITCHROOM_DISABLE_TTS_NORMALIZE` is unset fleet-wide. This is a narrow, surgical fix to the existing regex; it deliberately does not touch the surrounding structure of either file (a separate consolidation workstream is running in parallel — see [switchroom/switchroom#4689](https://github.com/switchroom/switchroom/issues/4689) for the one piece of duplication this PR had to introduce).

**Updated after adversarial review** (see "Adversarial review findings" below for the full list of what changed and why).

## Corpus, corrected

`/tmp/claude-0/tts/corpus.json` (1,679 samples) is **already-normalized production output**, not raw input — it contains strings like `"code block omitted"`, `"S S H"`, `"six hundred one milliseconds"`. The original PR description's "~250/1,679" claim was wrong and so was the assumption behind it. The measured numbers, re-derived against the actual corpus contents:

- **146 samples** already carry the shipped mangle artifact this fix removes (the decimal-split / comma-split reading).
- **53 samples** carry an unfixed decimal- or comma-glued number+unit token even after this fix (see "known trade-off" below).
- **61 samples** change under this fix — every one of them trades a wrong reading for an unspoken unit (see MAJOR-1 below).
- **22 samples** are pure wins from the case-sensitivity split alone: 14 are "G" memory sizes (`4G`/`12G`/`97G`) that were being read as **grams**, plus an RTX **`4080S`** read as "four thousand eighty seconds".

## Before / after (identical shape in both files)

**Before** (`tts-normalize.ts`, pass 2 — `voice-normalize-text.ts` pass 1 had the same defects on its own smaller unit set):
```js
s.replace(
  /\b(\d{1,9})\s?(ms|sec|min|km|cm|mm|kg|kb|mb|gb|tb|ghz|mhz|hr|mi|s|m|h|d|g)(?![a-z])/gi,
  ...
)
```

**After:**
```js
// Multi-letter units stay case-insensitive: 5MB / 500ms / 10KB must keep working.
s.replace(
  /(?<![\d.,])\b(\d{1,9})\s?(ms|sec|min|km|cm|mm|kg|kb|mb|gb|tb|ghz|mhz|hr|mi)(?![a-zA-Z])/gi,
  unitReplacer,
)
// Single-letter units are case-sensitive, lowercase-only, in a second pass.
s.replace(
  /(?<![\d.,])\b(\d{1,9})\s?(s|m|h|d|g)(?![a-zA-Z])/g,
  unitReplacer,
)
```

## Defect 1 — no leading lookbehind (decimal AND comma)

`\b` is satisfied between a decimal point (or thousands comma) and the digits that follow — the boundary in `0.17s` sits between `.` and `1` — so `17s` alone matched and the number got split apart: `0.17s` → `"0.seventeen seconds"`; `1,500s` → `"1,five hundred seconds"`; `12,000s` → `"12,zero seconds"`; `1,024MB` → `"1,twenty-four megabytes"`. Fix: `(?<![\d.,])` lookbehind before the digit group (both `.` and `,` excluded) so a digit run immediately preceded by another digit, a `.`, or a `,` is never re-anchored on. The lookbehind is adjacency-only, so an ordinary sentence comma (`"wait, 5s"`) still expands correctly — only a digit glued directly to the comma is blocked.

## Defect 2 — `/i` let a bare capital letter match a single-letter unit

The whole alternation ran case-insensitively, so a bare capital letter matched a single-letter unit it was never meant to: money shorthand (`"Revenue was 5M this year"` → `"...five minutes..."` / `"...five metres..."`), a memory size (`"4G"`/`"12G"`/`"97G"` → `"four grams"` etc. via pass 2's `g`→gram mapping), a product name (`"4080S"` → `"four thousand eighty seconds"`). **Chosen fix: split the alternation** rather than dropping `/i` outright — multi-letter units (`ms`, `GB`, `sec`, `min`, …) keep case-insensitive matching in their own pass (so `5MB`, `500ms`, `10KB`, `2GB` are unaffected — pinned by tests), and only the single-letter units (`s`, `m`, `h`, `d`, and `g` in pass 2) move to a second, case-sensitive, lowercase-only pass.

Note: `$5M` specifically was already not reading as literal "minutes" pre-fix — the currency regex consumes `$5` first and leaves a bare `M` dangling (`"five dollarsM"`), a separate pre-existing quirk not touched here. The regression this PR fixes and pins with tests is the **bare** capital-letter case (no `$`) — `"Revenue was 5M this year"`, `"a 503M error"`, `"4G"`, `"4080S"` — which is what the corpus shows going through the unit-suffix path.

## MAJOR-1 (from review): a new, disclosed behaviour class — unspoken units

The fix trades a **mangled** number for an **unspoken** unit. A decimal- or comma-glued number+unit token (`27.5s`, `89.5g`, `1,500s`, `9.5 min`, `0.7-0.8 m`) is now left completely unexpanded — the unit goes unspoken — rather than being mangled the way it was before (e.g. `89.5g` used to at least say "grams"; now it says nothing, TTS reads the raw digits/letters). Corpus-measured: samples containing a digit-adjacent unspoken unit go **65 → 122** (61 samples change, every one gaining an unspoken unit). This is a defensible, deliberate hotfix scope call — correctly expanding a decimal/comma-glued number is a new feature (decimal-to-words expansion), not a regex hotfix, and is explicitly out of scope here — but it is disclosed rather than shipped silently: in both source file comments (the "KNOWN GAP" block above each unit regex), in both test suites (pinning `13.0 GB` / `89.5g` / `27.5 s` / `9.5 min` / `0.7-0.8 m` as the baseline), and in the CHANGELOG entry.

## Scope

Fixed identically in both files, structure otherwise untouched:
- `telegram-plugin/tts-normalize.ts` (pass 2)
- `telegram-plugin/voice-normalize-text.ts` (pass 1)

One real, pre-existing asymmetry between the two passes is **load-bearing**, not accidental collateral of this fix, and is now named in both files' comments instead of being papered over by the "fixed identically" framing: pass 2 allows an optional space between the number and the unit (`\s?`) and maps `m` → METRE; pass 1 has no `\s?` and maps `m` → MINUTE. That's exactly what makes `"5m"` (glued) come out of the composed pipeline as minutes and `"16 m"` (spaced) come out as metres — pinned by a new composed-pipeline test (see Test plan).

## Test plan

Tests added/updated in both existing suites (145 → **152** total across `tts-normalize.test.ts` + `voice-normalize-text.test.ts` + the dependent `voice-out-one-send.test.ts`, 0 fail):

- Decimal survival: `0.17s`/`1.5s`/`2.25s`/`0.9s`, `90s` still expands.
- Comma leak (new): `1,500s`/`12,000s`/`1,024MB` unmangled, `"wait, 5s"` (sentence comma) still expands.
- Known-gap pinning (new, MAJOR-1): `13.0 GB`/`89.5g`/`27.5 s`/`9.5 min`/`0.7-0.8 m` left unexpanded.
- Case-sensitivity: `500ms`/`5MB`/`2GB`/`16 m` unaffected; bare `5M`/`503M` no longer read as minutes/metres; `"$5M"` pinned to its actual (pre-existing, unchanged) `"five dollarsM"` output instead of a vacuous `.not.toContain` assertion.
- Corpus wins pinned (new, MINOR-3): bare capitals `5S`/`3H`/`10D`/`2G`/`16 M` stay untouched; `4G`/`12G`/`97G` no longer read as grams; `4080S` no longer read as a duration.
- Composed-pipeline (new, MINOR-4): `normalizeForTts(normalizeForSpeech('run 5m'))` → minutes, `normalizeForTts(normalizeForSpeech('ran 16 m'))` → metres — the emergent pass1+pass2 behaviour that neither suite guarded before.

**Confirmed RED on unpatched `origin/main` (08262924) before the original fix**, and **RED again for the comma-leak tests specifically against the intermediate commit (609b6f8f, which already had the case-split but not the comma fix)**, both confirmed GREEN after their respective fixes — details and counts in the commit messages on this branch.

Also ran `tsc --noEmit` scoped to the touched files (no new errors — pre-existing `nostr-tools` module-resolution errors elsewhere in the tree are an artifact of this worktree's symlinked `node_modules` from a stale checkout, unrelated to this diff, reproduced identically on unpatched `origin/main`).

A broader `bun test telegram-plugin/tests` run showed 3 pre-existing failure clusters (`render/*` unhandled errors, `gateway boot-smoke`) — reproduced identically against pristine `origin/main` with this diff stashed out, confirming they are pre-existing/environment-only and unrelated to this change (classification per repo `CLAUDE.md` § Tests).

## Risk

Low. Narrowly scoped regex change behind existing call sites; no behavior change for any previously-correct case (pinned by regression tests against the existing `5km`/`10GB`/`500ms`/`5MB`/`2GB` suite entries, all still green). The one new, disclosed behaviour class (MAJOR-1) trades a wrong reading for a skipped one, not a new wrong reading.

## Adversarial review findings addressed (this branch, same PR)

An independent adversarial reviewer reproduced the red-then-green, proved the two-pass split introduces no ordering hazard (800k random-string differential against a single-scan equivalent, zero divergences), confirmed the minute/metre composed-pipeline boundary does not shift, and verified the `$5M` claim — the regex design itself was not in question. What was blocking:

- **MAJOR-1** — disclosed (source comments, tests, CHANGELOG) rather than fixed; see above.
- **MAJOR-2** — corpus numbers corrected; see "Corpus, corrected" above.
- **MINOR-1** — comma leak closed (`(?<![\d.])` → `(?<![\d.,])`) in both regexes in both files; tested.
- **MINOR-2** — vacuous `.not.toContain` assertions replaced with a `.toBe` pinning the actual `$5M` output.
- **MINOR-3** — corpus wins (`5S`/`3H`/`10D`/`2G`/`16 M`, `4G`/`12G`/`97G` grams fix, `4080S`) now pinned.
- **MINOR-4** — composed-pipeline test added.
- **MINOR-5** — the pass1/pass2 `\s?` + `m`-unit asymmetry is now named in both files' comments.
- **MINOR-6** — filed [switchroom/switchroom#4689](https://github.com/switchroom/switchroom/issues/4689) for the duplicated `unitReplacer` helper; not fixed here (parallel consolidation workstream owns it).
- **MINOR-7** — CHANGELOG entry given a real body covering the behaviour changes, including MAJOR-1.

Job spec: [feel-like-a-colleague.md](../blob/main/reference/jobs/feel-like-a-colleague.md) — a voice reply that mangles a decimal or reads a dollar-shorthand/memory-size amount as a duration/mass breaks the "reads like a person" bar this job spec sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

