### PR TITLE
chore: release v0.21.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.21.10 — the Telegram render pipeline stops deleting prose and corrupting fenced code, and TTS stops failing on long messages
+
 ### Bug fixes
 
 - **voice: TTS chunks on phoneme length, not characters — long messages stop


### PR DESCRIPTION
CHANGELOG-only release commit for `v0.21.10`, per `skills/switchroom-release/SKILL.md` Step 1.

- Renames `## Unreleased` → `## v0.21.10 — Telegram render pipeline stops corrupting fenced code and raw HTML; TTS unit-suffix hotfix`
- Re-seeds a fresh empty `## Unreleased` block (header + convention comment) for the next cycle

No `package.json` bump (placeholder discipline). Three commits ship in this release: #4691 (telegram render fix), #4687 (TTS unit-suffix hotfix), #4688 (flag-gated speech capture, off by default).

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)