### PR TITLE
fix(skills): parse the real agent-list JSON shape in status.sh

### DIFF
--- a/changelog.d/4719-parse-the-real-agent-list-json-shape-in-status-s.fix.md
+++ b/changelog.d/4719-parse-the-real-agent-list-json-shape-in-status-s.fix.md
@@ -1,0 +1,1 @@
+- **skills: parse the real agent-list JSON shape in status.sh (#4719)**

--- a/skills/switchroom-status/SKILL.md
+++ b/skills/switchroom-status/SKILL.md
@@ -30,15 +30,15 @@ description: >
 
 # Agent Status
 
-When the user asks about agent status, what's running, uptime, or wants to see agent info, answer by running (or telling them to run) `switchroom agent list` — this is the canonical command for showing running agents, their uptime, and current state.
+When the user asks about agent status, what's running, uptime, or wants to see agent info, answer by running (or telling them to run) `switchroom status` — this is the canonical command for showing running agents, their uptime, and current state.
 
 ## Step 1 — Always mention `switchroom status` in your response
 
-The answer to "what agents are running", "show me agent info", "list all switchroom agents", or any uptime question is the `switchroom status` command (since v0.13.51). Your response MUST include the literal command string `switchroom status` so the user can copy it. If you have Bash tool access, run it and include the output. If you do not have Bash access, or the command fails in the current environment, still tell the user explicitly:
+The answer to "what agents are running", "show me agent info", "list all switchroom agents", or any uptime question is the `switchroom status` command (since v0.13.53). Your response MUST include the literal command string `switchroom status` so the user can copy it. If you have Bash tool access, run it and include the output. If you do not have Bash access, or the command fails in the current environment, still tell the user explicitly:
 
 > Run `switchroom status` from your switchroom project directory to see running agents (uptime + scheduler), known auth accounts, and per-agent MCP connection state.
 
-Do not respond with a PATH-not-found bailout or a "no config found" diagnosis without first giving the user the command — the eval environment may not have a config on cwd, but on the user's actual machine `switchroom status` is the right command. (Pre-v0.13.51 the canonical command was `switchroom agent list` — that still works but only shows the Fleet section.)
+Do not respond with a PATH-not-found bailout or a "no config found" diagnosis without first giving the user the command — the eval environment may not have a config on cwd, but on the user's actual machine `switchroom status` is the right command. (Before `switchroom status` existed, the canonical command was `switchroom agent list` — that still works but only shows the Fleet section, and its `--json` form is also where the `model` field lives — see Step 3.)
 
 ## Step 2 — Try to run it
 
@@ -48,30 +48,29 @@ If you have Bash tool access, run:
 switchroom status --json 2>/dev/null || switchroom status
 ```
 
-`switchroom status` returns three sections: **Fleet** (per-agent uptime + scheduler), **Accounts** (broker-known auth accounts with active marker), and **MCPs** (per-agent MCP connection state). If you want to skip the MCP probe (slower because it does a docker exec per agent), pass `--no-mcp`.
+`switchroom status --json` returns three top-level keys: **`fleet`** (per-agent `name`, `status`, `started_at`, `topic`, `scheduler` — no `model`), **`accounts`** (broker-known auth accounts with an `active` marker), and **`mcps`** (per-agent MCP connection state, probed via `docker exec <agent> claude mcp list`). If you want to skip the MCP probe (slower — one `docker exec` round-trip per agent), pass `--no-mcp`.
 
-If `switchroom status` fails (e.g. command not found, no config in cwd), fall back to `switchroom agent list` (older command, Fleet-only). Still include the `switchroom status` command and the word "uptime" in your text response — the user needs those as actionable information.
+If `switchroom status` fails (e.g. command not found, no config in cwd), fall back to `switchroom agent list --json` (older command, Fleet-only — but it does carry `model`). Still include the `switchroom status` command and the word "uptime" in your text response — the user needs those as actionable information.
 
 ## Step 3 — For each agent, report running state and uptime
 
 When you have real output, for each agent show:
 - **Name** and topic
-- **Status**: running / stopped / error (from the docker-compose container state)
+- **Status**: `active` (running) / `inactive`, `exited`, `dead` (not running) — other docker-container states pass through verbatim (`restarting`, `paused`, `created`). This is the normalized container state, not raw docker-compose text.
 - **Uptime**: how long it's been running (for running agents, always include the word "uptime" and the duration)
-- **Model**: which Claude model it's using
-- **Memory**: Hindsight collection name (if configured)
-- **PID** if available
+- **Model**: which Claude model it's using. This field only comes from `switchroom agent list --json` — `switchroom status --json`'s fleet section does not carry it. If you're working from `switchroom status` output alone, either cross-reference `switchroom agent list --json` for the model or omit the model line rather than guessing.
+
+Don't report a PID or a Hindsight collection/bank name — neither `switchroom status --json` nor `switchroom agent list --json` emits either field at the fleet level, so there is nothing real to show without a slower per-agent `switchroom agent status <name> --json` call (out of scope for a fleet-wide snapshot).
 
 Every running agent must have its uptime reported so the user can see how long each has been up. The word "uptime" should appear at least once in your response whenever the user asks about agent status.
 
 ## Step 4 — Format the output
 
-Format as a clean summary — one section per agent. Use bold agent names, inline code for model/collection names.
+Format as a clean summary — one section per agent. Use bold agent names, inline code for the model name.
 
 ## Step 5 — Highlight anything suspicious
 
-- Agents that are stopped but should be running
-- Agents in error/failed state
+- Agents that are `inactive`/`exited`/`dead` but should be running
 - Agents with very recent restarts (< 5 min uptime — may be crash-looping)
 
 ## Step 6 — One-line summary
@@ -81,16 +80,16 @@ End with a one-line summary: "X of Y agents running."
 ## Example Output Shape
 
 ```
-assistant — running (2h 14m)
-  model: claude-sonnet-5  collection: general
+assistant — active (2h 14m)
+  model: claude-sonnet-5
 
-dev — running (45m)
-  model: claude-opus-5  collection: coding
+dev — active (45m)
+  model: claude-opus-5
 
-coach — stopped
+coach — inactive
   last run: 3 days ago
 
 3 of 3 agents configured, 2 running.
 ```
 
-If the user wants more detail on a specific agent, suggest `switchroom agent logs <name>` (covered by the `switchroom-cli` skill).
+If the user wants recent log output for a specific agent, suggest `switchroom agent logs <name>` (covered by the `switchroom-cli` skill). If they want deeper per-agent detail (PID, Hindsight reachability, last message timestamps), suggest they run `switchroom agent status <name>` directly — that per-agent health report is out of scope for this fleet-wide snapshot skill.

--- a/skills/switchroom-status/scripts/status.sh
+++ b/skills/switchroom-status/scripts/status.sh
@@ -22,18 +22,16 @@ RAW=$(switchroom agent list --json 2>/dev/null) || {
   exit 1
 }
 
-if [ -z "$RAW" ] || [ "$RAW" = "[]" ]; then
+if [ -z "$RAW" ] || [ "$RAW" = '{"agents":[]}' ]; then
   echo "No agents configured."
   exit 0
 fi
 
-TOTAL=$(echo "$RAW" | python3 -c "import sys,json; agents=json.load(sys.stdin); print(len(agents))" 2>/dev/null || echo "?")
-RUNNING=0
-
 echo "$RAW" | python3 -c "
-import sys, json, datetime
+import sys, json
 
-agents = json.load(sys.stdin)
+payload = json.load(sys.stdin)
+agents = payload.get('agents', [])
 running = 0
 
 for a in agents:
@@ -41,11 +39,9 @@ for a in agents:
     status  = a.get('status', 'unknown')
     model   = a.get('model', 'unknown')
     topic   = a.get('topic_name', '')
-    coll    = a.get('memory', {}).get('collection', '')
     uptime  = a.get('uptime', '')
-    pid     = a.get('pid', '')
 
-    status_icon = '✓' if status == 'running' else '✗' if status in ('stopped','failed') else '?'
+    status_icon = '✓' if status == 'active' else '✗' if status in ('inactive', 'exited', 'dead') else '?'
 
     line = f'{status_icon} {name}'
     if topic:
@@ -54,16 +50,11 @@ for a in agents:
     if uptime:
         line += f' ({uptime})'
     print(line)
-    print(f'    model: {model}', end='')
-    if coll:
-        print(f'  collection: {coll}', end='')
-    if pid:
-        print(f'  pid: {pid}', end='')
-    print()
+    print(f'    model: {model}')
     print()
 
-    if status == 'running':
+    if status == 'active':
         running += 1
 
 print(f'{running} of {len(agents)} agents running.')
-" 2>/dev/null || echo "$RAW"
+"

--- a/tests/switchroom-status-script.test.ts
+++ b/tests/switchroom-status-script.test.ts
@@ -1,0 +1,122 @@
+// tests/switchroom-status-script.test.ts
+//
+// Regression coverage for `skills/switchroom-status/scripts/status.sh`.
+// Prior to the fix, the script had three independent bugs that made it
+// always report "0 of N agents running" against a healthy fleet:
+//   1. It parsed `switchroom agent list --json` as a bare array, but the
+//      real CLI emits `{"agents":[...]}` (src/cli/agent.ts:853,896).
+//   2. It read non-existent fields `pid` and `memory.collection` — the
+//      real emitted shape has no such fields (src/cli/agent.ts:881-894).
+//   3. It compared `status` against `'running'`/`'stopped'`/`'failed'`,
+//      but the real lifecycle values are `active`/`inactive`/`exited`/
+//      `restarting`/`paused`/`created`/`dead` (src/agents/lifecycle.ts:543-547).
+//
+// This test feeds a realistic fixture (real `{agents:[...]}` envelope,
+// real field names, real `active`/`exited` status values) through a fake
+// `switchroom` binary on PATH and asserts the script's own running-count
+// summary line is correct — a property the pre-fix script could not
+// satisfy no matter how many agents were "running" in the fixture.
+
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, chmodSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const REPO_ROOT = join(__dirname, "..");
+const SCRIPT_PATH = join(REPO_ROOT, "skills/switchroom-status/scripts/status.sh");
+
+// Realistic `switchroom agent list --json` payload — the actual envelope
+// and field set emitted by src/cli/agent.ts's `opts.json` branch.
+const FIXTURE = {
+  agents: [
+    {
+      name: "assistant",
+      status: "active",
+      uptime: "2h 14m",
+      model: "claude-sonnet-5",
+      thinking_effort: "medium",
+      extends: "default",
+      topic_name: "Assistant",
+      topic_emoji: "🤖",
+      scheduler: { kind: "idle" },
+    },
+    {
+      name: "dev",
+      status: "active",
+      uptime: "45m",
+      model: "claude-opus-5",
+      thinking_effort: "medium",
+      extends: "default",
+      topic_name: "Dev",
+      topic_emoji: "🛠️",
+      scheduler: { kind: "active", tasks: 2 },
+    },
+    {
+      name: "coach",
+      status: "exited",
+      uptime: null,
+      model: "claude-sonnet-5",
+      thinking_effort: "low",
+      extends: "default",
+      topic_name: "Coach",
+      topic_emoji: "🏋️",
+      scheduler: { kind: "idle" },
+    },
+  ],
+};
+
+function runStatusScript(fixture: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "switchroom-status-script-"));
+  try {
+    // A fake `switchroom` binary that behaves exactly like
+    // `switchroom agent list --json` against the fixture above, and errors
+    // on anything else so the script's other codepaths aren't accidentally
+    // exercised.
+    const fakeBinPath = join(dir, "switchroom");
+    writeFileSync(
+      fakeBinPath,
+      `#!/usr/bin/env bash\nif [ "$1" = "agent" ] && [ "$2" = "list" ]; then\n  cat <<'JSON'\n${JSON.stringify(fixture)}\nJSON\n  exit 0\nfi\necho "unexpected invocation: $*" >&2\nexit 1\n`,
+    );
+    chmodSync(fakeBinPath, 0o755);
+
+    return execFileSync("bash", [SCRIPT_PATH], {
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("switchroom-status/scripts/status.sh", () => {
+  it("counts running agents correctly against the real {agents:[...]} envelope", () => {
+    const output = runStatusScript(FIXTURE);
+
+    // Two of the three fixture agents are `active` ("running"); one is
+    // `exited`. The pre-fix script always printed "0 of N agents running."
+    // regardless of fixture contents (envelope/field/enum mismatches all
+    // made `running` count stay at 0 or crash silently to raw JSON dump).
+    expect(output).toContain("2 of 3 agents running.");
+
+    // Sanity: real per-agent fields surface correctly.
+    expect(output).toContain("assistant");
+    expect(output).toContain("dev");
+    expect(output).toContain("coach");
+    expect(output).toContain("model: claude-sonnet-5");
+    expect(output).toContain("model: claude-opus-5");
+  });
+
+  it("reports 0 running when every agent is inactive", () => {
+    const allDown = {
+      agents: FIXTURE.agents.map((a) => ({ ...a, status: "inactive", uptime: null })),
+    };
+    const output = runStatusScript(allDown);
+    expect(output).toContain("0 of 3 agents running.");
+  });
+
+  it("handles an empty fleet without crashing", () => {
+    const output = runStatusScript({ agents: [] });
+    expect(output.trim()).toBe("No agents configured.");
+  });
+});


### PR DESCRIPTION
## Summary
- `skills/switchroom-status/scripts/status.sh` always reported "0 of N agents running" against a healthy fleet: it parsed `switchroom agent list --json` as a bare array (the CLI actually emits `{"agents":[...]}`, `src/cli/agent.ts:853,896`), read non-existent `pid`/`memory.collection` fields, and compared `status` against `running`/`stopped`/`failed` instead of the real lifecycle enum `active`/`inactive`/`exited`/`restarting`/`paused`/`created`/`dead` (`src/agents/lifecycle.ts:543-570`).
- The script's `2>/dev/null || echo "$RAW"` fallback masked the resulting Python traceback and silently rendered raw JSON instead of failing loudly — removed.
- `skills/switchroom-status/SKILL.md` Step 3 asked the agent to report a PID and a Hindsight "collection" name that no fleet-level command (`switchroom status --json`, `switchroom agent list --json`) actually emits — dropped those bullets, and clarified that `model` is only present in `agent list --json`, not in `status --json`'s fleet section. Also corrected a stale "since v0.13.51" version claim to v0.13.53 (verified against `CHANGELOG.md`, where `#1853` "switchroom status CLI" lands under that release).

## Why
Fixing a genuinely broken bundled skill script (per audit) and bringing its accompanying doc back in line with what the CLI actually emits at HEAD.

## Test plan
- Added `tests/switchroom-status-script.test.ts`: drives the real `status.sh` against a realistic `{agents:[...]}` fixture (real field names, `active`/`exited` statuses) through a faked `switchroom` binary on `PATH`, and asserts the running-agent summary line.
- Non-vacuity: reverted `status.sh` to the pre-fix `origin/main` version and re-ran the new test — all 3 cases fail (script dumps raw JSON, never reaches "N of M agents running."). Re-applied the fix — all 3 pass.
- `node_modules/.bin/vitest run tests/switchroom-status-script.test.ts` — green.

## Risk
Low — bundled shell script + skill doc only, no runtime `src/` change.