### PR TITLE
fix(ci): run the repo-pinned tsc in check-plugin-references, not `npx tsc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ switchroom-assets.tar.gz
 # while a mutation run is in flight; a leftover one is recovered (and deleted)
 # by the next run.
 .mutation-restore.json
+
+# Per-process temp config written by scripts/check-plugin-references.mjs
+tsconfig.plugin-refcheck.*.json

--- a/scripts/check-plugin-references.mjs
+++ b/scripts/check-plugin-references.mjs
@@ -14,8 +14,10 @@
  * own prose quoted "outboundDedup is not defined" inside ANOTHER reply
  * call (which also threw).
  *
- * This script catches the same class going forward. It runs `tsc
- * --noEmit` against a tsconfig that DOES include the plugin, filters
+ * This script catches the same class going forward. It runs the
+ * REPO-PINNED `tsc --noEmit` (never `npx tsc` — see `resolveTscBin()`
+ * below for why that distinction is load-bearing) against a tsconfig
+ * that DOES include the plugin, filters
  * the output to ONLY the dangerous error codes (undeclared names,
  * cannot-invoke-undefined, typo-suggestions), and exits non-zero if
  * any are found.
@@ -36,13 +38,45 @@
  * Run: `npm run lint:plugin-references` (also part of `npm run lint`).
  */
 
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { writeFileSync, unlinkSync, existsSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { createRequire } from 'node:module'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '..')
+
+/**
+ * Resolve the REPO-PINNED TypeScript compiler.
+ *
+ * This used to be a bare `npx tsc`, and that was a silent-false-pass bug.
+ * `npx` only prefers `./node_modules/.bin/tsc` when it is there; when it
+ * is not (a fresh worktree checked before `bun install`, a symlinked or
+ * partially-installed `node_modules`, a run from a different cwd), npx
+ * goes to the NETWORK and installs whatever package is named `tsc` — which
+ * on the public registry is NOT TypeScript. It is `tsc@2.0.4`,
+ * "A deprecated release of the TypeScript compiler", a squatted stub that
+ * prints a banner and exits. Its output contains no `error TS` lines, so
+ * this script's filter found zero errors and printed
+ * "plugin-references: clean" — a guard that had stopped guarding, reporting
+ * success. (Reproduced on 2026-08-15: with `node_modules/.bin/tsc` moved
+ * aside, this script exited 0 "clean" and left
+ * `~/.npm/_npx/<hash>/package.json` = `{"dependencies":{"tsc":"^2.0.4"}}`.)
+ *
+ * Same hazard class the repo already guards for Playwright in
+ * `scripts/check-no-unpinned-npx-playwright.mjs`: a bare `npx <name>` is an
+ * unpinned network fetch of an arbitrary registry package into a trusted path.
+ *
+ * So: resolve `typescript/bin/tsc` through node resolution from this file and
+ * run it with `process.execPath`. No PATH lookup, no shell, no network. If
+ * TypeScript is not installed we exit NON-ZERO with an actionable message —
+ * a missing compiler must never read as "clean".
+ */
+export function resolveTscBin() {
+  const require = createRequire(import.meta.url)
+  return require.resolve('typescript/bin/tsc')
+}
 
 // Codes that catch the bug class that broke clerk in PR #599.
 // Adding TS6133 (unused declaration) would catch dead variables but
@@ -73,54 +107,74 @@ const tmpConfigBody = {
   ],
 }
 
-writeFileSync(tmpConfig, JSON.stringify(tmpConfigBody, null, 2))
+function main() {
+  let tscBin
+  try {
+    tscBin = resolveTscBin()
+  } catch {
+    console.error(
+      'plugin-references: cannot resolve the repo-pinned TypeScript compiler ' +
+      "(`typescript/bin/tsc`).\n\nRun `bun install` first. This check does NOT " +
+      'fall back to `npx tsc`: the registry package named `tsc` is a deprecated ' +
+      'stub, not TypeScript, and running it would report a false "clean".'
+    )
+    process.exit(1)
+  }
 
-let out = ''
-try {
-  out = execSync(`npx tsc --noEmit -p ${tmpConfig}`, {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
-} catch (err) {
-  out = (err.stdout || '') + (err.stderr || '')
-} finally {
-  if (existsSync(tmpConfig)) unlinkSync(tmpConfig)
+  writeFileSync(tmpConfig, JSON.stringify(tmpConfigBody, null, 2))
+
+  let out = ''
+  try {
+    out = execFileSync(process.execPath, [tscBin, '--noEmit', '-p', tmpConfig], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (err) {
+    out = (err.stdout || '') + (err.stderr || '')
+  } finally {
+    if (existsSync(tmpConfig)) unlinkSync(tmpConfig)
+  }
+
+  const lines = out.split('\n')
+  const allErrors = lines.filter((l) => l.includes('error TS'))
+
+  // As of #623, all 52 pre-existing type-debt errors in plugin source
+  // have been cleaned up. The check now fails on ANY tsc error — not
+  // just the four "dangerous-class" codes that were originally filtered.
+  // If you hit a new error here, fix it (don't broaden the filter
+  // again). DANGEROUS_CODES kept for backwards-compat / diagnostic
+  // labelling.
+  if (allErrors.length > 0) {
+    const dangerous = allErrors.filter((l) =>
+      DANGEROUS_CODES.some((code) => l.includes(`error ${code}`))
+    )
+    if (dangerous.length > 0) {
+      console.error('plugin-references: found dangerous-class type errors:\n')
+      for (const line of dangerous) console.error('  ' + line)
+      console.error(
+        `\nThese errors mean a reference, invocation, or property is wrong — ` +
+        `the kind of bug that ships to production undetected because tsc doesn't ` +
+        `cover telegram-plugin/. See scripts/check-plugin-references.mjs for context.\n`
+      )
+    }
+    const other = allErrors.filter((l) => !dangerous.includes(l))
+    if (other.length > 0) {
+      console.error('plugin-references: tsc errors in plugin source:\n')
+      for (const line of other) console.error('  ' + line)
+      console.error(
+        `\nThe lint check now enforces a fully clean tsc over plugin source ` +
+        `(see #623). Fix the error rather than re-introducing a filter.`
+      )
+    }
+    process.exit(1)
+  }
+
+  console.log('plugin-references: clean (no tsc errors in plugin source — strict since #623).')
+  process.exit(0)
 }
 
-const lines = out.split('\n')
-const allErrors = lines.filter((l) => l.includes('error TS'))
-
-// As of #623, all 52 pre-existing type-debt errors in plugin source
-// have been cleaned up. The check now fails on ANY tsc error — not
-// just the four "dangerous-class" codes that were originally filtered.
-// If you hit a new error here, fix it (don't broaden the filter
-// again). DANGEROUS_CODES kept for backwards-compat / diagnostic
-// labelling.
-if (allErrors.length > 0) {
-  const dangerous = allErrors.filter((l) =>
-    DANGEROUS_CODES.some((code) => l.includes(`error ${code}`))
-  )
-  if (dangerous.length > 0) {
-    console.error('plugin-references: found dangerous-class type errors:\n')
-    for (const line of dangerous) console.error('  ' + line)
-    console.error(
-      `\nThese errors mean a reference, invocation, or property is wrong — ` +
-      `the kind of bug that ships to production undetected because tsc doesn't ` +
-      `cover telegram-plugin/. See scripts/check-plugin-references.mjs for context.\n`
-    )
-  }
-  const other = allErrors.filter((l) => !dangerous.includes(l))
-  if (other.length > 0) {
-    console.error('plugin-references: tsc errors in plugin source:\n')
-    for (const line of other) console.error('  ' + line)
-    console.error(
-      `\nThe lint check now enforces a fully clean tsc over plugin source ` +
-      `(see #623). Fix the error rather than re-introducing a filter.`
-    )
-  }
-  process.exit(1)
+// Only run the check when invoked directly — tests import `resolveTscBin`.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main()
 }
-
-console.log('plugin-references: clean (no tsc errors in plugin source — strict since #623).')
-process.exit(0)

--- a/scripts/check-plugin-references.mjs
+++ b/scripts/check-plugin-references.mjs
@@ -83,7 +83,11 @@ export function resolveTscBin() {
 // flag too much pre-existing debt; leave it off for now.
 const DANGEROUS_CODES = ['TS2304', 'TS2552', 'TS2722', 'TS2561']
 
-const tmpConfig = resolve(repoRoot, 'tsconfig.plugin-refcheck.json')
+// Per-process name: the config has to sit at repoRoot (its `extends` and the
+// `include` globs are repo-relative), but two concurrent runs — `npm run lint`
+// alongside the vitest suite, which drives this script end to end — would
+// otherwise share one path and delete each other's file mid-type-check.
+const tmpConfig = resolve(repoRoot, `tsconfig.plugin-refcheck.${process.pid}.json`)
 const tmpConfigBody = {
   extends: './tsconfig.json',
   // Override include so plugin source is in scope. Tests excluded —

--- a/tests/check-plugin-references.test.ts
+++ b/tests/check-plugin-references.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for `scripts/check-plugin-references.mjs` — specifically the compiler
+ * it runs.
+ *
+ * The bug these pin (2026-08-15): the script invoked a bare `npx tsc`. `npx`
+ * prefers `./node_modules/.bin/tsc` only when that file exists; when it does
+ * not (fresh worktree checked before `bun install`, symlinked/partial
+ * `node_modules`, a run from another cwd) npx goes to the NETWORK and installs
+ * the registry package literally named `tsc` — which is not TypeScript. It is
+ * `tsc@2.0.4`, "A deprecated release of the TypeScript compiler", a stub that
+ * prints a banner and exits. Its output contains no `error TS` lines, so the
+ * script's filter counted zero errors and printed "plugin-references: clean".
+ * The guard silently stopped guarding while reporting success.
+ *
+ * Reproduced before the fix: with `node_modules/.bin/tsc` moved aside, the
+ * script exited 0 "clean" and left
+ * `$npm_config_cache/_npx/<hash>/package.json` = `{"dependencies":{"tsc":"^2.0.4"}}`.
+ *
+ * These assert OUTCOMES, not code shape:
+ *  1. the compiler the guard resolves IS the repo-pinned TypeScript (same
+ *     version as the `typescript` dependency), and
+ *  2. with a hostile `npx` first on `PATH`, the script still passes — proving
+ *     it never consults `npx` at all. Under the old code the shim's output
+ *     would have been parsed as tsc output and failed the run.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { createRequire } from 'node:module'
+// @ts-expect-error — plain .mjs guard, no types; importing the pure helper.
+import { resolveTscBin } from '../scripts/check-plugin-references.mjs'
+
+const REPO = resolve(import.meta.dirname, '..')
+const SCRIPT = resolve(REPO, 'scripts/check-plugin-references.mjs')
+
+function runScript(env: NodeJS.ProcessEnv): {
+  ok: boolean
+  stdout: string
+  stderr: string
+} {
+  try {
+    const stdout = execFileSync('node', [SCRIPT], {
+      cwd: REPO,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env,
+    })
+    return { ok: true, stdout, stderr: '' }
+  } catch (err: unknown) {
+    const e = err as { stdout?: Buffer | string; stderr?: Buffer | string }
+    return {
+      ok: false,
+      stdout: e.stdout?.toString?.() ?? '',
+      stderr: e.stderr?.toString?.() ?? '',
+    }
+  }
+}
+
+describe('resolveTscBin', () => {
+  it('resolves the repo-pinned TypeScript, not a PATH/registry lookup', () => {
+    const bin = resolveTscBin() as string
+    expect(bin).toMatch(/[/\\]typescript[/\\]bin[/\\]tsc$/)
+
+    // The version the guard would actually run must equal the version of the
+    // `typescript` dependency this repo installed. `npx tsc` on a machine
+    // without `node_modules/.bin/tsc` resolves the squatted `tsc@2.0.4`
+    // package instead, which cannot satisfy this.
+    const reported = execFileSync(process.execPath, [bin, '--version'], {
+      encoding: 'utf8',
+    }).trim()
+    const require = createRequire(import.meta.url)
+    const pinned = require('typescript/package.json').version as string
+    expect(reported).toBe(`Version ${pinned}`)
+  })
+})
+
+describe('check-plugin-references.mjs', () => {
+  it(
+    'passes with a hostile `npx` first on PATH (it never shells out to npx)',
+    () => {
+      // Deliberately NOT os.tmpdir(): dev hosts and CI runners mount /tmp
+      // `noexec` (see CLAUDE.md > Tests), and a shim that cannot be exec'd
+      // would make this test vacuous. node_modules/.cache is exec-capable
+      // wherever the repo's own binaries are, and is gitignored.
+      const cacheRoot = join(REPO, 'node_modules', '.cache')
+      mkdirSync(cacheRoot, { recursive: true })
+      const dir = mkdtempSync(join(cacheRoot, 'plugin-refcheck-npx-'))
+      try {
+        // A shim that, if invoked, emits a line the script's filter counts as
+        // a tsc error. Old code (`npx tsc ...`) would have picked this up and
+        // exited 1; the fixed code must never call it.
+        const shim = join(dir, 'npx')
+        writeFileSync(
+          shim,
+          '#!/bin/sh\necho "poisoned.ts(1,1): error TS9999: hostile npx shim ran."\nexit 2\n'
+        )
+        chmodSync(shim, 0o755)
+
+        // Non-vacuity: the shim must really be runnable, otherwise "the
+        // script didn't emit TS9999" would prove nothing.
+        let shimOut = ''
+        try {
+          execFileSync(shim, [], { encoding: 'utf8' })
+        } catch (err) {
+          shimOut = (err as { stdout?: Buffer | string }).stdout?.toString() ?? ''
+        }
+        expect(shimOut).toContain('TS9999')
+
+        const res = runScript({
+          ...process.env,
+          PATH: `${dir}:${process.env.PATH ?? ''}`,
+        })
+
+        expect(res.stdout + res.stderr).not.toContain('TS9999')
+        expect(res.stdout).toContain('plugin-references: clean')
+        expect(res.ok).toBe(true)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    },
+    180_000
+  )
+})


### PR DESCRIPTION
## Summary

`scripts/check-plugin-references.mjs` ran a bare `npx tsc`. It now resolves
`typescript/bin/tsc` through node resolution and runs it with
`process.execPath` — no PATH lookup, no shell, no network. An unresolvable
compiler exits non-zero with an actionable message instead of reading as
"clean".

## Why

`npx` prefers `./node_modules/.bin/tsc` **only when that file exists**. When it
does not — a fresh worktree checked before `bun install`, a symlinked or
partially-installed `node_modules` (a pattern CLAUDE.md § Dev flow explicitly
recommends for worktrees), a run from another cwd — npx goes to the **network**
and installs the registry package literally named `tsc`.

That package is not TypeScript. It is [`tsc@2.0.4`](https://www.npmjs.com/package/tsc),
self-described as *"A deprecated release of the TypeScript compiler"*: a stub
that prints a banner and exits.

Its output carries no `error TS` lines. So the script's filter counted zero
errors and printed:

```
plugin-references: clean (no tsc errors in plugin source — strict since #623).
```

The guard that exists **because** the root `tsconfig.json` does not include
`telegram-plugin/` — the guard added after #599 shipped `outboundDedup is not
defined` to every agent — had silently stopped guarding, while reporting
success. It also meant an arbitrary registry package was being fetched over the
network into a trusted lint path on any machine that took that branch.

Reproduced on 2026-08-15 against `8330d872` (clean clone, `bun install`), by
moving `node_modules/.bin/tsc` aside:

```
$ mv node_modules/.bin/tsc node_modules/.bin/tsc.bak
$ npm_config_cache=/tmp/npxcache node scripts/check-plugin-references.mjs
plugin-references: clean (no tsc errors in plugin source — strict since #623).
EXIT:0
$ cat /tmp/npxcache/_npx/*/package.json
{
  "dependencies": {
    "tsc": "^2.0.4"
  }
}
```

Exit 0, "clean", and the compiler that produced that verdict was a 2016 stub
downloaded mid-run.

This is the same hazard class the repo already guards for Playwright in
`scripts/check-no-unpinned-npx-playwright.mjs`: *a bare `npx <name>` is an
unpinned network fetch of an arbitrary registry package into a trusted path.*
The durable fix there and here is a mechanism, not discipline.

## Test plan

`tests/check-plugin-references.test.ts` — both assertions are outcome-level and
**both fail against the old `npx tsc` invocation** (verified by reverting just
that line and re-running):

1. **The compiler the guard runs is the pinned TypeScript.** `resolveTscBin()`
   is spawned with `--version` and must report the same version as the
   `typescript` dependency in `node_modules`. The squatted `tsc@2.0.4` cannot
   satisfy this.
2. **A hostile `npx` first on `PATH` changes nothing.** A shim that emits
   `poisoned.ts(1,1): error TS9999: …` is placed ahead of the real `npx`; the
   script must still exit 0 "clean" and never surface `TS9999`. The test first
   executes the shim directly and asserts it emits `TS9999`, so a `noexec`
   mount can't make the assertion vacuous — and the shim dir is under
   `node_modules/.cache`, not `/tmp`, for the same reason (CLAUDE.md § Tests).

```
$ ./node_modules/.bin/vitest run tests/check-plugin-references.test.ts
 ✓ tests/check-plugin-references.test.ts (2 tests) 20218ms
 Test Files  1 passed (1)
      Tests  2 passed (2)

# with only the execFileSync line reverted to `execSync(`npx tsc …`)`:
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
   → expect(res.stdout + res.stderr).not.toContain('TS9999')
```

Full `bun run lint` is green on the branch, including `check-plugin-references`
itself and `check-mutation-coverage`.

## Risk

Low, and strictly in the safe direction.

- On a correctly-installed checkout the resolved binary is byte-identical to
  what `npx` was already picking (`node_modules/typescript/bin/tsc`), so the
  normal path's behaviour is unchanged — same compiler, same tsconfig, same
  output parsing.
- The behaviour that changes is the *broken* path: it used to pass silently,
  it now fails loudly with "run `bun install` first". A guard that cannot find
  its compiler must never read as clean.
- `execFileSync` with an argv array replaces a shell-interpolated command
  string, removing the (latent) quoting hazard on `tmpConfig`.
- The check body moved into `main()` behind the repo's standard
  `import.meta.url === pathToFileURL(process.argv[1]).href` entrypoint guard
  (same shape as `check-gateway-line-ratchet.mjs:198`,
  `check-ctx-send-wrapping.mjs:180`) so the test can import the resolver
  without running a 20s type-check on import. Direct `node scripts/…` and the
  `npm run lint` / `lint:plugin-references` wiring are unaffected.
- The new test adds ~20s to the vitest suite: it runs the real guard end to
  end, which is the only way to prove the compiler-selection outcome rather
  than a code shape.

## Job spec

`reference/jobs/fleet-stays-healthy.md` — *"A standing fleet of always-on
specialists fails silently."* A merge gate that reports "clean" while running
a stub compiler is that failure mode inside CI itself: the signal the fleet
relies on to catch `telegram-plugin/` reference bugs was green for a reason
unrelated to the code being correct.

Principle checks: **docs test** — the script's own docblock now states which
compiler it runs and why; **defaults test** — the default (and only) path is
the pinned compiler, with no opt-in required; **consistency test** — matches
the existing unpinned-`npx` guard's stance. No invariant crossed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)