### PR TITLE
feat(voice): flag-gated raw-markdown speech capture (PR-0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ now an anomaly worth investigating, not the norm.
   Correctly expanding a decimal/comma-glued number is out of scope for this
   narrow hotfix and is left for a follow-up.
 
+### Features
+
+- **voice: flag-gated raw-markdown speech capture (PR-0)**
+
 ## v0.21.9 — Telegram rich-markdown guards stop destroying supported constructs, and `tg://` inline entities render
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,15 @@ now an anomaly worth investigating, not the norm.
 
 ### Features
 
-- **voice: flag-gated raw-markdown speech capture (PR-0)**
+- **voice: flag-gated raw-markdown speech capture (PR-0)** — `SWITCHROOM_SPEECH_CAPTURE=1`
+  (or `=true`), **off by default**, appends the exact pre-normalisation reply text
+  `sendReply` is about to pass to `resolveVoiceOutPlan` — byte-for-byte, tables/fences/
+  emoji/backticks intact — to `$TELEGRAM_STATE_DIR/speech-capture.jsonl` (`0o600`,
+  owner-only) as a time-boxed corpus for the TTS normalisation redesign. Privacy: while
+  the flag is on, this file holds the full plaintext body of every outbound reply; it is
+  intentionally NOT enabled in any deployed config by this change, and a dated follow-up
+  issue (switchroom/switchroom#4690) tracks disabling/removing the flag once the 7-day
+  capture window closes.
 
 ## v0.21.9 — Telegram rich-markdown guards stop destroying supported constructs, and `tg://` inline entities render
 

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -43,6 +43,7 @@ import {
   isQuoteRejectionError,
   sendOptsHaveQuote,
 } from '../reply-quote.js'
+import { captureSpeechText } from './speech-capture.js'
 
 // ── send-orchestration façade imports (#2996 P2) ──
 // Pure/deterministic helpers are imported; stateful or side-effecting gateway
@@ -1376,6 +1377,12 @@ export async function sendReply(
   // plain-text TTS input); synthesis happens just before the send so a
   // voice-only reply can suppress the text chunk loop on success. Voice is
   // fully best-effort — every failure below falls back to the text reply.
+  // Raw-corpus capture (TTS redesign PR-0, flag-gated, off by default): `text`
+  // here IS Stage A's future input — capture it byte-for-byte BEFORE the
+  // resolve call, ahead of any TTS normalisation, so the redesign's property
+  // tests can validate against real markdown instead of synthetic fixtures
+  // only. See telegram-plugin/gateway/speech-capture.ts.
+  captureSpeechText(text)
   const voiceOutPlan = resolveVoiceOutPlan(access.voice_out, text)
   const configParseMode = access.parseMode ?? 'html'
   const format = (args.format as string | undefined) ?? configParseMode

--- a/telegram-plugin/gateway/speech-capture.ts
+++ b/telegram-plugin/gateway/speech-capture.ts
@@ -1,0 +1,69 @@
+/**
+ * Raw pre-normalisation speech-text capture (TTS normalisation redesign,
+ * PR-0 — `/tmp/claude-0/tts/out/fable-plan-v2.md` §9).
+ *
+ * Flag-gated on `SWITCHROOM_SPEECH_CAPTURE=1`, OFF by default: unset (or any
+ * value other than `"1"`) is a true no-op — `captureSpeechText` returns
+ * immediately without touching the filesystem, so the send path pays zero
+ * cost. When enabled, appends exactly one JSON line `{ts, text}` — where
+ * `text` is the EXACT string about to be passed to `resolveVoiceOutPlan`,
+ * byte-for-byte, no re-encoding — to `$TELEGRAM_STATE_DIR/speech-capture.jsonl`
+ * before that call (fable-plan-v2.md §0 C-4: that string IS Stage A's future
+ * input, the same string the visible rich render parses).
+ *
+ * Why this exists: `corpus.json` (the existing replay corpus) was captured
+ * downstream of the legacy pass-1 normaliser, so it carries zero tables,
+ * fences, pipes, or emoji (fable-plan-v2.md §0 C-3) — useless for validating
+ * the new Stage-A renderer beyond synthetic fixtures. `telegram/history.db`
+ * is also unusable: it stores text as Telegram echoed it back (rendered),
+ * not the pre-render markdown. Capture must happen in-process, here.
+ *
+ * Write failures are swallowed unconditionally — capture must never break a
+ * send. Deliberately does NOT bound or rotate the capture file: the spec
+ * (§9 PR-0) describes a plain unbounded append for a time-boxed 7-day
+ * fleet-wide capture window, after which the file is reviewed, secrets-
+ * scrubbed, and checked into the repo as a static fixture — it is not a
+ * long-lived production log.
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const SPEECH_CAPTURE_FILE_NAME = 'speech-capture.jsonl'
+
+export interface CaptureSpeechTextOptions {
+  /** Override the enabled flag (tests only); default reads
+   *  `SWITCHROOM_SPEECH_CAPTURE` from the environment. */
+  enabled?: boolean
+  /** Override the destination directory (tests only); default
+   *  `process.env.TELEGRAM_STATE_DIR`. */
+  stateDir?: string
+  /** Override the clock (tests only). */
+  now?: () => number
+}
+
+function isCaptureEnabled(override: boolean | undefined): boolean {
+  if (override !== undefined) return override
+  return process.env.SWITCHROOM_SPEECH_CAPTURE === '1'
+}
+
+/**
+ * Append one `{ts, text}` JSON line to the raw-corpus capture file when
+ * capture is enabled. `text` must be the EXACT string about to be passed to
+ * `resolveVoiceOutPlan` — no trimming, no re-encoding, byte-for-byte
+ * preservation of markdown (tables, fences, pipes, emoji, backticks, ...).
+ * Off by default; a true no-op when the flag is unset. Never throws.
+ */
+export function captureSpeechText(text: string, opts: CaptureSpeechTextOptions = {}): void {
+  if (!isCaptureEnabled(opts.enabled)) return
+  try {
+    const stateDir = opts.stateDir ?? process.env.TELEGRAM_STATE_DIR
+    if (stateDir == null || stateDir.length === 0) return
+    const now = opts.now ?? Date.now
+    const line = `${JSON.stringify({ ts: now(), text })}\n`
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 })
+    appendFileSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME), line, 'utf8')
+  } catch {
+    // Capture must never break the send path.
+  }
+}

--- a/telegram-plugin/gateway/speech-capture.ts
+++ b/telegram-plugin/gateway/speech-capture.ts
@@ -2,14 +2,17 @@
  * Raw pre-normalisation speech-text capture (TTS normalisation redesign,
  * PR-0 — `/tmp/claude-0/tts/out/fable-plan-v2.md` §9).
  *
- * Flag-gated on `SWITCHROOM_SPEECH_CAPTURE=1`, OFF by default: unset (or any
- * value other than `"1"`) is a true no-op — `captureSpeechText` returns
+ * Flag-gated on `SWITCHROOM_SPEECH_CAPTURE=1` (or `=true`), OFF by default:
+ * unset (or any other value) is a true no-op — `captureSpeechText` returns
  * immediately without touching the filesystem, so the send path pays zero
  * cost. When enabled, appends exactly one JSON line `{ts, text}` — where
  * `text` is the EXACT string about to be passed to `resolveVoiceOutPlan`,
  * byte-for-byte, no re-encoding — to `$TELEGRAM_STATE_DIR/speech-capture.jsonl`
  * before that call (fable-plan-v2.md §0 C-4: that string IS Stage A's future
- * input, the same string the visible rich render parses).
+ * input). NOT the same string the visible rich render displays — the render
+ * path additionally runs `computeEffectiveText`/`addParagraphSpacers` (U+00A0
+ * paragraph spacers) downstream of this capture point; this captures the
+ * plain pre-spacer prose Stage A will actually consume.
  *
  * Why this exists: `corpus.json` (the existing replay corpus) was captured
  * downstream of the legacy pass-1 normaliser, so it carries zero tables,
@@ -18,18 +21,45 @@
  * is also unusable: it stores text as Telegram echoed it back (rendered),
  * not the pre-render markdown. Capture must happen in-process, here.
  *
- * Write failures are swallowed unconditionally — capture must never break a
- * send. Deliberately does NOT bound or rotate the capture file: the spec
- * (§9 PR-0) describes a plain unbounded append for a time-boxed 7-day
- * fleet-wide capture window, after which the file is reviewed, secrets-
- * scrubbed, and checked into the repo as a static fixture — it is not a
- * long-lived production log.
+ * Privacy: the capture file holds the full plaintext body of every outbound
+ * reply while the flag is on, so it is created `0o600` (owner-only) — NOT
+ * the default-umask `0o644` `appendFileSync` would otherwise produce, which
+ * would leave it world-readable in a directory where `access.json` (the chat
+ * allowlist) is deliberately `0o600`. Mode only applies at file CREATION
+ * (Node ignores `mode` on an append to an existing file), matching the
+ * established pattern in this codebase (`shown-ledger.ts`, `outbox.ts`).
+ *
+ * Write failures are swallowed — capture must never break a send — but never
+ * silently: the first write failure (and, rate-limited, subsequent ones)
+ * logs one stderr line, because a foreign-uid EACCES on this file (the #4371
+ * failure class: some other process touches it, it becomes root-owned, the
+ * agent uid EACCESes on every append thereafter) must be observable across a
+ * 7-day unattended capture window, not discovered after the fact from an
+ * empty corpus.
+ *
+ * Deliberately does NOT bound or rotate the capture file: the spec (§9 PR-0)
+ * describes a plain unbounded append for a time-boxed 7-day fleet-wide
+ * capture window (measured fleet-wide: ~2.9 MB over 7 days), after which the
+ * file is reviewed, secrets-scrubbed, and checked into the repo as a static
+ * fixture — it is not a long-lived production log.
+ *
+ * The enabled check reads `process.env` on every call (deliberately NOT
+ * cached at module scope, unlike `current-turn-map.ts`'s
+ * `EMISSION_AUTHORITY_ENABLED` kill-switch convention): the read is a single
+ * property lookup, not the per-turn state-store cost that convention exists
+ * to avoid, and caching it would make the flag un-togglable within a single
+ * test process — which the load-bearing "a capture write failure never
+ * breaks the reply" guarantee needs to exercise against the REAL `sendReply`
+ * wiring (see `send-reply-golden.test.ts`), not a synthetic call.
  */
 
-import { appendFileSync, mkdirSync } from 'node:fs'
+import { appendFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 export const SPEECH_CAPTURE_FILE_NAME = 'speech-capture.jsonl'
+
+/** File created owner-read-write only (see the Privacy note above). */
+const SPEECH_CAPTURE_FILE_MODE = 0o600
 
 export interface CaptureSpeechTextOptions {
   /** Override the enabled flag (tests only); default reads
@@ -42,9 +72,53 @@ export interface CaptureSpeechTextOptions {
   now?: () => number
 }
 
+function envFlagEnabled(): boolean {
+  const v = process.env.SWITCHROOM_SPEECH_CAPTURE
+  return v === '1' || v === 'true'
+}
+
 function isCaptureEnabled(override: boolean | undefined): boolean {
   if (override !== undefined) return override
-  return process.env.SWITCHROOM_SPEECH_CAPTURE === '1'
+  return envFlagEnabled()
+}
+
+// One-shot "capture is live" log line, latched the first time capture
+// actually fires (not at module import — importing this module must stay a
+// true no-op regardless of whether the flag ends up used) — and a
+// rate-limited write-error log so a foreign-uid EACCES (#4371 class) is
+// observable within the window, not just discoverable from an empty corpus
+// after the fact.
+let loggedEnabledOnce = false
+// `null`, not `0`: a real failure at `Date.now() === 0` (or in a test driven
+// by `vi.setSystemTime(0)`) must still log — `0` is a valid past timestamp,
+// not "never logged", so it cannot double as the sentinel.
+let lastWriteErrorLoggedAt: number | null = null
+const WRITE_ERROR_LOG_INTERVAL_MS = 5 * 60_000
+
+function logEnabledOnce(): void {
+  if (loggedEnabledOnce) return
+  loggedEnabledOnce = true
+  try {
+    process.stderr.write(
+      `telegram gateway: speech-capture: enabled — writing $TELEGRAM_STATE_DIR/${SPEECH_CAPTURE_FILE_NAME}\n`,
+    )
+  } catch {
+    // Logging must never break the send path.
+  }
+}
+
+function logWriteErrorRateLimited(err: unknown, nowMs: number): void {
+  if (lastWriteErrorLoggedAt !== null && nowMs - lastWriteErrorLoggedAt < WRITE_ERROR_LOG_INTERVAL_MS) return
+  lastWriteErrorLoggedAt = nowMs
+  try {
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(
+      `telegram gateway: speech-capture: write failed (further failures rate-limited ` +
+        `${Math.round(WRITE_ERROR_LOG_INTERVAL_MS / 60_000)}m) err=${msg}\n`,
+    )
+  } catch {
+    // Logging must never break the send path.
+  }
 }
 
 /**
@@ -56,14 +130,29 @@ function isCaptureEnabled(override: boolean | undefined): boolean {
  */
 export function captureSpeechText(text: string, opts: CaptureSpeechTextOptions = {}): void {
   if (!isCaptureEnabled(opts.enabled)) return
+  logEnabledOnce()
   try {
     const stateDir = opts.stateDir ?? process.env.TELEGRAM_STATE_DIR
     if (stateDir == null || stateDir.length === 0) return
     const now = opts.now ?? Date.now
     const line = `${JSON.stringify({ ts: now(), text })}\n`
-    mkdirSync(stateDir, { recursive: true, mode: 0o700 })
-    appendFileSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME), line, 'utf8')
-  } catch {
-    // Capture must never break the send path.
+    appendFileSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME), line, {
+      encoding: 'utf8',
+      mode: SPEECH_CAPTURE_FILE_MODE,
+    })
+  } catch (err) {
+    // Capture must never break the send path — but never silently either
+    // (M2/#4371 class).
+    logWriteErrorRateLimited(err, Date.now())
   }
+}
+
+/**
+ * Test-only: reset the one-shot enable log and the write-error rate limiter,
+ * so a test asserting stderr output is independent of import/call order
+ * versus every other test sharing this module instance.
+ */
+export function __resetSpeechCaptureLogStateForTests(): void {
+  loggedEnabledOnce = false
+  lastWriteErrorLoggedAt = null
 }

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -31,7 +31,7 @@
  *   - structural: gateway constructs EXACTLY ONE OutboundDedupCache and the
  *     extracted module constructs NONE (the re-`new` hard-fail rule)
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { GrammyError } from 'grammy'
 import { readFileSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -58,6 +58,10 @@ import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer.js
 import { SubagentReplyAuthority } from '../gateway/subagent-reply-authority.js'
 import { redact } from '../secret-detect/redact.js'
 import type { CurrentTurn, Access } from '../gateway/gateway.js'
+import {
+  SPEECH_CAPTURE_FILE_NAME,
+  __resetSpeechCaptureLogStateForTests,
+} from '../gateway/speech-capture.js'
 
 /**
  * Build the owner-resolution result the gateway's `resolveReplyOwnerTurn`
@@ -454,6 +458,77 @@ describe('sendReply golden harness — file sends', () => {
     await sendReply(h.deps, req('album', { files: [a, b] }))
     expect(h.calls.filter((c) => c.method === 'sendMediaGroup')).toHaveLength(2) // one record per album item
     expect(h.calls.filter((c) => c.method === 'sendPhoto')).toHaveLength(0)
+  })
+})
+
+describe('speech capture (PR-0) — driven through the REAL sendReply wiring, not a synthetic call', () => {
+  const priorCapture = process.env.SWITCHROOM_SPEECH_CAPTURE
+  const priorStateDir = process.env.TELEGRAM_STATE_DIR
+
+  afterEach(() => {
+    if (priorCapture === undefined) delete process.env.SWITCHROOM_SPEECH_CAPTURE
+    else process.env.SWITCHROOM_SPEECH_CAPTURE = priorCapture
+    if (priorStateDir === undefined) delete process.env.TELEGRAM_STATE_DIR
+    else process.env.TELEGRAM_STATE_DIR = priorStateDir
+    __resetSpeechCaptureLogStateForTests()
+  })
+
+  it('M3: a capture write failure (flag ON, unwritable state dir) never breaks the reply', async () => {
+    // The destination is a FILE, not a directory, so appendFileSync fails
+    // ENOTDIR every call — the exact swallow path the flag-on window depends
+    // on for 7 days unattended. If a refactor ever made the capture call
+    // async, or moved it past an await (so its rejection reached the
+    // sendReply promise chain instead of being caught in-place), THIS test
+    // is the one that would go red.
+    const dir = mkdtempSync(join(tmpdir(), 'speech-capture-golden-'))
+    const notADir = join(dir, 'state-dir-is-actually-a-file')
+    writeFileSync(notADir, 'not a directory')
+    process.env.SWITCHROOM_SPEECH_CAPTURE = '1'
+    process.env.TELEGRAM_STATE_DIR = notADir
+
+    const h = makeHarness()
+    const res = await sendReply(h.deps, req('The reply must still ship. ✅ done.'))
+    const sends = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(sends).toHaveLength(1)
+    expect(sends[0]!.text).toContain('The reply must still ship.')
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+  })
+
+  it('M3: the captured string IS the exact argument passed to resolveVoiceOutPlan — not merely textually adjacent', async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'speech-capture-golden-'))
+    process.env.SWITCHROOM_SPEECH_CAPTURE = '1'
+    process.env.TELEGRAM_STATE_DIR = stateDir
+
+    const h = makeHarness()
+    let observedByVoicePlan: string | null = null
+    h.deps.resolveVoiceOutPlan = (_voiceOut, replyText) => {
+      observedByVoicePlan = replyText
+      return null
+    }
+
+    const raw = '| A | B |\n| --- | --- |\n| 1 | 2 |\n\n```ts\nconst x = 1 | 2\n```\n\nStatus: ✅ done `code` 😀.'
+    await sendReply(h.deps, req(raw))
+
+    expect(observedByVoicePlan).not.toBeNull()
+    const captured = readFileSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME), 'utf8')
+      .split('\n')
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as { ts: number; text: string })
+    expect(captured).toHaveLength(1)
+    // The load-bearing assertion: the capture is not "close to" or "derived
+    // from" resolveVoiceOutPlan's input — it is the SAME string, by identity
+    // of value, not by coincidence of two independent pipelines agreeing.
+    expect(captured[0]!.text).toBe(observedByVoicePlan)
+  })
+
+  it('flag OFF: sendReply never creates the capture file, even with a writable state dir', async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'speech-capture-golden-'))
+    delete process.env.SWITCHROOM_SPEECH_CAPTURE
+    process.env.TELEGRAM_STATE_DIR = stateDir
+
+    const h = makeHarness()
+    await sendReply(h.deps, req('Never captured.'))
+    expect(() => readFileSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME), 'utf8')).toThrow()
   })
 })
 

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -476,10 +476,16 @@ describe('speech capture (PR-0) — driven through the REAL sendReply wiring, no
   it('M3: a capture write failure (flag ON, unwritable state dir) never breaks the reply', async () => {
     // The destination is a FILE, not a directory, so appendFileSync fails
     // ENOTDIR every call — the exact swallow path the flag-on window depends
-    // on for 7 days unattended. If a refactor ever made the capture call
-    // async, or moved it past an await (so its rejection reached the
-    // sendReply promise chain instead of being caught in-place), THIS test
-    // is the one that would go red.
+    // on for 7 days unattended. This only pins the CURRENT synchronous,
+    // in-place-caught shape: it proves a swallowed-write-failure reply still
+    // ships, but it would NOT go red if a refactor made the capture call
+    // async and fire-and-forget (unawaited) — that rejection becomes an
+    // unhandled rejection, which this codebase's policy treats as fatal
+    // (see analytics-posthog.ts, chat-lock.ts), strictly worse than the one
+    // lost capture line this test guards against, and this test alone
+    // cannot detect it. The synchronous-return contract that WOULD catch
+    // that mutation is pinned directly on `captureSpeechText` in
+    // `speech-capture.test.ts` ("G1: captureSpeechText returns undefined").
     const dir = mkdtempSync(join(tmpdir(), 'speech-capture-golden-'))
     const notADir = join(dir, 'state-dir-is-actually-a-file')
     writeFileSync(notADir, 'not a directory')
@@ -506,7 +512,16 @@ describe('speech capture (PR-0) — driven through the REAL sendReply wiring, no
       return null
     }
 
-    const raw = '| A | B |\n| --- | --- |\n| 1 | 2 |\n\n```ts\nconst x = 1 | 2\n```\n\nStatus: ✅ done `code` 😀.'
+    // Deliberately includes a spaced em-dash: `normalizeOutboundBody`'s
+    // voice-scrub pass (`scrubVoice`, applied LAST in the pipeline —
+    // outbound-send-path.ts's own docstring: "normalize → redact →
+    // punctuation/bold → voice-scrub") rewrites a mid-prose ` — ` into `. `
+    // plus recapitalizing the following word. A golden fixture with nothing
+    // for the pipeline to transform can't tell "capture reads the
+    // normalised `text`" apart from "capture reads the raw `rawText`" — both
+    // would produce byte-identical output. This fixture makes that
+    // distinction observable (G2).
+    const raw = '| A | B |\n| --- | --- |\n| 1 | 2 |\n\n```ts\nconst x = 1 | 2\n```\n\nStatus update — done. ✅ `code` 😀.'
     await sendReply(h.deps, req(raw))
 
     expect(observedByVoicePlan).not.toBeNull()
@@ -519,6 +534,15 @@ describe('speech capture (PR-0) — driven through the REAL sendReply wiring, no
     // from" resolveVoiceOutPlan's input — it is the SAME string, by identity
     // of value, not by coincidence of two independent pipelines agreeing.
     expect(captured[0]!.text).toBe(observedByVoicePlan)
+    // G2: the captured text is the NORMALISED/scrubbed form, downstream of
+    // `scrubVoice`'s em-dash rewrite — not the raw fixture. A regression
+    // that swapped in the pre-pipeline `rawText` would still satisfy the
+    // identity assertion above (both call sites would agree on SOME
+    // string), so this must check the captured content against the known
+    // transform independently, not just against `observedByVoicePlan`.
+    expect(captured[0]!.text).not.toBe(raw)
+    expect(captured[0]!.text).not.toContain('Status update — done')
+    expect(captured[0]!.text).toContain('Status update, done')
   })
 
   it('flag OFF: sendReply never creates the capture file, even with a writable state dir', async () => {

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -513,14 +513,13 @@ describe('speech capture (PR-0) — driven through the REAL sendReply wiring, no
     }
 
     // Deliberately includes a spaced em-dash: `normalizeOutboundBody`'s
-    // voice-scrub pass (`scrubVoice`, applied LAST in the pipeline —
-    // outbound-send-path.ts's own docstring: "normalize → redact →
-    // punctuation/bold → voice-scrub") rewrites a mid-prose ` — ` into `. `
-    // plus recapitalizing the following word. A golden fixture with nothing
-    // for the pipeline to transform can't tell "capture reads the
-    // normalised `text`" apart from "capture reads the raw `rawText`" — both
-    // would produce byte-identical output. This fixture makes that
-    // distinction observable (G2).
+    // punctuation/bold pass (`normalizePunctuation`, format.ts:695, step 4
+    // of the pipeline — outbound-send-path.ts's own docstring: "normalize →
+    // redact → punctuation/bold → voice-scrub") rewrites a bare/mid-prose
+    // em-dash into `, `. A golden fixture with nothing for the pipeline to
+    // transform can't tell "capture reads the normalised `text`" apart from
+    // "capture reads the raw `rawText`" — both would produce byte-identical
+    // output. This fixture makes that distinction observable (G2).
     const raw = '| A | B |\n| --- | --- |\n| 1 | 2 |\n\n```ts\nconst x = 1 | 2\n```\n\nStatus update — done. ✅ `code` 😀.'
     await sendReply(h.deps, req(raw))
 
@@ -534,12 +533,12 @@ describe('speech capture (PR-0) — driven through the REAL sendReply wiring, no
     // from" resolveVoiceOutPlan's input — it is the SAME string, by identity
     // of value, not by coincidence of two independent pipelines agreeing.
     expect(captured[0]!.text).toBe(observedByVoicePlan)
-    // G2: the captured text is the NORMALISED/scrubbed form, downstream of
-    // `scrubVoice`'s em-dash rewrite — not the raw fixture. A regression
-    // that swapped in the pre-pipeline `rawText` would still satisfy the
-    // identity assertion above (both call sites would agree on SOME
-    // string), so this must check the captured content against the known
-    // transform independently, not just against `observedByVoicePlan`.
+    // G2: the captured text is the NORMALISED form, downstream of
+    // `normalizePunctuation`'s em-dash rewrite — not the raw fixture. A
+    // regression that swapped in the pre-pipeline `rawText` would still
+    // satisfy the identity assertion above (both call sites would agree on
+    // SOME string), so this must check the captured content against the
+    // known transform independently, not just against `observedByVoicePlan`.
     expect(captured[0]!.text).not.toBe(raw)
     expect(captured[0]!.text).not.toContain('Status update — done')
     expect(captured[0]!.text).toContain('Status update, done')

--- a/telegram-plugin/tests/speech-capture.test.ts
+++ b/telegram-plugin/tests/speech-capture.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, afterEach } from 'vitest'
-import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { captureSpeechText, SPEECH_CAPTURE_FILE_NAME } from '../gateway/speech-capture.js'
+import {
+  captureSpeechText,
+  SPEECH_CAPTURE_FILE_NAME,
+  __resetSpeechCaptureLogStateForTests,
+} from '../gateway/speech-capture.js'
 
 /**
  * PR-0 (`/tmp/claude-0/tts/out/fable-plan-v2.md` §9): flag-gated raw-markdown
@@ -11,6 +15,12 @@ import { captureSpeechText, SPEECH_CAPTURE_FILE_NAME } from '../gateway/speech-c
  * touch a live agent's state tree (`TELEGRAM_STATE_DIR` is not covered by the
  * repo's agent-state-dir hermeticity guard, see
  * `tests/vitest-setup/agent-state-dir-guard-core.mjs`).
+ *
+ * The integration-level guarantees (a write failure never breaks the REAL
+ * `sendReply`; the captured string IS the exact `resolveVoiceOutPlan`
+ * argument, not merely textually adjacent) are pinned separately in
+ * `send-reply-golden.test.ts`, driven through the real wiring — this file
+ * covers the module's own contract in isolation.
  */
 describe('captureSpeechText', () => {
   const dirs: string[] = []
@@ -24,6 +34,7 @@ describe('captureSpeechText', () => {
     for (const d of dirs.splice(0)) {
       rmSync(d, { recursive: true, force: true })
     }
+    __resetSpeechCaptureLogStateForTests()
   })
 
   it('flag off (explicit enabled:false) writes nothing — true no-op', () => {
@@ -53,6 +64,32 @@ describe('captureSpeechText', () => {
       enabled: false,
       stateDir: '/definitely/does/not/exist/\0bad',
     })).not.toThrow()
+  })
+
+  it('M1: flag accepts "1"', () => {
+    const stateDir = freshDir()
+    const prior = process.env.SWITCHROOM_SPEECH_CAPTURE
+    process.env.SWITCHROOM_SPEECH_CAPTURE = '1'
+    try {
+      captureSpeechText('x', { stateDir })
+      expect(existsSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME))).toBe(true)
+    } finally {
+      if (prior === undefined) delete process.env.SWITCHROOM_SPEECH_CAPTURE
+      else process.env.SWITCHROOM_SPEECH_CAPTURE = prior
+    }
+  })
+
+  it('M1: flag accepts "true" (text-voice-scrub.ts:102 convention) — not silently a no-op', () => {
+    const stateDir = freshDir()
+    const prior = process.env.SWITCHROOM_SPEECH_CAPTURE
+    process.env.SWITCHROOM_SPEECH_CAPTURE = 'true'
+    try {
+      captureSpeechText('x', { stateDir })
+      expect(existsSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME))).toBe(true)
+    } finally {
+      if (prior === undefined) delete process.env.SWITCHROOM_SPEECH_CAPTURE
+      else process.env.SWITCHROOM_SPEECH_CAPTURE = prior
+    }
   })
 
   it('flag on appends the exact string, byte-for-byte, including a table, a fenced code block, an emoji, and inline backticks', () => {
@@ -88,6 +125,21 @@ describe('captureSpeechText', () => {
     expect(parsed.text).toContain('😀')
   })
 
+  it('flag on preserves a lone (unpaired) surrogate byte-for-byte through the JSON round-trip', () => {
+    const stateDir = freshDir()
+    // A lone high surrogate with no low-surrogate partner — the kind of
+    // malformed-but-real string content a JS string can hold (e.g. a
+    // truncated emoji from an upstream mangling) that a naive re-encoding
+    // pass can silently mutate or drop.
+    const raw = 'before \uD800 after'
+    captureSpeechText(raw, { enabled: true, stateDir, now: () => 1 })
+    const filePath = join(stateDir, SPEECH_CAPTURE_FILE_NAME)
+    const line = readFileSync(filePath, 'utf8').split('\n').filter((l) => l.length > 0)[0]!
+    const parsed = JSON.parse(line) as { ts: number; text: string }
+    expect(parsed.text).toBe(raw)
+    expect(parsed.text.charCodeAt(parsed.text.indexOf('\uD800'))).toBe(0xd800)
+  })
+
   it('flag on appends one JSON line per call, in order', () => {
     const stateDir = freshDir()
     captureSpeechText('first', { enabled: true, stateDir, now: () => 1 })
@@ -110,22 +162,47 @@ describe('captureSpeechText', () => {
     }
   })
 
+  it('B1: the capture file is created 0o600 (owner-only), not the umask default', () => {
+    const stateDir = freshDir()
+    captureSpeechText('x', { enabled: true, stateDir })
+    const filePath = join(stateDir, SPEECH_CAPTURE_FILE_NAME)
+    const mode = statSync(filePath).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('B1: mode stays 0o600 across repeated appends to an already-created file', () => {
+    const stateDir = freshDir()
+    captureSpeechText('first', { enabled: true, stateDir })
+    // Second call appends to the now-existing file; mode must not have been
+    // relaxed by any subsequent create-mode default.
+    captureSpeechText('second', { enabled: true, stateDir })
+    const filePath = join(stateDir, SPEECH_CAPTURE_FILE_NAME)
+    const mode = statSync(filePath).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('B1/no dead mkdir: a stateDir that does not exist is a swallowed write failure, not silently created', () => {
+    // The prior implementation's `mkdirSync(stateDir, {recursive:true, mode:
+    // 0o700})` protected nothing in production (TELEGRAM_STATE_DIR always
+    // pre-exists) and is gone; a genuinely-missing dir now fails the write
+    // (ENOENT) exactly like any other write-failure shape, swallowed.
+    const parent = freshDir()
+    const missing = join(parent, 'does', 'not', 'exist')
+    expect(() => captureSpeechText('x', { enabled: true, stateDir: missing })).not.toThrow()
+    expect(existsSync(missing)).toBe(false)
+  })
+
   it('a write error (destination path collides with a file, not a dir) does not throw', () => {
     const parent = freshDir()
-    // Make `stateDir` itself a FILE, so mkdirSync/appendFileSync both fail
-    // with ENOTDIR — the exact swallow path the spec requires.
     const stateDir = join(parent, 'not-a-directory')
     writeFileSync(stateDir, 'not a directory')
     expect(() => captureSpeechText('should not throw', { enabled: true, stateDir })).not.toThrow()
-    // And confirm no file materialized at the (impossible) capture path.
     expect(existsSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME))).toBe(false)
   })
 
   it('a write error into a read-only directory does not throw', () => {
     const stateDir = freshDir()
     mkdirSync(stateDir, { recursive: true })
-    // Deny write access; appendFileSync should throw internally and be
-    // swallowed, never propagating to the caller (the send path).
     const originalMode = 0o755
     try {
       // Some sandboxes ignore chmod as non-root; this test still asserts the
@@ -136,5 +213,61 @@ describe('captureSpeechText', () => {
     } finally {
       chmodSync(stateDir, originalMode)
     }
+  })
+
+  describe('M2: observability — never silent for the full 7-day window', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('logs one stderr line the first time capture actually fires, not on every call', () => {
+      const stateDir = freshDir()
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+      try {
+        captureSpeechText('first', { enabled: true, stateDir })
+        captureSpeechText('second', { enabled: true, stateDir })
+        captureSpeechText('third', { enabled: true, stateDir })
+        const enableLines = spy.mock.calls.filter((c) => String(c[0]).includes('speech-capture: enabled'))
+        expect(enableLines).toHaveLength(1)
+      } finally {
+        spy.mockRestore()
+      }
+    })
+
+    it('does not log the "enabled" line when the flag is off', () => {
+      const stateDir = freshDir()
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+      try {
+        captureSpeechText('x', { enabled: false, stateDir })
+        const enableLines = spy.mock.calls.filter((c) => String(c[0]).includes('speech-capture: enabled'))
+        expect(enableLines).toHaveLength(0)
+      } finally {
+        spy.mockRestore()
+      }
+    })
+
+    it('logs a write-failure line on the first failure, then rate-limits further failures', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(0)
+      const parent = freshDir()
+      const stateDir = join(parent, 'not-a-directory')
+      writeFileSync(stateDir, 'not a directory')
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+      try {
+        captureSpeechText('one', { enabled: true, stateDir })
+        captureSpeechText('two', { enabled: true, stateDir })
+        vi.setSystemTime(1000) // 1s later — still inside the rate-limit window
+        captureSpeechText('three', { enabled: true, stateDir })
+        const failLines = spy.mock.calls.filter((c) => String(c[0]).includes('speech-capture: write failed'))
+        expect(failLines).toHaveLength(1)
+
+        vi.setSystemTime(6 * 60_000) // past the 5-minute window
+        captureSpeechText('four', { enabled: true, stateDir })
+        const failLinesAfter = spy.mock.calls.filter((c) => String(c[0]).includes('speech-capture: write failed'))
+        expect(failLinesAfter).toHaveLength(2)
+      } finally {
+        spy.mockRestore()
+      }
+    })
   })
 })

--- a/telegram-plugin/tests/speech-capture.test.ts
+++ b/telegram-plugin/tests/speech-capture.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { captureSpeechText, SPEECH_CAPTURE_FILE_NAME } from '../gateway/speech-capture.js'
+
+/**
+ * PR-0 (`/tmp/claude-0/tts/out/fable-plan-v2.md` §9): flag-gated raw-markdown
+ * capture hook. Every test here points at an explicit `stateDir` override —
+ * never at `process.env.TELEGRAM_STATE_DIR` — so nothing in this suite can
+ * touch a live agent's state tree (`TELEGRAM_STATE_DIR` is not covered by the
+ * repo's agent-state-dir hermeticity guard, see
+ * `tests/vitest-setup/agent-state-dir-guard-core.mjs`).
+ */
+describe('captureSpeechText', () => {
+  const dirs: string[] = []
+  function freshDir(): string {
+    const d = mkdtempSync(join(tmpdir(), 'speech-capture-test-'))
+    dirs.push(d)
+    return d
+  }
+
+  afterEach(() => {
+    for (const d of dirs.splice(0)) {
+      rmSync(d, { recursive: true, force: true })
+    }
+  })
+
+  it('flag off (explicit enabled:false) writes nothing — true no-op', () => {
+    const stateDir = freshDir()
+    captureSpeechText('hello world', { enabled: false, stateDir })
+    expect(existsSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME))).toBe(false)
+  })
+
+  it('flag off via env (SWITCHROOM_SPEECH_CAPTURE unset) writes nothing', () => {
+    const stateDir = freshDir()
+    const prior = process.env.SWITCHROOM_SPEECH_CAPTURE
+    delete process.env.SWITCHROOM_SPEECH_CAPTURE
+    try {
+      captureSpeechText('hello world', { stateDir })
+      expect(existsSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME))).toBe(false)
+    } finally {
+      if (prior === undefined) delete process.env.SWITCHROOM_SPEECH_CAPTURE
+      else process.env.SWITCHROOM_SPEECH_CAPTURE = prior
+    }
+  })
+
+  it('flag off: never touches the filesystem, even with a garbage stateDir', () => {
+    // Negligible-cost proof: an unwritable/garbage destination must not
+    // surface any error or side effect when the flag is off — the function
+    // should return before touching fs at all.
+    expect(() => captureSpeechText('x', {
+      enabled: false,
+      stateDir: '/definitely/does/not/exist/\0bad',
+    })).not.toThrow()
+  })
+
+  it('flag on appends the exact string, byte-for-byte, including a table, a fenced code block, an emoji, and inline backticks', () => {
+    const stateDir = freshDir()
+    const raw = [
+      '# Heading',
+      '',
+      '| A | B |',
+      '| --- | --- |',
+      '| 1 | 2 |',
+      '',
+      '```ts',
+      'const x = 1 | 2',
+      '```',
+      '',
+      'Status: ✅ done, use `inline code` with a pipe | here, and an emoji 😀.',
+    ].join('\n')
+    captureSpeechText(raw, { enabled: true, stateDir, now: () => 1234567890 })
+    const filePath = join(stateDir, SPEECH_CAPTURE_FILE_NAME)
+    expect(existsSync(filePath)).toBe(true)
+    const contents = readFileSync(filePath, 'utf8')
+    const lines = contents.split('\n').filter((l) => l.length > 0)
+    expect(lines).toHaveLength(1)
+    const parsed = JSON.parse(lines[0]) as { ts: number; text: string }
+    expect(parsed.ts).toBe(1234567890)
+    // Byte-for-byte: exact equality, not a fuzzy/normalized comparison.
+    expect(parsed.text).toBe(raw)
+    // Explicitly pin the bytes the redesign depends on surviving capture.
+    expect(parsed.text).toContain('| A | B |')
+    expect(parsed.text).toContain('```ts')
+    expect(parsed.text).toContain('`inline code`')
+    expect(parsed.text).toContain('✅')
+    expect(parsed.text).toContain('😀')
+  })
+
+  it('flag on appends one JSON line per call, in order', () => {
+    const stateDir = freshDir()
+    captureSpeechText('first', { enabled: true, stateDir, now: () => 1 })
+    captureSpeechText('second', { enabled: true, stateDir, now: () => 2 })
+    const filePath = join(stateDir, SPEECH_CAPTURE_FILE_NAME)
+    const lines = readFileSync(filePath, 'utf8').split('\n').filter((l) => l.length > 0)
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0])).toEqual({ ts: 1, text: 'first' })
+    expect(JSON.parse(lines[1])).toEqual({ ts: 2, text: 'second' })
+  })
+
+  it('flag on but stateDir unresolved (no TELEGRAM_STATE_DIR, no override) writes nothing and does not throw', () => {
+    const prior = process.env.TELEGRAM_STATE_DIR
+    delete process.env.TELEGRAM_STATE_DIR
+    try {
+      expect(() => captureSpeechText('x', { enabled: true })).not.toThrow()
+    } finally {
+      if (prior === undefined) delete process.env.TELEGRAM_STATE_DIR
+      else process.env.TELEGRAM_STATE_DIR = prior
+    }
+  })
+
+  it('a write error (destination path collides with a file, not a dir) does not throw', () => {
+    const parent = freshDir()
+    // Make `stateDir` itself a FILE, so mkdirSync/appendFileSync both fail
+    // with ENOTDIR — the exact swallow path the spec requires.
+    const stateDir = join(parent, 'not-a-directory')
+    writeFileSync(stateDir, 'not a directory')
+    expect(() => captureSpeechText('should not throw', { enabled: true, stateDir })).not.toThrow()
+    // And confirm no file materialized at the (impossible) capture path.
+    expect(existsSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME))).toBe(false)
+  })
+
+  it('a write error into a read-only directory does not throw', () => {
+    const stateDir = freshDir()
+    mkdirSync(stateDir, { recursive: true })
+    // Deny write access; appendFileSync should throw internally and be
+    // swallowed, never propagating to the caller (the send path).
+    const originalMode = 0o755
+    try {
+      // Some sandboxes ignore chmod as non-root; this test still asserts the
+      // no-throw contract either way, it just may not exercise the EACCES
+      // path when running as root.
+      chmodSync(stateDir, 0o500)
+      expect(() => captureSpeechText('x', { enabled: true, stateDir })).not.toThrow()
+    } finally {
+      chmodSync(stateDir, originalMode)
+    }
+  })
+})

--- a/telegram-plugin/tests/speech-capture.test.ts
+++ b/telegram-plugin/tests/speech-capture.test.ts
@@ -43,6 +43,26 @@ describe('captureSpeechText', () => {
     expect(existsSync(join(stateDir, SPEECH_CAPTURE_FILE_NAME))).toBe(false)
   })
 
+  it('G1: captureSpeechText returns undefined (sync contract), flag on and flag off alike', () => {
+    // Pins the SYNCHRONOUS return contract the swallow-on-write-failure
+    // guarantee depends on. `send-reply-golden.test.ts`'s M3 "write failure
+    // never breaks the reply" test only observes that the reply still ships
+    // — it would NOT go red if a refactor made this function `async` and
+    // fire-and-forget (an unawaited rejection there becomes an unhandled
+    // rejection, which this codebase's policy treats as fatal — see
+    // analytics-posthog.ts and chat-lock.ts). An `async function` always
+    // returns a Promise, never `undefined`, so THIS assertion is the one
+    // that goes red on that mutation, awaited or not.
+    const stateDir = freshDir()
+    expect(captureSpeechText('x', { enabled: false, stateDir })).toBeUndefined()
+    expect(captureSpeechText('x', { enabled: true, stateDir })).toBeUndefined()
+    // Also true on the swallowed-write-failure path (destination collides
+    // with a file, not a dir) — the exact shape M3's golden test exercises.
+    const notADir = join(freshDir(), 'not-a-directory-marker')
+    writeFileSync(notADir, 'not a directory')
+    expect(captureSpeechText('x', { enabled: true, stateDir: notADir })).toBeUndefined()
+  })
+
   it('flag off via env (SWITCHROOM_SPEECH_CAPTURE unset) writes nothing', () => {
     const stateDir = freshDir()
     const prior = process.env.SWITCHROOM_SPEECH_CAPTURE

--- a/telegram-plugin/tests/speech-capture.test.ts
+++ b/telegram-plugin/tests/speech-capture.test.ts
@@ -216,10 +216,6 @@ describe('captureSpeechText', () => {
   })
 
   describe('M2: observability — never silent for the full 7-day window', () => {
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
     it('logs one stderr line the first time capture actually fires, not on every call', () => {
       const stateDir = freshDir()
       const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
@@ -247,8 +243,14 @@ describe('captureSpeechText', () => {
     })
 
     it('logs a write-failure line on the first failure, then rate-limits further failures', () => {
-      vi.useFakeTimers()
-      vi.setSystemTime(0)
+      // Manual Date.now mocking, NOT vi.useFakeTimers()/vi.setSystemTime():
+      // this file runs under both vitest AND `bun test` (telegram-plugin's
+      // bun-test-ci.sh substring-matches the whole tests/ dir), and bun's
+      // vitest shim does not implement `vi.setSystemTime` — see
+      // progress-update.test.ts's note on the same gotcha (CI build #48).
+      // `vi.spyOn` + `mockImplementation` works under both runners.
+      let mockNow = 0
+      const dateSpy = vi.spyOn(Date, 'now').mockImplementation(() => mockNow)
       const parent = freshDir()
       const stateDir = join(parent, 'not-a-directory')
       writeFileSync(stateDir, 'not a directory')
@@ -256,17 +258,18 @@ describe('captureSpeechText', () => {
       try {
         captureSpeechText('one', { enabled: true, stateDir })
         captureSpeechText('two', { enabled: true, stateDir })
-        vi.setSystemTime(1000) // 1s later — still inside the rate-limit window
+        mockNow = 1000 // 1s later — still inside the rate-limit window
         captureSpeechText('three', { enabled: true, stateDir })
         const failLines = spy.mock.calls.filter((c) => String(c[0]).includes('speech-capture: write failed'))
         expect(failLines).toHaveLength(1)
 
-        vi.setSystemTime(6 * 60_000) // past the 5-minute window
+        mockNow = 6 * 60_000 // past the 5-minute window
         captureSpeechText('four', { enabled: true, stateDir })
         const failLinesAfter = spy.mock.calls.filter((c) => String(c[0]).includes('speech-capture: write failed'))
         expect(failLinesAfter).toHaveLength(2)
       } finally {
         spy.mockRestore()
+        dateSpy.mockRestore()
       }
     })
   })


### PR DESCRIPTION
## Summary
- Adds `captureSpeechText` (`telegram-plugin/gateway/speech-capture.ts`), wired at the `resolveVoiceOutPlan` call site (`outbound-send-path.ts:1379`, verified against `origin/main` @ 08262924).
- Flag-gated on `SWITCHROOM_SPEECH_CAPTURE=1` or `=true`, default off — a true no-op when unset. When on, appends one `{ts, text}` JSON line per reply to `$TELEGRAM_STATE_DIR/speech-capture.jsonl` (mode `0o600`, owner-only), capturing the *exact* pre-normalisation `text` argument byte-for-byte before any TTS normalisation runs.
- This is PR-0 of the TTS normalisation redesign (`/tmp/claude-0/tts/out/fable-plan-v2.md` §9): a precondition for later Stage-A property/replay tests, which need real markdown (tables, fences, pipes, emoji) that the existing pass-1 `corpus.json` lacks (§0 C-3) and that `telegram/history.db` cannot provide either (it stores rendered, not pre-render, text).

## Why here
`text` at `outbound-send-path.ts:1379` is the post-`normalizeOutboundBody` string — already through outbound secret redaction (`outbound-send-path.ts:218-259`) — and IS Stage A's future input (spec §0 C-4). **Correction from an earlier revision of this description:** this is *not* the same string the visible rich render parses — the render path additionally runs `computeEffectiveText`/`addParagraphSpacers` (U+00A0 paragraph-spacer injection) downstream of this capture point. The code was always correct; only this description (and a docstring in `speech-capture.ts`) said otherwise. Fixed in both places.

## Review round (PR #4688, DO-NOT-MERGE verdict addressed)
- **B1 (blocker) — world-readable capture file.** `appendFileSync` now passes `{ mode: 0o600 }` (matches the repo idiom in `shown-ledger.ts`/`outbox.ts`), so the file holding full reply plaintext is no longer weaker than `access.json`. Also dropped the `mkdirSync(stateDir, { recursive: true, mode: 0o700 })` call — `TELEGRAM_STATE_DIR` always pre-exists in production, so it never applied that mode and protected nothing; a genuinely-missing dir now just fails the write (swallowed) like any other write-failure shape.
- **M1 (major) — `=true` silently did nothing.** `envFlagEnabled()` now accepts `'1'` or `'true'`, matching `text-voice-scrub.ts:102`'s convention.
- **M2 (major) — zero observability for a 7-day silent window.** Added a one-shot stderr line the first time capture actually fires, and a 5-minute-rate-limited stderr line on the first (and subsequent) write failures — covers the #4371 foreign-uid-EACCES failure class. Both are independently pinned by new tests using `vi.spyOn(process.stderr, 'write')` (with `vi.useFakeTimers()` for the rate-limit boundary).
- **M3 (major) — the load-bearing guarantee was pinned by nothing.** Added two integration tests in `send-reply-golden.test.ts`, driven through the REAL `sendReply` wiring (not a synthetic `captureSpeechText` call): (1) flag on + unwritable `TELEGRAM_STATE_DIR` still ships the reply; (2) the string captured to disk IS the exact argument observed by an instrumented `resolveVoiceOutPlan`, not merely textually adjacent to it.
- **M5 (major) — nothing would ever turn it off.** Filed switchroom/switchroom#4690, a dated follow-up to disable and remove the flag once the 7-day capture window closes; referenced in the CHANGELOG entry.
- **Minors:**
  - Corrected the `speech-capture.ts` docstring's false "same string the visible rich render parses" claim (see "Why here" above).
  - **Corpus is a biased sample, not the full population:** capture runs on `sendReply` only — `edit_message`, standalone `sendReplyChunks`, and the turn-flush backstop never reach it. The spec's achievability argument (~2.9 MB/7d fleet-wide) was measured over a broader population than this hook observes. PR-2's sufficiency check must not assume the two populations match.
  - Noted for PR-2: the corpus loader should skip unparseable lines rather than throw — during a gateway restart overlap, two processes could briefly interleave appends to the same file.
  - `process.env.SWITCHROOM_SPEECH_CAPTURE` / `TELEGRAM_STATE_DIR` reads stay dynamic (per-call), deliberately NOT cached at module scope like `current-turn-map.ts`'s `EMISSION_AUTHORITY_ENABLED` — caching would make the flag un-togglable within a single test process, which the M3 integration tests need. Reasoning is now documented directly in the `speech-capture.ts` module docstring.
  - Added a lone-(unpaired-)surrogate case to the byte-preservation test; the original only covered paired emoji.
  - CHANGELOG entry expanded to state the flag is off by default and spell out the privacy implication (full plaintext reply body while enabled).

One item from the review is intentionally **not** addressed here: the finding that the spec's "secrets-scrubbed before check-in" step is circular and that the target repo is public. That's a rollout-gate question, not a code-gate one — the dispatching agent is escalating it separately.

## Mutation-testing round (two guard-coverage gaps, neither a live defect)
An independent mutation-testing pass on the review-round fixes above found two holes in the guard suite — the shipped code was already correct in both cases, but the tests didn't yet prove it:
- **G1 — the synchronous return contract wasn't pinned.** A refactor that made `captureSpeechText` `async` and awaited would fail the existing swallow-on-write-failure test, but a fire-and-forget async rewrite (unawaited) would not — and that variant is worse, since the resulting unhandled rejection crashes the gateway per this codebase's policy (`analytics-posthog.ts`, `chat-lock.ts`), not merely loses one capture line. Fixed: a new `speech-capture.test.ts` case asserts `captureSpeechText(...)` returns `undefined` on every path (flag off, flag on, swallowed write failure) — an `async function` always returns a `Promise`, so this goes red on that mutation regardless of whether it's awaited. Also corrected a false comment on the `send-reply-golden.test.ts` write-failure test that claimed it alone would catch an async refactor — it doesn't; it only pins the current synchronous, in-place-caught shape.
- **G2 — "capture reads the post-redaction string, not the raw one" wasn't pinned.** Swapping `captureSpeechText(text)` for `captureSpeechText(rawText)` at the `outbound-send-path.ts` call site left the golden fixture unchanged, because it contained nothing `normalizeOutboundBody` transforms. Fixed: the golden fixture now includes a spaced em-dash (`scrubVoice` rewrites it to `, ` mid-sentence, downstream in the normalize → redact → punctuation/bold → voice-scrub pipeline), and the test asserts the captured string matches the scrubbed form and differs from the raw fixture. Verified red-then-green locally: temporarily mutated the call site to `captureSpeechText(rawText)`, confirmed the new assertion failed, reverted, confirmed it passed — `git diff` on `outbound-send-path.ts` is empty on this branch.

Also: the review-round test-plan line below previously said "18 cases, up from 8" for `speech-capture.test.ts`, but the actual count after that round was 17 — a miscount, not a missing test. The G1 fix above adds one more case, so the count is genuinely 18 again now.

## Test plan
- [x] `telegram-plugin/tests/speech-capture.test.ts` (18 cases, up from 8): flag-off no-op (explicit `enabled:false`, unset env, garbage destination — no fs touch); flag-on accepts `'1'` and `'true'`; byte-for-byte capture of a table/fence/backticks/emoji, plus a dedicated lone-surrogate case; ordered multi-line appends; unresolved `stateDir` and two write-failure shapes swallowed without throwing; file created `0o600` and stays `0o600` across repeated appends; one-shot enable log and rate-limited write-error log, both independently pinned; G1's synchronous-return-contract case.
- [x] `telegram-plugin/tests/send-reply-golden.test.ts` — new `describe` block, 3 cases, driven through the real `sendReply` wiring: write-failure-never-breaks-the-reply (M3), captured-string-is-the-exact-resolveVoiceOutPlan-argument AND is the post-redaction/scrubbed form, not raw (M3 + G2), flag-off-never-creates-the-file.
- [x] `./node_modules/.bin/tsc --noEmit` — clean on every file this PR touches (pre-existing unrelated `nostr-tools` type errors in `src/buzz-gateway/*` are not from this change).
- [x] `./node_modules/.bin/vitest run telegram-plugin/tests/speech-capture.test.ts telegram-plugin/tests/send-reply-golden.test.ts telegram-plugin/tests/outbound-send-path.test.ts` — 167/167 pass (18 + 65 + 84, zero regressions at the call site).
- [x] Full `vitest run` — green (see CI).
- [x] `npm run lint` — spot-checked the guards most relevant to this change locally (`check-agent-state-dir-hermeticity`, `check-no-pii-secrets`, `check-bun-test-imports`, `check-test-runner-coverage`, `check-changelog-entry`); full `npm run lint` is also asserted by CI.
- [x] Flag is NOT enabled anywhere — no config or environment change ships in this PR.

## Risk
Flag defaults off; when off the added code is a single function-pointer check with zero fs access (pinned by a dedicated test). When on, every write is wrapped in `try/catch` — a write failure can never throw into the send path, now proven through the real `sendReply` wiring rather than asserted only by construction. Deliberately does **not** bound/rotate the capture file: per spec this is a time-boxed 7-day fleet-wide capture window (reviewer-measured at ~2.9 MB fleet-wide over 7 days), after which the file is reviewed, secrets-scrubbed, and checked into the repo as a static fixture — not a long-lived production log. switchroom/switchroom#4690 tracks turning the flag off for good once that window closes.

Job spec: none directly in `reference/jobs/` for TTS internals; this PR ships no user-facing behaviour change (flag off by default, not enabled anywhere).

