### PR TITLE
chore: use a synthetic supergroup id in docs and tests

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -166,7 +166,7 @@ agents:
   marko:
     channels:
       telegram:
-        chat_id: "-1003831053471"      # the supergroup marko owns
+        chat_id: "-1001234567890"      # the supergroup this agent posts into
         default_topic_id: 1            # General — where untargeted crons land
         topic_aliases:
           meta: 3                      # "Meta Campaigns"

--- a/reference/rfcs/supergroup-easy-defaults.md
+++ b/reference/rfcs/supergroup-easy-defaults.md
@@ -84,7 +84,7 @@ agents:
   marko:
     channels:
       telegram:
-        chat_id: "-1003831053471"   # that's it — answers everywhere, DMs still work
+        chat_id: "-1001234567890"   # that's it — answers everywhere, DMs still work
 ```
 
 ### Phase 2 (follow-up PRs)

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -29,12 +29,12 @@ import {
 
 describe("TelegramChannelSchema — supergroup smart defaults", () => {
   it("defaults default_topic_id to General (1) when chat_id is set and it is omitted", () => {
-    const r = TelegramChannelSchema.parse({ chat_id: "-1003831053471" });
+    const r = TelegramChannelSchema.parse({ chat_id: "-1001234567890" });
     expect(r?.default_topic_id).toBe(1);
   });
 
   it("preserves an explicit default_topic_id", () => {
-    const r = TelegramChannelSchema.parse({ chat_id: "-1003831053471", default_topic_id: 17 });
+    const r = TelegramChannelSchema.parse({ chat_id: "-1001234567890", default_topic_id: 17 });
     expect(r?.default_topic_id).toBe(17);
   });
 

--- a/telegram-plugin/gateway/answer-thread-resolve.test.ts
+++ b/telegram-plugin/gateway/answer-thread-resolve.test.ts
@@ -120,7 +120,7 @@ describe('resolveAnswerThreadId — legacy (frameworkTopicAuthority:false)', () 
 // failed FIRST API call rather than a lost message. Each case below asserts the
 // RESOLVED THREAD, not that a branch ran.
 const CHAT_A = '12345678' // a DM — the reply target
-const CHAT_B = '-1003831053471' // a forum supergroup — where the anchor lives
+const CHAT_B = '-1001234567890' // a forum supergroup — where the anchor lives
 
 describe('resolveAnswerThreadId — cross-chat anchor guard', () => {
   it("THE bug: a live turn in supergroup B must not lend its topic to a reply into chat A", () => {

--- a/telegram-plugin/gateway/reply-route-log.test.ts
+++ b/telegram-plugin/gateway/reply-route-log.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { formatReplyRouteLog, type ReplyRouteLogInput } from './reply-route-log.js'
 
 const CHAT_A = '12345678' // DM — the reply target
-const CHAT_B = '-1003831053471' // forum supergroup — where the anchor lives
+const CHAT_B = '-1001234567890' // forum supergroup — where the anchor lives
 
 function line(over: Partial<ReplyRouteLogInput> = {}): string {
   return formatReplyRouteLog({

--- a/telegram-plugin/registry/subagents-bugs.test.ts
+++ b/telegram-plugin/registry/subagents-bugs.test.ts
@@ -431,9 +431,9 @@ function seedTurn(turnKey: string, chatId = '12345', threadId: string | null = n
 describe('Bug 5 — parent_turn_key stamped from the turn-active marker', () => {
   it('stamps parent_turn_key = marker.turnKey when a turn is active', () => {
     // Supergroup forum-topic turn_key (chat:thread:startedAt).
-    const turnKey = '-1003831053471:4:1780370238492'
-    seedTurn(turnKey, '-1003831053471', '4')
-    writeTurnActiveMarker(turnKey, '-1003831053471', '4')
+    const turnKey = '-1001234567890:4:1780370238492'
+    seedTurn(turnKey, '-1001234567890', '4')
+    writeTurnActiveMarker(turnKey, '-1001234567890', '4')
 
     const event = {
       session_id: 'sess-turnkey',

--- a/telegram-plugin/tests/status-pin.test.ts
+++ b/telegram-plugin/tests/status-pin.test.ts
@@ -404,7 +404,7 @@ describe('unified reconcile path — pin-rights 400 must never crash (marko 2026
     // rejection to the process.
     const next = await reconcilePin({
       api,
-      chatId: '-1003831053471',
+      chatId: '-1001234567890',
       prevState: null,
       desired: { pinned: true, messageId: 4 },
       onError: (phase, err) =>
@@ -437,7 +437,7 @@ describe('unified reconcile path — pin-rights 400 must never crash (marko 2026
       // Fire-and-forget, exactly as the gateway's auto-pin callsites do.
       void reconcilePin({
         api,
-        chatId: '-1003831053471',
+        chatId: '-1001234567890',
         prevState: null,
         desired: { pinned: true, messageId: 4 },
         onError: () => {},

--- a/tests/scaffold.reconcile-group.test.ts
+++ b/tests/scaffold.reconcile-group.test.ts
@@ -13,7 +13,7 @@ import type { AgentConfig, TelegramConfig } from "../src/config/schema.js";
  * group_unknown). Must be strictly additive + non-destructive.
  */
 
-const SG = "-1003831053471";
+const SG = "-1001234567890";
 const FLEET_FORUM = "-1003852747971"; // a DIFFERENT chat — the shared fleet forum
 const agent = (overrides: Partial<AgentConfig> = {}): AgentConfig =>
   ({ extends: "default", ...overrides } as unknown as AgentConfig);


### PR DESCRIPTION
## What

Eight tracked files (2 docs/RFC, 6 tests) used a **real** Telegram supergroup id as example/fixture data — 12 occurrences in total. This replaces every one of them with `-1001234567890`, the id this repo already uses everywhere else for examples (~150 existing occurrences), and neutralises one line of docs prose that also named which agent owned the group.

## Why

Example data in a public repo should be synthetic. A real chat id is not a credential and nothing here is exploitable — group membership is approval-gated, so knowing an id gets you nothing — but it is still live infrastructure detail with no reason to be in a docs snippet. This is hygiene, not an incident.

## Placeholder choice

`-1001234567890` was already the repo's de-facto example id. It keeps the `-100`-prefixed shape any parser or validator expects while being unmistakably fake, and it avoids inventing a second convention.

## Test semantics

Unchanged. In every touched test the id is an opaque chat identifier — nothing asserts on its value, only on routing/identity behaviour keyed by it. Where a test needs two *distinct* chats they remain distinct after the swap:

- `answer-thread-resolve.test.ts` / `reply-route-log.test.ts` — `CHAT_A` (`'12345678'`, a DM) vs `CHAT_B` (the supergroup)
- `scaffold.reconcile-group.test.ts` — `SG` vs `FLEET_FORUM`
- `status-pin.test.ts` — the swapped id does not collide with the file's `-10090000000xx` family
- `schema.test.ts` — the two parses are independent; the file's other uses of `-1001234567890` are in unrelated describe blocks

## Gates

- `npx vitest run` (5 touched suites): 269 passed
- `bun test telegram-plugin/registry/subagents-bugs.test.ts`: 20 passed, 54 assertions
- `npx tsc --noEmit`: clean
- `bun run lint`: clean

No CHANGELOG entry: docs + tests only, so `check-changelog-entry` correctly reports `no shippable code changed`. `CHANGELOG.md` is untouched by this branch.

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)