### PR TITLE
fix(telegram): keep prose in the raw-HTML fold; balance-check passthrough (#4691 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,39 @@ now an anomaly worth investigating, not the norm.
   the highest safe value — kokoro flushes a batch at `>=` 510), and an
   out-of-range setting is warned about at startup rather than clamped
   silently.
+
+- **telegram/render: the raw-HTML fold deleted prose, not just markup** —
+  #4691 (merged, unreleased) degraded every HTML token it could not fold or
+  pass through by DELETING it. That is right for markup and catastrophic for
+  prose: `Use the <service>/<key> convention`, `switchroom vault get <key>`,
+  `/host-home/.switchroom/logs/<agent>/` and "the `<b>` tag" all shipped with
+  the placeholders silently gone. The discriminator is now MATCHING rather
+  than the tag name — a balanced pair is markup (drop the markup, keep the
+  content), an UNMATCHED marker is prose and survives as literal text with
+  `&`/`<`/`>` HTML-entity-escaped, which Bot API Rich HTML documents as
+  supported named entities, so content is kept without risking the
+  `unsupported start tag` 400. Also in this pass:
+  `<pre>`/`<pre><code class="language-…">` now folds to a real fenced block
+  (it previously became an inline code span wrapping a newline, which
+  Telegram will not parse) and degrades to an inline span only where a fence
+  cannot survive (heading, table cell); structural tags (`<li>`, `<p>`,
+  `<div>`, `<td>`, …) leave a hard line break so
+  `<ul><li>one</li><li>two</li></ul>` no longer glues into `onetwo`; the
+  wire-verified passthrough allowlist (`<u>`, `<sub>`, `<details>`, …) is now
+  balance-checked document-wide before being emitted raw, closing the
+  unbalanced-`<u>` path to the exact `unclosed start tag` 400 the module
+  exists to prevent (whose fallback resends the whole message as PLAIN text);
+  `<br>` inside a heading or table cell degrades to a space instead of
+  breaking the block; a nested `<a>`'s href is kept as literal text instead
+  of being silently dropped; and `escapeLinkHref` percent-encodes ASCII
+  whitespace/control characters, which a backslash cannot rescue because a
+  bare link destination ends at the first whitespace byte.
+  `html-fold.ts`'s "content is never lost" invariant is restated accurately
+  and now names its one residual (a `<` mdast hands over as a TEXT node never
+  reaches this module). Pinned by 31 outcome tests in
+  `telegram-plugin/tests/render/html-dialect-content-loss.test.ts`, every one
+  of which fails on `fa9018a7`.
+
 - **voice: unit-suffix regex lookbehind + case-sensitivity hotfix** — the
   number+unit-suffix regex shared by both TTS normalization passes
   (`telegram-plugin/voice-normalize-text.ts`, `telegram-plugin/tts-normalize.ts`)

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -99,9 +99,26 @@ export function codeSpanSafe(s: string): string {
  * `\` first (so we never double-escape a following escape), then BOTH `(` and
  * `)` — the whole URL is preserved balanced and micromark decodes it back to
  * the original href on round-trip. Bot API 10.1 lists `(`/`)` as escapable.
+ *
+ * WHITESPACE and control characters are PERCENT-ENCODED rather than
+ * backslash-escaped. A bare link destination ends at the first ASCII
+ * whitespace character, so a space or a newline inside the href does not just
+ * truncate the URL — the remainder is re-read as a link title, or (for a
+ * newline) the inline link is terminated outright, leaving a structurally
+ * broken construct with URL fragments visible as prose. Backslash cannot
+ * rescue that: whitespace is not escapable in a bare destination. `%20` /
+ * `%0A` are the canonical URL encodings, so the href a client resolves is
+ * equivalent to the one the author wrote.
  */
 export function escapeLinkHref(href: string): string {
-  return href.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)')
+  return href
+    .replace(/\\/g, '\\\\')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(
+      /[\x00-\x20\x7f]/g,
+      (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')}`,
+    )
 }
 
 /**

--- a/telegram-plugin/render/html-fold.ts
+++ b/telegram-plugin/render/html-fold.ts
@@ -27,15 +27,44 @@
 //                   <code>             -> code span     `…`
 //                   <a href="URL">     -> link          [label](URL)
 //                   <br>               -> a line break
+//                   <pre>              -> fenced code block ```…```
 //   • PASSTHROUGH — the wire-verified allowlist above is emitted RAW and
 //                 UNESCAPED (an IR `raw` inline), which is also what stops
-//                 `escapeMarkdown` from mangling their attributes.
-//   • DEGRADE   — anything else (unknown tags, unmatched open/close markers,
-//                 comments) has its MARKUP dropped while its CONTENT is kept
-//                 and rendered normally. Never emit a construct the renderer
-//                 cannot guarantee: shipping an unknown tag verbatim risks the
-//                 400 -> plain-text fallback that shows the reader raw markup,
-//                 which is strictly worse than showing them the text.
+//                 `escapeMarkdown` from mangling their attributes. Requires a
+//                 MATCHED close: an unbalanced `<u>` emitted raw is exactly
+//                 the `unclosed start tag` 400 this module exists to prevent.
+//   • DEGRADE   — everything else, split by whether the token delimits
+//                 content. The discriminator is MATCHING, not the tag name:
+//                   – A MATCHED pair (`<marquee>…</marquee>`, `<div>…</div>`)
+//                     is markup wrapped around content. The markup is dropped
+//                     and the content kept; a block-level name additionally
+//                     leaves a hard line break, so `<li>one</li><li>two</li>`
+//                     cannot glue into `onetwo`.
+//                   – A comment, or a void / self-closing tag (`<hr/>`,
+//                     `<img …/>`), delimits nothing. Markup dropped; a
+//                     block-level one leaves the same separator.
+//                   – An UNMATCHED open/close marker is not markup at all — it
+//                     is PROSE. `<service>/<key>`, `<agent>`, "the `<b>` tag",
+//                     `run switchroom vault get <key>` are pervasive in this
+//                     project's own agent output, and DELETING them silently
+//                     mangles the agent's own reply. Such a token is kept as
+//                     LITERAL TEXT with `&`/`<`/`>` HTML-entity-escaped (see
+//                     `escapeHtmlLiteral`). Bot API rich markdown "can contain
+//                     arbitrary HTML … parsed as described in Rich HTML
+//                     style", and Rich HTML documents `&lt;`, `&gt;` and
+//                     `&amp;` among its supported named entities — so the
+//                     entity form is the DOCUMENTED way to ship a literal
+//                     angle bracket without tripping `unsupported start tag`.
+//
+// ── The invariant ─────────────────────────────────────────────────────────
+// CONTENT is never lost. Only MARKUP is dropped, and only where dropping it
+// loses no reader-visible text: a matched pair, a comment, a void tag.
+// Anything not demonstrably markup survives to the wire as escaped literal
+// text. (Known residual, NOT introduced by this module and not fixed here: a
+// `<` in prose that mdast hands over as a TEXT node rather than an `html` node
+// — the decoded `&lt;c&gt;`, or `response in <1s` — never reaches this module
+// and still ships unescaped. That is a `plain`-node / `escapeMarkdown`
+// concern.)
 //
 // This is a deterministic code-level guarantee, deliberately not a prompt
 // instruction to the agents that emit the tags.
@@ -54,8 +83,16 @@ export interface HtmlTagInfo {
   attrs: string;
 }
 
-/** The IR construct a foldable tag maps onto. */
-export type HtmlFoldTarget = "bold" | "italic" | "strike" | "code" | "link" | "break";
+/** The IR construct a foldable tag maps onto. `pre` is BLOCK-level (a fenced
+ *  code block); every other target is inline. */
+export type HtmlFoldTarget =
+  | "bold"
+  | "italic"
+  | "strike"
+  | "code"
+  | "link"
+  | "break"
+  | "pre";
 
 /** Tags with an exact native markdown equivalent on the Bot API 10.1 rich
  *  path. Folding them means the wire sees markdown it definitely parses
@@ -71,7 +108,120 @@ export const HTML_FOLD_TAGS: Readonly<Record<string, HtmlFoldTarget>> = {
   code: "code",
   a: "link",
   br: "break",
+  // `<pre>` is the one BLOCK-level fold. Telegram's own Rich HTML reference
+  // pairs `<pre><code class="language-…">` with the ```` ```lang ```` fence,
+  // so the fenced block is the exact native equivalent. Without it `<pre>`
+  // dropped its markup and the inner `<code>` folded to an INLINE span
+  // wrapping a newline — a construct Telegram will not parse, leaving the
+  // reader literal backticks around broken text.
+  pre: "pre",
 };
+
+/** HTML elements that carry no content of their own (void elements) plus the
+ *  XHTML self-closing spelling. Dropping such a token's markup cannot lose
+ *  text, so it degrades silently rather than surviving as literal prose.
+ *  `br` is excluded — it FOLDS to a line break. */
+export const HTML_VOID_TAGS: ReadonlySet<string> = new Set([
+  "area",
+  "base",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+/** Structural / block-level element names. A degrade of one of these leaves a
+ *  hard line break behind so its neighbours do not glue together
+ *  (`<ul><li>one</li><li>two</li></ul>` -> `onetwo` was the defect). The
+ *  passthrough allowlist (`details`, `summary`, `aside`, `cite`) is
+ *  deliberately absent — those never degrade. */
+export const HTML_BLOCK_LEVEL_TAGS: ReadonlySet<string> = new Set([
+  "address",
+  "article",
+  "blockquote",
+  "center",
+  "dd",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hr",
+  "li",
+  "main",
+  "nav",
+  "ol",
+  "p",
+  "section",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "tr",
+  "ul",
+]);
+
+/** True when a degraded token should leave a line break behind. */
+export function isBlockLevelTag(name: string): boolean {
+  return HTML_BLOCK_LEVEL_TAGS.has(name);
+}
+
+/** True for a tag that delimits no content of its own. */
+export function isVoidTag(name: string): boolean {
+  return HTML_VOID_TAGS.has(name);
+}
+
+/**
+ * HTML-entity-escape a run of literal text so its angle brackets reach the
+ * reader instead of being parsed as a tag (or 400ing as an unsupported one).
+ *
+ * Bot API rich markdown "can contain arbitrary HTML … parsed as described in
+ * Rich HTML style", and Rich HTML's supported named entities are documented as
+ * exactly `&lt; &gt; &amp; &quot; &apos; &nbsp; &hellip; &mdash; &ndash;
+ * &lsquo; &rsquo; &ldquo; &rdquo;` (https://core.telegram.org/bots/api). Only
+ * the first three are needed here. `&` is escaped FIRST so an already-entity
+ * -looking run cannot be double-decoded.
+ */
+export function escapeHtmlLiteral(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** The `class="language-xxx"` hint on a `<pre><code …>` block, or null. */
+const LANGUAGE_CLASS_RE = /(?:^|\s)class\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/i;
+
+/** Pull the fenced-block language out of a `<code class="language-python">`
+ *  tag's attributes, or null. Telegram's reference spells the language hint
+ *  exactly this way; anything else yields a plain fence. */
+export function languageOf(tag: HtmlTagInfo): string | null {
+  const m = LANGUAGE_CLASS_RE.exec(tag.attrs);
+  if (m == null) return null;
+  const cls = m[1] ?? m[2] ?? m[3] ?? "";
+  const lang = cls
+    .split(/\s+/)
+    .map((c) => /^language-(.+)$/.exec(c)?.[1])
+    .find((c): c is string => c != null && c.length > 0);
+  // A fence info string cannot contain a backtick (it would close the fence).
+  return lang != null && !lang.includes("`") ? lang : null;
+}
 
 /** Tags PROVEN on the wire by raw `sendRichMessage` probes (2026-08-13) to
  *  render as native typed nodes. These pass through raw and unescaped.
@@ -118,6 +268,46 @@ export function hrefOf(tag: HtmlTagInfo): string | null {
 /** True when this tag is emitted raw and unescaped (wire-verified allowlist). */
 export function isPassthroughTag(tag: HtmlTagInfo): boolean {
   return tag.name.length > 0 && HTML_PASSTHROUGH_TAGS.has(tag.name);
+}
+
+/**
+ * Decide which HTML tokens in a DOCUMENT are balanced markup and which are
+ * bare prose, given every token in document order.
+ *
+ * Matching cannot be decided inside a single mdast `html` node: micromark
+ * splits `<details open>…\n\nbody\n\n</details>` into THREE nodes, so the open
+ * and close markers arrive in different streams. A document-level pass is the
+ * only place the question is answerable. Feeding it mdast `html` nodes (rather
+ * than the raw source) also means tags inside a code fence or a code span are
+ * never counted — they are not markup and must not balance anything.
+ *
+ * Standard HTML-ish matching: opens are pushed on a stack and a close pops to
+ * the nearest same-named open, leaving anything above it unmatched. Void and
+ * self-closing tags are balanced by definition and are not tracked.
+ *
+ * Returns the SOURCE OFFSETS of every token that has a partner; a token whose
+ * offset is absent is unmatched — prose, per the module policy above.
+ */
+export function matchedTagOffsets(
+  tokens: ReadonlyArray<{ tag: HtmlTagInfo; start: number }>,
+): Set<number> {
+  const matched = new Set<number>();
+  const stack: { name: string; start: number }[] = [];
+  for (const { tag, start } of tokens) {
+    if (tag.kind === "open" && !isVoidTag(tag.name)) {
+      stack.push({ name: tag.name, start });
+      continue;
+    }
+    if (tag.kind !== "close") continue;
+    for (let i = stack.length - 1; i >= 0; i--) {
+      if (stack[i].name !== tag.name) continue;
+      matched.add(stack[i].start);
+      matched.add(start);
+      stack.length = i;
+      break;
+    }
+  }
+  return matched;
 }
 
 /** A piece of a raw-HTML string: either an HTML token or a run of text. */

--- a/telegram-plugin/render/parse.ts
+++ b/telegram-plugin/render/parse.ts
@@ -103,8 +103,13 @@ import type {
 } from "./ir.js";
 import {
   HTML_FOLD_TAGS,
+  escapeHtmlLiteral,
   hrefOf,
+  isBlockLevelTag,
   isPassthroughTag,
+  isVoidTag,
+  languageOf,
+  matchedTagOffsets,
   tokenizeHtml,
   type HtmlFoldTarget,
   type HtmlTagInfo,
@@ -158,9 +163,24 @@ function isTgInlineEntityHref(href: string): boolean {
 
 /** A top-level fenced-code delimiter: 3+ backticks or tildes, indented 0–3
  *  spaces. Deeper indentation is not a fence, and a fence nested inside a
- *  blockquote / list item is prefixed by its container's markup — so a
- *  column-0 `**>` line can only ever be code content inside a fence this
- *  matches, which is exactly the region the rewrite must not touch. */
+ *  blockquote / list item is prefixed by its container's markup, so this only
+ *  ever tracks TOP-LEVEL fences.
+ *
+ *  KNOWN LIMITATION (pre-existing, not a safety property): tracking only
+ *  top-level fences does NOT establish that every column-0 `**>` line outside
+ *  one is a real blockquote candidate. Counterexample:
+ *
+ *      > ```
+ *      **> lazy
+ *      > ```
+ *
+ *  The `> ``` ` opener is inside a blockquote so it never matches here; the
+ *  column-0 `**> lazy` line is rewritten to `  > lazy` and the `**` is eaten.
+ *  CommonMark forbids lazy continuation into fenced code, so that line should
+ *  CLOSE the blockquote and stay literal. Fixing it needs real container
+ *  tracking (blockquote/list prefixes), not a wider fence regex. The case is
+ *  pinned by a test in `tests/render/html-dialect.test.ts` so any future
+ *  container-aware rewrite has to decide it deliberately. */
 const FENCE_DELIM_RE = /^ {0,3}(`{3,}|~{3,})/;
 
 /** Pre-transform expandable-blockquote markers so mdast can parse them as
@@ -243,7 +263,7 @@ function foldAlign(a: AlignType | undefined): "left" | "center" | "right" | null
   return a ?? null;
 }
 
-function foldInline(node: PhrasingContent, source: string): Inline {
+function foldInline(node: PhrasingContent, source: string, ctx: FoldCtx): Inline {
   switch (node.type) {
     case "text":
       return { type: "plain", text: node.value, ...pos(node) };
@@ -254,21 +274,21 @@ function foldInline(node: PhrasingContent, source: string): Inline {
       const underline = source.slice(p.start, p.start + 2) === "__";
       return {
         type: underline ? "underline" : "bold",
-        children: foldInlineChildren(node, source),
+        children: foldInlineChildren(node, source, ctx),
         ...p,
       };
     }
     case "emphasis":
-      return { type: "italic", children: foldInlineChildren(node, source), ...pos(node) };
+      return { type: "italic", children: foldInlineChildren(node, source, ctx), ...pos(node) };
     case "delete":
-      return { type: "strike", children: foldInlineChildren(node, source), ...pos(node) };
+      return { type: "strike", children: foldInlineChildren(node, source, ctx), ...pos(node) };
     case "inlineCode":
       return { type: "code", text: node.value, ...pos(node) };
     case "link":
       return {
         type: "link",
         href: node.url,
-        children: foldInlineChildren(node, source),
+        children: foldInlineChildren(node, source, ctx),
         ...pos(node),
       };
     case "image": {
@@ -406,19 +426,86 @@ function inlineLiteralText(nodes: Inline[]): string | null {
   return out;
 }
 
+/** Where a folded run is being emitted. `noBreaks` marks a container whose
+ *  content must stay on ONE line — a heading or a table cell — so a `<br>` or
+ *  a structural separator has to degrade to a space instead of a line break,
+ *  and a `<pre>` to an inline code span instead of a fence. Without this a
+ *  `# a<br>b` heading emitted `# a  \nb`, which ends the heading block and
+ *  drops `b` out of it. */
+interface FoldCtx {
+  noBreaks?: boolean;
+  /** Source offsets of every HTML token the DOCUMENT-level pass found a
+   *  partner for (`matchedTagOffsets`). A token missing from this set is
+   *  unmatched — prose, not markup. Empty means "no HTML in this document",
+   *  in which case nothing consults it. */
+  matched: ReadonlySet<number>;
+}
+
+/** Separator nodes this module synthesized while degrading structural markup.
+ *  Tracked by identity so `normalizeSeparators` can collapse and trim OUR
+ *  separators without touching a hard break the author actually wrote with
+ *  `<br>` (`a<br><br>b` must keep both). */
+const structuralSeparators = new WeakSet<Inline>();
+
+/** The whitespace a degraded block-level tag leaves behind. A GFM HARD break
+ *  (two spaces + newline), not a bare `\n`: the renderer runs AFTER
+ *  `normalizeParagraphBreaks`, so a lone `\n` would never be promoted and
+ *  Telegram collapses it to a space. */
+function mkSeparator(ctx: FoldCtx, start: number, end: number): Inline {
+  const node: Inline = {
+    type: "raw",
+    text: ctx.noBreaks === true ? " " : "  \n",
+    start,
+    end,
+  };
+  structuralSeparators.add(node);
+  return node;
+}
+
+/** Drop leading/trailing synthesized separators and collapse runs of them, so
+ *  a degrade never contributes stray whitespace at the edges of a block
+ *  (`<div></div>` must still render to nothing, and a `<pre>` fence must not
+ *  leave a dangling newline). */
+function normalizeSeparators(nodes: Inline[]): Inline[] {
+  const out: Inline[] = [];
+  for (const node of nodes) {
+    if (!structuralSeparators.has(node)) {
+      out.push(node);
+      continue;
+    }
+    if (out.length === 0) continue;
+    if (structuralSeparators.has(out[out.length - 1])) continue;
+    out.push(node);
+  }
+  while (out.length > 0 && structuralSeparators.has(out[out.length - 1])) out.pop();
+  return out;
+}
+
+/** An unmatched marker or unclassifiable token kept as LITERAL text, with its
+ *  angle brackets HTML-entity-escaped so the wire sees prose, not a tag. */
+function literalTag(tag: HtmlTagInfo, start: number, end: number): Inline {
+  return { type: "plain", text: escapeHtmlLiteral(tag.raw), start, end };
+}
+
 /**
- * Apply the three-bucket HTML policy over a mixed tag/inline stream.
+ * Apply the HTML dialect policy over a mixed tag/inline stream.
  *
- * `active` carries the emphasis constructs already open in an ANCESTOR fold.
- * Markdown cannot nest same-kind emphasis — `**a **b** c**` is asterisk soup
- * on the reader's screen, not nested bold — so a tag whose target is already
- * active degrades to its children. Combined with the single-child unwrap in
- * `buildFoldedTag`, `<b>a <b>b</b> c</b>` and `<b>**already**</b>` both come
- * out as ONE bold run.
+ * `active` carries the constructs already open in an ANCESTOR fold. Markdown
+ * cannot nest same-kind emphasis — `**a **b** c**` is asterisk soup on the
+ * reader's screen, not nested bold — so an emphasis tag whose target is
+ * already active degrades to its children. Combined with the single-child
+ * unwrap in `buildFoldedTag`, `<b>a <b>b</b> c</b>` and `<b>**already**</b>`
+ * both come out as ONE bold run. A nested `<a>` is NOT unwrapped that way: its
+ * href is content, so it degrades to escaped literal markup instead of being
+ * silently deleted.
+ *
+ * See `html-fold.ts` for the bucket policy and the matched-vs-unmatched
+ * discriminator this implements.
  */
 function foldHtmlItems(
   items: HtmlFoldItem[],
-  active: ReadonlySet<HtmlFoldTarget> = new Set(),
+  active: ReadonlySet<HtmlFoldTarget>,
+  ctx: FoldCtx,
 ): Inline[] {
   const out: Inline[] = [];
   let i = 0;
@@ -430,50 +517,183 @@ function foldHtmlItems(
       continue;
     }
     const tag = it.tag;
-    // Bucket 2: wire-verified allowlist — emitted raw and unescaped.
-    if (isPassthroughTag(tag) && tag.kind !== "comment" && tag.kind !== "other") {
-      out.push({ type: "raw", text: tag.raw, start: it.start, end: it.end });
+
+    // A comment renders nothing anywhere: dropping it loses no content.
+    if (tag.kind === "comment") {
       i++;
       continue;
     }
-    // Bucket 1: fold to the native IR construct.
-    const target = tag.kind === "open" || tag.kind === "selfclose"
-      ? HTML_FOLD_TAGS[tag.name]
-      : undefined;
-    if (target === "break") {
-      // `<br>` / `<br/>`: a GFM HARD break (two spaces + newline), not a bare
-      // `\n`. The renderer runs AFTER `normalizeParagraphBreaks`
-      // (gateway/outbound-send-path.ts stage 1), so a lone `\n` inserted here
-      // would never be promoted and Telegram would collapse it to a space —
-      // silently losing the author's break. Emitted as `raw` so the two
-      // trailing spaces are not touched.
-      out.push({ type: "raw", text: "  \n", start: it.start, end: it.end });
+
+    // `<br>` / `<br/>` — a real line break (a space where breaks are illegal).
+    if (HTML_FOLD_TAGS[tag.name] === "break" && tag.kind !== "close") {
+      out.push(
+        ctx.noBreaks === true
+          ? { type: "raw", text: " ", start: it.start, end: it.end }
+          : { type: "raw", text: "  \n", start: it.start, end: it.end },
+      );
       i++;
       continue;
     }
-    if (target !== undefined && tag.kind === "open") {
+
+    // Void / self-closing tags delimit no content, so dropping their markup
+    // cannot lose text. Block-level ones still leave a separator.
+    if (tag.kind === "selfclose" || (tag.kind === "open" && isVoidTag(tag.name))) {
+      if (isPassthroughTag(tag)) {
+        out.push({ type: "raw", text: tag.raw, start: it.start, end: it.end });
+      } else if (isBlockLevelTag(tag.name)) {
+        out.push(mkSeparator(ctx, it.start, it.end));
+      }
+      i++;
+      continue;
+    }
+
+    // Bucket 2: the wire-verified allowlist, now BALANCE-CHECKED. Emitting an
+    // unmatched `<u>` raw is precisely the `unclosed start tag` 400 the fold
+    // policy exists to prevent — and the fallback resends the whole message as
+    // PLAIN TEXT, so one stray marker in relayed content degrades the entire
+    // reply. The check is document-level because a `<details>` open and close
+    // legitimately land in different mdast blocks.
+    if (isPassthroughTag(tag) && (tag.kind === "open" || tag.kind === "close")) {
+      out.push(
+        ctx.matched.has(it.start)
+          ? { type: "raw", text: tag.raw, start: it.start, end: it.end }
+          : literalTag(tag, it.start, it.end),
+      );
+      i++;
+      continue;
+    }
+
+    // Everything else must be BALANCED to count as markup.
+    if (tag.kind === "open") {
       const close = findClosingTag(items, i + 1, tag.name);
       const closeItem = close >= 0 ? items[close] : undefined;
       if (closeItem !== undefined && closeItem.kind === "tag") {
-        const nested = new Set(active);
-        nested.add(target);
-        const inner = foldHtmlItems(items.slice(i + 1, close), nested);
-        const folded = active.has(target)
-          ? null
-          : buildFoldedTag(target, tag, inner, it.start, closeItem.end);
-        // A tag we cannot represent faithfully (an `<a>` with no href, a
-        // `<code>` wrapping structure, an emphasis already open above)
-        // degrades to its CONTENT — bucket 3.
-        out.push(...(folded !== null ? [folded] : inner));
+        out.push(
+          ...foldMatchedTag(tag, closeItem, items.slice(i + 1, close), active, ctx, {
+            start: it.start,
+            end: closeItem.end,
+          }),
+        );
         i = close + 1;
         continue;
       }
     }
-    // Bucket 3: unknown tag, comment, or an unmatched open/close marker —
-    // drop the markup, keep everything around it.
+
+    // Matched somewhere ELSE in the document (a `<div>` whose `</div>` is a
+    // separate mdast block) — markup, so drop it, but leave a separator for a
+    // block-level name so the neighbouring blocks do not glue.
+    if (ctx.matched.has(it.start) && tag.kind !== "other") {
+      if (isBlockLevelTag(tag.name)) out.push(mkSeparator(ctx, it.start, it.end));
+      i++;
+      continue;
+    }
+
+    // Unmatched open, stray close, or an unclassifiable token: PROSE.
+    out.push(literalTag(tag, it.start, it.end));
     i++;
   }
-  return out;
+  return normalizeSeparators(out);
+}
+
+/** Emit a tag whose closing partner was found. */
+function foldMatchedTag(
+  tag: HtmlTagInfo,
+  closeTag: HtmlFoldItem & { kind: "tag" },
+  innerItems: HtmlFoldItem[],
+  active: ReadonlySet<HtmlFoldTarget>,
+  ctx: FoldCtx,
+  span: Pos,
+): Inline[] {
+  const target = HTML_FOLD_TAGS[tag.name];
+
+  // `<pre>` — the one BLOCK-level fold (see html-fold.ts).
+  if (target === "pre") {
+    const folded = buildPreBlock(innerItems, ctx, span);
+    if (folded !== null) return folded;
+  }
+
+  if (target !== undefined && target !== "break" && target !== "pre") {
+    const nested = new Set(active);
+    nested.add(target);
+    const inner = foldHtmlItems(innerItems, nested, ctx);
+    // A LINK cannot nest in markdown, and its href is content — degrading to
+    // the children would silently delete the inner URL. Keep the markup as
+    // escaped literal text instead.
+    if (active.has(target)) {
+      return target === "link"
+        ? [
+            literalTag(tag, span.start, span.start + tag.raw.length),
+            ...inner,
+            literalTag(closeTag.tag, closeTag.start, closeTag.end),
+          ]
+        : inner;
+    }
+    const folded = buildFoldedTag(target, tag, inner, span.start, span.end);
+    // A tag we cannot represent faithfully (an `<a>` with no href, a `<code>`
+    // wrapping structure) degrades to its CONTENT — nothing is lost.
+    return folded !== null ? [folded] : inner;
+  }
+
+  // Unknown but BALANCED: markup dropped, content kept. A block-level name
+  // leaves a separator so its neighbours cannot glue together.
+  const inner = foldHtmlItems(innerItems, active, ctx);
+  if (!isBlockLevelTag(tag.name)) return inner;
+  return [
+    mkSeparator(ctx, span.start, span.start + tag.raw.length),
+    ...inner,
+    mkSeparator(ctx, closeTag.start, closeTag.end),
+  ];
+}
+
+/** Build the fenced-code equivalent of a matched `<pre>…</pre>`, or null when
+ *  the content is not literal text a fence can carry (in which case the caller
+ *  falls back to the ordinary degrade). An optional single `<code …>` wrapper
+ *  is unwrapped, and its `class="language-…"` becomes the fence info string —
+ *  exactly the shape Telegram's own Rich HTML reference documents. */
+function buildPreBlock(
+  innerItems: HtmlFoldItem[],
+  ctx: FoldCtx,
+  span: Pos,
+): Inline[] | null {
+  let body = innerItems;
+  let language: string | null = null;
+  const first = body[0];
+  const last = body[body.length - 1];
+  if (
+    body.length >= 2 &&
+    first?.kind === "tag" &&
+    first.tag.kind === "open" &&
+    first.tag.name === "code" &&
+    last?.kind === "tag" &&
+    last.tag.kind === "close" &&
+    last.tag.name === "code"
+  ) {
+    language = languageOf(first.tag);
+    body = body.slice(1, -1);
+  }
+  let text = "";
+  for (const item of body) {
+    if (item.kind !== "inline" || item.node.type !== "plain") return null;
+    text += item.node.text;
+  }
+  // `<pre>` content routinely starts on the line after the tag and ends on the
+  // line before the close; those layout newlines are not content.
+  text = text.replace(/^\r?\n/, "").replace(/[ \t]*\r?\n[ \t]*$/, "");
+  // A fence cannot survive inside a heading or a table cell — degrade to an
+  // inline code span there, with the newlines flattened.
+  if (ctx.noBreaks === true) {
+    return [{ type: "code", text: text.replace(/\s*\r?\n\s*/g, " "), ...span }];
+  }
+  const fence = "```";
+  return [
+    mkSeparator(ctx, span.start, span.start),
+    {
+      type: "raw",
+      text: `${fence}${language ?? ""}\n${text}\n${fence}`,
+      ...span,
+    },
+    mkSeparator(ctx, span.end, span.end),
+  ];
 }
 
 function buildFoldedTag(
@@ -522,7 +742,11 @@ function htmlStringToItems(raw: string, base: number, source: string): HtmlFoldI
  *  then apply the raw-HTML tag policy across the whole run (open/close markers
  *  are SIBLING mdast `html` nodes, never a parent, so matching has to happen
  *  at this level). */
-function buildInlines(children: ReadonlyArray<MdastNode>, source: string): Inline[] {
+function buildInlines(
+  children: ReadonlyArray<MdastNode>,
+  source: string,
+  ctx: FoldCtx,
+): Inline[] {
   const items: HtmlFoldItem[] = [];
   let sawHtml = false;
   for (const child of children) {
@@ -532,24 +756,31 @@ function buildInlines(children: ReadonlyArray<MdastNode>, source: string): Inlin
       items.push(...htmlStringToItems(slice(source, child), p.start, source));
       continue;
     }
-    const folded = foldInline(child as PhrasingContent, source);
+    const folded = foldInline(child as PhrasingContent, source, ctx);
     const expanded = folded.type === "plain" ? expandPlainNode(folded, source) : [folded];
     for (const node of expanded) items.push({ kind: "inline", node });
   }
   if (!sawHtml) return items.map((it) => (it as { node: Inline }).node);
-  return foldHtmlItems(items);
+  return foldHtmlItems(items, new Set(), ctx);
 }
 
-function foldInlineChildren(node: MdastParent, source: string): Inline[] {
-  return buildInlines(node.children, source);
+function foldInlineChildren(
+  node: MdastParent,
+  source: string,
+  ctx: FoldCtx,
+): Inline[] {
+  return buildInlines(node.children, source, ctx);
 }
 
 function foldTableRow(
   row: Extract<RootContent, { type: "tableRow" }>,
   source: string,
+  ctx: FoldCtx,
 ): TableRow {
   const cells: TableCell[] = row.children.map((cell) => ({
-    children: buildInlines(cell.children, source),
+    // A table cell is one line on the wire — a `<br>` or a structural degrade
+    // inside it must not emit a newline (it would end the row).
+    children: buildInlines(cell.children, source, { ...ctx, noBreaks: true }),
     ...pos(cell),
   }));
   return { cells, ...pos(row) };
@@ -569,9 +800,10 @@ function foldBlocks(
   nodes: ReadonlyArray<RootContent>,
   source: string,
   expandableLineStarts: Set<number>,
+  ctx: FoldCtx,
 ): Block[] {
   return nodes
-    .map((n) => foldBlock(n, source, expandableLineStarts))
+    .map((n) => foldBlock(n, source, expandableLineStarts, ctx))
     .filter((b) => !isEmptyBlock(b));
 }
 
@@ -579,15 +811,18 @@ function foldBlock(
   node: RootContent,
   source: string,
   expandableLineStarts: Set<number>,
+  ctx: FoldCtx,
 ): Block {
   switch (node.type) {
     case "paragraph":
-      return { type: "paragraph", children: foldInlineChildren(node, source), ...pos(node) };
+      return { type: "paragraph", children: foldInlineChildren(node, source, ctx), ...pos(node) };
     case "heading":
       return {
         type: "heading",
         level: node.depth,
-        children: foldInlineChildren(node, source),
+        // A heading is a single `#…` LINE: an embedded newline would end the
+        // block and orphan the rest of the text (`# a<br>b`).
+        children: foldInlineChildren(node, source, { ...ctx, noBreaks: true }),
         ...pos(node),
       };
     case "blockquote": {
@@ -597,7 +832,7 @@ function foldBlock(
       const expandable = expandableLineStarts.has(lineStart(source, p.start));
       return {
         type: "blockquote",
-        children: foldBlocks(node.children, source, expandableLineStarts),
+        children: foldBlocks(node.children, source, expandableLineStarts, ctx),
         expandable,
         ...p,
       };
@@ -611,7 +846,7 @@ function foldBlock(
       };
     case "list": {
       const items: ListItem[] = node.children.map((li) => ({
-        children: foldBlocks(li.children, source, expandableLineStarts),
+        children: foldBlocks(li.children, source, expandableLineStarts, ctx),
         checked: li.checked ?? null,
         // mdast `listItem.spread`: whether this item's block children are
         // separated by a blank line. Tight (false) keeps a paragraph and its
@@ -636,8 +871,8 @@ function foldBlock(
       const [headerRow, ...bodyRows] = rows;
       return {
         type: "table",
-        header: foldTableRow(headerRow, source),
-        rows: bodyRows.map((r) => foldTableRow(r, source)),
+        header: foldTableRow(headerRow, source, ctx),
+        rows: bodyRows.map((r) => foldTableRow(r, source, ctx)),
         align: (node.align ?? []).map(foldAlign),
         ...pos(node),
       };
@@ -664,7 +899,11 @@ function foldBlock(
       const p = pos(node);
       return {
         type: "paragraph",
-        children: foldHtmlItems(htmlStringToItems(slice(source, node), p.start, source)),
+        children: foldHtmlItems(
+          htmlStringToItems(slice(source, node), p.start, source),
+          new Set(),
+          ctx,
+        ),
         ...p,
       };
     }
@@ -692,6 +931,33 @@ export function parse(markdown: string): Document {
     mdastExtensions: [gfmFromMarkdown()],
   });
   return {
-    blocks: foldBlocks(tree.children, markdown, expandableLineStarts),
+    blocks: foldBlocks(tree.children, markdown, expandableLineStarts, {
+      matched: matchedTagOffsets(collectHtmlTokens(tree.children, markdown)),
+    }),
   };
+}
+
+/** Every HTML token in the tree, in document order, for the balance pass.
+ *  Walks mdast `html` nodes only — a tag inside a code fence or a code span is
+ *  not markup and must not balance anything. */
+function collectHtmlTokens(
+  nodes: ReadonlyArray<MdastNode>,
+  source: string,
+): { tag: HtmlTagInfo; start: number }[] {
+  const out: { tag: HtmlTagInfo; start: number }[] = [];
+  const walk = (list: ReadonlyArray<MdastNode>): void => {
+    for (const node of list) {
+      if (node.type === "html") {
+        const p = pos(node);
+        for (const piece of tokenizeHtml(slice(source, node), p.start)) {
+          if (piece.kind === "tag") out.push({ tag: piece.tag, start: piece.start });
+        }
+        continue;
+      }
+      const children = (node as MdastParent).children;
+      if (Array.isArray(children)) walk(children);
+    }
+  };
+  walk(nodes);
+  return out;
 }

--- a/telegram-plugin/tests/render/html-dialect-content-loss.test.ts
+++ b/telegram-plugin/tests/render/html-dialect-content-loss.test.ts
@@ -1,0 +1,253 @@
+// Outcome tests for the content-loss regressions found in the raw-HTML
+// dialect fold (#4691, merged as fa9018a7, unreleased).
+//
+// Every assertion here FAILS on fa9018a7. They drive the real `renderOutbound`
+// (`parse` -> `renderSafe`), i.e. exactly what the live send path calls, so
+// they assert the WIRE OUTCOME rather than an internal code path.
+//
+// The through-line: fa9018a7's degrade bucket DELETED any token it could not
+// fold or pass through. That is safe for markup but catastrophic for prose —
+// `<service>/<key>`, `<agent>` and "the `<b>` tag" are pervasive in this
+// project's own agent output, and they were silently vanishing from replies.
+// The discriminator is now MATCHING, not the tag name: a balanced pair is
+// markup (drop it, keep the content), an unmatched marker is prose (keep it,
+// HTML-entity-escaped so the wire cannot read it as a tag).
+
+import { describe, it, expect } from "vitest";
+import { renderOutbound } from "../../render/rich-render.js";
+import { parse } from "../../render/parse.js";
+import { escapeLinkHref } from "../../format.js";
+
+const render = (src: string): string => renderOutbound(src).text;
+
+describe("BLOCKER: angle-bracket placeholders in prose survive (#4691 regression)", () => {
+  it("keeps a `<service>/<key>` convention line intact", () => {
+    // fa9018a7: "Use the / convention."
+    expect(render("Use the <service>/<key> convention.")).toBe(
+      "Use the &lt;service&gt;/&lt;key&gt; convention.",
+    );
+  });
+
+  it("keeps a trailing `<key>` placeholder on a command line", () => {
+    // fa9018a7: "run switchroom vault get "
+    expect(render("run switchroom vault get <key>")).toBe(
+      "run switchroom vault get &lt;key&gt;",
+    );
+  });
+
+  it("keeps an `<agent>` path segment", () => {
+    // fa9018a7: "logs live at /host-home/.switchroom/logs//"
+    expect(render("logs live at /host-home/.switchroom/logs/<agent>/")).toBe(
+      "logs live at /host-home/.switchroom/logs/&lt;agent&gt;/",
+    );
+  });
+
+  it("keeps a tag NAMED in prose when nothing closes it", () => {
+    // fa9018a7: "The  tag is bold and  is italic"
+    expect(render("The <b> tag is bold and <i> is italic")).toBe(
+      "The &lt;b&gt; tag is bold and &lt;i&gt; is italic",
+    );
+  });
+
+  it("never emits a bare `<` for a token it kept as prose", () => {
+    // The escape is what makes keeping the token safe: Rich HTML documents
+    // `&lt;`/`&gt;`/`&amp;` as supported named entities, so this cannot trip
+    // `unsupported start tag` the way a bare `<service>` would.
+    const out = render("Use <service>/<key> and <agent>.");
+    expect(out).not.toMatch(/<[A-Za-z/]/);
+    expect(out).toBe("Use &lt;service&gt;/&lt;key&gt; and &lt;agent&gt;.");
+  });
+
+  it("does not double-escape when its own output is re-parsed", () => {
+    // Re-parsing decodes `&lt;` back to a text-node `<`, which never reaches
+    // the fold at all (the documented residual in html-fold.ts's header), so
+    // the second pass is NOT byte-idempotent. What must never happen is a
+    // compounding `&amp;lt;` that the reader actually sees.
+    const once = render("Use the <service>/<key> convention.");
+    expect(once).toBe("Use the &lt;service&gt;/&lt;key&gt; convention.");
+    expect(render(once)).not.toContain("&amp;");
+  });
+
+  it("still DROPS the markup of a balanced unknown pair (content kept)", () => {
+    // The other half of the discriminator: a matched pair really is markup.
+    expect(render("<marquee>scrolling</marquee>")).toBe("scrolling");
+    expect(render(`<span data-x="1">t</span>`)).toBe("t");
+  });
+});
+
+describe("MAJOR 1: `<pre>` folds to a fenced block, not a broken code span", () => {
+  it("renders `<pre><code>` as a real fence", () => {
+    // fa9018a7: "`const a = 1;\nconst b = 2;`" — a backtick span wrapping a
+    // newline, which Telegram will not parse, so the reader sees literal
+    // backticks around broken text.
+    expect(render("<pre><code>const a = 1;\nconst b = 2;</code></pre>")).toBe(
+      "```\nconst a = 1;\nconst b = 2;\n```",
+    );
+  });
+
+  it("never emits a code span containing a newline", () => {
+    const out = render("<pre><code>a\nb</code></pre>");
+    expect(out).not.toMatch(/(^|[^`])`[^`]*\n[^`]*`/);
+  });
+
+  it("carries the `class=\"language-…\"` hint into the fence info string", () => {
+    expect(
+      render(`<pre><code class="language-python">print(1)</code></pre>`),
+    ).toBe("```python\nprint(1)\n```");
+  });
+
+  it("handles a bare `<pre>` with no inner `<code>`", () => {
+    expect(render("<pre>one\ntwo</pre>")).toBe("```\none\ntwo\n```");
+  });
+
+  it("leaves no stray leading or trailing newline around the fence", () => {
+    // The layout newlines a `<pre>` block carries are not content.
+    expect(render("<pre>\nbody\n</pre>")).toBe("```\nbody\n```");
+    expect(render("<pre>\nbody\n</pre>")).not.toMatch(/^\n|\n$/);
+  });
+
+  it("degrades to an inline code span where a fence cannot survive", () => {
+    // A fence inside a `#` line or a table cell would end the block/row.
+    expect(render("# a <pre>x</pre> b")).toBe("# a `x` b");
+    expect(render("| h |\n| --- |\n| <pre>x</pre> |")).toContain("| `x` |");
+  });
+});
+
+describe("MAJOR 2: structural tags do not glue their content together", () => {
+  it("separates list items instead of emitting `onetwo`", () => {
+    expect(render("<ul><li>one</li><li>two</li></ul>")).toBe("one  \ntwo");
+  });
+
+  it("separates paragraphs instead of emitting `para onepara two`", () => {
+    expect(render("<p>para one</p><p>para two</p>")).toBe(
+      "para one  \npara two",
+    );
+  });
+
+  it("separates table cells", () => {
+    expect(render("<table><tr><td>a</td><td>b</td></tr></table>")).toBe(
+      "a  \nb",
+    );
+  });
+
+  it("leaves no separator hanging at the edges of the block", () => {
+    const out = render("<div>only</div>");
+    expect(out).toBe("only");
+  });
+
+  it("still renders a markup-only block to nothing", () => {
+    // Regression guard for the separator: an empty structural block must not
+    // become a whitespace-only paragraph and a spurious `\n\n`.
+    expect(render("a\n\n<div></div>\n\nb")).toBe("a\n\nb");
+    expect(render("a\n\n<!-- c -->\n\nb")).toBe("a\n\nb");
+  });
+
+  it("uses a space, not a newline, inside a table cell", () => {
+    // A newline in a cell ends the row.
+    const out = render("| h |\n| --- |\n| <p>x</p><p>y</p> |");
+    expect(out).toContain("| x y |");
+  });
+});
+
+describe("MAJOR 3: the passthrough bucket is balance-checked", () => {
+  it("does not ship an unmatched `<u>` raw", () => {
+    // fa9018a7 emitted this verbatim -> `unclosed start tag` 400 -> the
+    // fallback resends the WHOLE message as plain text. One stray marker in
+    // relayed content was a denial-of-formatting on the agent's reply.
+    expect(render("hello <u>world")).toBe("hello &lt;u&gt;world");
+  });
+
+  it("does not ship a stray close marker raw", () => {
+    expect(render("</details>")).toBe("&lt;/details&gt;");
+  });
+
+  it("keeps the balanced inner pair and escapes only the unmatched outer", () => {
+    expect(render("<u><u>x</u>")).toBe("&lt;u&gt;<u>x</u>");
+  });
+
+  it("still passes a BALANCED allowlist tag through raw", () => {
+    for (const src of [
+      "<u>under</u>",
+      "H<sub>2</sub>O",
+      "x<sup>2</sup>",
+      "<aside><cite>note</cite></aside>",
+    ]) {
+      expect(render(src)).toBe(src);
+    }
+  });
+
+  it("passes a `<details>` block through even though it spans mdast blocks", () => {
+    // The balance check MUST be document-level: micromark splits this into
+    // three separate `html` nodes, so a per-node check would wrongly call the
+    // open and close markers unmatched and escape them.
+    const src = "<details open><summary>S</summary>\n\nbody\n\n</details>";
+    expect(render(src)).toBe(src);
+  });
+
+  it("does not let a tag inside a code fence balance a prose marker", () => {
+    // Tags in a fence are not markup and must not satisfy anything outside it.
+    const out = render("```\n</u>\n```\n\nhello <u>world");
+    expect(out).toContain("```\n</u>\n```");
+    expect(out).toContain("hello &lt;u&gt;world");
+  });
+});
+
+describe("MAJOR 4: the fence comment's claimed safety property (pinned)", () => {
+  it("PINS the lazy-continuation counterexample the comment gets wrong", () => {
+    // The `**>` rewrite tracks TOP-LEVEL fences only, so the `> ``` ` opener
+    // here is invisible to it and the column-0 `**> lazy` line is rewritten,
+    // eating the `**`. CommonMark forbids lazy continuation into fenced code,
+    // so that line should CLOSE the blockquote and stay literal.
+    //
+    // This is PRE-EXISTING and identical before #4691 — NOT a regression — and
+    // fixing it needs real container tracking, not a wider fence regex. Pinned
+    // so any future container-aware rewrite has to decide it deliberately;
+    // `FENCE_DELIM_RE`'s doc comment now describes this instead of claiming
+    // the case cannot happen.
+    expect(render("> ```\n**> lazy\n> ```")).toBe("> ```\n> lazy\n> ```");
+  });
+});
+
+describe("nits: breaks, nested links, and href hygiene", () => {
+  it("does not break a heading block with `<br>`", () => {
+    // fa9018a7: "# a  \nb" — the hard break ends the heading and orphans `b`.
+    expect(render("# a<br>b")).toBe("# a b");
+    expect(parse("# a<br>b").blocks).toHaveLength(1);
+  });
+
+  it("keeps a `<br>` a real break in ordinary prose", () => {
+    expect(render("one<br>two")).toBe("one  \ntwo");
+    // Two explicit breaks are the author's, not synthesized separators — they
+    // must not be collapsed by the separator normalizer.
+    expect(render("a<br><br>b")).toBe("a  \n  \nb");
+  });
+
+  it("does not silently drop a nested `<a>`'s href", () => {
+    // fa9018a7: "[out in](https://o.example)" — the inner URL vanished.
+    const out = render(
+      '<a href="https://o.example">out <a href="https://i.example">in</a></a>',
+    );
+    expect(out).toContain("i.example");
+  });
+
+  it("percent-encodes whitespace in a link destination", () => {
+    // A bare destination ends at the first whitespace character, so a raw
+    // space turned the rest of the URL into a title and a raw newline
+    // terminated the link outright.
+    expect(render('<a href="https://ex.com/a b">x</a>')).toBe(
+      "[x](https://ex.com/a%20b)",
+    );
+    expect(render('<a href="https://ex.com/a\nb">x</a>')).toBe(
+      "[x](https://ex.com/a%0Ab)",
+    );
+  });
+
+  it("escapeLinkHref still balances parens and is a no-op for clean URLs", () => {
+    expect(escapeLinkHref("https://e.com/a_(b)")).toBe(
+      "https://e.com/a_\\(b\\)",
+    );
+    expect(escapeLinkHref("https://e.com/plain?a=1&b=2")).toBe(
+      "https://e.com/plain?a=1&b=2",
+    );
+  });
+});

--- a/telegram-plugin/tests/render/html-dialect.test.ts
+++ b/telegram-plugin/tests/render/html-dialect.test.ts
@@ -167,9 +167,12 @@ describe("markdown-equivalent HTML tags fold to native constructs (defect 3)", (
     );
   });
 
-  it("drops an unmatched open or close marker but keeps the text", () => {
-    expect(renderOutbound("<b>dangling").text).toBe("dangling");
-    expect(renderOutbound("dangling</b>").text).toBe("dangling");
+  it("keeps an unmatched open or close marker as escaped literal text", () => {
+    // An unmatched marker delimits nothing, so it is PROSE, not markup —
+    // deleting it silently mangles the author's sentence. Entity-escaped so
+    // the wire still cannot read it as an unsupported start tag.
+    expect(renderOutbound("<b>dangling").text).toBe("&lt;b&gt;dangling");
+    expect(renderOutbound("dangling</b>").text).toBe("dangling&lt;/b&gt;");
   });
 
   it("turns `<br>` into a GFM HARD break rather than deleting it", () => {


### PR DESCRIPTION
Follow-up to #4691 (merged as `fa9018a7`, **unreleased** — no tag contains it). A retrospective review found the degrade bucket DELETES content. Fresh PR against `main`; the merged branch is untouched.

## What was wrong

`fa9018a7`'s degrade bucket dropped every HTML token it could not fold or pass through. That is right for markup and catastrophic for prose. Reproduced on current `origin/main` before changing anything — **every claim reproduced**:

| input | `fa9018a7` | now |
| --- | --- | --- |
| `Use the <service>/<key> convention.` | `Use the / convention.` | `Use the &lt;service&gt;/&lt;key&gt; convention.` |
| `run switchroom vault get <key>` | `run switchroom vault get ` | `run switchroom vault get &lt;key&gt;` |
| `logs/<agent>/` | `logs//` | `logs/&lt;agent&gt;/` |
| ``The `<b>` tag is bold and `<i>` is italic`` | `The  tag is bold and  is italic` | `The &lt;b&gt; tag is bold and &lt;i&gt; is italic` |

The PR's own justification did not survive its pipeline: `"a &amp; b &lt;c&gt;"` rendered to `"a & b <c>"` — a literal `<c>` on the wire — because that path arrives as a `plain` node, not an mdast `html` node. Identical wire bytes, opposite treatment. Confirmed, and it is why the fix is to ESCAPE rather than delete.

## The fix

The discriminator is now **MATCHING**, not the tag name:

- a **balanced** pair is markup → drop the markup, keep the content (unchanged behaviour)
- an **unmatched** marker is prose → keep it as literal text with `&`/`<`/`>` HTML-entity-escaped

Entity escaping is the documented wire-safe form, not a guess: Bot API rich markdown "can contain arbitrary HTML … parsed as described in Rich HTML style", and Rich HTML lists `&lt; &gt; &amp;` among its supported named entities. So the content is kept AND `unsupported start tag` is still avoided.

Matching is decided by a **document-level** pass (`matchedTagOffsets`) over mdast `html` nodes, because micromark splits `<details>…</details>` across several nodes so a per-node check would wrongly escape a valid pair. Sourcing it from `html` nodes also means a tag inside a fence or code span can never balance a prose marker.

Also in this PR:

- **MAJOR 1** — `<pre>` added to the fold table with a block-level target: `<pre><code class=\"language-python\">` → a real ` ```python ` fence. It previously became an inline code span wrapping a newline, which Telegram will not parse. Degrades to an inline span only where a fence cannot survive (heading, table cell).
- **MAJOR 2** — `<li>`/`<p>`/`<div>`/`<td>`/… degrade with a hard-break separator, so `<ul><li>one</li><li>two</li></ul>` is no longer `onetwo`. A space is used inside a table cell (a newline ends the row). Separators are identity-tracked in a `WeakSet` so an author's own `<br><br>` is never collapsed, and leading/trailing/duplicate synthesized ones are normalized away.
- **MAJOR 3** — the passthrough bucket is balance-checked. `hello <u>world` shipped raw, which is the exact `unclosed start tag` 400 this module exists to prevent — and per `rich-send.ts:141-143` that fallback resends the whole body as PLAIN text, a denial-of-formatting on the whole message.
- **MAJOR 4** — comment only, as expected. The `FENCE_DELIM_RE` safety claim is false (`\"> \`\`\`\\n**> lazy\\n> \`\`\`\"`), but it is **PRE-EXISTING and identical before #4691 — not a regression**. Fixing it needs real container tracking, not a wider regex; the comment now documents the limitation and the case is pinned by a test so any future rewrite decides it deliberately.
- **Nits** — `<br>` in a heading/table cell degrades to a space instead of ending the block; a nested `<a>`'s href is kept literally instead of silently dropped; `escapeLinkHref` percent-encodes ASCII whitespace/control bytes (a bare destination ends at the first whitespace byte and a backslash cannot rescue it); the `<pre>` degrade strips its layout newlines.
- The `html-fold.ts` header invariant is restated so it is TRUE as written, and names its one residual: a `<` that mdast hands over as a TEXT node (the decoded `&lt;c&gt;`, or `response in <1s`) never reaches this module and still ships unescaped. Deliberately out of scope — entity-escaping all prose `<`/`&` is a much wider bet and would look wrong on the plain-text fallback path.

## Tests

31 outcome tests in `telegram-plugin/tests/render/html-dialect-content-loss.test.ts`, driving the real `renderOutbound` (the live send path). Run against the unmodified `fa9018a7` source: **23 failed | 8 passed** — the 8 passing are deliberate counter-guards (a balanced unknown pair must STILL drop its markup, a balanced allowlist tag must still pass raw, a markup-only block must not leave a blank-line hole). Every fix above has at least one red-on-`fa9018a7` assertion.

One existing assertion in `html-dialect.test.ts` encoded the buggy policy (`<b>dangling` → `dangling`) and is updated to the new one, with the reasoning in-place.

Scoped local run, green: `telegram-plugin/tests/render` + `formatting-parse-regression` → **19 files, 449 tests passed**. `tsc --noEmit` clean for the touched files. Full suite is CI's call.

## Not done, deliberately

Not merged, not enqueued, per instruction.