### PR TITLE
docs(architecture): fix drift in switchroom-architecture skill against HEAD

### DIFF
--- a/skills/switchroom-architecture/SKILL.md
+++ b/skills/switchroom-architecture/SKILL.md
@@ -12,13 +12,15 @@ Switchroom is a multi-agent orchestrator built on Claude Code. It manages multip
 
 **One `switchroom.yaml` to rule them all.** All agents are configured from a single file using a three-layer cascade. See [cascade.md](cascade.md) for full merge semantics.
 
-**Agents as Docker containers.** Each agent runs as a long-lived `claude` process inside its own container (`switchroom-<name>`), supervised by Docker Compose with `restart: unless-stopped` and a healthcheck. The `start.sh` script sets environment variables and execs into `claude`. Claude Code handles session persistence and tool execution.
+**Agents as Docker containers.** Each agent runs as a long-lived `claude` process inside its own container (`switchroom-<name>`), supervised by Docker Compose with `restart: always` (`src/agents/compose.ts`). The agent service itself has NO healthcheck — it `depends_on` `vault-broker` (`service_started`), `approval-kernel` (`service_started`), and `switchroom-auth-broker` (`service_healthy`), so it waits on the auth-broker's healthcheck before booting. Healthchecks exist on `vault-broker`, `approval-kernel`, `switchroom-auth-broker`, and `voice-sidecar` — not on the agent container. The `start.sh` script sets environment variables and execs into `claude`. Claude Code handles session persistence and tool execution.
 
-**Telegram as the primary interface.** The `switchroom-telegram` MCP plugin connects Claude Code to Telegram, providing 10 tools for message handling. See [telegram.md](telegram.md) for details.
+**Telegram as the primary interface.** The `switchroom-telegram` MCP plugin connects Claude Code to Telegram, providing message-handling tools (see [telegram.md](telegram.md) for the current tool list and categories — don't hard-code a count here, it drifts).
 
 **Hindsight for memory.** Cross-session memory uses the Hindsight MCP server — a semantic vector store with knowledge graphs, mental models, and directives. Each agent has its own named collection.
 
-**Skills as reusable behavior.** Shared skills live in `~/.switchroom/skills/` (or `switchroom.skills_dir`). Scaffold symlinks selected skills into each agent's `skills/` directory. Claude Code loads them at session start.
+**Skills as reusable behavior.** Shared skills live in `~/.switchroom/skills/` (or `switchroom.skills_dir`). Scaffold symlinks selected skills into each agent's `.claude/skills/` directory (`src/agents/scaffold.ts`; `migrateLegacySkillsDir` migrates any pre-existing symlinks from the old `<agentDir>/skills/` location). Claude Code loads them at session start.
+
+**Beyond the agent containers.** The agent fleet's compose file (`generateCompose`, `src/agents/compose.ts`) emits the per-agent `switchroom-<name>` services plus three shared services every agent depends on: `vault-broker`, `approval-kernel`, and `switchroom-auth-broker` (agent `depends_on`, `src/agents/compose.ts` around `emitAgentService`'s `depends_on` block). Optionally, per-agent `voice-sidecar` services are emitted too. `hostd` (`src/cli/hostd.ts`) and `web` (`src/cli/webd.ts`) run as their OWN separate compose projects (`switchroom-hostd`, `switchroom-web`) — not part of the agent fleet compose file, and not self-healing on an image-pin bump the way agents are.
 
 ## Directory layout
 
@@ -34,10 +36,12 @@ Switchroom is a multi-agent orchestrator built on Claude Code. It manages multip
         ├── start.sh        # launcher (sets env, execs claude)
         ├── settings.json   # Claude Code settings
         ├── .mcp.json       # MCP server config
-        ├── CLAUDE.md       # agent identity (never overwritten by reconcile)
-        ├── skills/         # symlinks to ~/.switchroom/skills/<name>/
+        ├── CLAUDE.md       # agent identity (reconcile rewrites content ABOVE the
+        │                   # `# --- Yours ---` marker; below it always survives.
+        │                   # `--preserve-claude-md` opts out of the rewrite.)
         ├── .claude/
-        │   └── agents/     # sub-agent definition files
+        │   ├── agents/     # sub-agent definition files
+        │   └── skills/     # symlinks to ~/.switchroom/skills/<name>/
         └── telegram/
             ├── history.db  # SQLite message buffer
             └── access.json # per-agent access control
@@ -52,7 +56,7 @@ Switchroom is a multi-agent orchestrator built on Claude Code. It manages multip
 5. MCP servers connect (Hindsight, switchroom-telegram, others)
 6. Telegram plugin polls for messages
 7. User sends message → plugin fires `UserPromptSubmit` hook → Claude responds
-8. `switchroom agent reconcile <name>` — re-apply switchroom.yaml (no CLAUDE.md touch)
+8. `switchroom agent reconcile <name>` — re-apply switchroom.yaml (rewrites `.mcp.json` + `settings.json` + `start.sh` + CLAUDE.md's managed section above the `# --- Yours ---` marker; pass `--preserve-claude-md` to skip the CLAUDE.md rewrite)
 
 ## Deep dives
 

--- a/skills/switchroom-architecture/cascade.md
+++ b/skills/switchroom-architecture/cascade.md
@@ -16,13 +16,16 @@ The resolved value at any field is determined by the **merge type** for that fie
 
 | Merge type | Fields | Behavior |
 |---|---|---|
-| **Union** | `tools.allow`, `tools.deny`, `skills` | Combine across all layers, dedup |
+| **Union** | `tools.allow`, `tools.deny`, `skills`, `secrets`, `allowed_tools`, `disallowed_tools`, `extra_stable_files` | Combine across all layers, dedup-preserving-order (defaults first) |
 | **Override** | `model`, `extends`, `dangerous_mode`, most scalars | Agent wins entirely |
-| **Per-key merge** | `mcp_servers`, `env`, `subagents` | Agent wins on key conflict, others preserved |
-| **Per-field merge** | `soul`, `memory`, `session`, `channels` | Agent wins per sub-field |
-| **Per-event concat** | `hooks` | Defaults appended first, then agent |
+| **Per-key merge** | `mcp_servers`, `env`, `bundled_skills` | Agent wins on key conflict, others preserved |
+| **Per-key merge with field-level merge on conflict** | `subagents` | Agent wins per key; on a key present at both layers, fields are merged field-by-field (not a whole-definition replacement — that was the pre-#682 bug) |
+| **Per-field merge** | `soul`, `session`, `session_continuity`, `channels`, `reactions`, `reaction_dispatch` | Agent wins per sub-field. `channels` and `reactions`/`reaction_dispatch` sub-arrays (e.g. `trigger_emojis`) use REPLACE semantics, not union. |
+| **One-level-deep merge** | `memory` (`recall`/`retain`/`disposition` sub-objects), `litellm` (scalars + per-key `tags`) | Top-level fields override; the named sub-object merges one level deep instead of replacing wholesale, so overriding one knob doesn't drop its siblings |
+| **Per-event concat** | `hooks` | Defaults appended first, then agent (no dedup — identical entries may be intentional) |
 | **Concatenate** | `schedule`, `system_prompt_append`, `claude_md_raw`, `cli_args` | Defaults prepended |
 | **Deep merge** | `settings_raw` | Recursive object merge, agent wins |
+| **Replace-if-unset** | `release` | Whole-block replace; an agent-declared `release` is NOT field-merged with defaults (deliberate — a pinned agent must not silently inherit a channel/pin from the fleet, or vice versa) |
 
 ## Examples
 
@@ -65,7 +68,7 @@ Prefer TypeScript.
 Never use `any`.
 ```
 
-### subagents per-key merge
+### subagents per-key merge with field-level merge on conflict
 ```yaml
 defaults:
   subagents:
@@ -77,11 +80,16 @@ agents:
   dev:
     subagents:
       worker:
-        description: "Code implementation with tests"  # replaces default worker
-        model: sonnet
-        tools: [Read, Edit, Write, Bash]
+        description: "Code implementation with tests"  # overrides only this field
+        tools: [Read, Edit, Write, Bash]                # added; model still inherited
     # researcher and reviewer inherited from defaults unchanged
 ```
+`worker`'s resolved definition is `{ description: "Code implementation with
+tests", model: sonnet, tools: [Read, Edit, Write, Bash] }` — the agent layer
+merges field-by-field onto the matching default key, it does not replace the
+whole `worker` definition (`src/config/merge.ts`, `subagents: per-key merge,
+with field-level merge on conflict`; whole-def replacement was the pre-#682
+bug this fixed).
 
 ### hooks per-event concat
 ```yaml
@@ -103,10 +111,21 @@ agents:
 Profiles can be defined in two places (inline takes priority):
 
 1. **Inline** in `profiles:` section of switchroom.yaml
-2. **Filesystem** at `profiles/<name>/` — contains `CLAUDE.md.hbs`, `SOUL.md.hbs`, optional `skills/`
+2. **Filesystem** at `profiles/<name>/` — contains `CLAUDE.md.hbs`, plus optional `SOUL.md.hbs` and `skills/`
 
 An agent inherits from at most one profile via `extends: <name>`. Profiles themselves do not chain.
 
 ## Vault references
 
-Secrets in switchroom.yaml use `vault:key-name` syntax. They're resolved at scaffold/reconcile time from `~/.switchroom/vault.enc`. Vault values are written into `start.sh` as environment variables — never stored in plaintext in switchroom.yaml.
+Secrets in switchroom.yaml use `vault:key-name` syntax; `vault:<key>#<filename>`
+additionally inlines one named file's contents as a string from a
+`kind: "files"` vault entry (`src/vault/resolver.ts:194`,
+`resolveSingleReference`). At scaffold/reconcile time these are resolved
+from `~/.switchroom/vault.enc` and written into `start.sh` as environment
+variables — never stored in plaintext in switchroom.yaml.
+
+In production, agent-runtime vault reads do NOT go through that scaffold-time
+decrypt path — they go through the vault-broker daemon over a local socket
+(`resolveVaultReferencesViaBroker`, `src/vault/resolver.ts:288`), which is
+what enforces the per-agent grant/deny model (`VAULT-BROKER-DENIED`,
+`vault_request_access`) documented for agents at runtime.

--- a/skills/switchroom-architecture/sub-agents.md
+++ b/skills/switchroom-architecture/sub-agents.md
@@ -2,9 +2,15 @@
 
 Switchroom generates Claude Code custom sub-agent files (`.claude/agents/<name>.md`) from `switchroom.yaml`. This enables the "Opus plans, Sonnet implements" pattern: the main agent delegates to cheaper models running in the background.
 
-## Default sub-agents
+## Default sub-agents (starter template, not a hard-coded default)
 
-Switchroom ships three default sub-agents that every agent inherits:
+`subagents` is `.optional()` with no schema-level `.default()`
+(`src/config/schema.ts`), and nothing in `src/agents/scaffold.ts` injects a
+worker/researcher/reviewer set — an agent with no `subagents` block anywhere
+in its cascade simply has none. The three-sub-agent pattern below is the
+**starter template** shipped in `examples/switchroom.yaml` (`worker` at
+`:111`, `researcher` at `:137`, `reviewer` at `:149`), not something
+switchroom ships by default:
 
 | Sub-agent | Model | Purpose |
 |-----------|-------|---------|
@@ -12,7 +18,9 @@ Switchroom ships three default sub-agents that every agent inherits:
 | **researcher** | Haiku | Exploration — codebase search, docs, investigation |
 | **reviewer** | Sonnet | Quality review — correctness, completeness, security |
 
-These are defined in `defaults.subagents` and flow through the cascade to every agent.
+If you want this pattern, declare it under `defaults.subagents` (or a
+profile) yourself — copy it from `examples/switchroom.yaml` — and it will
+then flow through the cascade to every agent.
 
 ## How delegation works
 
@@ -30,15 +38,15 @@ Each sub-agent supports the full Claude Code frontmatter spec:
 
 | Field | Description |
 |-------|-------------|
-| `description` | (required) When the main agent should delegate here |
+| `description` | Schema-optional (a partial override, e.g. `isolation` only, need not restate it — the cascade retains the base definition's description on merge) but effectively required for a fresh, non-overriding definition: when the main agent should delegate here |
 | `model` | `sonnet`, `opus`, `haiku`, full model ID, or `inherit` |
 | `background` | Run non-blocking. Default: false |
 | `isolation` | `worktree` — own git branch for file work |
 | `tools` | Tool allowlist (inherits all if omitted) |
 | `disallowedTools` | Tool denylist |
 | `maxTurns` | Auto-stop after N turns |
-| `permissionMode` | `default`, `acceptEdits`, `auto`, `bypassPermissions`, `plan` |
-| `effort` | `low`, `medium`, `high`, `max` |
+| `permissionMode` | `default`, `acceptEdits`, `auto`, `dontAsk`, `bypassPermissions`, `plan` |
+| `effort` | `low`, `medium`, `high`, `xhigh`, `max` |
 | `color` | Display color in task list |
 | `memory` | `user`, `project`, or `local` for persistent learning |
 | `skills` | Skills to preload |
@@ -46,7 +54,7 @@ Each sub-agent supports the full Claude Code frontmatter spec:
 
 ## Cascade behavior
 
-Sub-agents are **per-key merged**. An agent overrides a specific sub-agent by declaring one with the same name:
+Sub-agents are **per-key merged, with field-level merge on conflict** (`src/config/merge.ts`) — see [cascade.md](cascade.md). An agent overrides a specific sub-agent by declaring one with the same name; only the fields it sets are replaced, everything else is inherited from the base definition:
 
 ```yaml
 defaults:
@@ -66,22 +74,15 @@ agents:
       # researcher and reviewer inherited unchanged from defaults
 ```
 
-## Model resolution order (highest wins)
+## Model resolution and Claude Code's built-in sub-agents
 
-1. `CLAUDE_CODE_SUBAGENT_MODEL` env var — switchroom deliberately doesn't set this (it would override ALL sub-agents including Claude Code built-ins)
-2. Per-invocation `model` parameter (user/main-agent override)
-3. Sub-agent file's `model` frontmatter (what switchroom sets)
-4. Main conversation's model
-
-## Coexistence with Claude Code built-ins
-
-| Agent | Model | Origin |
-|-------|-------|--------|
-| Explore | Haiku | Claude Code built-in |
-| Plan | Inherit | Claude Code built-in |
-| general-purpose | Inherit | Claude Code built-in |
-| worker | Sonnet | Switchroom default |
-| researcher | Haiku | Switchroom default |
-| reviewer | Sonnet | Switchroom default |
-
-All sub-agents share the same `.claude/agents/` directory. Switchroom-generated files don't conflict with Claude Code's built-ins.
+How Claude Code itself resolves a sub-agent's model (env var precedence,
+per-invocation overrides) and how switchroom-generated `.claude/agents/*.md`
+files coexist with Claude Code's own built-in sub-agents (e.g. Explore,
+Plan, general-purpose) is upstream Claude Code CLI behaviour — this repo's
+`src/` has no code that reads or sets a `CLAUDE_CODE_SUBAGENT_MODEL` env var,
+so switchroom's own source cannot confirm or deny any specific precedence
+order or built-in roster here. Consult Anthropic's Claude Code documentation
+for the authoritative answer; all switchroom does is render one `.md` file
+per configured sub-agent into `.claude/agents/<name>.md` and let Claude Code
+own everything downstream of that file.

--- a/skills/switchroom-architecture/telegram.md
+++ b/skills/switchroom-architecture/telegram.md
@@ -2,32 +2,45 @@
 
 Switchroom ships an enhanced `switchroom-telegram` MCP plugin that replaces the official marketplace plugin. It is the default — no configuration needed.
 
-## 9 MCP tools
+## MCP tools
 
-| Tool | What it does |
-|------|-------------|
-| `reply` | Send text, photos, or documents — the single final-answer tool. Chunks anything over the 32768-char rich-message cap (4096 applies only to plain-text degradations). Supports threading, topic routing, file attachments. |
-| `react` | Add emoji reactions to messages (Telegram whitelist: 👍 👎 ❤️ 🔥 👀 🎉 etc). |
-| `edit_message` | Update a previously sent message. Edits are silent (no push notification). |
-| `delete_message` | Remove a bot-sent message (48h Telegram API limit). |
-| `forward_message` | Quote/resurface earlier messages with thread support. |
-| `send_typing` | Show typing indicator (5s auto-expire). Use during long operations. |
-| `download_attachment` | Fetch files attached to inbound messages. |
-| `get_recent_messages` | Query SQLite history buffer with pagination and thread filtering. |
+The plugin's tool count changes as features land — don't hard-code a number
+here; `telegram-plugin/bridge/bridge.ts`'s `TOOL_SCHEMAS` array is the source
+of truth. As of this writing it defines 21 tool schemas, grouped by purpose:
+
+| Category | Tools | What it does |
+|----------|-------|-------------|
+| Messaging | `reply`, `edit_message`, `delete_message`, `forward_message`, `progress_update` | `reply` is the single final-answer tool — send text, photos, or documents. Chunks anything over the 32768-char rich-message cap (4096 applies only to plain-text degradations). Supports threading, topic routing, file attachments. `edit_message` updates a previously sent message silently (no push notification). `delete_message` removes a bot-sent message (48h Telegram API limit). `forward_message` quotes/resurfaces earlier messages with thread support. `progress_update` posts a short interim status line mid-turn. |
+| Interactivity | `react`, `send_typing`, `ask_user`, `send_checklist`, `update_checklist`, `send_sticker`, `send_gif` | `react` adds emoji reactions (Telegram whitelist). `send_typing` shows a typing indicator (5s auto-expire). `ask_user` blocks for a structured reply. `send_checklist`/`update_checklist` render and mutate a tappable checklist card. `send_sticker`/`send_gif` send media. |
+| History & attachments | `download_attachment`, `get_recent_messages` | Fetch files attached to inbound messages; query the SQLite history buffer with pagination and thread filtering. |
+| Vault & secrets | `vault_request_save`, `vault_request_access`, `request_secret` | Post approval cards for saving/granting/requesting vault-backed secrets. |
+| Memory | `mental_model_propose` | Post an approval card to create/refresh a Hindsight mental model. |
+| Linear (conditional) | `linear_agent_activity`, `linear_create_issue`, `linear_agent_setup` | Only registered when Linear integration is configured for the agent. |
 
 ## Emoji status lifecycle
 
-The plugin automatically reacts to inbound messages with a lifecycle progression:
+The plugin automatically reacts to inbound messages with a state machine
+(`telegram-plugin/status-reactions.ts`) tracking CURRENT TURN ACTIVITY, not
+delivery state. The real state set: `queued, thinking, coding, web,
+compacting, awaiting, undelivered, error, stallSoft, stallHard`. Working
+states (`thinking`, `tool`, `coding`, `web`, `compacting`) cycle freely and
+bidirectionally within one turn — none is "higher" than another. The only
+terminal state is reached via `finalize()`, triggered by the Stop hook
+(`turn_end`).
+
+A representative progression:
 
 ```
-👀 queued → 🤔 thinking → 👨‍💻 tool use → 🔥 streaming → 👍 done
+👀 queued → 🤔 thinking → 👨‍💻 coding → 👍 done
 ```
 
-Stall watchdogs: `🥱` at 30s idle, `😨` at 90s — so the user always knows the agent is alive.
+Stall watchdogs auto-promote to `🥱` (stallSoft) at 30s idle, `😨` (stallHard)
+at 90s — so the user always knows the agent is alive. `🔥` is reserved for
+genuine 5xx server errors, not for "streaming" — there is no streaming state.
 
 Tool-specific reactions:
-- `👨‍💻` for Bash/Edit/Write
-- `⚡` for web search/fetch
+- `👨‍💻` for Bash/Edit/Write (coding)
+- `⚡` for web search/fetch (web)
 
 ## Message history
 
@@ -54,6 +67,20 @@ conversion and no `parse_mode` on this path. Smart chunking
 bisecting code fences or table rows; bodies that degrade to plain text fall
 back to the legacy 4096-char cap. See
 `reference/telegram-formatting-guide.md` for the full vocabulary.
+
+## Inbound message attributes
+
+Every inbound Telegram message arrives as a `<channel source="telegram" ...>`
+tag whose attributes are built in
+`telegram-plugin/gateway/inbound-router.ts:112-484`. Notable ones:
+
+| Attribute | Meaning |
+|-----------|---------|
+| `reply_to_message_id` | Set when the user long-pressed a prior message and chose Reply — that message is the antecedent for "this"/"that" pronoun references. `reply_to_text`/`reply_to_role`/`reply_to_kind` accompany it. |
+| `message_thread_id` | The forum topic the message came from. |
+| `origin_turn_id` | Pass this back on a reply (instead of `message_thread_id`) so the answer routes to the topic this message came from, even if a message from another topic arrived mid-turn. |
+| `attachment_file_id`, `attachment_kind` | Present when the inbound message has a file attachment; feed `attachment_file_id` to `download_attachment`. |
+| `forwarded_from`, `forwarded_from_type`, `forwarded_from_id`, `forwarded_date` | Server-stamped forward-origin context (Bot API 7.0+ `forward_origin`) — trustworthy provenance, unlike the forwarded body text. A multi-origin burst carries numbered siblings (`forwarded_from_2`, ...). |
 
 ## Access control
 

--- a/skills/telegram-test-harness/SKILL.md
+++ b/skills/telegram-test-harness/SKILL.md
@@ -23,8 +23,12 @@ at `telegram-plugin/tests/`. Use it to lock in the Bot API call
 sequences switchroom emits — what the user actually sees in chat — so
 regressions fail a test instead of going silent in production.
 
-This skill is a quick-reference for that harness. The full guide lives
-at [`telegram-plugin/tests/HARNESS.md`](../../telegram-plugin/tests/HARNESS.md).
+This skill is the reference for that harness — there is no separate
+`HARNESS.md` guide file (it existed briefly, was deleted in the pinned
+progress-card removal (#1126), and was never recreated). Read the fake
+implementations directly for the authoritative contract:
+`telegram-plugin/tests/fake-bot-api.ts`, `update-factory.ts`,
+`bot-api.harness.ts`.
 
 ## When to use this harness
 
@@ -147,8 +151,6 @@ Example pairs:
 
 - `slot-banner.test.ts` (pure decision) +
   `slot-banner-driver.e2e.test.ts` (Bot API dispatch)
-- `auto-fallback.test.ts` (pure plan) +
-  `auto-fallback-dispatcher.e2e.test.ts` (notification dispatch)
 
 ## Test-design checklist
 
@@ -187,7 +189,6 @@ Before writing the test, ask:
 
 ## See also
 
-- `telegram-plugin/tests/HARNESS.md` — full guide
 - `telegram-plugin/tests/fake-bot-api.test.ts` — meta-test of the fake;
   read first when adding new fake-bot capabilities
 - `telegram-plugin/tests/streaming-e2e.test.ts` — worked example of a


### PR DESCRIPTION
## Summary

Re-verified every claim in `skills/switchroom-architecture/{SKILL,cascade,sub-agents,telegram}.md` against `src/`, `telegram-plugin/`, and `examples/switchroom.yaml` at HEAD, and corrected everything that no longer matched. Also fixed two dead file references in `skills/telegram-test-harness/SKILL.md`.

- **telegram.md**: the "9 MCP tools" + 8-row table is stale (`bridge.ts`'s `TOOL_SCHEMAS` defines 21 schemas today, 3 conditionally). Replaced with a category table pointing at `bridge.ts` as the source of truth so it can't drift the same way again. Fixed the emoji lifecycle to the real `status-reactions.ts` state set (no "streaming" state; `🔥` is reserved for genuine 5xx errors). Added a new section documenting inbound `<channel>` attributes (`reply_to_message_id`, `message_thread_id`, `origin_turn_id`, `attachment_file_id`, `forwarded_from`/`_type`/`_id`/`_date`) sourced from `inbound-router.ts:112-484`.
- **cascade.md**: fixed the `subagents` per-key-merge comment/example — it's a field-level merge on key conflict, not whole-definition replacement (that was the pre-#682 bug `merge.ts` itself documents). Documented `memory`'s one-level-deep merge of `recall`/`retain`/`disposition`. Added the merge-type table's missing fields: `secrets`, `bundled_skills`, `litellm`, `session_continuity`, `release` (replace-if-unset), `allowed_tools`/`disallowed_tools`, `extra_stable_files`, `reactions`/`reaction_dispatch`. Documented the `vault:<key>#<filename>` file-inlining syntax and the vault-broker daemon's production resolution path.
- **SKILL.md**: fixed the restart policy (`restart: always`, not `unless-stopped`) and healthcheck claim (the agent container has none; `vault-broker`/`approval-kernel`/`switchroom-auth-broker`/`voice-sidecar` do). Fixed the CLAUDE.md-never-overwritten claim — `reconcile` rewrites the section above the `# --- Yours ---` marker; `--preserve-claude-md` opts out. Fixed the skills symlink target (`.claude/skills/`, not `skills/`; `migrateLegacySkillsDir` moves old links). Added the container topology: `vault-broker`/`approval-kernel`/`switchroom-auth-broker` are agent-fleet compose dependencies, while `hostd`/`web` run as their own separate compose projects.
- **sub-agents.md**: reframed the three-sub-agent table — it's the `examples/switchroom.yaml` starter template, not something switchroom injects by default (`subagents` is schema-optional with no injected default anywhere in `scaffold.ts`). Added the missing `permissionMode` (`dontAsk`) and `effort` (`xhigh`) enum values. **Deleted** the `CLAUDE_CODE_SUBAGENT_MODEL` precedence list and the Claude-Code-built-ins coexistence table per an explicit operator directive mid-task: the only citation for either claim was circular (another switchroom doc asserting the same thing), with zero backing anywhere in `src/`. Replaced with a pointer to upstream Claude Code documentation.
- **telegram-test-harness/SKILL.md**: removed references to `telegram-plugin/tests/HARNESS.md` and `auto-fallback-dispatcher.e2e.test.ts`. Both existed at one point (contra my dispatch brief, which said "neither has ever existed" — git history shows they did) but were deleted in #1126 and #1333 respectively and never recreated; neither exists at HEAD.

Docs-only change (all touched paths are `*.md`) — exempt from the changelog-fragment guard per `changelog.d/README.md`'s `EXEMPT_RE`; verified with `node scripts/check-changelog-entry.mjs` (OK, no shippable code changed).

## Test plan

- [x] Re-verified every specific/falsifiable claim in the four architecture-skill files and the two dead references against HEAD source (cited file:line throughout the diff/commit message)
- [x] `node scripts/check-changelog-entry.mjs` — OK, no shippable code changed
- [x] `node scripts/check-stale-tool-descriptions.mjs` — clean
- [ ] `npm run lint` — blocked on a pre-existing, unrelated environment issue: `tsc --noEmit` fails on `node_modules/.bun/zod@3.25.76/node_modules/zod/v3/types.d.cts:1007` with a duplicate-zod-version type error. **Reproduces identically on a clean `origin/main` checkout with zero changes applied** (verified via `git stash` + `tsc --noEmit`), so it is not caused by this PR — CI's own install should not hit the same partial/corrupted `bun install` state this sandbox did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)