### PR TITLE
chore: release v0.21.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep this header present and non-empty; an empty Unreleased at release time is
 now an anomaly worth investigating, not the norm.
 -->
 
+## v0.21.11 — obligation escalations stop nagging over a delivered answer, fleet-health detectors stop laundering silent passes as green, and long messages stop breaking TTS
+
 ### Tooling
 
 - **`lint` now rejects any unsanctioned Telegram `-100…` chat id in the tree.**


### PR DESCRIPTION
CHANGELOG-only release commit for `v0.21.11`, per `skills/switchroom-release/SKILL.md` Step 1.

- Inserts `## v0.21.11 — obligation escalations stop nagging over a delivered answer, fleet-health detectors stop laundering silent passes as green, and long messages stop breaking TTS` immediately below the `## Unreleased` convention comment, which closes the staged entries under the new version and leaves a fresh empty `## Unreleased` for the next cycle.
- `git diff --numstat origin/main...HEAD -- CHANGELOG.md` → `2 0`. Deletions column is 0; no released section was touched.
- No `package.json` / `.claude-plugin/plugin.json` bump. The git tag is the version source of truth (`scripts/build.mjs:resolveVersion()`, `CONTRIBUTING.md`).

[skip changelog]