### PR TITLE
fix(voice): surface TTS chunking degradation counters as response headers

### DIFF
--- a/changelog.d/4716-surface-tts-chunking-degradation-counters-as-res.fix.md
+++ b/changelog.d/4716-surface-tts-chunking-degradation-counters-as-res.fix.md
@@ -1,0 +1,13 @@
+- **voice: the TTS audio-degradation counters now actually reach the `/tts`
+  caller, as `X-Voice-Hard-Cuts` and `X-Voice-Unchunked-Pieces` (#4716).**
+  #4695 said `hardCuts` / `unchunkedPieces` were "counted into the `/tts`
+  response meta" so the condition "stops being invisible", and the code
+  carried a comment saying the same. Neither was true: `_handle_tts` emitted
+  only `X-Voice-Duration-Ms`, `X-Voice-Audio-Seconds` and `X-Voice-Voice`, and
+  dropped the rest of the meta dict — so a mid-word phoneme cut or an
+  unphonemizable piece reached the container's stderr and nowhere else, and
+  only when non-zero. Found by capturing full response headers on live `/tts`
+  probes during v0.21.11 release validation. Both counters are now sent on
+  every 200, including `0`: an absent header means an old sidecar, never a
+  clean request. No caller was reading them yet, so nothing changes for
+  existing clients.

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -66,6 +66,11 @@ HTTP contract
                 then each piece's PHONEME string is chunked to
                 VOICE_TTS_MAX_PHONEMES so Kokoro never hard-slices it,
                 each synthesized on the GPU, and re-joined into a SINGLE file.
+                Response headers: X-Voice-Duration-Ms, X-Voice-Audio-Seconds,
+                X-Voice-Voice, and the #4695 degradation counters
+                X-Voice-Hard-Cuts / X-Voice-Unchunked-Pieces — both ALWAYS
+                sent, "0" on a clean run, so an absent header means an old
+                sidecar rather than a clean request.
               → 4xx/5xx { ok: false, reason, detail }
   GET  /healthz
               → 200 { ok: true, status: "ready", stt: true, tts: true }
@@ -1069,8 +1074,10 @@ def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> t
             "pieces": len(pieces),
             "batches": batches,
             "chars": len(text),
-            # Non-zero => audio quality was degraded on this request. Surfaced
-            # in the response so a caller can act on it, not only in the log.
+            # Non-zero => audio quality was degraded on this request. Emitted
+            # by _handle_tts as the X-Voice-Hard-Cuts /
+            # X-Voice-Unchunked-Pieces response headers (always, including 0)
+            # so a caller can act on it, not only in the log.
             "hardCuts": hard_cuts,
             "unchunkedPieces": unchunked_pieces,
         }
@@ -1359,6 +1366,12 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("X-Voice-Duration-Ms", str(meta["durationMs"]))
         self.send_header("X-Voice-Audio-Seconds", str(meta["audioSeconds"]))
         self.send_header("X-Voice-Voice", meta["voice"])
+        # Degradation counters (#4695). Emitted ALWAYS, including as "0":
+        # only-when-non-zero would make an absent header ambiguous between
+        # "this request was clean" and "this sidecar is too old to report it",
+        # which is exactly the signal a caller needs to act on.
+        self.send_header("X-Voice-Hard-Cuts", str(meta["hardCuts"]))
+        self.send_header("X-Voice-Unchunked-Pieces", str(meta["unchunkedPieces"]))
         self.end_headers()
         self.wfile.write(ogg)
 

--- a/docker/voice-sidecar/test_server.py
+++ b/docker/voice-sidecar/test_server.py
@@ -1,4 +1,6 @@
-"""Unit tests for the voice sidecar's TTS speed clamp (server._clamp_speed).
+"""Unit tests for the voice sidecar's HTTP surface — the /tts speed clamp
+(server._clamp_speed), text splitting, multipart parsing, auth, the wedge
+watchdog, and the /tts response headers.
 
 The sidecar accepts an optional `speed` in the /tts JSON body, clamps it to
 [0.5, 2.0], and defaults to 1.0 when absent/invalid (exactly today's
@@ -11,6 +13,8 @@ Run: python3 -m unittest discover -s docker/voice-sidecar -p 'test_*.py'
 
 from __future__ import annotations
 
+import json
+import re
 import unittest
 
 import server
@@ -268,6 +272,170 @@ class WatchdogTests(unittest.TestCase):
         # A late success does NOT un-wedge — we let the restart happen.
         server._note_success()
         self.assertTrue(server._is_wedged())
+
+
+class _FakeTtsHandler:
+    """Drives server.Handler._handle_tts without opening a real socket, and
+    records the response line, headers and body bytes it emits.
+
+    Same unbound-call pattern as _FakeAuthHandler above: the methods under
+    test are the REAL ones, only the socket boundary is faked. `_authed` is
+    the real implementation so the auth contract still holds."""
+
+    _authed = server.Handler._authed
+
+    class _Headers:
+        def __init__(self, d: dict) -> None:
+            self._d = d
+
+        def get(self, name: str, default: str = "") -> str:
+            return self._d.get(name, default)
+
+    class _Rfile:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def read(self, n: int) -> bytes:
+            return self._body[:n]
+
+    class _Wfile:
+        def __init__(self) -> None:
+            self.written = b""
+
+        def write(self, b: bytes) -> None:
+            self.written += b
+
+    def __init__(self, body: bytes, token: str) -> None:
+        self._headers = {
+            "X-Voice-Token": token,
+            "Content-Length": str(len(body)),
+            "Content-Type": "application/json",
+        }
+        self.rfile = self._Rfile(body)
+        self.wfile = self._Wfile()
+        self.status: int | None = None
+        self.sent_headers: list[tuple[str, str]] = []
+        self.json_sent: tuple[int, dict] | None = None
+
+    @property
+    def headers(self):  # noqa: ANN201
+        return self._Headers(self._headers)
+
+    def send_response(self, status: int) -> None:
+        self.status = status
+
+    def send_header(self, name: str, value) -> None:
+        self.sent_headers.append((name, str(value)))
+
+    def end_headers(self) -> None:
+        pass
+
+    def _send_json(self, status: int, body: dict) -> None:
+        self.status = status
+        self.json_sent = (status, body)
+
+    def header(self, name: str) -> str | None:
+        """Case-insensitive lookup, matching how an HTTP client reads them."""
+        for k, v in self.sent_headers:
+            if k.lower() == name.lower():
+                return v
+        return None
+
+
+class _FakeFuture:
+    def __init__(self, value) -> None:
+        self._value = value
+
+    def result(self, timeout=None):  # noqa: ANN001, ANN201, ARG002
+        return self._value
+
+
+class _FakePool:
+    """Stands in for server._tts_pool — runs nothing, returns a canned
+    (ogg, meta) so the header emission is the only thing under test."""
+
+    def __init__(self, value) -> None:
+        self._value = value
+        self.submitted: list[tuple] = []
+
+    def submit(self, _fn, *args):  # noqa: ANN001, ANN201
+        self.submitted.append(args)
+        return _FakeFuture(self._value)
+
+
+class TtsResponseHeaderTests(unittest.TestCase):
+    """#4695 documented the chunking degradation counters as reaching the
+    caller in the /tts response; they only ever reached the meta dict and
+    stderr. These assert the ACTUAL response headers."""
+
+    META = {
+        "audioSeconds": 2.5,
+        "durationMs": 1234,
+        "voice": "af_heart",
+        "speed": 1.0,
+        "pieces": 3,
+        "batches": 5,
+        "chars": 42,
+        "hardCuts": 0,
+        "unchunkedPieces": 0,
+    }
+
+    def setUp(self) -> None:
+        self._orig_token = server.SHARED_TOKEN
+        self._orig_tts = server._tts
+        self._orig_pool = server._tts_pool
+        server.SHARED_TOKEN = "s3cret"
+        server._tts = object()  # "model ready"
+
+    def tearDown(self) -> None:
+        server.SHARED_TOKEN = self._orig_token
+        server._tts = self._orig_tts
+        server._tts_pool = self._orig_pool
+
+    def _synth(self, meta: dict):
+        body = json.dumps({"text": "hello world"}).encode("utf-8")
+        server._tts_pool = _FakePool((b"OGGBYTES", meta))
+        h = _FakeTtsHandler(body, token="s3cret")
+        server.Handler._handle_tts(h)
+        return h
+
+    def test_clean_run_still_emits_both_counters_as_zero(self) -> None:
+        # Always emitted, not only when non-zero: a caller must be able to
+        # tell "no degradation" from "server too old to report it".
+        h = self._synth(dict(self.META))
+
+        self.assertEqual(h.status, 200)
+        self.assertIsNone(h.json_sent)
+        self.assertEqual(h.wfile.written, b"OGGBYTES")
+        self.assertEqual(h.header("X-Voice-Hard-Cuts"), "0")
+        self.assertEqual(h.header("X-Voice-Unchunked-Pieces"), "0")
+
+    def test_degraded_run_reports_the_counts_to_the_caller(self) -> None:
+        h = self._synth({**self.META, "hardCuts": 3, "unchunkedPieces": 2})
+
+        self.assertEqual(h.status, 200)
+        self.assertEqual(h.header("X-Voice-Hard-Cuts"), "3")
+        self.assertEqual(h.header("X-Voice-Unchunked-Pieces"), "2")
+
+    def test_existing_headers_are_unchanged(self) -> None:
+        h = self._synth(dict(self.META))
+
+        self.assertEqual(h.header("Content-Type"), "audio/ogg")
+        self.assertEqual(h.header("Content-Length"), str(len(b"OGGBYTES")))
+        self.assertEqual(h.header("X-Voice-Duration-Ms"), "1234")
+        self.assertEqual(h.header("X-Voice-Audio-Seconds"), "2.5")
+        self.assertEqual(h.header("X-Voice-Voice"), "af_heart")
+
+    def test_counter_header_names_follow_the_meta_key_convention(self) -> None:
+        # Every X-Voice-* header derives from its camelCase meta key
+        # (durationMs -> X-Voice-Duration-Ms). Pins that for the two counters
+        # so renaming one side without the other fails here rather than
+        # silently shipping a header no caller is reading.
+        h = self._synth(dict(self.META))
+        emitted = {k.lower() for k, _ in h.sent_headers}
+        for key in ("hardCuts", "unchunkedPieces"):
+            header = "x-voice-" + re.sub(r"(?<!^)(?=[A-Z])", "-", key).lower()
+            self.assertIn(header, emitted, msg=f"{key} not surfaced as {header}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The voice sidecar's `/tts` path computes two audio-degradation counters — `hardCuts` (an unbreakable phoneme run split mid-word, leaving an audible seam) and `unchunkedPieces` (a piece neither G2P engine could phonemize, so Kokoro may truncate it) — and puts them in the `meta` dict returned by `_run_synthesis`. Nothing ever sent them to the caller.

This PR emits them as `X-Voice-Hard-Cuts` and `X-Voice-Unchunked-Pieces` on the 200 response, alongside the existing three `X-Voice-*` headers.

## Why

Two places in the tree assert the counters already reach the caller, and both were false:

- `CHANGELOG.md:542` (#4695, v0.21.10): "counted into the `/tts` response meta (`hardCuts`, `unchunkedPieces`)" so the condition "stops being invisible".
- `docker/voice-sidecar/server.py:1072-1073`: *"Surfaced in the response so a caller can act on it, not only in the log."*

`_handle_tts` emitted exactly three headers — `X-Voice-Duration-Ms`, `X-Voice-Audio-Seconds`, `X-Voice-Voice` (`server.py:1359-1361` at `origin/main`) — and discarded the rest of the meta dict with the local variable. The counters reached **stderr only**, via a `WARNING` that fires only when non-zero, so a caller had no way to observe a degraded synth at all.

**How it was found:** live validation of release v0.21.11. Full response headers were captured on three real `/tts` probes against the running sidecar; neither counter appeared on any of them. The source at HEAD confirms why.

No caller in this repo was reading these headers — `telegram-plugin/voice-synthesize-sidecar.ts:246-257` parses only the three that existed, and a tree-wide grep for `hardCuts` / `unchunkedPieces` finds only `server.py`, its own tests, and the changelog line. So this is a documented-contract gap rather than a silently-broken consumer. Wiring the gateway client to read and act on them is deliberately **not** in this PR (single concern); the headers have to exist before a consumer can be written against them.

## Design choice: always emitted, including `0`

Only-when-non-zero would make an absent header ambiguous between "this request was clean" and "this sidecar predates the header", which destroys the signal for exactly the caller the comment says should act on it. So both are always sent, `"0"` on a clean run. Naming follows the existing convention — the camelCase meta key rendered Train-Case (`durationMs` → `X-Voice-Duration-Ms`, so `hardCuts` → `X-Voice-Hard-Cuts`).

Also corrected: the misleading comment at `server.py:1072`, and the module's `HTTP contract` docstring now documents the `/tts` response headers (it previously documented none).

## Test plan

New `TtsResponseHeaderTests` in `docker/voice-sidecar/test_server.py` (4 tests) drives the real `server.Handler._handle_tts` with the socket boundary faked — same unbound-call pattern as the existing `_FakeAuthHandler` — and asserts the **actual emitted response headers**, not the meta dict. `_authed` is the real implementation; only `rfile`/`wfile`/`send_header`/`_tts_pool` are stubbed.

Red on `origin/main` (3 of the 4 fail; the fourth pins that the existing three headers are unchanged, and correctly passes before and after):

```
FAIL: test_clean_run_still_emits_both_counters_as_zero
AssertionError: None != '0'

FAIL: test_degraded_run_reports_the_counts_to_the_caller
AssertionError: None != '3'

FAIL: test_counter_header_names_follow_the_meta_key_convention
AssertionError: 'x-voice-hard-cuts' not found in {'x-voice-voice',
'x-voice-duration-ms', 'content-type', 'x-voice-audio-seconds',
'content-length'} : hardCuts not surfaced as x-voice-hard-cuts

Ran 31 tests in 0.002s
FAILED (failures=3)
```

Green with the fix, full sidecar suite:

```
$ python3 -m unittest discover -s docker/voice-sidecar -p 'test_*.py'
Ran 143 tests in 0.220s
OK (skipped=4)
```

`npm run lint` clean locally (`check-changelog-entry` SKIPs without the `commonmark` devDependency; CI is the authority there).

## Risk

Low. Additive: two response headers on the 200 path, no behavior change to synthesis, no change to the request contract, no existing header touched. `meta["hardCuts"]` uses bracket access to match the three lines above it — `_run_synthesis` is the only producer and always sets both keys, and a `KeyError` here would be the same class of failure the existing three already carry, so this deliberately does not add a `.get()` default that would mask drift.

## Job spec

`reference/jobs/fleet-stays-healthy.md` — "A standing fleet of always-on specialists fails silently." A degraded voice message that only ever whispers to a container's stderr is precisely that failure shape; the counters are the fleet's own health signal for the TTS path, and until now they never left the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
