### PR TITLE
fix(telegram): share ONE fence-width rule — a `<pre>` containing ``` no longer ships an unterminated fence (#4702 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+### Bug fixes
+
+- **telegram/render: a `<pre>` whose body contained ``` shipped an
+  unterminated fence** — #4702's `<pre>` fold (`buildPreBlock`,
+  `telegram-plugin/render/parse.ts`) emitted a HARDCODED three-backtick
+  delimiter as a `raw` node — verbatim wire passthrough, so nothing downstream
+  widened it — without ever inspecting the body. A `<pre>` carrying its own
+  ``` therefore went to the wire with THREE delimiters instead of two:
+  Telegram opens at the first, closes at the embedded one, reads the remainder
+  as prose, and the trailing delimiter opens a fence that never terminates —
+  `can't find end of Pre entity`, a 400, and a plain-text resend of the WHOLE
+  message, which is precisely the denial-of-formatting outcome that module
+  exists to prevent. `fa9018a7` escaped the backticks instead: cosmetically
+  worse, but wire-correct, so the regression traded a cosmetic defect for a
+  400. The fence-width rule now has exactly ONE implementation, `codeFenceFor`
+  (`telegram-plugin/format.ts`) — one backtick longer than the longest run in
+  the body — and all three call sites use it: the `<pre>` fold, plus
+  `renderCodeBlock` and `degradeToCodeFence` (`telegram-plugin/render/render.ts`),
+  which each carried their own copy. Pinned by six outcome tests, five of
+  which fail on `6c120cee`, including a property check that the delimiter run
+  appears on exactly two lines and is strictly longer than every run inside.
+  Consolidating also fixed a latent crash both copies shared: the width scan
+  was `Math.max(0, ...runs.map(…))`, one argument per run, which throws
+  `RangeError: Maximum call stack size exceeded` out of the render path from
+  about 125k backtick runs (~375 KB, measured). That is reachable because
+  `renderOutboundChunks` renders the WHOLE raw body first and only re-splits
+  on overflow (`telegram-plugin/render/rich-render.ts:146`), so the fence scan
+  is not bounded by the 32768-character rich cap. The shared helper scans with
+  a loop instead; same O(n), cannot throw.
+
 ## v0.21.10 — the Telegram render pipeline stops deleting prose and corrupting fenced code, and TTS stops failing on long messages
 
 ### Bug fixes
@@ -80,11 +110,13 @@ now an anomaly worth investigating, not the norm.
   of being silently dropped; and `escapeLinkHref` percent-encodes ASCII
   whitespace/control characters, which a backslash cannot rescue because a
   bare link destination ends at the first whitespace byte.
-  `html-fold.ts`'s "content is never lost" invariant is restated accurately
-  and now names its one residual (a `<` mdast hands over as a TEXT node never
-  reaches this module). Pinned by 31 outcome tests in
-  `telegram-plugin/tests/render/html-dialect-content-loss.test.ts`, every one
-  of which fails on `fa9018a7`.
+  `html-fold.ts`'s content-loss invariant is restated accurately and now names
+  its residuals (a `<` mdast hands over as a TEXT node never reaches this
+  module; a BALANCED pair of prose angle brackets is dropped as markup, the
+  accepted cost of the matching discriminator). Pinned by outcome tests in
+  `telegram-plugin/tests/render/html-dialect-content-loss.test.ts` — of the 37
+  now in that file, 29 fail on `fa9018a7` and 8 are guards that pass on both
+  revisions.
 
 - **voice: unit-suffix regex lookbehind + case-sensitivity hotfix** — the
   number+unit-suffix regex shared by both TTS normalization passes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,12 @@ now an anomaly worth investigating, not the norm.
   delimiter as a `raw` node — verbatim wire passthrough, so nothing downstream
   widened it — without ever inspecting the body. A `<pre>` carrying its own
   ``` therefore went to the wire with THREE delimiters instead of two:
-  Telegram opens at the first, closes at the embedded one, reads the remainder
-  as prose, and the trailing delimiter opens a fence that never terminates —
-  `can't find end of Pre entity`, a 400, and a plain-text resend of the WHOLE
-  message, which is precisely the denial-of-formatting outcome that module
-  exists to prevent. `fa9018a7` escaped the backticks instead: cosmetically
-  worse, but wire-correct, so the regression traded a cosmetic defect for a
-  400. The fence-width rule now has exactly ONE implementation, `codeFenceFor`
+  Telegram opens at the first, closes at the embedded one, and the trailing
+  delimiter opens a fence that never terminates: `can't find end of Pre
+  entity`, a 400, and a plain-text resend of the WHOLE message — the
+  denial-of-formatting outcome that module exists to prevent. (`fa9018a7`
+  escaped the backticks instead: cosmetically worse but wire-correct.)
+  The fence-width rule now has exactly ONE implementation, `codeFenceFor`
   (`telegram-plugin/format.ts`) — one backtick longer than the longest run in
   the body — and all three call sites use it: the `<pre>` fold, plus
   `renderCodeBlock` and `degradeToCodeFence` (`telegram-plugin/render/render.ts`),
@@ -38,12 +37,20 @@ now an anomaly worth investigating, not the norm.
   appears on exactly two lines and is strictly longer than every run inside.
   Consolidating also fixed a latent crash both copies shared: the width scan
   was `Math.max(0, ...runs.map(…))`, one argument per run, which throws
-  `RangeError: Maximum call stack size exceeded` out of the render path from
-  about 125k backtick runs (~375 KB, measured). That is reachable because
-  `renderOutboundChunks` renders the WHOLE raw body first and only re-splits
-  on overflow (`telegram-plugin/render/rich-render.ts:146`), so the fence scan
-  is not bounded by the 32768-character rich cap. The shared helper scans with
-  a loop instead; same O(n), cannot throw.
+  `RangeError: Maximum call stack size exceeded` out of the render path once
+  the body carries more backtick runs than the engine's argument limit. That
+  limit is ENGINE-DEPENDENT, so no single number states it: measured by
+  bisection on the pinned toolchain it is 638,621 runs (~1.9 MB) on Bun
+  1.3.13, the shipping runtime, and 125,289 (~375 KB) on Node 22 — the
+  vitest runner. Input is unbounded — `renderOutboundChunks` renders the WHOLE
+  raw body before any chunking (`telegram-plugin/render/rich-render.ts:146`),
+  so the scan is not capped by the 32768-character rich limit — though on Bun
+  a ~1.9 MB single message is an unlikely body, so this was latent there
+  rather than routine. The shared helper loops instead (same O(n), cannot
+  throw), so the fix does not depend on winning that reachability argument.
+  The regression test was raised to 1M runs: at the 200k it started at, the
+  reinstated spread form still PASSES under Bun — the guard asserted nothing
+  in the shipping runtime.
 
 ## v0.21.10 — the Telegram render pipeline stops deleting prose and corrupting fenced code, and TTS stops failing on long messages
 

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -86,6 +86,47 @@ export function codeSpanSafe(s: string): string {
 }
 
 /**
+ * Compute the delimiter for a fenced code block whose body is `text`.
+ *
+ * Fenced content is verbatim per the formatting guide; the only hazard is a
+ * backtick run inside the body CLOSING the fence early. A hardcoded ``` around
+ * a body that carries its own ``` ships three delimiters instead of two: the
+ * wire opens at the first, closes at the embedded one, reads the remainder as
+ * prose, and the trailing delimiter opens a fence that never terminates —
+ * `can't find end of Pre entity`, a 400, and a whole-message plain-text
+ * resend. Widening the delimiter to one backtick longer than the longest run
+ * already present makes the open/close pair the only runs of that width, so
+ * nothing in the body can match them.
+ *
+ * This is the canonical home for the rule (as `codeSpanSafe` is for the code
+ * SPAN hazard above): the markdown fence (`renderCodeBlock`), the degraded
+ * table fence (`degradeToCodeFence`) and the raw-HTML `<pre>` fold
+ * (`buildPreBlock`, render/parse.ts) all call it, so there is exactly ONE
+ * implementation of the width rule rather than a copy per call site.
+ *
+ * The scan is a LOOP, not `Math.max(0, ...runs.map(…))`. The spread form
+ * (which both former copies of this rule used) passes one argument per run,
+ * and a body with ~125k separate backtick runs — reachable well before the
+ * pre-chunking size ceiling, since render runs on the whole message — blows
+ * the argument limit with `RangeError: Maximum call stack size exceeded`,
+ * throwing out of the render path entirely. Iterating is O(n) either way and
+ * cannot throw.
+ */
+export function codeFenceFor(text: string): string {
+  let longestRun = 0
+  let current = 0
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '`') {
+      current++
+      if (current > longestRun) longestRun = current
+    } else {
+      current = 0
+    }
+  }
+  return '`'.repeat(Math.max(3, longestRun + 1))
+}
+
+/**
  * Make a URL safe to interpolate as the destination of a `[label](href)`
  * inline link.
  *

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -106,11 +106,26 @@ export function codeSpanSafe(s: string): string {
  *
  * The scan is a LOOP, not `Math.max(0, ...runs.map(…))`. The spread form
  * (which both former copies of this rule used) passes one argument per run,
- * and a body with ~125k separate backtick runs — reachable well before the
- * pre-chunking size ceiling, since render runs on the whole message — blows
- * the argument limit with `RangeError: Maximum call stack size exceeded`,
- * throwing out of the render path entirely. Iterating is O(n) either way and
- * cannot throw.
+ * so a body with enough separate backtick runs blows the argument limit with
+ * `RangeError: Maximum call stack size exceeded`, throwing out of the render
+ * path entirely.
+ *
+ * The limit is ENGINE-DEPENDENT, so no single number describes it. The
+ * shipping runtime is Bun (`telegram-plugin/package.json` `start`,
+ * docker/Dockerfile.agent), where it measures at ~639k runs (~1.9 MB body);
+ * this file is also collected by the vitest/Node runner, where it is ~125k
+ * (~375 KB). Both measured on the pinned toolchain (Bun 1.3.13 — the CI
+ * default in .github/actions/setup-switchroom/action.yml — and Node 22), and
+ * both move with an engine upgrade.
+ *
+ * We deliberately do NOT rely on that threshold. Input here is unbounded:
+ * `renderOutboundChunks` renders the WHOLE raw body before any
+ * `splitMarkdownChunks` (render/rich-render.ts:146), so the fence scan is not
+ * bounded by the 32768-character rich cap. Being honest about the size: on
+ * Bun a ~1.9 MB single message is an unlikely body, so there this is a latent
+ * crash rather than a routine one. The loop is O(n) either way and cannot
+ * throw, so correctness costs nothing and the reachability argument does not
+ * have to be won.
  */
 export function codeFenceFor(text: string): string {
   let longestRun = 0

--- a/telegram-plugin/render/html-fold.ts
+++ b/telegram-plugin/render/html-fold.ts
@@ -57,10 +57,28 @@
 //                     angle bracket without tripping `unsupported start tag`.
 //
 // ── The invariant ─────────────────────────────────────────────────────────
-// CONTENT is never lost. Only MARKUP is dropped, and only where dropping it
-// loses no reader-visible text: a matched pair, a comment, a void tag.
-// Anything not demonstrably markup survives to the wire as escaped literal
-// text. (Known residual, NOT introduced by this module and not fixed here: a
+// Only MARKUP is dropped. A token that is not demonstrably markup — an
+// UNMATCHED open/close marker, which is overwhelmingly the shape prose
+// actually takes — always survives to the wire as escaped literal text. That
+// case is protected absolutely. The three shapes classified as markup, and so
+// dropped, are a matched pair, a comment, and a void tag.
+//
+// The invariant is NOT "content is never lost", and must not be read that
+// way. MATCHING is a syntactic discriminator, not a semantic one, so a
+// BALANCED pair of angle brackets in prose is indistinguishable from real
+// markup and is dropped with it:
+//   "Use <key> then later </key> done."      -> "Use  then later  done."
+//   "Wrap it in <b> and close with </b>."    -> "Wrap it in ** and close
+//                                               with **."
+// — author-visible prose is deleted in both, and the second additionally
+// re-wraps the surviving text in the construct the pair named. This is the
+// accepted, deliberate price of the matching discriminator, NOT a defect to
+// fix by weakening it: the alternative (classifying by tag NAME) is what
+// silently deleted every `<service>/<key>` and `<agent>` in this project's own
+// agent output — far more common, and far more damaging, than a balanced pair
+// of brackets in prose.
+//
+// (Second known residual, NOT introduced by this module and not fixed here: a
 // `<` in prose that mdast hands over as a TEXT node rather than an `html` node
 // — the decoded `&lt;c&gt;`, or `response in <1s` — never reaches this module
 // and still ships unescaped. That is a `plain`-node / `escapeMarkdown`

--- a/telegram-plugin/render/parse.ts
+++ b/telegram-plugin/render/parse.ts
@@ -114,6 +114,7 @@ import {
   type HtmlFoldTarget,
   type HtmlTagInfo,
 } from "./html-fold.js";
+import { codeFenceFor } from "../format.js";
 
 /** Copy UTF-16 offsets off an mdast node. Falls back to 0-length when a
  *  synthesized node lacks a position (from-markdown always sets one, but the
@@ -684,7 +685,14 @@ function buildPreBlock(
   if (ctx.noBreaks === true) {
     return [{ type: "code", text: text.replace(/\s*\r?\n\s*/g, " "), ...span }];
   }
-  const fence = "```";
+  // The fence ships as a `raw` node — verbatim wire passthrough, so nothing
+  // downstream will widen it for us. A hardcoded ``` around a body carrying
+  // its own ``` earns `can't find end of Pre entity` and a plain-text resend
+  // of the whole message. Width comes from the same shared rule
+  // `renderCodeBlock` uses (`codeFenceFor`, format.ts): `buildPreBlock`
+  // returns `Inline[]` and so cannot route through `renderCodeBlock` (which
+  // takes a `Block`), but the width rule is SHARED, not copied.
+  const fence = codeFenceFor(text);
   return [
     mkSeparator(ctx, span.start, span.start),
     {

--- a/telegram-plugin/render/render.ts
+++ b/telegram-plugin/render/render.ts
@@ -32,7 +32,13 @@
 // equivalent entities rather than accidentally re-triggering formatting or
 // breaking out of a code span.
 
-import { escapeMarkdown, codeSpanSafe, escapeLinkHref, RICH_MESSAGE_MAX_CHARS } from "../format.js";
+import {
+  escapeMarkdown,
+  codeSpanSafe,
+  codeFenceFor,
+  escapeLinkHref,
+  RICH_MESSAGE_MAX_CHARS,
+} from "../format.js";
 import type {
   Block,
   BlockquoteNode,
@@ -165,15 +171,11 @@ function renderBlockquote(node: BlockquoteNode): string {
 
 function renderCodeBlock(node: CodeBlockNode): string {
   const lang = node.language ?? "";
-  // Fenced code content is verbatim per the formatting guide; the only
-  // hazard is an embedded ``` closing the fence early. Widen the fence to a
-  // run of backticks one longer than the longest run already present in the
-  // content, mirroring the guide's `preBlock` defusal strategy.
-  const longestRun = Math.max(
-    0,
-    ...(node.text.match(/`+/g) ?? []).map((run) => run.length),
-  );
-  const fence = "`".repeat(Math.max(3, longestRun + 1));
+  // Fenced code content is verbatim per the formatting guide; the only hazard
+  // is an embedded ``` closing the fence early. Width comes from the shared
+  // rule (`codeFenceFor`, format.ts) — one backtick longer than the longest
+  // run in the body — which the `<pre>` fold and `degradeToCodeFence` use too.
+  const fence = codeFenceFor(node.text);
   return `${fence}${lang}\n${node.text}\n${fence}`;
 }
 
@@ -415,11 +417,10 @@ function tableDegradationReason(node: TableNode): string | null {
 
 /** Wrap a block's raw source text in a widened preformatted code fence — the
  *  degraded rendering for a malformed table (content verbatim, no broken
- *  markup). Fence-widening mirrors `renderCodeBlock`. */
+ *  markup). Fence-widening is the shared `codeFenceFor` rule. */
 function degradeToCodeFence(source: string, node: Block): string {
   const raw = source.slice(node.start, node.end);
-  const longestRun = Math.max(0, ...(raw.match(/`+/g) ?? []).map((run) => run.length));
-  const fence = "`".repeat(Math.max(3, longestRun + 1));
+  const fence = codeFenceFor(raw);
   return `${fence}\n${raw}\n${fence}`;
 }
 

--- a/telegram-plugin/tests/render/html-dialect-content-loss.test.ts
+++ b/telegram-plugin/tests/render/html-dialect-content-loss.test.ts
@@ -1,9 +1,17 @@
 // Outcome tests for the content-loss regressions found in the raw-HTML
 // dialect fold (#4691, merged as fa9018a7, unreleased).
 //
-// Every assertion here FAILS on fa9018a7. They drive the real `renderOutbound`
-// (`parse` -> `renderSafe`), i.e. exactly what the live send path calls, so
-// they assert the WIRE OUTCOME rather than an internal code path.
+// 29 of the 37 tests here fail on fa9018a7 — measured by running this exact
+// file against that revision, not asserted. The other 8 pass on both and are
+// guards: they pin behaviour the fix must not disturb. (An earlier revision of
+// this header claimed "every assertion fails on fa9018a7"; at 31 tests the
+// true figure was 23.) Five of the 29 — the `<pre>` fence-width cases — also
+// fail on 6c120cee, the first fix's own merge commit, which emitted a
+// hardcoded three-backtick fence.
+//
+// They drive the real `renderOutbound` (`parse` -> `renderSafe`), i.e. exactly
+// what the live send path calls, so they assert the WIRE OUTCOME rather than
+// an internal code path.
 //
 // The through-line: fa9018a7's degrade bucket DELETED any token it could not
 // fold or pass through. That is safe for markup but catastrophic for prose —
@@ -110,6 +118,71 @@ describe("MAJOR 1: `<pre>` folds to a fenced block, not a broken code span", () 
     // A fence inside a `#` line or a table cell would end the block/row.
     expect(render("# a <pre>x</pre> b")).toBe("# a `x` b");
     expect(render("| h |\n| --- |\n| <pre>x</pre> |")).toContain("| `x` |");
+  });
+
+  // ── Regression: the fold's fence must be WIDER than its own body ────────
+  // `buildPreBlock` emitted a hardcoded three-backtick delimiter as a `raw`
+  // node (verbatim wire passthrough — nothing downstream widens it). A `<pre>`
+  // whose body carried its own ``` therefore shipped THREE delimiters: the
+  // wire opens at #1, closes at #2, reads the remainder as prose, and #3 opens
+  // a fence that never terminates -> `can't find end of Pre entity` 400 and a
+  // whole-message plain-text resend. `fa9018a7` escaped the backticks instead
+  // — cosmetically worse, but wire-correct; this restores wire-correctness
+  // using the same width rule `renderCodeBlock` already applies.
+  it("widens the fence past a three-backtick run in the body", () => {
+    expect(render("<pre>\na\n```\nb\n</pre>")).toBe("````\na\n```\nb\n````");
+  });
+
+  it("widens the fence past a longer run than three", () => {
+    expect(render("<pre>\na\n````\nb\n</pre>")).toBe("`````\na\n````\nb\n`````");
+    expect(render("<pre>\na\n`````\nb\n</pre>")).toBe(
+      "``````\na\n`````\nb\n``````",
+    );
+  });
+
+  it("widens past a run that shares a line with other text", () => {
+    expect(render("<pre><code>x ``` y</code></pre>")).toBe(
+      "````\nx ``` y\n````",
+    );
+  });
+
+  it("still emits a plain three-backtick fence when the body has no run", () => {
+    // The widening must not inflate the common case.
+    expect(render("<pre>\nplain body\n</pre>")).toBe("```\nplain body\n```");
+    expect(render("<pre>\na ` b `` c\n</pre>")).toBe("```\na ` b `` c\n```");
+  });
+
+  it("keeps the language hint attached to the widened delimiter", () => {
+    expect(
+      render('<pre><code class="language-md">see ```\n</code></pre>'),
+    ).toBe("````md\nsee ```\n````");
+  });
+
+  it("emits a terminating fence for every inner backtick run length", () => {
+    // Outcome, not shape: whatever the body carries, the delimiter run must
+    // appear on exactly TWO lines (open and close) and be strictly longer than
+    // every run inside, so the wire can neither close it early nor leave it
+    // open. This is the property whose violation produced the 400.
+    for (const inner of ["```", "````", "`````", "` `` ```", "a```b", "```` x"]) {
+      const src = `<pre>\nhead\n${inner}\ntail\n</pre>`;
+      const out = render(src);
+      const lines = out.split("\n");
+      const delim = lines[0];
+      expect(delim, `open delimiter for ${JSON.stringify(inner)}`).toMatch(
+        /^`{3,}$/,
+      );
+      expect(lines[lines.length - 1], `close delimiter for ${inner}`).toBe(
+        delim,
+      );
+      // Every backtick run in the BODY is strictly shorter than the delimiter.
+      const body = lines.slice(1, -1).join("\n");
+      for (const run of body.match(/`+/g) ?? []) {
+        expect(
+          run.length,
+          `body run ${JSON.stringify(run)} vs delimiter ${delim}`,
+        ).toBeLessThan(delim.length);
+      }
+    }
   });
 });
 

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -20,9 +20,50 @@ import {
   escapeMarkdown,
   splitMarkdownChunks,
   addParagraphSpacers,
+  codeFenceFor,
   PARAGRAPH_SPACER,
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
+
+// ---------------------------------------------------------------------------
+// codeFenceFor — the single shared fence-width rule (#4702 follow-up)
+// ---------------------------------------------------------------------------
+
+describe('codeFenceFor', () => {
+  test('defaults to three backticks when the body carries no long run', () => {
+    expect(codeFenceFor('')).toBe('```')
+    expect(codeFenceFor('plain body')).toBe('```')
+    expect(codeFenceFor('a ` b `` c')).toBe('```')
+  })
+
+  test('widens to one longer than the longest run in the body', () => {
+    expect(codeFenceFor('a\n```\nb')).toBe('````')
+    expect(codeFenceFor('a\n````\nb')).toBe('`````')
+    expect(codeFenceFor('` `` ``` ````')).toBe('`````')
+    expect(codeFenceFor('x```y')).toBe('````')
+  })
+
+  test('the delimiter is strictly longer than every run in the body', () => {
+    // The property the wire depends on: with the open/close pair the only
+    // runs of that width, nothing in the body can close the fence early or
+    // leave one open.
+    for (const body of ['no ticks', '`', '```', '``````', 'a ``` b ````` c']) {
+      const fence = codeFenceFor(body)
+      for (const run of body.match(/`+/g) ?? []) {
+        expect(run.length).toBeLessThan(fence.length)
+      }
+    }
+  })
+
+  test('does not blow the stack on a body with very many backtick runs', () => {
+    // The former `Math.max(0, ...runs.map(…))` form passed one argument per
+    // run and threw `RangeError: Maximum call stack size exceeded` from about
+    // 125k runs — inside the render path, on a body well under the wire cap
+    // the renderer sees before chunking.
+    const body = 'x `'.repeat(200_000)
+    expect(codeFenceFor(body)).toBe('```')
+  })
+})
 
 // ---------------------------------------------------------------------------
 // escapeMarkdown — narrowed inline-special escaper (#2669)

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -57,10 +57,21 @@ describe('codeFenceFor', () => {
 
   test('does not blow the stack on a body with very many backtick runs', () => {
     // The former `Math.max(0, ...runs.map(…))` form passed one argument per
-    // run and threw `RangeError: Maximum call stack size exceeded` from about
-    // 125k runs — inside the render path, on a body well under the wire cap
-    // the renderer sees before chunking.
-    const body = 'x `'.repeat(200_000)
+    // run and threw `RangeError: Maximum call stack size exceeded` past the
+    // engine's argument limit, from inside the render path.
+    //
+    // THE COUNT IS LOAD-BEARING and has to clear the argument limit of EVERY
+    // engine that runs this file, because the limit is engine-dependent and
+    // this file is collected by BOTH runners: `bun test` (the shipping
+    // runtime, via the `tests/` positional in scripts/bun-test-ci.sh) and
+    // vitest/Node. Measured on the pinned toolchain by bisecting the former
+    // spread form on this exact body shape — highest surviving run count is
+    // 638,621 on Bun 1.3.13 and 125,289 on Node 22.23.2. So the 200_000 this
+    // started at passed on Bun WITH the bug reinstated: it asserted nothing
+    // in the shipping runtime. 1M is ~1.57x the higher (Bun) limit, and the
+    // shipping loop scans the resulting 2.9 MB body in single-digit
+    // milliseconds, so the margin is nearly free.
+    const body = 'x `'.repeat(1_000_000)
     expect(codeFenceFor(body)).toBe('```')
   })
 })


### PR DESCRIPTION
## ⛔ ON HOLD — do not merge or enqueue pending review

Opened for review only. Not enqueued, auto-merge not armed.

---

## The major: `<pre>` containing ``` ships an unterminated fence → 400 → whole-message plain-text resend

`buildPreBlock` (`telegram-plugin/render/parse.ts:687` on `6c120cee`) emitted a **hardcoded three-backtick delimiter** as a `raw` node — verbatim wire passthrough, so nothing downstream widens it — and never inspected the body.

A `<pre>` whose body carries its own ``` therefore shipped **three** delimiters instead of two. Telegram opens at #1, closes at #2 (content `a`), reads `b` as prose, then #3 opens a fence that never terminates → `can't find end of Pre entity` → 400 → the fallback resends the **entire message as plain text**. That is exactly the denial-of-formatting outcome the module exists to prevent.

The pre-#4702 base `fa9018a7` **escaped** the backticks — cosmetically worse, but wire-correct. The regression traded a cosmetic defect for a 400.

Confirmed live on `6c120cee`:

```
"<pre>\na\n```\nb\n</pre>"  =>  "```\na\n```\nb\n```"
"<pre>\na\n````\nb\n</pre>" =>  "```\na\n````\nb\n```"
```

### The fix: ONE fence-width rule, shared — not forked

The correct implementation already existed in `renderCodeBlock`. It is now extracted to **`codeFenceFor` (`telegram-plugin/format.ts`)**, alongside `codeSpanSafe`, which that file already documents as "the canonical home for the helper … so there's one implementation".

All three call sites use it:

| call site | before |
|---|---|
| `buildPreBlock` (`render/parse.ts`) | hardcoded ``` ` ``` ×3 |
| `renderCodeBlock` (`render/render.ts`) | its own copy of the rule |
| `degradeToCodeFence` (`render/render.ts`) | a second copy of the rule |

`buildPreBlock` returns `Inline[]` and cannot route through `renderCodeBlock` (which takes a `Block`), so the **rule** is shared rather than the call path. Nothing is copy-pasted; two existing duplicates were removed.

### Bonus: a latent `RangeError` both former copies shared

Consolidating exposed it. The scan was `Math.max(0, ...runs.map(…))` — one argument per run — which throws `RangeError: Maximum call stack size exceeded` **out of the render path** from ~125k backtick runs (~375 KB, measured; 100k passes, 125k throws).

Reachable: `renderOutboundChunks` renders the **whole raw body** first and only re-splits on overflow (`render/rich-render.ts:146`), so the scan is not bounded by the 32768-char rich cap. The shared helper scans with a loop — same O(n), cannot throw.

## Red-then-green

**Fence, against `6c120cee` (verbatim):**

```
FAIL telegram-plugin/tests/render/html-dialect-content-loss.test.ts > MAJOR 1 > widens the fence past a three-backtick run in the body
AssertionError: expected '```\na\n```\nb\n```' to be '````\na\n```\nb\n````' // Object.is equality

FAIL ... > emits a terminating fence for every inner backtick run length
AssertionError: body run "```" vs delimiter ```: expected 3 to be less than 3

 Tests  5 failed | 32 passed (37)
```

**Stack overflow, against the spread form (verbatim):**

```
FAIL telegram-plugin/tests/telegram-format.test.ts > codeFenceFor > does not blow the stack on a body with very many backtick runs
RangeError: Maximum call stack size exceeded
 ❯ codeFenceFor telegram-plugin/format.ts:116:27
    116|   const longestRun = Math.max(
       |                           ^
    117|     0,
    118|     ...(text.match(/`+/g) ?? []).map((run) => run.length),
```

**Green:** `19 test files, 479 tests passed` (`telegram-plugin/tests/render/` + `telegram-format.test.ts`), `tsc --noEmit` clean.

The suite includes a **property** test, not just golden strings: for every inner run shape, the delimiter must appear on exactly two lines and be strictly longer than every run in the body — the invariant whose violation produced the 400.

## Two documentation corrections (no behaviour change)

**1. `html-fold.ts`'s invariant claimed something false.** It read "CONTENT is never lost." Falsified by:

```
"Use <key> then later </key> done."   -> "Use  then later  done."
"Wrap it in <b> and close with </b>." -> "Wrap it in ** and close with **."
```

I verified this is **byte-identical on `fa9018a7`**, so it is the deliberate cost of the matching discriminator, not a new bug. The header now states that cost explicitly and says why the discriminator must not be weakened (name-based classification is what deleted every `<service>/<key>` in the first place). **The discriminator is unchanged.**

**2. "Every assertion here FAILS on `fa9018a7`" was overstated.** Measured by running the file against `fa9018a7`, not taken on faith: at the then-31 tests, **23** failed. With the six new fence tests the file is 37, of which **29** fail there and **8** are guards that pass on both revisions. Corrected in the test header and the CHANGELOG.

Note: correction 2 edits the `#4691` entry **in situ**, which the `v0.21.10` cut moved into a released section. It corrects a false claim rather than adding a new entry there; the new entry is under `## Unreleased`. Flagging it explicitly in case the project prefers released text stay frozen.

## Deliberately not fixed

- **The `<pre>` fold does not reach inside a blockquote or a list item.** Pre-existing coverage gap in #4702, out of scope here.
- **The lazy-continuation counterexample** pinned by the existing `MAJOR 4` test. Pre-existing, needs real container tracking.
- **The `<` that mdast hands over as a TEXT node** still ships unescaped. Pre-existing residual, documented in the header, a `plain`-node concern.
