### PR TITLE
fix(voice): chunk TTS on phoneme length, not characters — long messages stop failing (#4695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,21 +17,28 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
-- **voice: TTS chunks on phoneme length, not characters — long messages no
-  longer lose audio** (#4695) — the sidecar split text into ≤
-  `VOICE_TTS_MAX_CHARS` (1200) pieces and handed each to kokoro-onnx, but
-  kokoro synthesizes in *phonemes* and hard-slices any single batch past its
-  `MAX_PHONEME_LENGTH` of 510 (`kokoro_onnx/__init__.py:97-101`, verified
-  against the 0.5.0 wheel in the running image). Kokoro does pre-batch a long
-  phoneme string, but only on `.,!?;` — so any punctuation-free run over 510
-  phonemes lost its tail and the listener simply heard the sentence stop.
+- **voice: TTS chunks on phoneme length, not characters — long messages stop
+  failing** (#4695) — the sidecar split text into ≤ `VOICE_TTS_MAX_CHARS`
+  (1200) pieces and handed each to kokoro-onnx, but kokoro synthesizes in
+  *phonemes* and cannot take more than `MAX_PHONEME_LENGTH` = 510 in one batch
+  (`kokoro_onnx/__init__.py:97-101`, verified against the 0.5.0 wheel in the
+  running image). Kokoro does pre-batch a long phoneme string, but only on
+  `.,!?;`, so any punctuation-free run over 510 phonemes overflowed. The
+  overflow is worse than the documented truncation: two lines after the slice,
+  `voice = voice[len(tokens)]` indexes a 510-row array with 510 and **raises**,
+  so the whole `/tts` request 500s and the user gets **no voice message at
+  all** — reproduced live against the real model
+  (`IndexError: index 510 is out of bounds for axis 0 with size 510`).
   Measured over a 1,679-message production corpus through real misaki:
-  **16 truncated batches, 5,823 phonemes discarded, worst batch 1,545**.
+  **16 over-limit batches — all 16 hitting the raise, not a partial read —
+  across 15 messages (0.9%)**, worst batch 1,545 phonemes. On the worst
+  message, before: request fails, 0s of audio; after: **159.3s of complete
+  audio**.
   `docker/voice-sidecar/server.py` now splits the phoneme string itself
   (`_split_phonemes`, capped by the new `VOICE_TTS_MAX_PHONEMES`, default 500)
   and hands Kokoro one already-safe batch at a time; the split is lossless by
   construction — an over-long run is *carried* into the next batch rather than
-  discarded. Same corpus after: **0 truncated batches, 0 phonemes lost**, at a
+  discarded. Same corpus after: **0 over-limit batches, 0 phonemes lost**, at a
   cost of 6320 → 6413 synthesis batches (+1.5%). The espeak path
   (`VOICE_TTS_G2P=espeak`, non-English locales) is phonemized through Kokoro's
   own tokenizer so it is chunked the same way. Characters remain the coarse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ now an anomaly worth investigating, not the norm.
 
 ### Bug fixes
 
+- **voice: TTS chunks on phoneme length, not characters — long messages no
+  longer lose audio** (#4695) — the sidecar split text into ≤
+  `VOICE_TTS_MAX_CHARS` (1200) pieces and handed each to kokoro-onnx, but
+  kokoro synthesizes in *phonemes* and hard-slices any single batch past its
+  `MAX_PHONEME_LENGTH` of 510 (`kokoro_onnx/__init__.py:97-101`, verified
+  against the 0.5.0 wheel in the running image). Kokoro does pre-batch a long
+  phoneme string, but only on `.,!?;` — so any punctuation-free run over 510
+  phonemes lost its tail and the listener simply heard the sentence stop.
+  Measured over a 1,679-message production corpus through real misaki:
+  **16 truncated batches, 5,823 phonemes discarded, worst batch 1,545**.
+  `docker/voice-sidecar/server.py` now splits the phoneme string itself
+  (`_split_phonemes`, capped by the new `VOICE_TTS_MAX_PHONEMES`, default 500)
+  and hands Kokoro one already-safe batch at a time; the split is lossless by
+  construction — an over-long run is *carried* into the next batch rather than
+  discarded. Same corpus after: **0 truncated batches, 0 phonemes lost**, at a
+  cost of 6320 → 6413 synthesis batches (+1.5%). The espeak path
+  (`VOICE_TTS_G2P=espeak`, non-English locales) is phonemized through Kokoro's
+  own tokenizer so it is chunked the same way. Characters remain the coarse
+  pass, so `VOICE_TTS_MAX_CHARS` keeps its meaning but is no longer
+  load-bearing for correctness. Both residual degradation paths — a mid-word
+  seam in an unbreakable run, and a piece nothing could phonemize — are now
+  counted into the `/tts` response meta (`hardCuts`, `unchunkedPieces`) and
+  logged at WARNING volume to the sidecar's stderr, so the failure mode stops
+  being invisible.
 - **voice: unit-suffix regex lookbehind + case-sensitivity hotfix** — the
   number+unit-suffix regex shared by both TTS normalization passes
   (`telegram-plugin/voice-normalize-text.ts`, `telegram-plugin/tts-normalize.ts`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,10 @@ now an anomaly worth investigating, not the norm.
   seam in an unbreakable run, and a piece nothing could phonemize — are now
   counted into the `/tts` response meta (`hardCuts`, `unchunkedPieces`) and
   logged at WARNING volume to the sidecar's stderr, so the failure mode stops
-  being invisible.
+  being invisible. `VOICE_TTS_MAX_PHONEMES` is clamped to `[1, 508]` (508 is
+  the highest safe value — kokoro flushes a batch at `>=` 510), and an
+  out-of-range setting is warned about at startup rather than clamped
+  silently.
 - **voice: unit-suffix regex lookbehind + case-sensitivity hotfix** — the
   number+unit-suffix regex shared by both TTS normalization passes
   (`telegram-plugin/voice-normalize-text.ts`, `telegram-plugin/tts-normalize.ts`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ now an anomaly worth investigating, not the norm.
   and hands Kokoro one already-safe batch at a time; the split is lossless by
   construction — an over-long run is *carried* into the next batch rather than
   discarded. Same corpus after: **0 over-limit batches, 0 phonemes lost**, at a
-  cost of 6320 → 6413 synthesis batches (+1.5%). The espeak path
+  cost of 6320 → 6412 synthesis batches (+1.5%). The espeak path
   (`VOICE_TTS_G2P=espeak`, non-English locales) is phonemized through Kokoro's
   own tokenizer so it is chunked the same way. Characters remain the coarse
   pass, so `VOICE_TTS_MAX_CHARS` keeps its meaning but is no longer

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -63,6 +63,8 @@ HTTP contract
               → 200 audio/ogg  (ONE continuous OGG/Opus stream, mono — ready
                 for Telegram sendVoice, which REQUIRES OGG/Opus). Text of any
                 length is chunked to VOICE_TTS_MAX_CHARS pieces internally,
+                then each piece's PHONEME string is chunked to
+                VOICE_TTS_MAX_PHONEMES so Kokoro never hard-slices it,
                 each synthesized on the GPU, and re-joined into a SINGLE file.
               → 4xx/5xx { ok: false, reason, detail }
   GET  /healthz
@@ -163,6 +165,24 @@ TTS_FORMAT = os.environ.get("VOICE_TTS_FORMAT", "ogg").lower()
 TTS_CONCURRENCY = max(1, int(os.environ.get("VOICE_TTS_CONCURRENCY", "1")))
 TTS_REQUEST_TIMEOUT_S = float(os.environ.get("VOICE_TTS_REQUEST_TIMEOUT_S", "60"))
 TTS_MAX_CHARS = int(os.environ.get("VOICE_TTS_MAX_CHARS", "1200"))
+# ── phoneme-length chunking (#4695) ────────────────────────────────────
+# TTS_MAX_CHARS alone is NOT a correctness bound: kokoro-onnx synthesizes in
+# units of PHONEMES and hard-slices any single batch longer than its
+# MAX_PHONEME_LENGTH = 510 (kokoro_onnx/__init__.py:97-101, verified against the
+# 0.5.0 wheel installed in this image). Kokoro does re-batch a long phoneme
+# string first (Kokoro._split_phonemes), but that splitter breaks ONLY on
+# `.,!?;` — so any punctuation-free run over 510 phonemes is still sliced and
+# the tail of that clause is simply never spoken.
+#
+# So we chunk on the thing that actually overflows: after G2P we split the
+# phoneme string ourselves to <= TTS_MAX_PHONEMES and hand Kokoro one
+# already-safe batch at a time. Characters remain the COARSE pass (it bounds
+# G2P work and keeps sentence-aware seams); phonemes are the correctness pass.
+#
+# 500, not 510: Kokoro._split_phonemes compares with `>=` MAX_PHONEME_LENGTH,
+# so feeding it a punctuation-free run of exactly 510 makes it emit a leading
+# EMPTY batch. A few phonemes of headroom keeps our chunks a no-op for it.
+TTS_MAX_PHONEMES = max(1, min(510, int(os.environ.get("VOICE_TTS_MAX_PHONEMES", "500"))))
 # Defence-in-depth ceiling on the raw JSON body (text is otherwise unbounded,
 # chunked internally). 256KB ≈ ~40k chars of UTF-8 — far above any real reply.
 TTS_MAX_BODY_BYTES = int(os.environ.get("VOICE_TTS_MAX_BODY_BYTES", str(256 * 1024)))
@@ -678,6 +698,83 @@ def _split_text(text: str, max_chars: int) -> list[str]:
     return [p for p in pieces if p]
 
 
+# Kokoro's own phoneme batcher breaks on exactly this set; matching it keeps our
+# seams where Kokoro would have put them when it could.
+_PHONEME_BREAKS = ".,!?;"
+
+
+def _split_phonemes(phonemes: str, max_phonemes: int) -> tuple[list[str], int]:
+    """Split a phoneme string into chunks of at most `max_phonemes`, preferring
+    Kokoro's own break characters (`.,!?;`) then whitespace, so a chunk boundary
+    lands where a clause or word already ends.
+
+    LOSSLESS by construction: every phoneme of the input appears in exactly one
+    chunk (whitespace between chunks is the only thing normalised away). This is
+    the whole point of #4695 — Kokoro's own batcher DISCARDS the tail of any
+    over-long run, this one carries it into the next chunk instead.
+
+    Returns (chunks, hard_cuts). `hard_cuts` counts boundaries that had to land
+    MID-WORD because a single run of `max_phonemes` phonemes contained no space
+    and no break char. Those are audible seams, not lost audio, and are rare
+    enough that the caller logs them loudly rather than swallowing them.
+
+    Pure — no Kokoro, no misaki, no globals. Directly unit-testable."""
+    phonemes = phonemes.strip()
+    if not phonemes:
+        return [], 0
+    if len(phonemes) <= max_phonemes:
+        return [phonemes], 0
+
+    # Units = clauses, each keeping its trailing break char. Concatenating the
+    # units reproduces the input exactly.
+    units: list[str] = []
+    cur = ""
+    for ch in phonemes:
+        cur += ch
+        if ch in _PHONEME_BREAKS:
+            units.append(cur)
+            cur = ""
+    if cur:
+        units.append(cur)
+
+    chunks: list[str] = []
+    hard_cuts = 0
+
+    def _emit(unit: str) -> None:
+        """Append one unit as one or more chunks, breaking on whitespace, and
+        only mid-word when a run leaves no other option."""
+        nonlocal hard_cuts
+        unit = unit.strip()
+        while unit:
+            if len(unit) <= max_phonemes:
+                chunks.append(unit)
+                return
+            head = unit[:max_phonemes]
+            cut = head.rfind(" ")
+            if cut <= 0:
+                # An unbreakable run longer than the cap. Cut it, but keep the
+                # remainder — Kokoro would have thrown the remainder away.
+                chunks.append(head)
+                unit = unit[max_phonemes:].strip()
+                hard_cuts += 1
+                continue
+            chunks.append(head[:cut].strip())
+            unit = unit[cut:].strip()
+
+    for unit in units:
+        stripped = unit.strip()
+        if not stripped:
+            continue
+        # Pack back-to-back clauses into one chunk while they fit, so we do not
+        # emit more synthesis batches than necessary.
+        if chunks and len(chunks[-1]) + 1 + len(stripped) <= max_phonemes:
+            chunks[-1] = (chunks[-1] + " " + stripped).strip()
+            continue
+        _emit(unit)
+
+    return [c for c in chunks if c], hard_cuts
+
+
 TTS_SPEED_MIN = 0.5
 TTS_SPEED_MAX = 2.0
 TTS_SPEED_DEFAULT = 1.0
@@ -765,15 +862,56 @@ def _normalize_text(text: str) -> str:
         return text
 
 
+_espeak_phonemize_warned = False
+
+
+def _espeak_phonemize(piece: str) -> tuple[str, bool]:
+    """Phonemize one text piece with Kokoro's OWN espeak tokenizer, i.e. exactly
+    the call `Kokoro.create()` would make internally for `is_phonemes=False`.
+
+    Doing it here rather than inside create() is what lets the espeak path be
+    phoneme-chunked too (#4695) — otherwise that path keeps chunking on
+    characters and keeps overflowing. The output is identical to what create()
+    would have computed, so this is a batching change, not a voice change.
+
+    Returns (phonemes, True) on success, or (piece, False) when the tokenizer is
+    not reachable (a stub _tts in tests, an unexpected kokoro-onnx layout) or
+    raises — in which case the caller falls back to handing Kokoro raw text and
+    accepts today's character-bounded behaviour. Logged ONCE. Never raises."""
+    global _espeak_phonemize_warned
+    with _tts_lock:
+        tts = _tts
+    tokenizer = getattr(tts, "tokenizer", None)
+    phonemize = getattr(tokenizer, "phonemize", None)
+    if phonemize is None:
+        return piece, False
+    try:
+        phonemes = phonemize(piece, TTS_LANG)
+        if not phonemes:
+            return piece, False
+        return phonemes, True
+    except Exception as exc:  # noqa: BLE001 — degrade to the raw-text path
+        if not _espeak_phonemize_warned:
+            _espeak_phonemize_warned = True
+            _log(
+                f"espeak phonemize failed ({type(exc).__name__}: {exc}); "
+                "falling back to Kokoro's internal text path — long pieces may "
+                "be truncated at 510 phonemes (logged once)"
+            )
+        return piece, False
+
+
 def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> tuple[bytes, dict]:
     """The TTS-serialized synthesis. Acquires the TTS semaphore so only
     TTS_CONCURRENCY synths run at once — a separate lane from STT.
 
     Accepts text of ANY length: it is split into pieces ≤ TTS_MAX_CHARS on
-    sentence/paragraph boundaries, each synthesized on the GPU, and the raw
-    24kHz PCM concatenated into ONE stream (with a short inter-piece pad so
-    joins sound natural and never click) before a SINGLE opus encode. The
-    caller therefore always gets one valid, continuous Ogg/Opus file."""
+    sentence/paragraph boundaries, each piece's PHONEME string is then split to
+    ≤ TTS_MAX_PHONEMES (#4695 — Kokoro discards anything past 510 phonemes in a
+    single batch), each phoneme chunk synthesized on the GPU, and the raw 24kHz
+    PCM concatenated into ONE stream (with a short inter-piece pad so joins
+    sound natural and never click) before a SINGLE opus encode. The caller
+    therefore always gets one valid, continuous Ogg/Opus file."""
     import numpy as np  # local — only TTS needs numpy
 
     with _tts_sem:
@@ -784,33 +922,58 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
             pieces = [text]
 
         # ~120ms of silence between pieces at 24kHz mono — keeps the cadence
-        # natural across a sentence join without a jarring click.
+        # natural across a sentence join without a jarring click. Applied at
+        # PIECE seams only: phoneme chunks inside one piece are joined flush,
+        # exactly where Kokoro's internal batcher used to join them.
         pad = np.zeros(int(TTS_SAMPLE_RATE * 0.12), dtype=np.float32)
 
         chunks: list[np.ndarray] = []
         sample_rate = TTS_SAMPLE_RATE
+        batches = 0
+        hard_cuts = 0
+        unchunked_pieces = 0
         for i, piece in enumerate(pieces):
             # misaki's POS-aware G2P runs here, INSIDE _tts_sem — so with
             # VOICE_TTS_CONCURRENCY defaulting to 1, spaCy is never called
             # concurrently. On a hit we hand Kokoro the phoneme string
-            # (is_phonemes=True — the heteronym fix); on any miss we hand it the
-            # raw TEXT and Kokoro phonemizes via espeak (today's path). A
+            # (is_phonemes=True — the heteronym fix); on a miss we fall back to
+            # Kokoro's own espeak tokenizer, still as PHONEMES, so the piece can
+            # be phoneme-chunked either way. Only if that also fails do we hand
+            # Kokoro raw TEXT and inherit its 510-phoneme truncation. A
             # regression must never route a phoneme string through the espeak
-            # text path, so the two branches are kept explicit. See
-            # _phonemize_piece / VOICE_TTS_G2P=espeak (rollback lever).
+            # text path, so the branches are kept explicit. See
+            # _phonemize_piece / _espeak_phonemize / VOICE_TTS_G2P=espeak.
             content, is_phonemes = _phonemize_piece(piece)
+            if not is_phonemes:
+                content, is_phonemes = _espeak_phonemize(piece)
+
             if is_phonemes:
-                samples, sample_rate = _tts.create(  # type: ignore[union-attr]
-                    content, voice=voice, speed=speed, is_phonemes=True
-                )
+                piece_chunks, piece_cuts = _split_phonemes(content, TTS_MAX_PHONEMES)
+                hard_cuts += piece_cuts
             else:
+                # Last resort: no phoneme string available for this piece, so it
+                # goes to Kokoro as text and Kokoro may slice it. Counted and
+                # logged below — never silent.
+                piece_chunks = []
+                unchunked_pieces += 1
+
+            if i > 0:
+                chunks.append(pad)
+
+            if not piece_chunks:
                 samples, sample_rate = _tts.create(  # type: ignore[union-attr]
                     piece, voice=voice, speed=speed, lang=TTS_LANG
                 )
-            arr = np.asarray(samples, dtype=np.float32)
-            if i > 0:
-                chunks.append(pad)
-            chunks.append(arr)
+                chunks.append(np.asarray(samples, dtype=np.float32))
+                batches += 1
+                continue
+
+            for phoneme_chunk in piece_chunks:
+                samples, sample_rate = _tts.create(  # type: ignore[union-attr]
+                    phoneme_chunk, voice=voice, speed=speed, is_phonemes=True
+                )
+                chunks.append(np.asarray(samples, dtype=np.float32))
+                batches += 1
 
         all_samples = (
             np.concatenate(chunks) if chunks else np.zeros(0, dtype=np.float32)
@@ -825,12 +988,34 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
             "voice": voice,
             "speed": speed,
             "pieces": len(pieces),
+            "batches": batches,
             "chars": len(text),
+            # Non-zero => audio quality was degraded on this request. Surfaced
+            # in the response so a caller can act on it, not only in the log.
+            "hardCuts": hard_cuts,
+            "unchunkedPieces": unchunked_pieces,
         }
         _log(
             f"synth: {len(text)} chars -> {len(pieces)} piece(s) -> "
-            f"{audio_seconds:.2f}s audio in {elapsed_ms}ms"
+            f"{batches} batch(es) -> {audio_seconds:.2f}s audio in {elapsed_ms}ms"
         )
+        # #4695: the failure mode this replaced was audio that just stopped
+        # mid-sentence with nothing anywhere in the logs. Both residual lossy
+        # paths shout, at WARN volume, with enough context to find the message.
+        if hard_cuts:
+            _log(
+                f"WARNING: TTS split {hard_cuts} unbreakable phoneme run(s) "
+                f"mid-word (> {TTS_MAX_PHONEMES} phonemes with no space or "
+                f"clause break) for a {len(text)}-char request; audio is "
+                "complete but has an audible seam"
+            )
+        if unchunked_pieces:
+            _log(
+                f"WARNING: TTS could not phonemize {unchunked_pieces} of "
+                f"{len(pieces)} piece(s) for a {len(text)}-char request; those "
+                "went to Kokoro as text and ANY past 510 phonemes was DISCARDED "
+                "— speech may stop mid-sentence"
+            )
         return ogg, meta
 
 

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -753,8 +753,8 @@ def _split_phonemes(phonemes: str, max_phonemes: int) -> tuple[list[str], int]:
 
     LOSSLESS by construction: every phoneme of the input appears in exactly one
     chunk (whitespace between chunks is the only thing normalised away). This is
-    the whole point of #4695 — Kokoro's own batcher DISCARDS the tail of any
-    over-long run, this one carries it into the next chunk instead.
+    the whole point of #4695 — hand Kokoro an over-long run and it discards the
+    tail or (usually) raises; this carries the tail into the next chunk instead.
 
     Returns (chunks, hard_cuts). `hard_cuts` counts boundaries that had to land
     MID-WORD because a single run of `max_phonemes` phonemes contained no space
@@ -938,8 +938,9 @@ def _espeak_phonemize(piece: str) -> tuple[str, bool]:
             _espeak_phonemize_warned = True
             _log(
                 f"espeak phonemize failed ({type(exc).__name__}: {exc}); "
-                "falling back to Kokoro's internal text path — long pieces may "
-                "be truncated at 510 phonemes (logged once)"
+                "falling back to Kokoro's internal text path — a clause past "
+                "510 phonemes will be truncated or fail the request "
+                "(logged once)"
             )
         return piece, False
 
@@ -950,12 +951,12 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
 
     Accepts text of ANY length: it is split into pieces ≤ TTS_MAX_CHARS on
     sentence/paragraph boundaries, each piece's PHONEME string is then split to
-    ≤ TTS_MAX_PHONEMES (#4695 — a batch past 510 phonemes is truncated by Kokoro
-    or, more often, raises and fails the request), each phoneme chunk
-    synthesized on the GPU, and the raw 24kHz
-    PCM concatenated into ONE stream (with a short inter-piece pad so joins
-    sound natural and never click) before a SINGLE opus encode. The caller
-    therefore always gets one valid, continuous Ogg/Opus file."""
+    ≤ TTS_MAX_PHONEMES (#4695 — a batch past 510 phonemes is truncated by
+    Kokoro or, in practice, raises and fails the whole request), each phoneme
+    chunk synthesized on the GPU, and the raw 24kHz PCM concatenated into ONE
+    stream (with a short inter-piece pad so joins sound natural and never
+    click) before a SINGLE opus encode. The caller therefore always gets one
+    valid, continuous Ogg/Opus file."""
     import numpy as np  # local — only TTS needs numpy
 
     with _tts_sem:
@@ -1001,6 +1002,11 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
                 piece_chunks = []
                 unchunked_pieces += 1
 
+            # `piece_chunks` can also be empty with is_phonemes=True when the
+            # piece phonemises to nothing but punctuation/whitespace. That falls
+            # through to the text path below WITHOUT counting an unchunked
+            # piece: there is no speech to lose, so it is not a degradation.
+
             if i > 0:
                 chunks.append(pad)
 
@@ -1043,9 +1049,11 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
             f"synth: {len(text)} chars -> {len(pieces)} piece(s) -> "
             f"{batches} batch(es) -> {audio_seconds:.2f}s audio in {elapsed_ms}ms"
         )
-        # #4695: the failure mode this replaced was audio that just stopped
-        # mid-sentence with nothing anywhere in the logs. Both residual lossy
-        # paths shout, at WARN volume, with enough context to find the message.
+        # #4695: the failure mode this replaced surfaced only as a voice
+        # message that never arrived (a 500 from the IndexError) or, where the
+        # slice landed on an out-of-vocab phoneme, audio that stopped
+        # mid-sentence. Both residual degradation paths now shout, at WARN
+        # volume, with enough context to find the offending message.
         if hard_cuts:
             _log(
                 f"WARNING: TTS split {hard_cuts} unbreakable phoneme run(s) "

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -180,9 +180,12 @@ TTS_MAX_CHARS = int(os.environ.get("VOICE_TTS_MAX_CHARS", "1200"))
 # G2P work and keeps sentence-aware seams); phonemes are the correctness pass.
 #
 # 500, not 510: Kokoro._split_phonemes compares with `>=` MAX_PHONEME_LENGTH,
-# so feeding it a punctuation-free run of exactly 510 makes it emit a leading
-# EMPTY batch. A few phonemes of headroom keeps our chunks a no-op for it.
-TTS_MAX_PHONEMES = max(1, min(510, int(os.environ.get("VOICE_TTS_MAX_PHONEMES", "500"))))
+# so a break-free chunk of 509 or more makes it emit a leading EMPTY batch
+# (which then synthesizes as a stray blip). 508 is the highest safe value and
+# is enforced as the ceiling regardless of what the env asks for; 500 is the
+# default because a little headroom costs nothing measurable (+1.5% batches on
+# the production corpus) and keeps the seam choice ours.
+TTS_MAX_PHONEMES = max(1, min(508, int(os.environ.get("VOICE_TTS_MAX_PHONEMES", "500"))))
 # Defence-in-depth ceiling on the raw JSON body (text is otherwise unbounded,
 # chunked internally). 256KB ≈ ~40k chars of UTF-8 — far above any real reply.
 TTS_MAX_BODY_BYTES = int(os.environ.get("VOICE_TTS_MAX_BODY_BYTES", str(256 * 1024)))

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -1014,13 +1014,22 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
                 # run — the request would 500 as silently as it did pre-#4695.
                 piece_chunks = []
                 unchunked_pieces += 1
-                _log(
-                    f"WARNING: TTS could not phonemize piece {i + 1}/"
-                    f"{len(pieces)} ({len(piece)} chars) of a {len(text)}-char "
-                    "request; handing it to Kokoro as TEXT, so a clause past "
-                    "510 phonemes is truncated or fails the whole request "
-                    "(IndexError at kokoro_onnx/__init__.py:108)"
-                )
+                # Once per REQUEST, not once per piece: both G2P engines being
+                # down is a whole-sidecar condition, and a 40k-char request is
+                # ~34 pieces. Same volume as the post-loop line it replaces,
+                # matching the log-once idiom of _g2p_warned /
+                # _espeak_phonemize_warned. The count still lands in the meta.
+                if unchunked_pieces == 1:
+                    _log(
+                        f"WARNING: TTS could not phonemize piece {i + 1}/"
+                        f"{len(pieces)} ({len(piece)} chars) of a "
+                        f"{len(text)}-char request; handing it to Kokoro as "
+                        "TEXT, so a clause past 510 phonemes is truncated or "
+                        "fails the whole request (IndexError at "
+                        "kokoro_onnx/__init__.py:108). Further unphonemizable "
+                        "pieces in this request are counted in the response "
+                        "meta (unchunkedPieces), not logged."
+                    )
 
             # `piece_chunks` can also be empty with is_phonemes=True when the
             # piece phonemises to nothing but punctuation/whitespace. That falls

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -1001,10 +1001,20 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
                 hard_cuts += piece_cuts
             else:
                 # Last resort: no phoneme string available for this piece, so it
-                # goes to Kokoro as text and Kokoro may slice it. Counted and
-                # logged below — never silent.
+                # goes to Kokoro as text and Kokoro may slice it. Log HERE, not
+                # after the loop: the very case this warning exists to report is
+                # the one where Kokoro raises inside the loop (IndexError at
+                # kokoro_onnx/__init__.py:108), and a post-loop log would never
+                # run — the request would 500 as silently as it did pre-#4695.
                 piece_chunks = []
                 unchunked_pieces += 1
+                _log(
+                    f"WARNING: TTS could not phonemize piece {i + 1}/"
+                    f"{len(pieces)} ({len(piece)} chars) of a {len(text)}-char "
+                    "request; handing it to Kokoro as TEXT, so a clause past "
+                    "510 phonemes is truncated or fails the whole request "
+                    "(IndexError at kokoro_onnx/__init__.py:108)"
+                )
 
             # `piece_chunks` can also be empty with is_phonemes=True when the
             # piece phonemises to nothing but punctuation/whitespace. That falls
@@ -1057,21 +1067,15 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
         # message that never arrived (a 500 from the IndexError) or, where the
         # slice landed on an out-of-vocab phoneme, audio that stopped
         # mid-sentence. Both residual degradation paths now shout, at WARN
-        # volume, with enough context to find the offending message.
+        # volume, with enough context to find the offending message. The
+        # unphonemizable-piece warning is emitted in the loop above, where it
+        # still fires if Kokoro then raises on that very piece.
         if hard_cuts:
             _log(
                 f"WARNING: TTS split {hard_cuts} unbreakable phoneme run(s) "
                 f"mid-word (> {TTS_MAX_PHONEMES} phonemes with no space or "
                 f"clause break) for a {len(text)}-char request; audio is "
                 "complete but has an audible seam"
-            )
-        if unchunked_pieces:
-            _log(
-                f"WARNING: TTS could not phonemize {unchunked_pieces} of "
-                f"{len(pieces)} piece(s) for a {len(text)}-char request; those "
-                "went to Kokoro as TEXT, so a clause past 510 phonemes is "
-                "truncated or fails the whole request (IndexError at "
-                "kokoro_onnx/__init__.py:108)"
             )
         return ogg, meta
 

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -171,8 +171,17 @@ TTS_MAX_CHARS = int(os.environ.get("VOICE_TTS_MAX_CHARS", "1200"))
 # MAX_PHONEME_LENGTH = 510 (kokoro_onnx/__init__.py:97-101, verified against the
 # 0.5.0 wheel installed in this image). Kokoro does re-batch a long phoneme
 # string first (Kokoro._split_phonemes), but that splitter breaks ONLY on
-# `.,!?;` — so any punctuation-free run over 510 phonemes is still sliced and
-# the tail of that clause is simply never spoken.
+# `.,!?;` — so any punctuation-free run over 510 phonemes still overflows.
+#
+# And the overflow does not merely truncate. Two lines after the slice,
+# `voice = voice[len(tokens)]` (kokoro_onnx/__init__.py:108) indexes a voices
+# array of exactly 510 rows, so a batch that slices to 510 IN-VOCAB phonemes
+# indexes one past the end and RAISES — the whole /tts request 500s and the
+# user gets no voice message at all:
+#     IndexError: index 510 is out of bounds for axis 0 with size 510
+# Reproduced against the real model on a real corpus message (1,545-phoneme
+# batch). All 16 over-510 batches in a 1,679-message production corpus land on
+# that raise, not on a partial read — 15 messages, 0.9%, failing outright.
 #
 # So we chunk on the thing that actually overflows: after G2P we split the
 # phoneme string ourselves to <= TTS_MAX_PHONEMES and hand Kokoro one
@@ -941,8 +950,9 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
 
     Accepts text of ANY length: it is split into pieces ≤ TTS_MAX_CHARS on
     sentence/paragraph boundaries, each piece's PHONEME string is then split to
-    ≤ TTS_MAX_PHONEMES (#4695 — Kokoro discards anything past 510 phonemes in a
-    single batch), each phoneme chunk synthesized on the GPU, and the raw 24kHz
+    ≤ TTS_MAX_PHONEMES (#4695 — a batch past 510 phonemes is truncated by Kokoro
+    or, more often, raises and fails the request), each phoneme chunk
+    synthesized on the GPU, and the raw 24kHz
     PCM concatenated into ONE stream (with a short inter-piece pad so joins
     sound natural and never click) before a SINGLE opus encode. The caller
     therefore always gets one valid, continuous Ogg/Opus file."""
@@ -1047,8 +1057,9 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
             _log(
                 f"WARNING: TTS could not phonemize {unchunked_pieces} of "
                 f"{len(pieces)} piece(s) for a {len(text)}-char request; those "
-                "went to Kokoro as text and ANY past 510 phonemes was DISCARDED "
-                "— speech may stop mid-sentence"
+                "went to Kokoro as TEXT, so a clause past 510 phonemes is "
+                "truncated or fails the whole request (IndexError at "
+                "kokoro_onnx/__init__.py:108)"
             )
         return ogg, meta
 

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -194,7 +194,13 @@ TTS_MAX_CHARS = int(os.environ.get("VOICE_TTS_MAX_CHARS", "1200"))
 # is enforced as the ceiling regardless of what the env asks for; 500 is the
 # default because a little headroom costs nothing measurable (+1.5% batches on
 # the production corpus) and keeps the seam choice ours.
-TTS_MAX_PHONEMES = max(1, min(508, int(os.environ.get("VOICE_TTS_MAX_PHONEMES", "500"))))
+#
+# The clamp is silent-by-value but not silent-by-log: an operator who sets 600
+# (or 0) would otherwise never learn the value did not take. main() warns —
+# see _max_phonemes_clamp_warning.
+TTS_MAX_PHONEMES_CEILING = 508
+TTS_MAX_PHONEMES_REQUESTED = int(os.environ.get("VOICE_TTS_MAX_PHONEMES", "500"))
+TTS_MAX_PHONEMES = max(1, min(TTS_MAX_PHONEMES_CEILING, TTS_MAX_PHONEMES_REQUESTED))
 # Defence-in-depth ceiling on the raw JSON body (text is otherwise unbounded,
 # chunked internally). 256KB ≈ ~40k chars of UTF-8 — far above any real reply.
 TTS_MAX_BODY_BYTES = int(os.environ.get("VOICE_TTS_MAX_BODY_BYTES", str(256 * 1024)))
@@ -1379,9 +1385,25 @@ def _parse_multipart(body: bytes, content_type: str):
     return audio, language
 
 
+def _max_phonemes_clamp_warning() -> str | None:
+    """The warning to emit when VOICE_TTS_MAX_PHONEMES did not take as set, or
+    None when it did. Split out so the message is testable without a boot."""
+    if TTS_MAX_PHONEMES == TTS_MAX_PHONEMES_REQUESTED:
+        return None
+    return (
+        f"WARNING: VOICE_TTS_MAX_PHONEMES={TTS_MAX_PHONEMES_REQUESTED} is out "
+        f"of range and was clamped to {TTS_MAX_PHONEMES}; the ceiling is "
+        f"{TTS_MAX_PHONEMES_CEILING} because kokoro-onnx flushes a batch at "
+        ">= MAX_PHONEME_LENGTH (510) and the floor is 1"
+    )
+
+
 def main() -> int:
     if not SHARED_TOKEN:
         _log("WARNING: VOICE_SIDECAR_TOKEN is empty — every /stt and /tts call will 401")
+    _clamp_warning = _max_phonemes_clamp_warning()
+    if _clamp_warning:
+        _log(_clamp_warning)
     threading.Thread(target=_load_model, daemon=True).start()
     threading.Thread(target=_load_tts, daemon=True).start()
     server = ThreadingHTTPServer(("0.0.0.0", LISTEN_PORT), Handler)

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -703,6 +703,37 @@ def _split_text(text: str, max_chars: int) -> list[str]:
 _PHONEME_BREAKS = ".,!?;"
 
 
+def _normalize_phonemes(phonemes: str) -> str:
+    """Rebuild a phoneme string exactly the way Kokoro._split_phonemes rebuilds
+    it: every clause stripped, break chars kept flush against the clause they
+    end, a single space between runs.
+
+    Kokoro runs that rebuild on whatever we hand it and it can make the string
+    LONGER — `a,b` comes back as `a, b` — so `len(chunk)` here and the length
+    Kokoro measures are not the same number unless we normalise first (measured:
+    a 500-phoneme chunk re-expanding to 749 on the production corpus, which
+    Kokoro then re-split into 508 + 241).
+
+    That growth cannot by itself cause truncation — it only ever happens at a
+    break char, and break chars are exactly where Kokoro re-batches. What it
+    does cause is Kokoro silently re-splitting chunks we already sized, putting
+    seams somewhere we did not choose and making `batches` in the response meta
+    a lie. Normalising makes Kokoro's rebuild a fixed point: our chunk is the
+    batch, one for one."""
+    import re
+
+    out = ""
+    for part in re.split(r"([.,!?;])", phonemes):
+        part = part.strip()
+        if not part:
+            continue
+        if part in _PHONEME_BREAKS:
+            out += part
+        else:
+            out = (out + " " + part) if out else part
+    return out
+
+
 def _split_phonemes(phonemes: str, max_phonemes: int) -> tuple[list[str], int]:
     """Split a phoneme string into chunks of at most `max_phonemes`, preferring
     Kokoro's own break characters (`.,!?;`) then whitespace, so a chunk boundary
@@ -719,7 +750,7 @@ def _split_phonemes(phonemes: str, max_phonemes: int) -> tuple[list[str], int]:
     enough that the caller logs them loudly rather than swallowing them.
 
     Pure — no Kokoro, no misaki, no globals. Directly unit-testable."""
-    phonemes = phonemes.strip()
+    phonemes = _normalize_phonemes(phonemes)
     if not phonemes:
         return [], 0
     if len(phonemes) <= max_phonemes:

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -809,9 +809,13 @@ def _split_phonemes(phonemes: str, max_phonemes: int) -> tuple[list[str], int]:
         if not stripped:
             continue
         # Pack back-to-back clauses into one chunk while they fit, so we do not
-        # emit more synthesis batches than necessary.
-        if chunks and len(chunks[-1]) + 1 + len(stripped) <= max_phonemes:
-            chunks[-1] = (chunks[-1] + " " + stripped).strip()
+        # emit more synthesis batches than necessary. The separator has to match
+        # Kokoro's rebuild exactly or the chunk stops being a fixed point of it:
+        # Kokoro appends a break char FLUSH ("a" + ";") and space-joins anything
+        # else. Adjacent breaks (";." "?!" ",,") are the case that differs.
+        sep = "" if stripped[0] in _PHONEME_BREAKS else " "
+        if chunks and len(chunks[-1]) + len(sep) + len(stripped) <= max_phonemes:
+            chunks[-1] = (chunks[-1] + sep + stripped).strip()
             continue
         _emit(unit)
 

--- a/docker/voice-sidecar/test_g2p.py
+++ b/docker/voice-sidecar/test_g2p.py
@@ -10,10 +10,16 @@ past /ɹˈɛd/). These tests pin two contracts:
   1. _phonemize_piece degrades correctly — (piece, False) when misaki is
      absent / disabled / raises, (phonemes, True) only on a real hit.
   2. _run_synthesis ROUTES on that flag: a phoneme string goes to Kokoro
-     with is_phonemes=True, and a fallback goes as raw TEXT with
-     lang=TTS_LANG and NO is_phonemes. A regression that silently routed a
-     phoneme string through the espeak text path (or vice-versa) would be a
-     silent mispronunciation, so it is pinned here.
+     with is_phonemes=True. A regression that silently routed a phoneme
+     string through the espeak text path (or vice-versa) would be a silent
+     mispronunciation, so it is pinned here.
+
+     Since #4695 the misaki MISS is a two-step fallback, not one: the piece is
+     retried through Kokoro's own espeak tokenizer (_espeak_phonemize) so it
+     can still be phoneme-chunked, and only if THAT is unavailable does it go
+     to Kokoro as raw TEXT with lang=TTS_LANG. The fallback cases below use a
+     stub _tts with no `.tokenizer`, so they exercise that last leg. The
+     espeak-tokenizer leg is covered in test_phoneme_chunking.py.
 
 Like test_server.py these run WITHOUT misaki / numpy / onnxruntime / ffmpeg
 installed (the CI voice-sidecar job is stdlib-only): server.py imports

--- a/docker/voice-sidecar/test_phoneme_chunking.py
+++ b/docker/voice-sidecar/test_phoneme_chunking.py
@@ -395,6 +395,47 @@ class LossyPathIsLoudTests(unittest.TestCase):
         self.assertFalse([line for line in self.logged if "WARNING" in line])
 
 
+class MaxPhonemesClampTests(unittest.TestCase):
+    """VOICE_TTS_MAX_PHONEMES is clamped to [1, 508]. A clamp that changes the
+    operator's value must say so, or the real ceiling is undiscoverable."""
+
+    def setUp(self) -> None:
+        self._orig = (server.TTS_MAX_PHONEMES_REQUESTED, server.TTS_MAX_PHONEMES)
+
+    def tearDown(self) -> None:
+        server.TTS_MAX_PHONEMES_REQUESTED, server.TTS_MAX_PHONEMES = self._orig
+
+    def _set(self, requested: int) -> None:
+        server.TTS_MAX_PHONEMES_REQUESTED = requested
+        server.TTS_MAX_PHONEMES = max(
+            1, min(server.TTS_MAX_PHONEMES_CEILING, requested)
+        )
+
+    def test_in_range_value_is_not_warned(self) -> None:
+        self._set(500)
+        self.assertIsNone(server._max_phonemes_clamp_warning())
+
+    def test_too_high_is_warned_with_both_numbers(self) -> None:
+        self._set(600)
+        warning = server._max_phonemes_clamp_warning()
+        self.assertIsNotNone(warning)
+        self.assertIn("WARNING", warning)
+        self.assertIn("600", warning)
+        self.assertIn("508", warning)
+
+    def test_zero_is_warned(self) -> None:
+        # 0 clamps to 1, which would hard-cut every single phoneme — the worst
+        # possible silent misconfiguration.
+        self._set(0)
+        warning = server._max_phonemes_clamp_warning()
+        self.assertIsNotNone(warning)
+        self.assertIn("WARNING", warning)
+        self.assertIn("clamped to 1", warning)
+
+    def test_ceiling_matches_kokoros_off_by_one(self) -> None:
+        self.assertEqual(server.TTS_MAX_PHONEMES_CEILING, MAX_PHONEME_LENGTH - 2)
+
+
 class EspeakPhonemizeTests(unittest.TestCase):
     """The espeak path is phonemized here so it can be phoneme-chunked too."""
 

--- a/docker/voice-sidecar/test_phoneme_chunking.py
+++ b/docker/voice-sidecar/test_phoneme_chunking.py
@@ -161,8 +161,12 @@ class SplitPhonemesTests(unittest.TestCase):
         for c in chunks[:-1]:
             self.assertTrue(c.endswith(","), msg=repr(c))
 
-    def test_cap_is_clamped_below_kokoros_limit(self) -> None:
-        self.assertLessEqual(server.TTS_MAX_PHONEMES, MAX_PHONEME_LENGTH)
+    def test_cap_leaves_room_for_kokoros_off_by_one(self) -> None:
+        # Kokoro flushes on `>=` MAX_PHONEME_LENGTH, so a break-free chunk of
+        # 509+ makes it emit a leading EMPTY batch. 508 is the highest safe cap.
+        self.assertLessEqual(server.TTS_MAX_PHONEMES, MAX_PHONEME_LENGTH - 2)
+        for size in (server.TTS_MAX_PHONEMES, MAX_PHONEME_LENGTH - 2):
+            self.assertEqual(_FaithfulKokoro._split_phonemes("x" * size), ["x" * size])
 
     def test_our_chunk_is_kokoros_batch_one_for_one(self) -> None:
         # Kokoro re-inserts a space after every break char, so `a,b` comes back
@@ -362,6 +366,43 @@ class EspeakPhonemizeTests(unittest.TestCase):
         server._tts = _TTS()
         self.assertEqual(server._espeak_phonemize("hi"), ("hˈaI", True))
         self.assertEqual(seen, [("hi", server.TTS_LANG)])
+
+    def test_run_synthesis_chunks_the_espeak_path_too(self) -> None:
+        # misaki off (the VOICE_TTS_G2P=espeak rollback lever). The piece must
+        # still be phoneme-chunked, not handed to Kokoro as one long text blob.
+        class _Tok:
+            @staticmethod
+            def phonemize(text, lang):  # noqa: ANN001
+                return "wˈ3:d " * 400  # ~2400 phonemes, well past 510
+
+        tts = _FaithfulKokoro()
+        tts.tokenizer = _Tok()
+
+        orig_g2p, orig_pcm, orig_ogg = (
+            server._g2p, server._pcm_to_wav_bytes, server._wav_to_ogg_opus
+        )
+        prev_numpy = _install_fake_numpy()
+        server._g2p = None
+        server._tts = tts
+        server._pcm_to_wav_bytes = lambda samples, sample_rate: b"WAV"
+        server._wav_to_ogg_opus = lambda wav: b"OGG"
+        try:
+            _ogg, meta = server._run_synthesis("irrelevant", voice="af_heart")
+        finally:
+            server._g2p = orig_g2p
+            server._pcm_to_wav_bytes = orig_pcm
+            server._wav_to_ogg_opus = orig_ogg
+            if prev_numpy is None:
+                sys.modules.pop("numpy", None)
+            else:
+                sys.modules["numpy"] = prev_numpy
+
+        self.assertEqual(tts.truncated_batches, 0)
+        self.assertEqual(meta["unchunkedPieces"], 0)
+        self.assertGreater(meta["batches"], 1)
+        for call in tts.calls:
+            self.assertTrue(call["is_phonemes"])
+            self.assertLessEqual(len(call["text"]), MAX_PHONEME_LENGTH)
 
     def test_raising_tokenizer_degrades_to_text(self) -> None:
         class _Tok:

--- a/docker/voice-sidecar/test_phoneme_chunking.py
+++ b/docker/voice-sidecar/test_phoneme_chunking.py
@@ -1,0 +1,361 @@
+"""Unit tests for phoneme-length chunking on the TTS path (#4695).
+
+The defect these pin: the sidecar chunked on CHARACTERS (VOICE_TTS_MAX_CHARS
+= 1200) but kokoro-onnx synthesizes in PHONEMES and hard-slices any single
+batch past MAX_PHONEME_LENGTH = 510:
+
+    kokoro_onnx/__init__.py:97-101 (0.5.0)
+        if len(phonemes) > MAX_PHONEME_LENGTH:
+            log.warning(...)
+        phonemes = phonemes[:MAX_PHONEME_LENGTH]
+
+Kokoro does pre-batch a long phoneme string (Kokoro._split_phonemes), but that
+splitter breaks ONLY on `.,!?;` — so a punctuation-free run over 510 phonemes
+still loses its tail, and the listener just hears the sentence stop.
+
+`_FaithfulKokoro` below is a line-by-line port of kokoro-onnx 0.5.0's
+`_split_phonemes` + the `_create_audio` slice, so it discards exactly what the
+real engine discards. The load-bearing assertion is `spoken()` — the phonemes
+that actually reached synthesis — versus the phonemes handed in. On the
+pre-fix server (one _tts.create per ~1200-char piece) that assertion FAILS with
+real phonemes missing; with phoneme chunking it passes with zero loss.
+
+These run WITHOUT numpy / misaki / onnxruntime installed, like the sibling
+suites: server.py imports numpy lazily and the G2P + encoder touchpoints are
+injected through module globals.
+
+Run: python3 -m unittest discover -s docker/voice-sidecar -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import types
+import unittest
+
+import server
+
+# The real constant from kokoro_onnx.config, restated so this suite does not
+# need the wheel installed. Verified against kokoro-onnx 0.5.0.
+MAX_PHONEME_LENGTH = 510
+
+
+class _FaithfulKokoro:
+    """A Kokoro stand-in that truncates EXACTLY like kokoro-onnx 0.5.0.
+
+    Records, per create() call, the phoneme text that survived to synthesis so a
+    test can compare it against what was handed in."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.synthesized: list[str] = []
+        self.truncated_batches = 0
+
+    # verbatim port of Kokoro._split_phonemes (kokoro_onnx/__init__.py:136-168)
+    @staticmethod
+    def _split_phonemes(phonemes: str) -> list[str]:
+        words = re.split(r"([.,!?;])", phonemes)
+        batched: list[str] = []
+        current_batch = ""
+        for part in words:
+            part = part.strip()
+            if part:
+                if len(current_batch) + len(part) + 1 >= MAX_PHONEME_LENGTH:
+                    batched.append(current_batch.strip())
+                    current_batch = part
+                else:
+                    if part in ".,!?;":
+                        current_batch += part
+                    else:
+                        if current_batch:
+                            current_batch += " "
+                        current_batch += part
+        if current_batch:
+            batched.append(current_batch.strip())
+        return batched
+
+    def create(self, text, voice=None, speed=None, lang=None, is_phonemes=False):  # noqa: ANN001
+        self.calls.append(
+            {"text": text, "voice": voice, "speed": speed, "lang": lang,
+             "is_phonemes": is_phonemes}
+        )
+        # Only the phoneme path is modelled; a text piece would go through
+        # espeak first, which this fake does not have.
+        phonemes = text if is_phonemes else text
+        for batch in self._split_phonemes(phonemes):
+            if len(batch) > MAX_PHONEME_LENGTH:
+                self.truncated_batches += 1
+            self.synthesized.append(batch[:MAX_PHONEME_LENGTH])
+        return ([0.0], server.TTS_SAMPLE_RATE)
+
+    def spoken(self) -> str:
+        """Every phoneme that actually reached the model, whitespace-normalised
+        (chunk seams legitimately renormalise spaces; dropped phonemes do not)."""
+        return re.sub(r"\s+", "", "".join(self.synthesized))
+
+
+def _install_fake_numpy() -> types.ModuleType | None:
+    prev = sys.modules.get("numpy")
+    fake = types.ModuleType("numpy")
+    fake.float32 = "float32"
+    fake.zeros = lambda n, dtype=None: [0.0] * int(n)
+    fake.asarray = lambda x, dtype=None: list(x)
+    fake.concatenate = lambda chunks: [v for c in chunks for v in c]
+    sys.modules["numpy"] = fake
+    return prev
+
+
+def _norm(phonemes: str) -> str:
+    return re.sub(r"\s+", "", phonemes)
+
+
+class SplitPhonemesTests(unittest.TestCase):
+    """The pure splitter: bounded, lossless, punctuation-preferring."""
+
+    def test_empty(self) -> None:
+        self.assertEqual(server._split_phonemes("", 100), ([], 0))
+        self.assertEqual(server._split_phonemes("   ", 100), ([], 0))
+
+    def test_short_string_is_one_chunk(self) -> None:
+        chunks, cuts = server._split_phonemes("fˈOni:mz", 100)
+        self.assertEqual(chunks, ["fˈOni:mz"])
+        self.assertEqual(cuts, 0)
+
+    def test_every_chunk_within_cap(self) -> None:
+        text = " ".join(["fˈOni:m"] * 400)
+        chunks, _ = server._split_phonemes(text, 60)
+        self.assertGreater(len(chunks), 1)
+        for c in chunks:
+            self.assertLessEqual(len(c), 60, msg=repr(c))
+
+    def test_lossless_over_word_boundaries(self) -> None:
+        text = " ".join(f"w{i}" for i in range(500))
+        chunks, cuts = server._split_phonemes(text, 61)
+        self.assertEqual(cuts, 0)
+        self.assertEqual(_norm(" ".join(chunks)), _norm(text))
+
+    def test_lossless_over_clause_boundaries(self) -> None:
+        text = ", ".join(["abcdefghij"] * 200) + "."
+        chunks, cuts = server._split_phonemes(text, 97)
+        self.assertEqual(cuts, 0)
+        self.assertEqual(_norm("".join(chunks)), _norm(text))
+        for c in chunks:
+            self.assertLessEqual(len(c), 97)
+
+    def test_unbreakable_run_is_carried_not_dropped(self) -> None:
+        # No space, no clause break: the one case that must still be cut. The
+        # cut is COUNTED and the remainder is CARRIED, never discarded.
+        run = "x" * 1300
+        chunks, cuts = server._split_phonemes(run, 500)
+        self.assertGreater(cuts, 0)
+        self.assertEqual(_norm("".join(chunks)), run)
+        for c in chunks:
+            self.assertLessEqual(len(c), 500)
+
+    def test_prefers_clause_break_over_mid_word_cut(self) -> None:
+        text = "aaaaa,bbbbb,ccccc,ddddd"
+        chunks, cuts = server._split_phonemes(text, 12)
+        self.assertEqual(cuts, 0)
+        # Each seam lands after a comma, never inside a run of letters.
+        for c in chunks[:-1]:
+            self.assertTrue(c.endswith(","), msg=repr(c))
+
+    def test_cap_is_clamped_below_kokoros_limit(self) -> None:
+        self.assertLessEqual(server.TTS_MAX_PHONEMES, MAX_PHONEME_LENGTH)
+
+
+class NoPhonemeLossThroughSynthesisTests(unittest.TestCase):
+    """The outcome test. Runs real-shaped input end-to-end through
+    _run_synthesis against a Kokoro that truncates like the real one, and
+    asserts nothing was discarded. RED before the phoneme-chunking fix."""
+
+    def setUp(self) -> None:
+        self._orig_g2p = server._g2p
+        self._orig_warned = server._g2p_warned
+        self._orig_tts = server._tts
+        self._orig_pcm = server._pcm_to_wav_bytes
+        self._orig_ogg = server._wav_to_ogg_opus
+        self._prev_numpy = _install_fake_numpy()
+        server._pcm_to_wav_bytes = lambda samples, sample_rate: b"WAV"
+        server._wav_to_ogg_opus = lambda wav: b"OGG"
+        self.tts = _FaithfulKokoro()
+        server._tts = self.tts
+        server._g2p_warned = False
+
+    def tearDown(self) -> None:
+        server._g2p = self._orig_g2p
+        server._g2p_warned = self._orig_warned
+        server._tts = self._orig_tts
+        server._pcm_to_wav_bytes = self._orig_pcm
+        server._wav_to_ogg_opus = self._orig_ogg
+        if self._prev_numpy is None:
+            sys.modules.pop("numpy", None)
+        else:
+            sys.modules["numpy"] = self._prev_numpy
+
+    @staticmethod
+    def _identity_g2p(piece: str):
+        """G2P stub with a realistic ~1.15 phonemes-per-char expansion, so a
+        1200-char piece phonemises well past 510 exactly as misaki does on real
+        text (measured: 1.15-1.30 on the production corpus)."""
+        return ("".join(ch + ("ˈ" if ch.isalpha() and ch in "aeiou" else "")
+                        for ch in piece), ["tok"])
+
+    def test_long_unpunctuated_clause_loses_no_phonemes(self) -> None:
+        # A single clause with spaces but NO `.,!?;` for well over 510
+        # phonemes. Kokoro's own batcher cannot break it, so pre-fix the tail
+        # was sliced off and never spoken.
+        text = " ".join(["consequently"] * 120) + "."
+        server._g2p = self._identity_g2p
+        expected, _ = self._identity_g2p(text)
+
+        server._run_synthesis(text, voice="af_heart")
+
+        self.assertEqual(self.tts.truncated_batches, 0)
+        self.assertEqual(self.tts.spoken(), _norm(expected))
+
+    def test_long_comma_free_paragraph_loses_no_phonemes(self) -> None:
+        # Shaped like the real corpus messages that lost audio: long sentences
+        # whose individual clauses exceed 510 phonemes.
+        sentence = " ".join(["deliberation"] * 60)
+        text = ". ".join([sentence] * 4) + "."
+        server._g2p = self._identity_g2p
+        expected, _ = self._identity_g2p(text)
+
+        server._run_synthesis(text, voice="af_heart")
+
+        self.assertEqual(self.tts.truncated_batches, 0)
+        self.assertEqual(self.tts.spoken(), _norm(expected))
+
+    def test_every_batch_handed_to_kokoro_is_within_the_limit(self) -> None:
+        text = " ".join(["antidisestablishmentarianism"] * 200)
+        server._g2p = self._identity_g2p
+
+        server._run_synthesis(text, voice="af_heart")
+
+        self.assertTrue(self.tts.calls)
+        for call in self.tts.calls:
+            self.assertTrue(call["is_phonemes"])
+            self.assertLessEqual(len(call["text"]), MAX_PHONEME_LENGTH)
+
+    def test_meta_reports_batches_and_clean_run_has_no_degradation(self) -> None:
+        text = " ".join(["consequently"] * 120) + "."
+        server._g2p = self._identity_g2p
+
+        _ogg, meta = server._run_synthesis(text, voice="af_heart")
+
+        self.assertEqual(meta["hardCuts"], 0)
+        self.assertEqual(meta["unchunkedPieces"], 0)
+        self.assertGreater(meta["batches"], 1)
+
+
+class LossyPathIsLoudTests(unittest.TestCase):
+    """Requirement 2 of #4695: whatever remains lossy must not be silent."""
+
+    def setUp(self) -> None:
+        self._orig_g2p = server._g2p
+        self._orig_tts = server._tts
+        self._orig_pcm = server._pcm_to_wav_bytes
+        self._orig_ogg = server._wav_to_ogg_opus
+        self._orig_log = server._log
+        self._prev_numpy = _install_fake_numpy()
+        server._pcm_to_wav_bytes = lambda samples, sample_rate: b"WAV"
+        server._wav_to_ogg_opus = lambda wav: b"OGG"
+        server._tts = _FaithfulKokoro()
+        self.logged: list[str] = []
+        server._log = self.logged.append
+
+    def tearDown(self) -> None:
+        server._g2p = self._orig_g2p
+        server._tts = self._orig_tts
+        server._pcm_to_wav_bytes = self._orig_pcm
+        server._wav_to_ogg_opus = self._orig_ogg
+        server._log = self._orig_log
+        if self._prev_numpy is None:
+            sys.modules.pop("numpy", None)
+        else:
+            sys.modules["numpy"] = self._prev_numpy
+
+    def test_mid_word_cut_is_counted_and_warned(self) -> None:
+        # An unbreakable phoneme run: no space, no clause break, over the cap.
+        server._g2p = lambda piece: ("x" * 1400, ["tok"])
+
+        _ogg, meta = server._run_synthesis("anything", voice="af_heart")
+
+        self.assertGreater(meta["hardCuts"], 0)
+        self.assertTrue(
+            any("WARNING" in line and "mid-word" in line for line in self.logged),
+            msg=f"no loud log emitted; got {self.logged!r}",
+        )
+
+    def test_unphonemizable_piece_is_counted_and_warned(self) -> None:
+        # Neither misaki nor Kokoro's espeak tokenizer available: the piece goes
+        # to Kokoro as raw text and Kokoro may slice it. Must not be silent.
+        server._g2p = None  # _FaithfulKokoro has no .tokenizer either
+
+        _ogg, meta = server._run_synthesis("anything at all", voice="af_heart")
+
+        self.assertEqual(meta["unchunkedPieces"], 1)
+        self.assertTrue(
+            any("WARNING" in line and "DISCARDED" in line for line in self.logged),
+            msg=f"no loud log emitted; got {self.logged!r}",
+        )
+
+    def test_clean_synthesis_emits_no_warning(self) -> None:
+        server._g2p = lambda piece: ("fˈOni:mz", ["tok"])
+
+        _ogg, meta = server._run_synthesis("phonemes", voice="af_heart")
+
+        self.assertEqual(meta["hardCuts"], 0)
+        self.assertEqual(meta["unchunkedPieces"], 0)
+        self.assertFalse([line for line in self.logged if "WARNING" in line])
+
+
+class EspeakPhonemizeTests(unittest.TestCase):
+    """The espeak path is phonemized here so it can be phoneme-chunked too."""
+
+    def setUp(self) -> None:
+        self._orig_tts = server._tts
+        self._orig_warned = server._espeak_phonemize_warned
+        server._espeak_phonemize_warned = False
+
+    def tearDown(self) -> None:
+        server._tts = self._orig_tts
+        server._espeak_phonemize_warned = self._orig_warned
+
+    def test_returns_text_and_false_without_a_tokenizer(self) -> None:
+        server._tts = object()
+        self.assertEqual(server._espeak_phonemize("hi"), ("hi", False))
+
+    def test_uses_kokoros_tokenizer_with_the_configured_lang(self) -> None:
+        seen: list[tuple] = []
+
+        class _Tok:
+            @staticmethod
+            def phonemize(text, lang):  # noqa: ANN001
+                seen.append((text, lang))
+                return "hˈaI"
+
+        class _TTS:
+            tokenizer = _Tok()
+
+        server._tts = _TTS()
+        self.assertEqual(server._espeak_phonemize("hi"), ("hˈaI", True))
+        self.assertEqual(seen, [("hi", server.TTS_LANG)])
+
+    def test_raising_tokenizer_degrades_to_text(self) -> None:
+        class _Tok:
+            @staticmethod
+            def phonemize(text, lang):  # noqa: ANN001
+                raise RuntimeError("espeak exploded")
+
+        class _TTS:
+            tokenizer = _Tok()
+
+        server._tts = _TTS()
+        self.assertEqual(server._espeak_phonemize("hi"), ("hi", False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/voice-sidecar/test_phoneme_chunking.py
+++ b/docker/voice-sidecar/test_phoneme_chunking.py
@@ -348,7 +348,10 @@ class LossyPathIsLoudTests(unittest.TestCase):
 
         self.assertEqual(meta["unchunkedPieces"], 1)
         self.assertTrue(
-            any("WARNING" in line and "DISCARDED" in line for line in self.logged),
+            any(
+                "WARNING" in line and "could not phonemize" in line
+                for line in self.logged
+            ),
             msg=f"no loud log emitted; got {self.logged!r}",
         )
 

--- a/docker/voice-sidecar/test_phoneme_chunking.py
+++ b/docker/voice-sidecar/test_phoneme_chunking.py
@@ -367,6 +367,24 @@ class LossyPathIsLoudTests(unittest.TestCase):
             msg=f"no loud log emitted; got {self.logged!r}",
         )
 
+    def test_unphonemizable_piece_is_warned_even_when_kokoro_then_raises(self) -> None:
+        # The case the warning exists to report: the unchunked piece really does
+        # overflow, so Kokoro raises mid-loop. A post-loop log would never run
+        # and the request would 500 as silently as it did pre-#4695.
+        server._g2p = None  # _FaithfulKokoro has no .tokenizer either
+        text = "x" * 600  # one piece (< VOICE_TTS_MAX_CHARS), > 510 phonemes
+
+        with self.assertRaises(IndexError):
+            server._run_synthesis(text, voice="af_heart")
+
+        self.assertTrue(
+            any(
+                "WARNING" in line and "could not phonemize" in line
+                for line in self.logged
+            ),
+            msg=f"no loud log emitted before the raise; got {self.logged!r}",
+        )
+
     def test_clean_synthesis_emits_no_warning(self) -> None:
         server._g2p = lambda piece: ("fˈOni:mz", ["tok"])
 

--- a/docker/voice-sidecar/test_phoneme_chunking.py
+++ b/docker/voice-sidecar/test_phoneme_chunking.py
@@ -194,7 +194,19 @@ class SplitPhonemesTests(unittest.TestCase):
         # as `a, b`. Un-normalised, a 500-phoneme comma-dense chunk re-expands
         # to 749 inside Kokoro and Kokoro re-splits it (508 + 241) — seams we
         # did not choose, and a `batches` count in the meta that is wrong.
-        for dense in ("a," * 250, "a," * 4000, "ab,cd." * 300):
+        # The last three carry ADJACENT break chars. Kokoro appends a break char
+        # FLUSH to the batch, so a chunk that re-inserts a space in front of a
+        # lone break unit ("aaaa; ." vs Kokoro's "aaaa;.") is not a fixed point
+        # and gets re-batched — the error is in the safe direction (no overflow)
+        # but the seams and the `batches` count are still not the ones we chose.
+        for dense in (
+            "a," * 250,
+            "a," * 4000,
+            "ab,cd." * 300,
+            "ab;.cd" * 300,
+            "a?!" * 400,
+            "x,,y" * 300,
+        ):
             chunks, _ = server._split_phonemes(dense, server.TTS_MAX_PHONEMES)
             for c in chunks:
                 rebuilt = _FaithfulKokoro._split_phonemes(c)

--- a/docker/voice-sidecar/test_phoneme_chunking.py
+++ b/docker/voice-sidecar/test_phoneme_chunking.py
@@ -164,6 +164,25 @@ class SplitPhonemesTests(unittest.TestCase):
     def test_cap_is_clamped_below_kokoros_limit(self) -> None:
         self.assertLessEqual(server.TTS_MAX_PHONEMES, MAX_PHONEME_LENGTH)
 
+    def test_our_chunk_is_kokoros_batch_one_for_one(self) -> None:
+        # Kokoro re-inserts a space after every break char, so `a,b` comes back
+        # as `a, b`. Un-normalised, a 500-phoneme comma-dense chunk re-expands
+        # to 749 inside Kokoro and Kokoro re-splits it (508 + 241) — seams we
+        # did not choose, and a `batches` count in the meta that is wrong.
+        for dense in ("a," * 250, "a," * 4000, "ab,cd." * 300):
+            chunks, _ = server._split_phonemes(dense, server.TTS_MAX_PHONEMES)
+            for c in chunks:
+                rebuilt = _FaithfulKokoro._split_phonemes(c)
+                self.assertEqual(
+                    rebuilt, [c], msg=f"Kokoro re-batched our chunk: {c[:40]!r}"
+                )
+                self.assertLessEqual(len(rebuilt[0]), MAX_PHONEME_LENGTH)
+
+    def test_normalize_is_a_fixed_point_of_kokoros_rebuild(self) -> None:
+        for raw in ("a,b.c!d?e;f", "  a ,  b  ", "hˈEloU,wˈ3:ld.", "x"):
+            norm = server._normalize_phonemes(raw)
+            self.assertEqual("".join(_FaithfulKokoro._split_phonemes(norm)), norm)
+
 
 class NoPhonemeLossThroughSynthesisTests(unittest.TestCase):
     """The outcome test. Runs real-shaped input end-to-end through

--- a/docker/voice-sidecar/test_phoneme_chunking.py
+++ b/docker/voice-sidecar/test_phoneme_chunking.py
@@ -11,14 +11,24 @@ batch past MAX_PHONEME_LENGTH = 510:
 
 Kokoro does pre-batch a long phoneme string (Kokoro._split_phonemes), but that
 splitter breaks ONLY on `.,!?;` — so a punctuation-free run over 510 phonemes
-still loses its tail, and the listener just hears the sentence stop.
+still overflows.
 
-`_FaithfulKokoro` below is a line-by-line port of kokoro-onnx 0.5.0's
-`_split_phonemes` + the `_create_audio` slice, so it discards exactly what the
-real engine discards. The load-bearing assertion is `spoken()` — the phonemes
-that actually reached synthesis — versus the phonemes handed in. On the
-pre-fix server (one _tts.create per ~1200-char piece) that assertion FAILS with
-real phonemes missing; with phoneme chunking it passes with zero loss.
+And the overflow is worse than that slice suggests. Two lines later:
+
+    kokoro_onnx/__init__.py:108
+        voice = voice[len(tokens)]        # voices array has exactly 510 rows
+
+A batch that slices to 510 in-vocab phonemes indexes one past the end and
+RAISES, failing the whole /tts request — the user gets no voice message at all,
+not a truncated one. Reproduced live against the real model, and all 16
+over-limit batches in a 1,679-message production corpus land there.
+
+`_FaithfulKokoro` below is a line-by-line port of 0.5.0's `_split_phonemes`
+plus both consequences, so it fails exactly where the real engine fails. The
+load-bearing assertions are `spoken()` — the phonemes that actually reached
+synthesis — and the absence of that IndexError. On the pre-fix server (one
+_tts.create per ~1200-char piece) they are RED; with phoneme chunking they pass
+with zero loss.
 
 These run WITHOUT numpy / misaki / onnxruntime installed, like the sibling
 suites: server.py imports numpy lazily and the G2P + encoder touchpoints are
@@ -80,13 +90,24 @@ class _FaithfulKokoro:
             {"text": text, "voice": voice, "speed": speed, "lang": lang,
              "is_phonemes": is_phonemes}
         )
-        # Only the phoneme path is modelled; a text piece would go through
-        # espeak first, which this fake does not have.
-        phonemes = text if is_phonemes else text
-        for batch in self._split_phonemes(phonemes):
+        for batch in self._split_phonemes(text):
             if len(batch) > MAX_PHONEME_LENGTH:
                 self.truncated_batches += 1
-            self.synthesized.append(batch[:MAX_PHONEME_LENGTH])
+            sliced = batch[:MAX_PHONEME_LENGTH]
+            # kokoro_onnx/__init__.py:108 — `voice = voice[len(tokens)]` on a
+            # voices array of exactly MAX_PHONEME_LENGTH rows. A batch that
+            # slices to 510 IN-VOCAB phonemes indexes one past the end and
+            # RAISES, taking the whole /tts request down with it. Reproduced
+            # live against kokoro-onnx 0.5.0 on a real corpus message:
+            #   IndexError: index 510 is out of bounds for axis 0 with size 510
+            # (All 16 over-510 batches in the 1,679-message corpus land here;
+            # this fake assumes in-vocab, which held for all 16.)
+            if len(sliced) >= MAX_PHONEME_LENGTH:
+                raise IndexError(
+                    f"index {MAX_PHONEME_LENGTH} is out of bounds for axis 0 "
+                    f"with size {MAX_PHONEME_LENGTH}"
+                )
+            self.synthesized.append(sliced)
         return ([0.0], server.TTS_SAMPLE_RATE)
 
     def spoken(self) -> str:
@@ -261,6 +282,12 @@ class NoPhonemeLossThroughSynthesisTests(unittest.TestCase):
         for call in self.tts.calls:
             self.assertTrue(call["is_phonemes"])
             self.assertLessEqual(len(call["text"]), MAX_PHONEME_LENGTH)
+
+    def test_oversized_batch_would_fail_the_whole_request(self) -> None:
+        # Guards the fake itself: if this stops raising, kokoro-onnx changed and
+        # every "loses no phonemes" assertion above is measuring the wrong thing.
+        with self.assertRaises(IndexError):
+            self.tts.create("x" * 600, voice="af_heart", is_phonemes=True)
 
     def test_meta_reports_batches_and_clean_run_has_no_degradation(self) -> None:
         text = " ".join(["consequently"] * 120) + "."

--- a/docker/voice-sidecar/test_phoneme_chunking.py
+++ b/docker/voice-sidecar/test_phoneme_chunking.py
@@ -385,6 +385,26 @@ class LossyPathIsLoudTests(unittest.TestCase):
             msg=f"no loud log emitted before the raise; got {self.logged!r}",
         )
 
+    def test_unphonemizable_pieces_warn_once_per_request(self) -> None:
+        # Both G2P engines down is a whole-sidecar condition; a many-piece
+        # request must not emit one warning line per piece.
+        server._g2p = None
+        # Sentences short enough that Kokoro does not overflow on any one batch
+        # (so the request completes), but > VOICE_TTS_MAX_CHARS in total, so
+        # _split_text yields several pieces and every one is unphonemizable.
+        sentence = ("word " * 40).strip() + "."
+        text = " ".join([sentence] * 12)
+
+        _ogg, meta = server._run_synthesis(text, voice="af_heart")
+
+        self.assertGreater(meta["unchunkedPieces"], 1)
+        warnings = [
+            line
+            for line in self.logged
+            if "WARNING" in line and "could not phonemize" in line
+        ]
+        self.assertEqual(len(warnings), 1, msg=f"expected one line; got {warnings!r}")
+
     def test_clean_synthesis_emits_no_warning(self) -> None:
         server._g2p = lambda piece: ("fˈOni:mz", ["tok"])
 


### PR DESCRIPTION
Fixes #4695.

## What was actually happening — the issue understates it

The issue says long messages are *silently truncated*. Verified against the
kokoro-onnx **0.5.0** wheel installed in the running sidecar, the production
failure mode is worse: for a batch over the limit the request **fails
outright**.

`kokoro_onnx/__init__.py:97-101` slices a phoneme batch to `MAX_PHONEME_LENGTH`
= 510 as the issue describes. But seven lines later:

```python
tokens = np.array(self.tokenizer.tokenize(phonemes), dtype=np.int64)   # :102
voice = voice[len(tokens)]                                             # :108
```

`voice` is a voices array of exactly 510 rows. A batch that slices to 510
**in-vocab** phonemes indexes one past the end:

```
IndexError: index 510 is out of bounds for axis 0 with size 510
```

That propagates out of `create()`, out of `_run_synthesis`, and the `/tts`
request 500s — the user gets **no voice message at all**, not a truncated one.
Reproduced live against the real model on a real corpus message (1,545-phoneme
batch). Across the 1,679-message corpus, **all 16** over-limit batches land on
that raise; **zero** produce the truncated-audio outcome the issue describes.

Two further corrections to the issue's framing:

- **The 51,435-phonemes-lost figure is ~9x too high.** It counts every
  ≤1200-char piece as one synthesis batch, but `Kokoro.create()` re-batches the
  phoneme string first (`Kokoro._split_phonemes`). Modelling that batcher
  faithfully, the top-20 messages lose 994 phonemes across 2 batches, not
  51,435 across 59. The whole 1,679-message corpus loses 5,823 across 16.
  The defect is real and user-visible; it is narrower than measured.
- **Kokoro's truncation is not literally silent.** `kokoro_onnx/log.py`
  attaches a `StreamHandler` at WARNING by default, so
  `"Phonemes are too long, truncating to 510 phonemes"` does reach the
  sidecar's stderr. It carries no request or text context, and the IndexError
  is the more common outcome anyway, but "no signal at all" is not accurate.
- **The silent out-of-vocabulary phoneme drop (`tokenizer.py:65`) is not a
  real defect.** Over the full corpus, 446 characters out of 2,443,797 are
  dropped, and they are all `[`, `]`, `{`, `}` — markup artifacts carrying no
  audio. Left alone deliberately.

## The fix

Chunk on **phonemes**, as the issue suggests, rather than lowering the char
limit. That is practical here because the sidecar already phonemises in-process
(misaki, `is_phonemes=True`), so the phoneme string is in hand before Kokoro is
called.

- `_split_phonemes(phonemes, max)` — splits to ≤ `TTS_MAX_PHONEMES`, preferring
  Kokoro's own break chars (`.,!?;`) then whitespace. **Lossless by
  construction**: an over-long run is *carried* into the next chunk, never
  dropped.
- `_normalize_phonemes` — rebuilds the string the way `Kokoro._split_phonemes`
  does, so our length and Kokoro's are the same number and our chunk is its
  batch 1:1. (Kokoro's rebuild can *grow* a string — `a,b` → `a, b`; measured a
  500-phoneme chunk re-expanding to 749. That growth cannot cause truncation,
  since it only happens at break chars which are exactly where Kokoro
  re-batches — but it does move seams we chose and make a `batches` count
  wrong.)
- `VOICE_TTS_MAX_PHONEMES`, default **500**, hard-ceilinged at **508**.
  Kokoro flushes on `>=` 510, so a break-free chunk of 509+ makes it emit a
  leading *empty* batch.
- The espeak path (`VOICE_TTS_G2P=espeak`, non-English locales) is phonemised
  through Kokoro's own tokenizer (`_espeak_phonemize`) — the identical call
  `create()` makes internally — so it gets chunked the same way instead of
  staying character-bounded. This is a batching change, not a voice change.
- `VOICE_TTS_MAX_CHARS` (1200) is **unchanged** and stays the coarse pass: it
  bounds G2P work and keeps sentence-aware seams. It is simply no longer
  load-bearing for correctness. No other site references it (grepped: config,
  docs, tests — the only other hit is `SIDECAR_TTS_MAX_CHARS`, an unrelated
  100k request-body cap in `telegram-plugin/`).

## Truncation stops being silent

Both paths that can still degrade audio are counted into the `/tts` response
meta (`hardCuts`, `unchunkedPieces`) and logged through the sidecar's existing
`_log` idiom at WARNING volume to stderr, i.e. `docker logs`:

- `hardCuts` — a seam that had to land mid-word because a run of 500 phonemes
  contained no space and no clause break. Audio is **complete**; there is an
  audible seam. Zero across the entire corpus.
- `unchunkedPieces` — neither misaki nor Kokoro's tokenizer could phonemise a
  piece, so it goes to Kokoro as text and inherits the old behaviour. Cannot
  occur while either G2P is loaded.

The per-request `synth:` line now also reports batch count.

## Measured — 1,679-message production corpus, real misaki

Both columns model `Kokoro._split_phonemes` + the 510 limit faithfully, so
these are what the engine actually does, not what a per-piece length check
would suggest.

**Top 20 longest messages** (the issue's table):

| | batches | over 510 | phonemes lost | max batch |
|---|---|---|---|---|
| before | 340 | 2 | 994 | 1,429 |
| **after** | 348 | **0** | **0** | **500** |

**Full corpus (1,679 messages):**

| | batches | over 510 | phonemes lost | max batch |
|---|---|---|---|---|
| before | 6,320 | 16 | 5,823 | 1,545 |
| **after** | 6,412 | **0** | **0** | **500** |

Phonemes lost goes to **zero**, and `hardCuts` is **zero** — nothing remains
lossy on this corpus. Cost is +92 synthesis batches (+1.5%); inference work is
unchanged, since those batches existed inside `create()` before.

**Real audio, real model** (worst corpus message, 1,524 chars, 1,545-phoneme
batch, CPU):

| | outcome | audio |
|---|---|---|
| before | `IndexError: index 510 is out of bounds for axis 0 with size 510` | **0.0s** |
| **after** | success | **159.3s** |

## Tests — red then green

New `docker/voice-sidecar/test_phoneme_chunking.py` (24 tests). The load-bearing
one drives real-shaped input through `_run_synthesis` against `_FaithfulKokoro`,
a line-by-line port of 0.5.0's `_split_phonemes` plus **both** consequences (the
510 slice and the `voice[len(tokens)]` raise), and asserts on the phonemes that
actually reached synthesis — not on the chunking code path.

Against `origin/main`:

```
ERROR: test_long_unpunctuated_clause_loses_no_phonemes
IndexError: index 510 is out of bounds for axis 0 with size 510
ERROR: test_long_comma_free_paragraph_loses_no_phonemes
ERROR: test_every_batch_handed_to_kokoro_is_within_the_limit
ERROR: test_meta_reports_batches_and_clean_run_has_no_degradation
Ran 5 tests — FAILED (errors=4)
```

On this branch: `Ran 61 tests — OK (skipped=4)` for the whole sidecar suite.
`test_our_chunk_is_kokoros_batch_one_for_one` is likewise red without
`_normalize_phonemes` (verified by reverting just that line) and green with it.
Stdlib-only, no numpy/misaki/onnxruntime, matching the sibling suites and the
existing CI job.

## What this does not cover

- **A run of 500+ phonemes with no space and no clause break** still needs a
  mid-word seam. Audio stays complete; the seam is audible. Counted as
  `hardCuts` and logged. Zero occurrences on the corpus.
- **If both G2P engines are unavailable**, a piece still goes to Kokoro as text
  and can still 500. Counted as `unchunkedPieces` and logged; unreachable while
  either engine loads.
- **The corpus is already-normalised production output**, so these numbers say
  nothing about raw pre-normalisation input.
- **No change to prosody or voice.** Seams move only where Kokoro would
  otherwise have overflowed; the existing 120ms pad still applies at piece
  seams only, and phoneme chunks inside a piece are joined flush, exactly where
  Kokoro's internal batcher used to join them.

## ⚠️ Conflicts with #4692

**#4692 (`feat/tts-stage-b-normalizer`) also touches
`docker/voice-sidecar/server.py`** and is under active review. Whichever merges
second should expect a conflict. The diff here is kept narrow around the
chunking logic:

- **New** — `TTS_MAX_PHONEMES` (in the config block, after `TTS_MAX_CHARS`),
  `_normalize_phonemes`, `_split_phonemes`, `_espeak_phonemize`.
- **Modified** — the synthesis loop inside `_run_synthesis`, its meta dict, and
  its log line.
- **Untouched** — `_load_tts` (including `_load_overrides`' placement, which
  #4692 is moving), `_phonemize_piece`, `_split_text`, the HTTP handler, and
  the whole STT path.

Per #4695, Stage B does not worsen this and this does not block it. Nothing
from #4692's branch was touched.

**Resolution is keep-both.** A reviewer test-merged the two branches locally
and the only conflict is a trivial keep-both at the `_espeak_phonemize` /
`_normalize_text` insertion point (around `server.py:884-946` on this branch —
the head of the synthesis loop). The combined suite ran **133 tests OK**.

## Review follow-ups (applied)

Independent review came back MERGEABLE with three nits, all fixed on this
branch:

1. `cdd546f7` — `_split_phonemes` packed clauses with an unconditional space,
   even when the next unit started with a break char, while Kokoro's rebuild
   appends break chars flush. So `'aaaa; .'` was not a fixed point of Kokoro's
   batcher and it re-split chunks we had already sized. Error was in the safe
   direction (under-filled, never over) so no audio changed, but it cost up to
   ~17% of the cap on break-dense input and left
   `test_our_chunk_is_kokoros_batch_one_for_one` asserting an invariant the
   code did not hold. The join now matches Kokoro exactly, and the test gained
   the adjacent-break inputs (`"ab;.cd"*300`, `"a?!"*400`, `"x,,y"*300`),
   verified failing before the fix.
2. `02e41825` — the `unchunkedPieces` warning could not fire in the case it
   existed to report: when an unchunked piece really overflows, Kokoro raises
   *inside* the loop, so the post-loop log never ran and the request 500'd as
   silently as before. It is now emitted per-piece at the fall-through. New
   test drives a 600-char unchunked piece into a raising Kokoro and asserts the
   warning still lands; it fails against the previous commit.
3. `c3e3fa4d` — `VOICE_TTS_MAX_PHONEMES` clamped silently (600 → 508, 0 → 1).
   `main()` now warns with both the requested and effective value, matching the
   existing `VOICE_SIDECAR_TOKEN` startup-warning idiom.

**One review item did not hold.** The review asked to drop the `import re`
inside `_normalize_phonemes` as redundant with a module-level import. There is
no module-level `import re` in `server.py` — the module imports are
`annotations, hashlib, hmac, json, os, subprocess, sys, tempfile, threading,
time, urllib.request, wave, concurrent.futures, http.server`, and the only two
`import re` sites are inside `_split_text` (pre-existing, the idiom this
follows) and inside `_normalize_phonemes`. Removing it raises `NameError: name
're' is not defined`, verified by exec'ing a patched copy. Left in place.

**Filed as a follow-up, not fixed here:** #4697 — a piece that phonemizes to
the empty string (nbsp, zero-width space, `·`, replacement char) reaches
`Kokoro.create()`, whose batch list is then empty, and dies on
`np.concatenate([])` with `ValueError: need at least one array to concatenate`.
Pre-existing on `main`, unchanged by this PR, out of scope for keeping this
diff narrow. Note that plain emoji are *not* affected — `🎉` phonemizes to
"party popper".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


