### PR TITLE
fix(worktree-gc): stop swallowing git stderr; handle cross-uid ownership

### DIFF
--- a/changelog.d/4722-gc-safe-directory-and-stderr.fix.md
+++ b/changelog.d/4722-gc-safe-directory-and-stderr.fix.md
@@ -1,0 +1,14 @@
+- **worktree gc: stop swallowing git stderr, and handle cross-uid ownership (#4722)** —
+  GC ran every git probe with stderr discarded, so a git *failure* and a git
+  *negative answer* were the same value. Combined with `fatal: detected dubious
+  ownership` on per-agent trees (owned by each agent's uid, inspected by the
+  operator's), every probe failed and every unreadable tree was silently
+  misfiled as "not a switchroom dir" — a live host reported `Ignored
+  non-switchroom dirs: 67` and classified 2 trees. Git is now invoked with a
+  **scoped** `safe.directory` exception (plus `core.fsmonitor=false` and
+  `core.hooksPath=/dev/null`, without which the ownership bypass would let an
+  agent-writable `.git/config` execute code as the invoking user), and a failed
+  probe is now reported separately as `Unreadable dirs — git probe failed,
+  kept`, never as a negative result. Same host after: 53 trees classified, 12
+  ignored, 4 genuinely-broken dirs surfaced with their real git errors — and
+  nothing newly eligible to be acted on.

--- a/docs/operators/worktree-gc.md
+++ b/docs/operators/worktree-gc.md
@@ -30,6 +30,30 @@ Always protected: the main checkout, bare repos, registry-claimed worktrees
 (`*/work/*`, `.claude/worktrees/*`, `agent/*`/`task/*` branches), and any
 `/tmp`, `/host`, `/state` (container-internal) paths.
 
+## Cross-uid trees and unreadable dirs
+
+Per-agent task trees under `~/.switchroom/agents/*/home/work/` are owned by each
+agent's own uid, not the operator's. A plain `git -C <dir> …` refuses those with
+`fatal: detected dubious ownership`, so GC runs every probe with a **scoped**
+`-c safe.directory=<dir>` (never `safe.directory=*`) plus
+`-c core.fsmonitor=false -c core.hooksPath=/dev/null` — an ownership bypass
+without those two would let an agent-writable `.git/config` execute arbitrary
+code as whoever runs GC. The three flags are inseparable; see `gitArgs()` in
+`src/worktree/gc.ts`.
+
+A git probe that **fails** is not a "no". Such dirs are reported separately:
+
+```
+Unreadable dirs — git probe failed, kept (N):
+```
+
+and are always kept — an unreadable or broken repo can never be classified as
+clean, so it can never be reaped. Only dirs whose probe *succeeded* and answered
+"not a switchroom repo" fall into the bland `Ignored non-switchroom dirs: N`
+count. If that count is implausibly large and the unreadable count is zero,
+you are probably looking at a real classification result; if the unreadable
+count is large, fix the ownership/permissions before trusting the plan.
+
 ## Usage
 
 ```bash

--- a/src/cli/worktree.ts
+++ b/src/cli/worktree.ts
@@ -367,8 +367,20 @@ export function registerWorktreeCommand(program: Command): void {
                 console.log(chalk.dim(`  ${t.verdict.replace("skip-", "")}: ${t.dir} [${t.branch ?? "detached"}] (pr=${t.prSignal})`));
             }
           }
-          if (plan.skipped.length) {
-            console.log(chalk.dim(`\nIgnored non-switchroom dirs: ${plan.skipped.length}`));
+          // A failed git probe is NOT a negative answer — the tree is unreadable
+          // and nothing about it is known. Surfaced separately and loudly, so a
+          // fleet-wide probe failure can never hide inside the bland
+          // "ignored non-switchroom dirs" count again.
+          const probeFailed = plan.skipped.filter((s) => s.kind === "probe-failed");
+          const notOurs = plan.skipped.filter((s) => s.kind !== "probe-failed");
+          if (probeFailed.length) {
+            console.log(
+              chalk.yellow(`\nUnreadable dirs — git probe failed, kept (${probeFailed.length}):`),
+            );
+            for (const s of probeFailed) console.log(chalk.dim(`  ${s.dir}: ${s.reason}`));
+          }
+          if (notOurs.length) {
+            console.log(chalk.dim(`\nIgnored non-switchroom dirs: ${notOurs.length}`));
           }
           console.log(chalk.dim("\nRe-run with --yes to act. Reclaimed trees are MOVED to the trash dir, not deleted."));
           return;

--- a/src/worktree/gc.ts
+++ b/src/worktree/gc.ts
@@ -339,6 +339,23 @@ export interface TaskTreeAction {
   willAct: boolean;
 }
 
+/**
+ * Why a candidate directory was left alone without a verdict.
+ *
+ * `not-ours` is a NEGATIVE RESULT — git answered, and the answer was "this is
+ * not a switchroom checkout". `probe-failed` is an ERROR — git never answered,
+ * so nothing about the directory is known. Both preserve the directory, but
+ * conflating them is what hid the dubious-ownership failure for an entire
+ * release: 67 unreadable trees were reported as "ignored non-switchroom dirs".
+ */
+export type SkipKind = "not-ours" | "probe-failed";
+
+export interface SkippedDir {
+  dir: string;
+  reason: string;
+  kind: SkipKind;
+}
+
 export interface GcPlan {
   roots: string[];
   taskTreeRoots: string[];
@@ -347,7 +364,7 @@ export interface GcPlan {
   registered: RegisteredAction[];
   taskTrees: TaskTreeAction[];
   reposToPrune: string[];
-  skipped: { dir: string; reason: string }[];
+  skipped: SkippedDir[];
 }
 
 export interface GcDeps {
@@ -379,8 +396,92 @@ export interface GcDeps {
   escapeHatch?: boolean;
 }
 
-const defaultExec = (file: string, args: string[], cwd?: string): string =>
-  execFileSync(file, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).toString();
+/**
+ * Build the argv for a git invocation scoped to `dir`.
+ *
+ * Two hardening concerns, both mandatory and both load-bearing:
+ *
+ * 1. **`safe.directory`.** GC runs host-side over `~/.switchroom/agents/<name>/`
+ *    trees owned by each agent's own uid, while the operator (or a root cron)
+ *    invokes it as a DIFFERENT uid. Git then refuses every command with
+ *    `fatal: detected dubious ownership in repository at '<dir>'`. The exception
+ *    is scoped to the exact directory being inspected — never the global `*`
+ *    wildcard — and is passed per-invocation on the command line, so nothing is
+ *    written to any git config file. A linked worktree resolves its ownership
+ *    from the worktree directory, so scoping to `dir` covers both shapes
+ *    (verified against a cross-uid `git worktree add`).
+ * 2. **Config-driven execution.** Bypassing the ownership check means git will
+ *    now read `<dir>/.git/config`, which the agent can write. `core.fsmonitor`
+ *    is a shell command git runs on `status`, so an ownership bypass WITHOUT
+ *    this second half hands any agent arbitrary code execution as the (often
+ *    root) invoking user. `core.fsmonitor=false` and `core.hooksPath=/dev/null`
+ *    neuter both config-driven exec vectors; command-line `-c` beats repo
+ *    config, so the repo cannot override them. Never split these two flags from
+ *    the `safe.directory` exception.
+ */
+export function gitArgs(dir: string, ...rest: string[]): string[] {
+  return [
+    "-c", `safe.directory=${dir}`,
+    "-c", "core.fsmonitor=false",
+    "-c", "core.hooksPath=/dev/null",
+    "-C", dir,
+    ...rest,
+  ];
+}
+
+/**
+ * One-line description of a failed `exec`, preferring the command's stderr.
+ *
+ * Callers use this to record WHY a git probe failed instead of silently folding
+ * the failure into a negative result. Pure, so the formatting is unit-testable.
+ */
+export function describeExecFailure(e: unknown): string {
+  const err = e as { stderr?: unknown; message?: unknown } | null;
+  const raw =
+    typeof err?.stderr === "string"
+      ? err.stderr
+      : err?.stderr && typeof (err.stderr as { toString?: () => string }).toString === "function"
+        ? String(err.stderr)
+        : "";
+  const stderr = raw.trim();
+  if (stderr) return stderr.split("\n")[0]!.trim();
+  const msg = typeof err?.message === "string" ? err.message.trim() : "";
+  return msg || "unknown error";
+}
+
+/**
+ * Run a command and return stdout.
+ *
+ * stderr is CAPTURED, not discarded. The previous `stdio[2] = "ignore"` meant a
+ * git failure (dubious ownership, a broken gitdir pointer, a corrupt repo) was
+ * indistinguishable from a clean negative answer at every call site — every
+ * probe failed silently and every unreadable tree was misfiled as "not a
+ * switchroom dir". Capturing it here is what lets `describeExecFailure` surface
+ * the real cause. It is captured rather than inherited so a sweep over dozens of
+ * trees does not spray git fatals across the operator's terminal.
+ *
+ * `maxBuffer` is raised off Node's 1 MB default because stdout and stderr now
+ * share that budget: `git ls-files -z` over a large checkout (~150 KB here, but
+ * unbounded for a repo that tracks vendored trees) plus a verbose fatal could
+ * blow it, and an ENOBUFS throw is indistinguishable from a real git failure.
+ * It would fail toward preservation, but for the wrong reason.
+ */
+export const execCapture = (file: string, args: string[], cwd?: string): string => {
+  try {
+    return execFileSync(file, args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 64 * 1024 * 1024,
+    }).toString();
+  } catch (e) {
+    const err = e as Error & { stderr?: unknown };
+    const detail = describeExecFailure(err);
+    const wrapped = new Error(`${file} ${args.join(" ")}: ${detail}`) as Error & { stderr?: unknown };
+    wrapped.stderr = err?.stderr;
+    throw wrapped;
+  }
+};
 
 function defaultPrSignal(repo: string, branch: string, exec: GcDeps["exec"]): PrSignal {
   try {
@@ -420,7 +521,7 @@ function defaultNewestTrackedMtimeMs(
 ): number {
   let out: string;
   try {
-    out = exec("git", ["-C", dir, "ls-files", "-z"]);
+    out = exec("git", gitArgs(dir, "ls-files", "-z"));
   } catch {
     return Date.now();
   }
@@ -469,7 +570,7 @@ export function planGc(
   const readDir = deps.readDir ?? ((p: string) => readdirSync(p));
   const readFile = deps.readFile ?? ((p: string) => readFileSync(p, "utf8"));
   const stat = deps.stat ?? ((p: string) => statSync(p));
-  const exec = deps.exec ?? defaultExec;
+  const exec = deps.exec ?? execCapture;
   const prSignal = deps.prSignal ?? ((repo: string, branch: string) => defaultPrSignal(repo, branch, exec));
   const stamp = deps.dateStamp ?? "undated";
   const trash = join(trashRoot(), stamp);
@@ -487,25 +588,28 @@ export function planGc(
     claimed = new Set();
   }
 
-  // Cache: repoRoot → is a validated switchroom repo?
-  const validatedRepo = new Map<string, boolean>();
-  const isSwitchroomRepo = (repoRoot: string): boolean => {
-    if (validatedRepo.has(repoRoot)) return validatedRepo.get(repoRoot)!;
-    let ok = false;
+  // Cache: repoRoot → validated switchroom repo, foreign repo, or unreadable.
+  // `probe-failed` is deliberately NOT cached as "foreign": it is an absence of
+  // information, and it must stay distinguishable downstream.
+  type RepoProbe = { ok: boolean; error: string | null };
+  const validatedRepo = new Map<string, RepoProbe>();
+  const probeSwitchroomRepo = (repoRoot: string): RepoProbe => {
+    const hit = validatedRepo.get(repoRoot);
+    if (hit) return hit;
+    let res: RepoProbe;
     try {
-      if (exists(repoRoot)) {
-        const url = exec("git", ["-C", repoRoot, "remote", "get-url", "origin"]);
-        ok = isSwitchroomRemote(url);
-      }
-    } catch {
-      ok = false;
+      res = exists(repoRoot)
+        ? { ok: isSwitchroomRemote(exec("git", gitArgs(repoRoot, "remote", "get-url", "origin"))), error: null }
+        : { ok: false, error: null };
+    } catch (e) {
+      res = { ok: false, error: describeExecFailure(e) };
     }
-    validatedRepo.set(repoRoot, ok);
-    return ok;
+    validatedRepo.set(repoRoot, res);
+    return res;
   };
 
   const orphans: OrphanAction[] = [];
-  const skipped: { dir: string; reason: string }[] = [];
+  const skipped: SkippedDir[] = [];
   const ownerRepos = new Set<string>(); // validated repos discovered via orphans
 
   // ── Phase A: orphan attribution + quarantine plan ──
@@ -539,8 +643,23 @@ export function planGc(
       if (!ptr) continue;
       const repoRoot = repoRootFromWorktreeGitdir(ptr);
       if (!repoRoot) continue;
-      if (!isSwitchroomRepo(repoRoot)) {
-        skipped.push({ dir, reason: `gitdir points outside a switchroom repo (${repoRoot})` });
+      const probe = probeSwitchroomRepo(repoRoot);
+      if (probe.error) {
+        // git never answered — we know NOTHING about this dir. Keep it, and say
+        // why, loudly enough that the operator can act on the real cause.
+        skipped.push({
+          dir,
+          reason: `owner repo probe failed, kept (${repoRoot}): ${probe.error}`,
+          kind: "probe-failed",
+        });
+        continue;
+      }
+      if (!probe.ok) {
+        skipped.push({
+          dir,
+          reason: `gitdir points outside a switchroom repo (${repoRoot})`,
+          kind: "not-ours",
+        });
         continue;
       }
       ownerRepos.add(repoRoot);
@@ -557,7 +676,7 @@ export function planGc(
   for (const repo of ownerRepos) {
     let porcelain = "";
     try {
-      porcelain = exec("git", ["-C", repo, "worktree", "list", "--porcelain"]);
+      porcelain = exec("git", gitArgs(repo, "worktree", "list", "--porcelain"));
     } catch {
       continue;
     }
@@ -574,7 +693,7 @@ export function planGc(
         sig = prSignal(repo, wt.branch);
         if (sig === "merged") {
           try {
-            const status = exec("git", ["-C", wt.path, "status", "--porcelain"]);
+            const status = exec("git", gitArgs(wt.path, "status", "--porcelain"));
             clean = isEffectivelyClean(status.split("\n"));
           } catch {
             clean = false;
@@ -621,14 +740,22 @@ export function planGc(
 
       // Safety gate: only ever touch a checkout of the canonical switchroom
       // repo. `git -C <dir> remote get-url origin` works for worktree AND clone.
+      // A FAILED probe is not a negative answer. Both keep the tree, but only
+      // the negative answer means "we looked and it isn't ours"; the failure
+      // means the tree is unreadable and needs the operator's attention.
       let remoteOk = false;
+      let remoteError: string | null = null;
       try {
-        remoteOk = isSwitchroomRemote(exec("git", ["-C", dir, "remote", "get-url", "origin"]));
-      } catch {
-        remoteOk = false;
+        remoteOk = isSwitchroomRemote(exec("git", gitArgs(dir, "remote", "get-url", "origin")));
+      } catch (e) {
+        remoteError = describeExecFailure(e);
+      }
+      if (remoteError) {
+        skipped.push({ dir, reason: `git probe failed, kept: ${remoteError}`, kind: "probe-failed" });
+        continue;
       }
       if (!remoteOk) {
-        skipped.push({ dir, reason: "not a switchroom task tree" });
+        skipped.push({ dir, reason: "not a switchroom task tree", kind: "not-ours" });
         continue;
       }
 
@@ -647,7 +774,7 @@ export function planGc(
       let branch: string | null = null;
       let detached = false;
       try {
-        const b = exec("git", ["-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]).trim();
+        const b = exec("git", gitArgs(dir, "rev-parse", "--abbrev-ref", "HEAD")).trim();
         if (b === "HEAD") detached = true;
         else branch = b;
       } catch {
@@ -662,7 +789,7 @@ export function planGc(
       // Effective cleanliness (build noise tolerated; anything else ⇒ dirty).
       let clean = false;
       try {
-        clean = isEffectivelyClean(exec("git", ["-C", dir, "status", "--porcelain"]).split("\n"));
+        clean = isEffectivelyClean(exec("git", gitArgs(dir, "status", "--porcelain")).split("\n"));
       } catch {
         clean = false; // can't inspect ⇒ assume dirty ⇒ keep
       }
@@ -673,14 +800,14 @@ export function planGc(
       if (!detached) {
         try {
           upstream =
-            exec("git", ["-C", dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]).trim() ||
+            exec("git", gitArgs(dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")).trim() ||
             null;
         } catch {
           upstream = null;
         }
         if (upstream) {
           try {
-            aheadCount = parseInt(exec("git", ["-C", dir, "rev-list", "--count", "@{upstream}..HEAD"]).trim(), 10);
+            aheadCount = parseInt(exec("git", gitArgs(dir, "rev-list", "--count", "@{upstream}..HEAD")).trim(), 10);
             if (!Number.isFinite(aheadCount)) aheadCount = -1;
           } catch {
             aheadCount = -1; // count failed ⇒ error ⇒ keep
@@ -774,7 +901,7 @@ export interface ApplyDeps {
 
 /** Execute a plan. Mutates disk/git. Caller gates this behind --yes. */
 export function applyGc(plan: GcPlan, deps: ApplyDeps = {}): GcApplyResult {
-  const exec = deps.exec ?? defaultExec;
+  const exec = deps.exec ?? execCapture;
   const mkdirp = deps.mkdirp ?? ((p: string) => void mkdirSync(p, { recursive: true }));
   // Default move: `mv` handles cross-device (rename would EXDEV); fall back to
   // renameSync only if mv is unavailable.
@@ -826,11 +953,11 @@ export function applyGc(plan: GcPlan, deps: ApplyDeps = {}): GcApplyResult {
         res.removed.push(r.path);
         continue;
       }
-      exec("git", ["-C", r.repo, "worktree", "remove", "--force", r.path]);
+      exec("git", gitArgs(r.repo, "worktree", "remove", "--force", r.path));
       res.removed.push(r.path);
       if (r.branch) {
         try {
-          exec("git", ["-C", r.repo, "branch", "-D", r.branch]);
+          exec("git", gitArgs(r.repo, "branch", "-D", r.branch));
           res.branchesDeleted.push(r.branch);
         } catch {
           /* branch may already be gone; non-fatal */
@@ -843,7 +970,7 @@ export function applyGc(plan: GcPlan, deps: ApplyDeps = {}): GcApplyResult {
 
   for (const repo of plan.reposToPrune) {
     try {
-      exec("git", ["-C", repo, "worktree", "prune"]);
+      exec("git", gitArgs(repo, "worktree", "prune"));
       res.pruned.push(repo);
     } catch (e) {
       res.errors.push(`prune ${repo}: ${(e as Error).message}`);

--- a/tests/worktree.gc.test.ts
+++ b/tests/worktree.gc.test.ts
@@ -25,6 +25,9 @@ import {
   pushStateFrom,
   isStablePerRepoBranch,
   classifyTaskTree,
+  gitArgs,
+  describeExecFailure,
+  execCapture,
   type GcDeps,
   type TaskTreeClassifyInput,
 } from "../src/worktree/gc.js";
@@ -704,6 +707,262 @@ describe("applyGc — quarantine move (real fs)", () => {
     expect(result.quarantined).toEqual([tree]);
     expect(existsSync(tree)).toBe(false);
     expect(result.pruned).toEqual([owner]);
-    expect(execCalls).toContainEqual(["git", "-C", owner, "worktree", "prune"]);
+    // Routed through gitArgs so the prune survives a cross-uid owner repo.
+    expect(execCalls).toContainEqual(["git", ...gitArgs(owner, "worktree", "prune")]);
+    const prune = execCalls.find((c) => c.includes("prune"))!;
+    expect(prune).toContain(`safe.directory=${owner}`);
+  });
+});
+
+// ── git probe hardening: stderr capture + cross-uid ownership (bug fix) ──────
+//
+// Two coupled defects made the shipped GC reclaim NOTHING against real agent
+// homes while reporting only a bland "Ignored non-switchroom dirs: 67":
+//
+//   1. `defaultExec` ran with `stdio: [_, _, "ignore"]`, so git's stderr was
+//      discarded and a FAILED probe was indistinguishable from a clean
+//      "this isn't a switchroom checkout" answer at every call site.
+//   2. Agent task trees are owned by each agent's own uid while GC runs as the
+//      operator/root, so every git command died with `fatal: detected dubious
+//      ownership` — silently, because of (1).
+//
+// These tests assert the OUTCOMES: the real cause reaches the plan, an
+// ownership-gated tree is actually classified, and nothing that was previously
+// preserved becomes reclaimable as a result.
+
+describe("gitArgs — cross-uid ownership + config-exec hardening", () => {
+  it("scopes safe.directory to the exact directory (never the global wildcard)", () => {
+    const args = gitArgs("/agents/a1/home/work/fix-1", "status", "--porcelain");
+    expect(args).toContain("safe.directory=/agents/a1/home/work/fix-1");
+    expect(args).not.toContain("safe.directory=*");
+  });
+
+  it("targets the directory and preserves the trailing git subcommand", () => {
+    const args = gitArgs("/d", "rev-list", "--count", "@{upstream}..HEAD");
+    expect(args[args.indexOf("-C") + 1]).toBe("/d");
+    expect(args.slice(-3)).toEqual(["rev-list", "--count", "@{upstream}..HEAD"]);
+  });
+
+  it("neuters config-driven execution — an ownership bypass without this is root RCE", () => {
+    // `core.fsmonitor` is a shell command git runs on `status`. Bypassing
+    // safe.directory makes git read an AGENT-WRITABLE .git/config, so dropping
+    // either flag hands any agent code execution as the invoking (root) user.
+    const args = gitArgs("/d", "status");
+    expect(args).toContain("core.fsmonitor=false");
+    expect(args).toContain("core.hooksPath=/dev/null");
+    // Command-line -c must precede -C so repo config cannot override it.
+    expect(args.indexOf("core.fsmonitor=false")).toBeLessThan(args.indexOf("-C"));
+  });
+});
+
+describe("describeExecFailure", () => {
+  it("prefers the command's stderr first line", () => {
+    const e = Object.assign(new Error("Command failed"), {
+      stderr: "fatal: detected dubious ownership in repository at '/x'\nhint: add an exception\n",
+    });
+    expect(describeExecFailure(e)).toBe("fatal: detected dubious ownership in repository at '/x'");
+  });
+  it("falls back to the message when stderr is empty", () => {
+    expect(describeExecFailure(Object.assign(new Error("boom"), { stderr: "  " }))).toBe("boom");
+  });
+  it("never returns an empty string", () => {
+    expect(describeExecFailure({})).toBe("unknown error");
+  });
+});
+
+describe("execCapture — git stderr reaches the caller (real git)", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "sw-gc-exec-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("surfaces the real git fatal instead of a generic 'Command failed'", () => {
+    // A real broken linked worktree: `.git` points at an admin dir that is gone
+    // (this is `wt-4702-base` on the live host). git fatals on STDERR; with
+    // `stdio[2] = "ignore"` — the bug — that text never reached the caller and
+    // the directory was misfiled as "not a switchroom dir".
+    const tree = join(tmp, "wt-dead");
+    mkdirSync(tree, { recursive: true });
+    writeFileSync(join(tree, ".git"), `gitdir: ${tmp}/gone/.git/worktrees/wt-dead\n`);
+
+    let caught: unknown;
+    try {
+      execCapture("git", gitArgs(tree, "remote", "get-url", "origin"));
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    // The concrete cause, obtainable ONLY from git's stderr.
+    expect((caught as Error).message).toContain("not a git repository");
+    expect(describeExecFailure(caught)).toContain("not a git repository");
+  });
+
+  it("returns stdout on success", () => {
+    expect(execCapture("git", ["--version"])).toContain("git version");
+  });
+});
+
+describe("planGc — a failed git probe is not a negative answer", () => {
+  const root = "/agents/a1/home/work";
+
+  function depsThatFail(err: unknown): GcDeps {
+    return {
+      dateStamp: "2026-08-15",
+      existsSync: (p: string) => p === root || p === `${root}/wt-dead/.git`,
+      readDir: (p: string) => (p === root ? ["wt-dead"] : []),
+      stat: () => ({ isDirectory: () => false }), // worktree shape
+      readFile: () => "gitdir: /gone/.git/worktrees/wt-dead\n",
+      exec: () => {
+        throw err;
+      },
+    };
+  }
+
+  it("records the git cause as a probe-failed skip, never as 'not a switchroom tree'", () => {
+    const err = Object.assign(new Error("Command failed"), {
+      stderr: `fatal: detected dubious ownership in repository at '${root}/wt-dead'\n`,
+    });
+    const plan = planGc([], depsThatFail(err), [root]);
+
+    const skip = plan.skipped.find((s) => s.dir === `${root}/wt-dead`);
+    expect(skip).toBeDefined();
+    expect(skip!.kind).toBe("probe-failed");
+    expect(skip!.reason).toContain("dubious ownership");
+    // Fail toward preservation: an unreadable tree is never actioned.
+    expect(plan.taskTrees).toHaveLength(0);
+    expect(plan.orphans).toHaveLength(0);
+  });
+
+  it("keeps an unreadable tree even under the operator escape hatch", () => {
+    const err = Object.assign(new Error("Command failed"), {
+      stderr: "fatal: not a git repository: /gone/.git/worktrees/wt-dead\n",
+    });
+    const plan = planGc([], { ...depsThatFail(err), escapeHatch: true }, [root]);
+    expect(plan.taskTrees.filter((t) => t.willAct)).toHaveLength(0);
+    expect(plan.skipped[0]!.kind).toBe("probe-failed");
+  });
+});
+
+describe("planGc — cross-uid task trees are classified, not silently ignored", () => {
+  const NOW = 1_700_000_000_000;
+  const DAY = 86_400_000;
+  const root = "/agents/a1/home/work";
+  const SR = "https://github.com/switchroom/switchroom.git\n";
+
+  interface Spec {
+    status?: string[];
+    branch?: string | null;
+    upstream?: string | null;
+    ahead?: number;
+    mtimeDaysAgo?: number;
+  }
+
+  /**
+   * An exec stub that models git's ACTUAL dubious-ownership behaviour: every
+   * command against a foreign-uid directory fatals unless the invocation
+   * carries `-c safe.directory=<that dir>`. On unfixed code no git call ever
+   * succeeds, so the tree is misfiled as "not a switchroom task tree".
+   */
+  function makeDeps(trees: Record<string, Spec>, escapeHatch = false): GcDeps {
+    const names = Object.keys(trees);
+    const byDir = new Map(names.map((n) => [`${root}/${n}`, trees[n]!]));
+    return {
+      dateStamp: "2026-08-15",
+      idleDays: 14,
+      nowMs: NOW,
+      escapeHatch,
+      existsSync: (p: string) => p === root || byDir.has(p.replace(/\/\.git$/, "")),
+      readDir: (p: string) => {
+        if (p === root) return names;
+        throw new Error("unexpected readDir " + p);
+      },
+      stat: () => ({ isDirectory: () => true }), // clone shape
+      readFile: () => "",
+      probeInUse: () => "free",
+      newestTrackedMtimeMs: (dir: string) => NOW - (byDir.get(dir)?.mtimeDaysAgo ?? 30) * DAY,
+      prSignal: () => "merged",
+      exec: (file: string, args: string[]) => {
+        const dir = args[args.indexOf("-C") + 1]!;
+        const spec = byDir.get(dir);
+        if (!spec) throw new Error("unexpected exec dir " + dir);
+        if (!args.includes(`safe.directory=${dir}`)) {
+          throw Object.assign(new Error("Command failed"), {
+            stderr: `fatal: detected dubious ownership in repository at '${dir}'\n`,
+          });
+        }
+        if (args.includes("remote")) return SR;
+        if (args.includes("status")) return (spec.status ?? []).join("\n");
+        if (args.includes("rev-parse") && !args.includes("@{upstream}")) {
+          return spec.branch === null ? "HEAD\n" : `${spec.branch ?? "feat/x"}\n`;
+        }
+        if (args.includes("rev-parse")) {
+          if (spec.upstream === null) throw new Error("no upstream");
+          return `${spec.upstream ?? "origin/feat/x"}\n`;
+        }
+        if (args.includes("rev-list")) return `${spec.ahead ?? 0}\n`;
+        throw new Error("unexpected exec " + file + " " + args.join(" "));
+      },
+    };
+  }
+
+  const verdictOf = (trees: Record<string, Spec>, name: string, hatch = false) =>
+    planGc([], makeDeps(trees, hatch), [root]).taskTrees.find((t) => t.dir === `${root}/${name}`);
+
+  it("a foreign-uid switchroom tree reaches a real verdict instead of the skipped bucket", () => {
+    const plan = planGc([], makeDeps({ "fix-3019": {} }), [root]);
+    // The bug: this dir landed in `skipped` as "not a switchroom task tree".
+    expect(plan.skipped.map((s) => s.dir)).not.toContain(`${root}/fix-3019`);
+    expect(plan.taskTrees).toHaveLength(1);
+    expect(plan.taskTrees[0]!.verdict).toBe("reap");
+  });
+
+  // Guard the blast radius of the fix: making a tree VISIBLE must not make it
+  // reclaimable. Each of these was preserved before the fix only by accident
+  // (the probe failed); it must now be preserved on purpose (a guard fires).
+  it("a newly-visible DIRTY tree is kept, not reaped", () => {
+    const t = verdictOf({ "fix-a": { status: ["  M src/index.ts"] } }, "fix-a");
+    expect(t?.verdict).toBe("skip-dirty");
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("a newly-visible DETACHED-HEAD tree is kept, not reaped", () => {
+    const t = verdictOf({ "fix-b": { branch: null } }, "fix-b");
+    expect(t?.verdict).toBe("skip-unpushed");
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("a newly-visible tree with commits ahead of upstream is kept, not reaped", () => {
+    const t = verdictOf({ "fix-c": { ahead: 3 } }, "fix-c");
+    expect(t?.verdict).toBe("skip-unpushed");
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("a newly-visible NEVER-PUSHED (no upstream) tree is kept, not reaped", () => {
+    const t = verdictOf({ "fix-d": { upstream: null } }, "fix-d");
+    expect(t?.verdict).toBe("skip-unpushed");
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("a newly-visible RECENTLY-ACTIVE dirty tree is untouched even under the escape hatch", () => {
+    const t = verdictOf({ "fix-e": { status: ["  M x"], mtimeDaysAgo: 1 } }, "fix-e", true);
+    expect(t?.verdict).toBe("skip-dirty");
+    expect(t?.idle).toBe(false);
+    expect(t?.willAct).toBe(false);
+  });
+
+  it("a genuinely foreign repo still reads as a negative answer, not a probe failure", () => {
+    const deps = makeDeps({ "clued-in": {} });
+    const inner = deps.exec!;
+    deps.exec = (file, args, cwd) =>
+      args.includes("remote") && args.includes(`safe.directory=${root}/clued-in`)
+        ? "https://github.com/someone/clued-in.git\n"
+        : inner(file, args, cwd);
+    const plan = planGc([], deps, [root]);
+    const skip = plan.skipped.find((s) => s.dir === `${root}/clued-in`);
+    expect(skip?.kind).toBe("not-ours");
+    expect(plan.taskTrees).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

`switchroom worktree gc` was blind on this host. A live dry-run reported
`Ignored non-switchroom dirs: 67` and classified **2** task trees. It reclaimed
nothing, and — worse — it reported that as a clean result.

Root cause is two bugs that only bite together:

1. **Swallowed stderr.** `defaultExec` ran every git probe with
   `stdio[2] = "ignore"` (`src/worktree/gc.ts:382-383` at `origin/main`). Every
   call site caught the throw and mapped it to `false` / "not ours". A git
   *failure* and a git *negative answer* were the same value.
2. **Cross-uid ownership.** GC inspects `~/.switchroom/agents/<name>/home/work/`
   trees owned by each agent's own uid while running as the operator's uid. Git
   refuses those outright:
   `fatal: detected dubious ownership in repository at '<dir>'`.

So every probe failed, and (1) turned every failure into a confident negative.
The bland "ignored non-switchroom dirs" counter absorbed the entire fleet.

Verified live before touching anything — probing each agent's task trees as a
foreign uid returned rc=128 dubious-ownership for uids 10821/10378/10679/10684,
while same-uid dirs probed fine.

## What changed

- **`execCapture`** (renamed from `defaultExec`) captures stderr and rethrows it
  as the error message. A failed probe is now legible instead of silent.
  `maxBuffer` is raised to 64 MB because stdout and stderr now share the budget,
  and an ENOBUFS throw would be indistinguishable from a real git failure.
- **`gitArgs(dir, ...rest)`** scopes every git invocation with
  `-c safe.directory=<dir>` — the exact directory, never the `*` wildcard, and
  never written to a config file.
- **`-c core.fsmonitor=false -c core.hooksPath=/dev/null`** ship with it, and are
  not optional. Bypassing the ownership check makes git read an agent-writable
  `.git/config`, and `core.fsmonitor` is a shell command git executes on
  `status`. I confirmed the hole was real: with
  `core.fsmonitor = touch /tmp/pwned-fsmonitor; false` in a repo config, a
  `safe.directory` bypass **executed it**; with these two flags it does not.
  An ownership bypass without them is root RCE from any agent. The three flags
  are documented in-code as inseparable.
- **`GcPlan.skipped` gains a `kind` discriminator** — `not-ours` (git answered,
  the answer was no) vs `probe-failed` (git never answered, nothing is known).
  A `probe-failed` result is deliberately **not** cached as "foreign".
- **The CLI surfaces `probe-failed` in its own loud section**
  (`Unreadable dirs — git probe failed, kept (N)`) with the real git error, so a
  fleet-wide probe failure can never hide inside the ignored-dirs count again.
- Operator doc gains a "Cross-uid trees and unreadable dirs" section.

## Why

`fleet-stays-healthy` and `give-each-agent-its-own-workspace`
(`reference/jobs/give-each-agent-its-own-workspace.md`): switchroom creates and
tears down per-agent workspaces "as part of the agent's lifecycle — the user
never thinks about it". The teardown half was silently a no-op for every
per-agent tree on the host, and the tool's own output actively asserted
otherwise. A safety-critical sweep that cannot distinguish "I looked and it's
not mine" from "I couldn't look" is not safe, it is just lucky.

## Before / after — same host, same command

| | before | after |
|---|---|---|
| task trees classified | 2 | **53** |
| `Ignored non-switchroom dirs` | 67 | **12** |
| unreadable dirs surfaced | 0 (hidden) | **4**, with real git errors |
| `willAct` (would be acted on) | `[]` | **`[]`** |

The 4 newly-surfaced unreadable dirs are genuine: 3× klanker trees with
`error: No such remote 'origin'`, and `overlord/home/work/rel2199` with
`fatal: not a git repository: …/.git/worktrees/rel2199` — a broken linked
worktree that GC had been reporting as "not ours".

The 51 newly-visible trees all landed on preserving verdicts:
`{skip-dirty: 21, skip-unpushed: 14, skip-unknown: 13, skip-active: 4,
skip-in-use: 1}`.

## Risk — can this delete data that previously survived?

Asked deliberately, answered path by path.

- **`probe-failed` dirs: no.** They are `continue`d before any verdict is
  computed, so they cannot reach `orphans`, `registered`, or `taskTrees`. Two
  tests assert this, including one that asserts nothing has `willAct` even with
  `escapeHatch: true`.
- **Newly-classifiable trees: nothing became newly auto-reapable.** `willAct` is
  empty on the live host. Automatic reap still requires clean **and** pushed
  **and** idle **and** merged/closed **and** provably-free, in that gauntlet.
  Making a tree *classifiable* is the point of the fix; every one of them was
  classified as "keep".
- **The escape hatch is unchanged and still opt-in.** `--reclaim-dirty` would now
  surface 28 idle dirty/unpushed trees, up from ~0. That is a real widening —
  but it requires an explicit operator flag, and it **quarantines** (moves to
  `~/.switchroom/worktree-gc-trash/<date>/`), recoverable until an explicit
  `--purge-trash --yes`. Nothing in this PR hard-deletes anything.
- **Phase B (`git worktree remove --force`) can now see repos it previously
  couldn't probe.** Removal still requires `gh` reporting the PR `MERGED` *and*
  `isEffectivelyClean`. This is pre-existing behaviour reaching a wider set; it
  produced zero removals on this host. Worth an operator's eyes on the first
  `--yes` run.
- **Error handling still fails toward preservation everywhere.** Every `catch` in
  the classification path resolves to the conservative value (`clean = false`,
  `aheadCount = -1`, mtime = now). None were flipped.

**No destructive sweep was run.** Every number above is from `--json` dry-runs.

## Test plan

`tests/worktree.gc.test.ts` — 76 pass. The new coverage, and the proof it is
real coverage rather than code-path decoration:

- **Reverting only the three bug halves** (stderr `pipe`→`ignore`, `gitArgs` →
  bare `["-C", dir, …]`, and re-conflating `remoteError || !remoteOk` into one
  branch) → **12 tests fail**.
- **Deleting `classifyTaskTree`'s `skip-dirty` / `skip-unpushed` guards** →
  **13 tests fail**.

New blocks:
- `gitArgs` — asserts the exception is scoped to the dir and **not** `*`, and
  that `core.fsmonitor=false` + `core.hooksPath=/dev/null` are present with `-c`
  ordered before `-C`.
- `execCapture` against **real git**: builds a broken linked worktree on disk and
  asserts the thrown message actually contains `not a git repository`. This is
  the test that fails against the old swallowed-stderr behaviour.
- `planGc` with an injected exec that throws a `dubious ownership` stderr —
  asserts `kind === "probe-failed"`, that the reason carries the real error, and
  that `taskTrees` / `orphans` stay empty.
- `planGc` with an exec stub modelling git's real behaviour (fatal unless the
  argv carries `safe.directory=<dir>`) — asserts a foreign-uid switchroom tree
  reaches `verdict === "reap"`, then walks the blast radius: dirty →
  `skip-dirty`, detached HEAD → `skip-unpushed`, ahead-of-upstream →
  `skip-unpushed`, no upstream → `skip-unpushed`, recently-active dirty under the
  escape hatch → `willAct` false.

Also green: `npm run lint` (all 32 guards, incl. `check-changelog-entry`,
`check-mutation-coverage`), `tsc --noEmit`, and the adjacent suites
`worktree.reaper` / `worktree.registry` / `worktree.schema` /
`worktree.claim-isolation` (39 pass).

## Deliberately out of scope

RFC `agent-home-lifecycle.md` §1–§3 as dispatched, and §4 — **§4 is already
implemented at `origin/main`** (`classifyTaskTree`, `defaultTaskTreeRoots`,
Phase C, the escape hatch, quarantine-not-`rm`). The dispatch asked me to build
it; the source says it exists. It was invisible only because of the bug this PR
fixes. Reporting the contradiction rather than re-implementing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
