### PR TITLE
fix(telegram): fence-aware `**>` repair + raw-HTML dialect folding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,30 @@ now an anomaly worth investigating, not the norm.
   change, every one trading a wrong reading for a silently-skipped one).
   Correctly expanding a decimal/comma-glued number is out of scope for this
   narrow hotfix and is left for a follow-up.
+- **telegram: fence-aware `**>` repair + raw-HTML dialect folding** — two
+  defects in the outbound render pipeline. (1) `markExpandableQuotes`
+  (`telegram-plugin/render/parse.ts`) rewrote every line opening with the
+  legacy `**>` expandable-blockquote marker *before* micromark parsed, with
+  no fence tracking — so a `**>` line inside a fenced code block was shipped
+  silently corrupted as `  >`, because `renderCodeBlock` emits `code.value`
+  from the rewritten tree. The rewrite is now fence-aware (CommonMark opener
+  and closer rules; inside a fence every line is copied verbatim), preserving
+  the length-preservation invariant the offset-based folds depend on.
+  (2) Raw HTML tags fell through to `plain` nodes and were run through
+  `escapeMarkdown`, which escapes `=` — so `<a href="…">` shipped as
+  `<a href\="…">` and could never render as a link, and unknown tags reached
+  the wire verbatim where Telegram can 400 with `unsupported start tag`,
+  whose fallback resends plain text and puts literal markup on the reader's
+  screen. A new `telegram-plugin/render/html-fold.ts` sorts tags into three
+  buckets: markdown-equivalent tags (`<b>`, `<i>`, `<s>`, `<code>`,
+  `<a href>`, …) fold into their native IR nodes; the wire-verified
+  passthrough allowlist (`<u>`, `<sub>`, `<sup>`, `<details>`/`<summary>`,
+  `<aside>`/`<cite>`) stays raw and unescaped; anything else has its markup
+  dropped and its content kept. **Deliberate behaviour change:** the renderer
+  now discards markup it cannot guarantee. Content is never lost;
+  unguaranteeable markup is — which beats a 400 that degrades the whole
+  message to plain text. Also locks in the blank-line-separated expandable
+  shape, the majority corpus shape, which worked but had no test.
 
 ## v0.21.9 — Telegram rich-markdown guards stop destroying supported constructs, and `tg://` inline entities render
 

--- a/telegram-plugin/render/html-fold.ts
+++ b/telegram-plugin/render/html-fold.ts
@@ -1,0 +1,164 @@
+// Raw-HTML dialect handling for the Bot API 10.1 rich-markdown render path.
+//
+// ── Why this module exists ────────────────────────────────────────────────
+// Agents habitually emit raw HTML tags in prose (`<b>`, `<i>`, `<a href>`).
+// Before this module those tags reached the wire byte-verbatim, which is two
+// distinct hazards at once:
+//
+//   1. Nothing establishes that Telegram's rich markdown parser accepts them.
+//      The wire-verified allowlist (raw `sendRichMessage` probes, 2026-08-13)
+//      covers exactly `<u>`, `<sub>`, `<sup>`, `<details>`/`<summary>` and
+//      `<aside>`/`<cite>`. `isParseEntitiesError` (`rich-send.ts`) matches
+//      `unsupported start tag` / `unclosed start tag`, so the wire CAN 400 on
+//      an unknown tag — and that fallback resends the body as PLAIN TEXT,
+//      where the reader then sees literal `<b>` markup.
+//   2. mdast `html` nodes degrade to `plain` in `parse.ts`, and `plain` is
+//      `escapeMarkdown`'d on render. `escapeMarkdown` escapes `=`, so
+//      `<a href="https://example.com">` shipped as `<a href\="…">` — an
+//      attribute no parser can read.
+//
+// ── The policy (three buckets, degrade by TYPE, never silently) ───────────
+//   • FOLD      — a tag with an exact native markdown equivalent is folded
+//                 into the IR node for that construct, so it renders as the
+//                 markdown the wire actually understands:
+//                   <b>/<strong>       -> bold          **…**
+//                   <i>/<em>           -> italic        *…*
+//                   <s>/<del>/<strike> -> strike        ~~…~~
+//                   <code>             -> code span     `…`
+//                   <a href="URL">     -> link          [label](URL)
+//                   <br>               -> a line break
+//   • PASSTHROUGH — the wire-verified allowlist above is emitted RAW and
+//                 UNESCAPED (an IR `raw` inline), which is also what stops
+//                 `escapeMarkdown` from mangling their attributes.
+//   • DEGRADE   — anything else (unknown tags, unmatched open/close markers,
+//                 comments) has its MARKUP dropped while its CONTENT is kept
+//                 and rendered normally. Never emit a construct the renderer
+//                 cannot guarantee: shipping an unknown tag verbatim risks the
+//                 400 -> plain-text fallback that shows the reader raw markup,
+//                 which is strictly worse than showing them the text.
+//
+// This is a deterministic code-level guarantee, deliberately not a prompt
+// instruction to the agents that emit the tags.
+
+/** How a raw HTML token reads. `other` covers anything the tokenizer matched
+ *  but could not classify (it degrades like an unknown tag). */
+export type HtmlTagKind = "open" | "close" | "selfclose" | "comment" | "other";
+
+export interface HtmlTagInfo {
+  kind: HtmlTagKind;
+  /** Lowercased tag name (`""` for a comment). */
+  name: string;
+  /** The raw source bytes of the token, verbatim. */
+  raw: string;
+  /** Raw attribute text between the tag name and the closing `>`. */
+  attrs: string;
+}
+
+/** The IR construct a foldable tag maps onto. */
+export type HtmlFoldTarget = "bold" | "italic" | "strike" | "code" | "link" | "break";
+
+/** Tags with an exact native markdown equivalent on the Bot API 10.1 rich
+ *  path. Folding them means the wire sees markdown it definitely parses
+ *  instead of HTML it may reject. */
+export const HTML_FOLD_TAGS: Readonly<Record<string, HtmlFoldTarget>> = {
+  b: "bold",
+  strong: "bold",
+  i: "italic",
+  em: "italic",
+  s: "strike",
+  del: "strike",
+  strike: "strike",
+  code: "code",
+  a: "link",
+  br: "break",
+};
+
+/** Tags PROVEN on the wire by raw `sendRichMessage` probes (2026-08-13) to
+ *  render as native typed nodes. These pass through raw and unescaped.
+ *  Deliberately an allowlist: an unprobed tag is not known-good syntax. */
+export const HTML_PASSTHROUGH_TAGS: ReadonlySet<string> = new Set([
+  "u",
+  "sub",
+  "sup",
+  "details",
+  "summary",
+  "aside",
+  "cite",
+]);
+
+/** Matches one HTML comment or one start/end tag. Attribute values containing
+ *  a raw `>` are not supported (they are invalid unquoted HTML and vanishingly
+ *  rare in agent prose); such a token simply degrades. */
+export const HTML_TOKEN_RE =
+  /<!--[\s\S]*?-->|<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*?)?\/?>/g;
+
+const TAG_RE = /^<(\/?)([A-Za-z][A-Za-z0-9-]*)((?:\s[^<>]*?)?)(\/?)>$/;
+const HREF_RE = /(?:^|\s)href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/i;
+
+/** Classify a single raw HTML token. */
+export function classifyHtmlTag(raw: string): HtmlTagInfo {
+  if (raw.startsWith("<!--")) return { kind: "comment", name: "", raw, attrs: "" };
+  const m = TAG_RE.exec(raw);
+  if (m == null) return { kind: "other", name: "", raw, attrs: "" };
+  const [, slash, name, attrs, selfClose] = m;
+  const kind: HtmlTagKind =
+    slash === "/" ? "close" : selfClose === "/" ? "selfclose" : "open";
+  return { kind, name: name.toLowerCase(), raw, attrs: attrs ?? "" };
+}
+
+/** Pull the `href` value out of a tag's attribute text, or null when absent
+ *  or empty. The ORIGINAL bytes are returned — never rewritten. */
+export function hrefOf(tag: HtmlTagInfo): string | null {
+  const m = HREF_RE.exec(tag.attrs);
+  if (m == null) return null;
+  const value = m[1] ?? m[2] ?? m[3] ?? "";
+  return value.length > 0 ? value : null;
+}
+
+/** True when this tag is emitted raw and unescaped (wire-verified allowlist). */
+export function isPassthroughTag(tag: HtmlTagInfo): boolean {
+  return tag.name.length > 0 && HTML_PASSTHROUGH_TAGS.has(tag.name);
+}
+
+/** A piece of a raw-HTML string: either an HTML token or a run of text. */
+export type HtmlPiece =
+  | { kind: "tag"; tag: HtmlTagInfo; start: number; end: number }
+  | { kind: "text"; text: string; start: number; end: number };
+
+/**
+ * Split a raw string into HTML tokens and the text runs between them.
+ * `base` is the absolute source offset the string starts at, so every piece
+ * carries usable UTF-16 offsets into the original markdown.
+ */
+export function tokenizeHtml(raw: string, base: number): HtmlPiece[] {
+  const pieces: HtmlPiece[] = [];
+  const re = new RegExp(HTML_TOKEN_RE.source, "g");
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(raw)) != null) {
+    if (m.index > last) {
+      pieces.push({
+        kind: "text",
+        text: raw.slice(last, m.index),
+        start: base + last,
+        end: base + m.index,
+      });
+    }
+    pieces.push({
+      kind: "tag",
+      tag: classifyHtmlTag(m[0]),
+      start: base + m.index,
+      end: base + m.index + m[0].length,
+    });
+    last = m.index + m[0].length;
+  }
+  if (last < raw.length) {
+    pieces.push({
+      kind: "text",
+      text: raw.slice(last),
+      start: base + last,
+      end: base + raw.length,
+    });
+  }
+  return pieces;
+}

--- a/telegram-plugin/render/parse.ts
+++ b/telegram-plugin/render/parse.ts
@@ -391,18 +391,35 @@ function findClosingTag(items: HtmlFoldItem[], from: number, name: string): numb
 }
 
 /** Flatten a folded run to literal text, or null when any child carries
- *  structure a code span cannot represent. Used for `<code>`. */
+ *  structure a code span cannot represent. Used for `<code>`. Deliberately
+ *  accepts ONLY `plain`: an inner `code` node's own backticks are not in its
+ *  `text`, so folding it in would silently DELETE them
+ *  (`<code>a `b` c</code>` -> `` `a b c` ``), and a `raw` node's wire bytes
+ *  would be swallowed into a literal span. Both degrade to the children
+ *  instead, which preserves every byte. */
 function inlineLiteralText(nodes: Inline[]): string | null {
   let out = "";
   for (const n of nodes) {
-    if (n.type === "plain" || n.type === "code" || n.type === "raw") out += n.text;
-    else return null;
+    if (n.type !== "plain") return null;
+    out += n.text;
   }
   return out;
 }
 
-/** Apply the three-bucket HTML policy over a mixed tag/inline stream. */
-function foldHtmlItems(items: HtmlFoldItem[]): Inline[] {
+/**
+ * Apply the three-bucket HTML policy over a mixed tag/inline stream.
+ *
+ * `active` carries the emphasis constructs already open in an ANCESTOR fold.
+ * Markdown cannot nest same-kind emphasis — `**a **b** c**` is asterisk soup
+ * on the reader's screen, not nested bold — so a tag whose target is already
+ * active degrades to its children. Combined with the single-child unwrap in
+ * `buildFoldedTag`, `<b>a <b>b</b> c</b>` and `<b>**already**</b>` both come
+ * out as ONE bold run.
+ */
+function foldHtmlItems(
+  items: HtmlFoldItem[],
+  active: ReadonlySet<HtmlFoldTarget> = new Set(),
+): Inline[] {
   const out: Inline[] = [];
   let i = 0;
   while (i < items.length) {
@@ -436,13 +453,17 @@ function foldHtmlItems(items: HtmlFoldItem[]): Inline[] {
     }
     if (target !== undefined && tag.kind === "open") {
       const close = findClosingTag(items, i + 1, tag.name);
-      if (close >= 0) {
-        const inner = foldHtmlItems(items.slice(i + 1, close));
-        const start = it.start;
-        const end = items[close].end;
-        const folded = buildFoldedTag(target, tag, inner, start, end);
+      const closeItem = close >= 0 ? items[close] : undefined;
+      if (closeItem !== undefined && closeItem.kind === "tag") {
+        const nested = new Set(active);
+        nested.add(target);
+        const inner = foldHtmlItems(items.slice(i + 1, close), nested);
+        const folded = active.has(target)
+          ? null
+          : buildFoldedTag(target, tag, inner, it.start, closeItem.end);
         // A tag we cannot represent faithfully (an `<a>` with no href, a
-        // `<code>` wrapping structure) degrades to its CONTENT — bucket 3.
+        // `<code>` wrapping structure, an emphasis already open above)
+        // degrades to its CONTENT — bucket 3.
         out.push(...(folded !== null ? [folded] : inner));
         i = close + 1;
         continue;
@@ -464,11 +485,12 @@ function buildFoldedTag(
 ): Inline | null {
   switch (target) {
     case "bold":
-      return { type: "bold", children, start, end };
     case "italic":
-      return { type: "italic", children, start, end };
     case "strike":
-      return { type: "strike", children, start, end };
+      // Already exactly that construct (`<b>**already**</b>`) — re-wrapping
+      // would emit `****already****`, which reads as literal asterisks.
+      if (children.length === 1 && children[0].type === target) return children[0];
+      return { type: target, children, start, end };
     case "code": {
       const text = inlineLiteralText(children);
       return text === null ? null : { type: "code", text, start, end };
@@ -533,6 +555,26 @@ function foldTableRow(
   return { cells, ...pos(row) };
 }
 
+/** True for a block that would render to the empty string. Only the raw-HTML
+ *  fold can produce one — a block that is nothing but markup we dropped
+ *  (`<!-- comment -->`, `<hr/>`, `<div></div>` on their own line). Left in,
+ *  each would contribute a spurious `\n\n` separator to the rendered document,
+ *  so they are filtered out at the point blocks are collected. */
+function isEmptyBlock(block: Block): boolean {
+  return block.type === "paragraph" && block.children.length === 0;
+}
+
+/** Fold a run of mdast block nodes, dropping any that render to nothing. */
+function foldBlocks(
+  nodes: ReadonlyArray<RootContent>,
+  source: string,
+  expandableLineStarts: Set<number>,
+): Block[] {
+  return nodes
+    .map((n) => foldBlock(n, source, expandableLineStarts))
+    .filter((b) => !isEmptyBlock(b));
+}
+
 function foldBlock(
   node: RootContent,
   source: string,
@@ -555,7 +597,7 @@ function foldBlock(
       const expandable = expandableLineStarts.has(lineStart(source, p.start));
       return {
         type: "blockquote",
-        children: node.children.map((c) => foldBlock(c, source, expandableLineStarts)),
+        children: foldBlocks(node.children, source, expandableLineStarts),
         expandable,
         ...p,
       };
@@ -569,7 +611,7 @@ function foldBlock(
       };
     case "list": {
       const items: ListItem[] = node.children.map((li) => ({
-        children: li.children.map((c) => foldBlock(c, source, expandableLineStarts)),
+        children: foldBlocks(li.children, source, expandableLineStarts),
         checked: li.checked ?? null,
         // mdast `listItem.spread`: whether this item's block children are
         // separated by a blank line. Tight (false) keeps a paragraph and its
@@ -650,8 +692,6 @@ export function parse(markdown: string): Document {
     mdastExtensions: [gfmFromMarkdown()],
   });
   return {
-    blocks: tree.children.map((child) =>
-      foldBlock(child, markdown, expandableLineStarts),
-    ),
+    blocks: foldBlocks(tree.children, markdown, expandableLineStarts),
   };
 }

--- a/telegram-plugin/render/parse.ts
+++ b/telegram-plugin/render/parse.ts
@@ -12,7 +12,11 @@
 //     `source.slice(node.start, node.end)` round-trips to the source text.
 //   - Never lose text. Any mdast node type outside the supported palette
 //     degrades to a `plain` inline (or a paragraph wrapping one) carrying the
-//     raw source slice, rather than being dropped.
+//     raw source slice, rather than being dropped. The ONE deliberate
+//     exception is raw-HTML MARKUP: an unrecognised tag has its angle-bracket
+//     token dropped while its content is kept and rendered (see the raw-HTML
+//     note below and `html-fold.ts`). Content is never lost; unguaranteeable
+//     markup is.
 //
 // Underline vs bold (`__…__` vs `**…**`):
 //   Telegram's Bot API 10.1 rich markdown reads a `__…__` double-underscore run
@@ -56,6 +60,25 @@
 //   marker characters differ, and they are never part of quoted content. The
 //   set of line-start offsets that carried the marker is threaded into
 //   `foldBlock` so the matching blockquote nodes get `expandable: true`.
+//
+//   The rewrite is FENCE-AWARE. Every other fold reads the ORIGINAL `markdown`
+//   through `slice()`, so the rewritten bytes never escape — except for the
+//   `code` fold, which must use mdast's `node.value` (the dedented, fence-
+//   stripped content, which offsets alone cannot reconstruct without
+//   re-implementing micromark's fence parser). That made a fenced block
+//   containing a line starting `**>` ship silently corrupted as `  >` —
+//   anyone documenting the legacy syntax got their code altered. Skipping
+//   fenced regions in the pre-pass fixes it at the one place the rewrite is
+//   decided, keeps `code.value` trustworthy for every consumer, and preserves
+//   the length invariant trivially (a skipped line is copied verbatim).
+//
+// Raw HTML handling:
+//   mdast `html` nodes (inline `<b>`/`<a href>` runs and whole HTML blocks)
+//   used to fall through to `plain`, which the renderer `escapeMarkdown`s —
+//   escaping `=` and shipping `<a href\="…">`. They now go through
+//   `html-fold.ts`'s three-bucket policy: fold to the native IR construct,
+//   pass through raw (wire-verified allowlist), or drop the markup and keep
+//   the content. See that module's header for the rationale.
 
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { gfm } from "micromark-extension-gfm";
@@ -78,6 +101,14 @@ import type {
   TableCell,
   TableRow,
 } from "./ir.js";
+import {
+  HTML_FOLD_TAGS,
+  hrefOf,
+  isPassthroughTag,
+  tokenizeHtml,
+  type HtmlFoldTarget,
+  type HtmlTagInfo,
+} from "./html-fold.js";
 
 /** Copy UTF-16 offsets off an mdast node. Falls back to 0-length when a
  *  synthesized node lacks a position (from-markdown always sets one, but the
@@ -125,13 +156,27 @@ function isTgInlineEntityHref(href: string): boolean {
   return TG_INLINE_ENTITY_HREFS.some((base) => h === base || h.startsWith(`${base}?`));
 }
 
+/** A top-level fenced-code delimiter: 3+ backticks or tildes, indented 0–3
+ *  spaces. Deeper indentation is not a fence, and a fence nested inside a
+ *  blockquote / list item is prefixed by its container's markup — so a
+ *  column-0 `**>` line can only ever be code content inside a fence this
+ *  matches, which is exactly the region the rewrite must not touch. */
+const FENCE_DELIM_RE = /^ {0,3}(`{3,}|~{3,})/;
+
 /** Pre-transform expandable-blockquote markers so mdast can parse them as
  *  ordinary blockquotes, WITHOUT shifting any source offset. Each line that
- *  opens with `**>` has its two `*` characters replaced by two spaces
- *  (`**>` → `  >`), which micromark reads as a normal (optionally
- *  1–3-space-indented) blockquote line. Returns the rewritten text plus the
- *  set of line-start offsets that carried the marker — `foldBlock` uses that
- *  set to flip `expandable: true` on the produced blockquote nodes. */
+ *  opens with `**>` — and is NOT inside a fenced code block — has its two `*`
+ *  characters replaced by two spaces (`**>` → `  >`), which micromark reads as
+ *  a normal (optionally 1–3-space-indented) blockquote line. Returns the
+ *  rewritten text plus the set of line-start offsets that carried the marker —
+ *  `foldBlock` uses that set to flip `expandable: true` on the produced
+ *  blockquote nodes.
+ *
+ *  Fence tracking mirrors CommonMark: an opener is 3+ backticks/tildes at
+ *  0–3 spaces of indent; the block closes on a delimiter of the SAME character
+ *  that is at least as long and carries nothing but whitespace after it, or at
+ *  end of document. Inside such a block every line is copied verbatim, so a
+ *  documented `**> …` example survives byte-identical into `code.value`. */
 function markExpandableQuotes(markdown: string): {
   text: string;
   expandableLineStarts: Set<number>;
@@ -139,8 +184,38 @@ function markExpandableQuotes(markdown: string): {
   const expandableLineStarts = new Set<number>();
   let out = "";
   let offset = 0;
+  /** The open fence's delimiter run, or null outside a fenced block. */
+  let openFence: string | null = null;
   // Split keeping the trailing newline on each line so offsets are exact.
   for (const line of markdown.split(/(?<=\n)/)) {
+    const body = line.replace(/\r?\n$/, "");
+    const fence = FENCE_DELIM_RE.exec(body)?.[1] ?? null;
+    if (openFence !== null) {
+      // Inside a fence: copy verbatim, and close on a matching delimiter.
+      out += line;
+      if (
+        fence !== null &&
+        fence[0] === openFence[0] &&
+        fence.length >= openFence.length &&
+        body.slice(body.indexOf(fence) + fence.length).trim() === ""
+      ) {
+        openFence = null;
+      }
+      offset += line.length;
+      continue;
+    }
+    if (fence !== null) {
+      // A backtick info string may not contain a backtick; such a line is not
+      // a fence opener at all (CommonMark), so only treat it as one when the
+      // rest of the line is clean.
+      const rest = body.slice(body.indexOf(fence) + fence.length);
+      if (!(fence[0] === "`" && rest.includes("`"))) {
+        openFence = fence;
+        out += line;
+        offset += line.length;
+        continue;
+      }
+    }
     if (EXPANDABLE_MARKER_RE.test(line)) {
       expandableLineStarts.add(offset);
       // Replace the leading two `*` chars with two spaces; the `>` and
@@ -290,12 +365,157 @@ function expandPlainNode(node: PlainNode, source: string): Inline[] {
   return out;
 }
 
+// ---------------------------------------------------------------------------
+// Raw-HTML tag folding (see html-fold.ts for the policy and its rationale)
+// ---------------------------------------------------------------------------
+
+/** One element of the stream the HTML matcher walks: either a classified HTML
+ *  token or an already-folded IR inline. */
+type HtmlFoldItem =
+  | { kind: "tag"; tag: HtmlTagInfo; start: number; end: number }
+  | { kind: "inline"; node: Inline };
+
+/** Index of the token that closes `name`, honouring same-name nesting, or -1. */
+function findClosingTag(items: HtmlFoldItem[], from: number, name: string): number {
+  let depth = 0;
+  for (let i = from; i < items.length; i++) {
+    const it = items[i];
+    if (it.kind !== "tag" || it.tag.name !== name) continue;
+    if (it.tag.kind === "open") depth++;
+    else if (it.tag.kind === "close") {
+      if (depth === 0) return i;
+      depth--;
+    }
+  }
+  return -1;
+}
+
+/** Flatten a folded run to literal text, or null when any child carries
+ *  structure a code span cannot represent. Used for `<code>`. */
+function inlineLiteralText(nodes: Inline[]): string | null {
+  let out = "";
+  for (const n of nodes) {
+    if (n.type === "plain" || n.type === "code" || n.type === "raw") out += n.text;
+    else return null;
+  }
+  return out;
+}
+
+/** Apply the three-bucket HTML policy over a mixed tag/inline stream. */
+function foldHtmlItems(items: HtmlFoldItem[]): Inline[] {
+  const out: Inline[] = [];
+  let i = 0;
+  while (i < items.length) {
+    const it = items[i];
+    if (it.kind === "inline") {
+      out.push(it.node);
+      i++;
+      continue;
+    }
+    const tag = it.tag;
+    // Bucket 2: wire-verified allowlist — emitted raw and unescaped.
+    if (isPassthroughTag(tag) && tag.kind !== "comment" && tag.kind !== "other") {
+      out.push({ type: "raw", text: tag.raw, start: it.start, end: it.end });
+      i++;
+      continue;
+    }
+    // Bucket 1: fold to the native IR construct.
+    const target = tag.kind === "open" || tag.kind === "selfclose"
+      ? HTML_FOLD_TAGS[tag.name]
+      : undefined;
+    if (target === "break") {
+      // `<br>` / `<br/>`: a GFM HARD break (two spaces + newline), not a bare
+      // `\n`. The renderer runs AFTER `normalizeParagraphBreaks`
+      // (gateway/outbound-send-path.ts stage 1), so a lone `\n` inserted here
+      // would never be promoted and Telegram would collapse it to a space —
+      // silently losing the author's break. Emitted as `raw` so the two
+      // trailing spaces are not touched.
+      out.push({ type: "raw", text: "  \n", start: it.start, end: it.end });
+      i++;
+      continue;
+    }
+    if (target !== undefined && tag.kind === "open") {
+      const close = findClosingTag(items, i + 1, tag.name);
+      if (close >= 0) {
+        const inner = foldHtmlItems(items.slice(i + 1, close));
+        const start = it.start;
+        const end = items[close].end;
+        const folded = buildFoldedTag(target, tag, inner, start, end);
+        // A tag we cannot represent faithfully (an `<a>` with no href, a
+        // `<code>` wrapping structure) degrades to its CONTENT — bucket 3.
+        out.push(...(folded !== null ? [folded] : inner));
+        i = close + 1;
+        continue;
+      }
+    }
+    // Bucket 3: unknown tag, comment, or an unmatched open/close marker —
+    // drop the markup, keep everything around it.
+    i++;
+  }
+  return out;
+}
+
+function buildFoldedTag(
+  target: HtmlFoldTarget,
+  tag: HtmlTagInfo,
+  children: Inline[],
+  start: number,
+  end: number,
+): Inline | null {
+  switch (target) {
+    case "bold":
+      return { type: "bold", children, start, end };
+    case "italic":
+      return { type: "italic", children, start, end };
+    case "strike":
+      return { type: "strike", children, start, end };
+    case "code": {
+      const text = inlineLiteralText(children);
+      return text === null ? null : { type: "code", text, start, end };
+    }
+    case "link": {
+      const href = hrefOf(tag);
+      return href === null ? null : { type: "link", href, children, start, end };
+    }
+    default:
+      return null;
+  }
+}
+
+/** Turn a raw HTML string into fold items: tokens stay tokens, the text
+ *  between them becomes `plain` inlines (with spoiler/highlight recognition,
+ *  matching how prose is treated everywhere else). */
+function htmlStringToItems(raw: string, base: number, source: string): HtmlFoldItem[] {
+  return tokenizeHtml(raw, base).flatMap<HtmlFoldItem>((piece) =>
+    piece.kind === "tag"
+      ? [{ kind: "tag", tag: piece.tag, start: piece.start, end: piece.end }]
+      : expandPlainNode(mkPlain(piece.text, piece.start, piece.end), source).map(
+          (node) => ({ kind: "inline", node }) as HtmlFoldItem,
+        ),
+  );
+}
+
 /** Fold a run of mdast phrasing children into IR inlines, then run the
- *  post-parse spoiler/highlight recognition over the produced `plain` nodes. */
+ *  post-parse spoiler/highlight recognition over the produced `plain` nodes,
+ *  then apply the raw-HTML tag policy across the whole run (open/close markers
+ *  are SIBLING mdast `html` nodes, never a parent, so matching has to happen
+ *  at this level). */
 function buildInlines(children: ReadonlyArray<MdastNode>, source: string): Inline[] {
-  return children
-    .map((c) => foldInline(c as PhrasingContent, source))
-    .flatMap((n) => (n.type === "plain" ? expandPlainNode(n, source) : [n]));
+  const items: HtmlFoldItem[] = [];
+  let sawHtml = false;
+  for (const child of children) {
+    if ((child as PhrasingContent).type === "html") {
+      sawHtml = true;
+      const p = pos(child);
+      items.push(...htmlStringToItems(slice(source, child), p.start, source));
+      continue;
+    }
+    const folded = foldInline(child as PhrasingContent, source);
+    const expanded = folded.type === "plain" ? expandPlainNode(folded, source) : [folded];
+    for (const node of expanded) items.push({ kind: "inline", node });
+  }
+  if (!sawHtml) return items.map((it) => (it as { node: Inline }).node);
+  return foldHtmlItems(items);
 }
 
 function foldInlineChildren(node: MdastParent, source: string): Inline[] {
@@ -391,7 +611,22 @@ function foldBlock(
         children: [{ type: "raw", text: slice(source, node), ...pos(node) }],
         ...pos(node),
       };
-    // Not in the palette (html, definition, …): degrade to a paragraph
+    // A raw HTML BLOCK (`<details>…`, `<div>…`, a bare `<b>alone</b>` line).
+    // mdast hands the whole block over as one opaque string, so tokenize it
+    // and run the same three-bucket policy the inline path uses: the
+    // wire-verified allowlist passes through raw (which is also what stops
+    // `escapeMarkdown` mangling `<details open="x">` into `open\="x"`),
+    // markdown-equivalent tags fold, everything else drops its markup and
+    // keeps its content.
+    case "html": {
+      const p = pos(node);
+      return {
+        type: "paragraph",
+        children: foldHtmlItems(htmlStringToItems(slice(source, node), p.start, source)),
+        ...p,
+      };
+    }
+    // Not in the palette (definition, …): degrade to a paragraph
     // carrying the raw source slice so no content is dropped.
     default:
       return {

--- a/telegram-plugin/tests/render/html-dialect.test.ts
+++ b/telegram-plugin/tests/render/html-dialect.test.ts
@@ -135,7 +135,10 @@ describe("markdown-equivalent HTML tags fold to native constructs (defect 3)", (
   });
 
   it("handles same-name nesting without closing on the inner tag", () => {
-    expect(renderOutbound("<b>a <b>b</b> c</b>").text).toBe("**a **b** c**");
+    // Depth tracking matters: matching the FIRST `</b>` would leave a dangling
+    // ` c` outside the bold run. The inner bold collapses into the outer one
+    // (see the asterisk-soup test below) so every byte lands inside `**…**`.
+    expect(renderOutbound("<b>a <b>b</b> c</b>").text).toBe("**a b c**");
   });
 
   it("passes the wire-verified allowlist through raw", () => {
@@ -189,6 +192,29 @@ describe("markdown-equivalent HTML tags fold to native constructs (defect 3)", (
     // Text between tags is still ordinary prose and must be escaped, or a
     // `[`/`*` in it could re-trigger formatting downstream.
     expect(renderOutbound("<b>a [b] c</b>").text).toBe("**a \\[b\\] c**");
+  });
+
+  it("never emits nested same-kind emphasis (asterisk soup)", () => {
+    // `**a **b** c**` renders as literal asterisks on the reader's screen.
+    expect(renderOutbound("<b>**already**</b>").text).toBe("**already**");
+    expect(renderOutbound("<b>a <b>b</b> c</b>").text).toBe("**a b c**");
+    expect(renderOutbound("<i>*x*</i>").text).toBe("*x*");
+    // DIFFERENT kinds still nest, as markdown allows.
+    expect(renderOutbound("<b><i>bi</i></b>").text).toBe("***bi***");
+  });
+
+  it("never swallows an inner code span's backticks into `<code>`", () => {
+    // Folding the inner `code` node's text would DELETE its backticks
+    // (`a b c`). Degrade to the children instead — every byte survives.
+    expect(renderOutbound("<code>a `b` c</code>").text).toBe("a `b` c");
+    expect(renderOutbound("<code><u>x</u></code>").text).toBe("<u>x</u>");
+  });
+
+  it("does not leave a blank-line hole where a dropped block used to be", () => {
+    // A block that is nothing but dropped markup must not contribute an empty
+    // paragraph and a spurious `\n\n` separator.
+    expect(renderOutbound("a\n\n<!-- c -->\n\nb").text).toBe("a\n\nb");
+    expect(renderOutbound("a\n\n<div></div>\n\nb").text).toBe("a\n\nb");
   });
 
   it("does not treat `a < b` as a tag", () => {

--- a/telegram-plugin/tests/render/html-dialect.test.ts
+++ b/telegram-plugin/tests/render/html-dialect.test.ts
@@ -1,0 +1,254 @@
+// Outcome tests for the three v0.21.9 outbound-render residuals:
+//
+//   1. `markExpandableQuotes` rewrote `**>` lines INSIDE fenced code blocks,
+//      corrupting documented examples into `  >` on the wire.
+//   2. `escapeMarkdown` ran over raw-HTML `plain` nodes and escaped `=`, so
+//      `<a href="…">` shipped as `<a href\="…">` — an unreadable attribute.
+//   3. Raw HTML tags reached the wire byte-verbatim with nothing establishing
+//      that Telegram's rich parser accepts them.
+//
+// Every assertion here FAILS on the v0.21.9 pipeline. They drive the real
+// `renderOutbound` (`parse` -> `renderSafe`), i.e. exactly what the live send
+// path calls, so they assert the wire OUTCOME, not an internal code path.
+
+import { describe, it, expect } from "vitest";
+import { renderOutbound } from "../../render/rich-render.js";
+import { parse } from "../../render/parse.js";
+import { classifyHtmlTag, hrefOf } from "../../render/html-fold.js";
+
+describe("fenced code blocks are immune to the `**>` input repair (defect 1)", () => {
+  it("keeps a `**>` line inside a fence byte-identical", () => {
+    // The exact corruption: on v0.21.9 this came back as "```md\n  > tap…".
+    const src = "```md\n**> tap to expand\n> body\n```";
+    expect(renderOutbound(src).text).toBe(src);
+    const code = parse(src).blocks[0] as { type: string; text: string };
+    expect(code.type).toBe("code-block");
+    expect(code.text).toBe("**> tap to expand\n> body");
+  });
+
+  it("keeps a `**>` line inside a TILDE fence byte-identical", () => {
+    const src = "~~~\n**> quoted\n~~~";
+    const code = parse(src).blocks[0] as { type: string; text: string };
+    expect(code.type).toBe("code-block");
+    expect(code.text).toBe("**> quoted");
+  });
+
+  it("still repairs a `**>` quote OUTSIDE the fence in the same document", () => {
+    const src = "```\n**> literal\n```\n\n**> repaired";
+    const out = renderOutbound(src).text;
+    expect(out).toContain("```\n**> literal\n```");
+    expect(out).toContain("> repaired");
+    // The repaired quote is a real quote, not a literal `**>` paragraph.
+    expect(out.split("\n\n").at(-1)).toBe("> repaired");
+  });
+
+  it("does not lose the repair after a CLOSED fence earlier in the body", () => {
+    // Guards the fence tracker's close detection: a stuck-open scanner would
+    // silently stop repairing every legacy quote after the first fence.
+    const src = "```js\nconst a = 1;\n```\n\n**> still repaired";
+    expect(renderOutbound(src).text.endsWith("> still repaired")).toBe(true);
+  });
+
+  it("treats an UNCLOSED fence as running to end of document", () => {
+    const src = "```\n**> never repaired";
+    const code = parse(src).blocks[0] as { type: string; text: string };
+    expect(code.type).toBe("code-block");
+    expect(code.text).toBe("**> never repaired");
+  });
+
+  it("keeps a fence's `**>` content intact through an inline code round-trip", () => {
+    // A wider fence in the source must not change the content bytes.
+    const src = "````\n```\n**> nested\n```\n````";
+    const code = parse(src).blocks[0] as { type: string; text: string };
+    expect(code.text).toBe("```\n**> nested\n```");
+  });
+});
+
+describe("raw HTML links fold to native markdown links (defect 2)", () => {
+  it("`<a href>` becomes a working link with no escaped `=`", () => {
+    const out = renderOutbound(
+      `<a href="https://example.com">label</a>`,
+    ).text;
+    expect(out).toBe("[label](https://example.com)");
+    expect(out).not.toContain("\\=");
+  });
+
+  it("an `<a href>` embedded in prose keeps its surroundings", () => {
+    const out = renderOutbound(
+      `see <a href="https://example.com/a_b">the docs</a> now`,
+    ).text;
+    expect(out).toBe("see [the docs](https://example.com/a_b) now");
+    expect(out).not.toContain("\\=");
+  });
+
+  it("accepts a single-quoted href", () => {
+    expect(renderOutbound(`<a href='https://e.com'>x</a>`).text).toBe(
+      "[x](https://e.com)",
+    );
+  });
+
+  it("reads an unquoted href value (tokenizer level)", () => {
+    // Exercised directly: an UNQUOTED href never reaches the fold through
+    // micromark — GFM's autolink-literal extension consumes
+    // `https://e.com>x` before the tag can become an mdast `html` node (a
+    // documented upstream limitation, not something this layer can reach).
+    // The attribute reader still handles the form for the block-HTML path.
+    expect(hrefOf(classifyHtmlTag(`<a href=https://e.com>`))).toBe(
+      "https://e.com",
+    );
+    expect(hrefOf(classifyHtmlTag(`<a href="https://e.com/a(b)">`))).toBe(
+      "https://e.com/a(b)",
+    );
+    expect(hrefOf(classifyHtmlTag(`<a name="x">`))).toBeNull();
+  });
+
+  it("an `<a>` with no href degrades to its label, not to broken markup", () => {
+    expect(renderOutbound(`<a name="anchor">label</a>`).text).toBe("label");
+  });
+
+  it("a wire-verified allowlist tag keeps its `=` attribute unescaped", () => {
+    // `<details open="open">` on v0.21.9 shipped as `open\="open"`.
+    const src = `<details open="open"><summary>S</summary>body</details>`;
+    expect(renderOutbound(src).text).toBe(src);
+  });
+});
+
+describe("markdown-equivalent HTML tags fold to native constructs (defect 3)", () => {
+  it("folds bold / italic / strike / code", () => {
+    expect(renderOutbound("<b>bold</b>").text).toBe("**bold**");
+    expect(renderOutbound("<strong>bold</strong>").text).toBe("**bold**");
+    expect(renderOutbound("<i>it</i>").text).toBe("*it*");
+    expect(renderOutbound("<em>it</em>").text).toBe("*it*");
+    expect(renderOutbound("<s>gone</s>").text).toBe("~~gone~~");
+    expect(renderOutbound("<del>gone</del>").text).toBe("~~gone~~");
+    expect(renderOutbound("<code>x_y</code>").text).toBe("`x_y`");
+  });
+
+  it("folds a tag mid-sentence without disturbing the prose", () => {
+    expect(renderOutbound("the <b>only</b> way").text).toBe("the **only** way");
+  });
+
+  it("folds nested tags", () => {
+    expect(renderOutbound("<b>bold <i>and italic</i></b>").text).toBe(
+      "**bold *and italic***",
+    );
+  });
+
+  it("handles same-name nesting without closing on the inner tag", () => {
+    expect(renderOutbound("<b>a <b>b</b> c</b>").text).toBe("**a **b** c**");
+  });
+
+  it("passes the wire-verified allowlist through raw", () => {
+    for (const src of [
+      "<u>under</u>",
+      "H<sub>2</sub>O",
+      "x<sup>2</sup>",
+      "<aside><cite>note</cite></aside>",
+    ]) {
+      expect(renderOutbound(src).text).toBe(src);
+    }
+  });
+
+  it("drops the markup of an unrecognised tag but keeps its content", () => {
+    // Never ship a construct we cannot guarantee: an unknown tag risks the
+    // `unsupported start tag` 400 whose fallback resends PLAIN text, showing
+    // the reader literal markup.
+    expect(renderOutbound(`<marquee>scrolling</marquee>`).text).toBe("scrolling");
+    expect(renderOutbound(`<div class="x">body</div>`).text).toBe("body");
+    expect(renderOutbound(`<span data-x="1">t</span>`).text).toBe("t");
+  });
+
+  it("drops an HTML comment entirely", () => {
+    expect(renderOutbound("before <!-- hidden --> after").text).toBe(
+      "before  after",
+    );
+  });
+
+  it("drops an unmatched open or close marker but keeps the text", () => {
+    expect(renderOutbound("<b>dangling").text).toBe("dangling");
+    expect(renderOutbound("dangling</b>").text).toBe("dangling");
+  });
+
+  it("turns `<br>` into a GFM HARD break rather than deleting it", () => {
+    // A bare `\n` would be collapsed to a space by Telegram — the renderer
+    // runs after `normalizeParagraphBreaks`, so nothing downstream promotes
+    // it. Two trailing spaces are the GFM hard-break syntax.
+    expect(renderOutbound("one<br>two").text).toBe("one  \ntwo");
+    expect(renderOutbound("one<br/>two").text).toBe("one  \ntwo");
+  });
+
+  it("folds a block-level HTML line (not just inline runs)", () => {
+    // A paragraph that is entirely a tag is a mdast `html` BLOCK, a different
+    // fold path from an inline `html` phrasing node.
+    expect(renderOutbound("para\n\n<b>alone</b>\n\nmore").text).toBe(
+      "para\n\n**alone**\n\nmore",
+    );
+  });
+
+  it("escapes prose around a folded tag as prose (no smuggled formatting)", () => {
+    // Text between tags is still ordinary prose and must be escaped, or a
+    // `[`/`*` in it could re-trigger formatting downstream.
+    expect(renderOutbound("<b>a [b] c</b>").text).toBe("**a \\[b\\] c**");
+  });
+
+  it("does not treat `a < b` as a tag", () => {
+    expect(renderOutbound("if a < b then c").text).toBe("if a < b then c");
+  });
+
+  it("leaves an autolink alone", () => {
+    expect(renderOutbound("<https://example.com>").text).toBe(
+      "[https://example.com](https://example.com)",
+    );
+  });
+
+  it("leaves tags inside a fenced code block completely untouched", () => {
+    const src = '```html\n<a href="https://e.com">x</a>\n<b>y</b>\n```';
+    expect(renderOutbound(src).text).toBe(src);
+  });
+
+  it("leaves tags inside an inline code span untouched", () => {
+    expect(renderOutbound("use `<b>bold</b>` here").text).toBe(
+      "use `<b>bold</b>` here",
+    );
+  });
+});
+
+describe("the blank-line-separated expandable shape (majority corpus shape)", () => {
+  // `**> header`, a BLANK line, then the `> …` body. Existing coverage only
+  // pinned the contiguous and lone-marker variants; this shape is what the
+  // corpus actually carries, and nothing locked it in.
+  const src = "**> tap to expand\n\n> line one\n> line two";
+
+  it("emits no `**>` marker anywhere", () => {
+    expect(renderOutbound(src).text).not.toContain("**>");
+  });
+
+  it("renders the header and the body as quotes, content intact", () => {
+    const out = renderOutbound(src).text;
+    expect(out).toBe("> tap to expand\n\n> line one\n> line two");
+  });
+
+  it("marks the header blockquote expandable and leaves the body plain", () => {
+    const blocks = parse(src).blocks as Array<{
+      type: string;
+      expandable?: boolean;
+    }>;
+    expect(blocks.map((b) => b.type)).toEqual(["blockquote", "blockquote"]);
+    expect(blocks[0].expandable).toBe(true);
+    expect(blocks[1].expandable).toBe(false);
+  });
+
+  it("survives a body carrying formatting and a link", () => {
+    const rich =
+      "**> tap to expand\n\n> **bold** body\n> see [docs](https://e.com)";
+    const out = renderOutbound(rich).text;
+    expect(out).not.toContain("**>");
+    expect(out).toContain("> **bold** body");
+    expect(out).toContain("> see [docs](https://e.com)");
+  });
+
+  it("is idempotent — re-rendering the output does not re-quote it", () => {
+    const once = renderOutbound(src).text;
+    expect(renderOutbound(once).text).toBe(once);
+  });
+});

--- a/telegram-plugin/tests/render/parse.test.ts
+++ b/telegram-plugin/tests/render/parse.test.ts
@@ -218,17 +218,21 @@ describe("parse: nested inline", () => {
 });
 
 describe("parse: unsupported construct fallback", () => {
-  it("degrades a raw HTML block to plain text without dropping content", () => {
-    // Raw HTML blocks (mdast `html`) are outside the palette; they must
-    // survive as plain source text.
+  it("degrades an UNRECOGNISED raw HTML block to its content, markup dropped", () => {
+    // Raw HTML blocks (mdast `html`) are outside the palette. An unrecognised
+    // tag is NOT passed through verbatim: nothing establishes that Telegram's
+    // rich parser accepts `<div>`, and `isParseEntitiesError` (rich-send.ts)
+    // shows the wire can 400 with `unsupported start tag` — whose fallback
+    // resends the body as PLAIN TEXT, putting literal `<div class="x">` on the
+    // reader's screen. Degrade by type: markup dropped, content kept.
     const md = "<div class=\"x\">raw</div>";
     const doc = parse(md);
     const block = doc.blocks[0] as any;
     expect(block.type).toBe("paragraph");
     const plain = block.children[0];
     expect(plain.type).toBe("plain");
-    expect(plain.text).toBe(md);
-    expect(md.slice(plain.start, plain.end)).toBe(md);
+    expect(plain.text).toBe("raw");
+    expect(md.slice(plain.start, plain.end)).toBe("raw");
   });
 });
 


### PR DESCRIPTION
## Summary

Three residual defects in the outbound render layer, found by executing the
shipped v0.21.9 pipeline (`renderOutbound` → `guardAccidentalFormatting`)
against a 2474-message corpus. All three are fixed here; the `**>` retirement
from #4685 is confirmed genuinely fixed and is not touched.

**1. `markExpandableQuotes` corrupted fenced code blocks (data loss).**
`markExpandableQuotes` rewrote *every* line matching `/^\*\*>/` to `  >` before
micromark parsed, including inside fenced code. `renderCodeBlock` emits mdast
`code.value`, which comes from the rewritten text — so a documented `**>`
example inside a fence shipped silently mangled. `markExpandableQuotes` is now
fence-aware (`telegram-plugin/render/parse.ts:164`, `:180-215`).

**2. `escapeMarkdown` mangled HTML attributes.** mdast `html` nodes fell through
to `plain`, and `render.ts:74` escapes `plain` — including `=`. So
`<a href="https://example.com">label</a>` shipped as `<a href\="…">`, an
attribute nothing can read.

**3. Raw HTML reached the wire byte-verbatim with no policy.** Corpus
measurement: `reggie` emits raw tags in ~72% of messages, `clerk` 18%,
`gymbro` 7%. Nothing established that Telegram's rich parser accepts them, and
`isParseEntitiesError` (`telegram-plugin/rich-send.ts:141-143`) matches
`unsupported start tag` / `unclosed start tag` — the wire *can* 400, and that
fallback resends **plain text**, putting literal `<b>` on the reader's screen.

## Why

New module `telegram-plugin/render/html-fold.ts` (164 lines) states one
three-bucket policy, applied by both the inline and block fold paths:

| bucket | tags | behaviour |
|---|---|---|
| **fold** | `<b>/<strong>`, `<i>/<em>`, `<s>/<del>/<strike>`, `<code>`, `<a href>`, `<br>` | folded to the native IR node, so the wire sees markdown it definitely parses |
| **passthrough** | `<u> <sub> <sup> <details> <summary> <aside> <cite>` — the wire-verified allowlist (2026-08-13 raw `sendRichMessage` probes) | emitted as an IR `raw` inline: unescaped, so attributes survive (this is also the defect-2 fix) |
| **degrade** | everything else, plus comments and unmatched open/close markers | markup dropped, **content kept** and rendered normally |

**Unrecognised tags drop their markup and keep their content.** Shipping an
unknown tag verbatim risks the 400 → plain-text fallback that shows the reader
raw markup — strictly worse than showing them the text. This is the one
deliberate exception to the module's "never lose text" rule, and it is
documented as such in the `parse.ts` header: *content is never lost;
unguaranteeable markup is.* Same principle as openclaw's documented pipeline —
never emit a construct the renderer can't guarantee; degrade by type rather
than break silently.

**Fence fix: option A (fence-aware pre-pass), not option B (slice `code` from
the original source).** `code.value` is dedented, fence-stripped content;
reconstructing it from offsets means re-implementing micromark's fence parser
(info string, indent stripping, closing-fence detection) inside the fold, and
leaves `code.value` untrustworthy for every *other* consumer. The pre-pass skip
is one scanner at the single place the rewrite is decided, and it preserves the
length invariant trivially — a skipped line is copied verbatim, so the `**` → two
spaces length-preservation that keeps `slice(source, node)` valid still holds
everywhere the rewrite does run.

Deterministic code, deliberately not a prompt instruction to the agents that
emit the tags.

## Test plan

New `telegram-plugin/tests/render/html-dialect.test.ts` (35 tests) drives the
real `renderOutbound`, i.e. exactly what the send path calls — wire outcomes,
not code paths. Proven to fail on the bug: replayed against pristine
`origin/main`, **20 of 32 failed**; the 12 that passed are exactly the
deliberate lock-ins and non-regression guards.

- fence immunity: `**>` inside backtick and tilde fences, unclosed fence,
  nested wider fence, and the repair still working outside/after a fence
- `<a href="…">label</a>` → `[label](https://example.com)`, no `\=`
- `<b>/<i>/<s>/<code>` folding, nesting, mid-sentence, block-level
- `<details open="open">` byte-identical (was `open\="open"`)
- the blank-line-separated expandable shape (`**> header`, blank line, `> body`)
  — the majority corpus shape, previously untested; it worked, now locked in
- adversarial guards from reviewing my own diff: no nested same-kind emphasis
  (`<b>**x**</b>` → `**x**`, not `****x****`), no swallowed backticks in
  `<code>a \`b\` c</code>`, no blank-line hole where a dropped block was

```
Test Files  17 passed (17)
     Tests  392 passed (392)      # telegram-plugin/tests/render/
```
```
 33 pass / 0 fail / 54 expect() calls   # bun test telegram-plugin/tests/telegraph.test.ts
```
`npm run lint` green, including `check-plugin-references` (fully-clean tsc over
plugin source) and `check-changelog-entry`.

`telegram-plugin/tests/render/parse.test.ts:220-237` is the one existing test
changed: it pinned "unrecognised HTML block survives as plain text", which is
precisely the behaviour replaced. Renamed and re-asserted with the rationale.

## Risk

Behaviour change on the outbound path for every message containing raw HTML —
by measurement, most of `reggie`'s. The change is strictly toward *renderable*
output (a folded tag renders; a raw one was a coin flip), but a reader used to
seeing literal `<span>` markup will now see just its text.

Known limitation, deliberately not chased: an **unquoted** `href`
(`<a href=https://e.com>x</a>`) never reaches this layer — GFM's autolink-literal
extension consumes `https://e.com>x` before micromark can make it an `html`
node. The attribute reader handles the form for the block path and is unit-tested
directly; the inline case is upstream.

Serves `reference/jobs/talk-to-agents-from-anywhere.md` — *"the user can drive
their fleet from a phone as naturally as from a laptop"*. A message whose links
are unclickable and whose markup shows through is not that surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
