### PR TITLE
feat(compose): relocate agent build caches onto a bulk scratch volume

### DIFF
--- a/changelog.d/4723-scratch-volume.feat.md
+++ b/changelog.d/4723-scratch-volume.feat.md
@@ -1,0 +1,25 @@
+- **agent caches move off the root disk onto a bulk scratch volume (#4723)** —
+  Every agent's package caches lived under its HOME on the operator's root
+  disk (`~/.cache/uv`, `~/.npm`, `~/.bun/install/cache`, `~/.cache/puppeteer`,
+  `~/.cache/ms-playwright`, `~/.local/lib`). On the reference fleet that
+  reached ~20 GiB and pushed the root filesystem to 85% full; a manual sweep
+  reclaimed 32 GiB and the caches regrew within hours. Every agent now gets a
+  per-agent directory on the host's bulk device bind-mounted read-write at
+  `/scratch`, plus the env redirects that make the package managers actually
+  write there (`XDG_CACHE_HOME`, `TMPDIR`, `npm_config_cache`,
+  `BUN_INSTALL_CACHE_DIR`, `PYTHONUSERBASE`, `PLAYWRIGHT_BROWSERS_PATH`,
+  `PUPPETEER_CACHE_DIR`, and `SWITCHROOM_AGENT_SCRATCH` as the discovery
+  contract). The last two are not covered by `XDG_CACHE_HOME` — playwright's
+  path is baked into `Dockerfile.agent` at a HOME location and puppeteer reads
+  `os.homedir()` directly, so an umbrella redirect alone would have left both
+  on the root disk. Configure with `scratch: {enabled, volume, subdir}`;
+  `volume` defaults to `/mnt/bulkdata` and must already exist, so a
+  single-disk machine gets a hard no-op with byte-identical compose output.
+  The mount is **framework-injected** for every agent rather than routed
+  through `bind_mounts:` — that key is an admin-only escalation (#1164) and
+  the biggest cache consumers on a real fleet are ordinary non-admin agents.
+  Directories are pre-created and chowned to each agent's deterministic
+  container uid at apply time, so the read-only-rootfs non-root container can
+  actually write to them. One behaviour change: `PYTHONUSERBASE` moves
+  python's user-site, so packages installed with `pip install` before the
+  cutover need reinstalling once.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1202,6 +1202,54 @@ Host prerequisites:
 - Python venvs need `python3-venv` (on Debian/Ubuntu: `apt install python3.12-venv`). `switchroom health` reports missing deps.
 - Node envs use `bun` by default. `npm` is available as an alternate installer.
 
+## Scratch volume — keeping caches off the root disk
+
+Every agent's HOME lives on the operator's root disk, and every package
+manager an agent reaches for caches under it: `~/.cache/uv`, `~/.npm`,
+`~/.bun/install/cache`, `~/.cache/puppeteer`, `~/.cache/ms-playwright`, and
+pip's user-site tree. On a working fleet that is tens of gigabytes, and
+sweeping it by hand does not hold — the caches regrow within hours.
+
+If the host has a second, larger device, point the fleet at it:
+
+```yaml
+scratch:
+  enabled: true                # default
+  volume: /mnt/bulkdata        # default. Must already exist.
+  subdir: switchroom/scratch   # default
+```
+
+Each agent gets `<volume>/<subdir>/<agent>` bind-mounted read-write at
+`/scratch` inside its container, created and owned by that agent's container
+uid at `switchroom apply` time, and these environment redirects so the caches
+actually land there:
+
+| Variable | Value | Why it needs its own redirect |
+|---|---|---|
+| `SWITCHROOM_AGENT_SCRATCH` | `/scratch` | How an agent or skill discovers it has scratch space |
+| `XDG_CACHE_HOME` | `/scratch/cache` | uv, pip's HTTP cache, and most XDG-aware tooling |
+| `TMPDIR` | `/scratch/tmp` | Large unpacks; `/tmp` is a RAM-backed tmpfs with a size ceiling |
+| `npm_config_cache` | `/scratch/cache/npm` | npm ignores XDG (`~/.npm`) |
+| `BUN_INSTALL_CACHE_DIR` | `/scratch/cache/bun` | bun ignores XDG |
+| `PYTHONUSERBASE` | `/scratch/python` | The tree `PIP_USER=1` installs into |
+| `PLAYWRIGHT_BROWSERS_PATH` | `/scratch/cache/ms-playwright` | Overrides the image's baked HOME path |
+| `PUPPETEER_CACHE_DIR` | `/scratch/cache/puppeteer` | puppeteer resolves `~/.cache` directly, ignoring XDG |
+
+This is applied to **every** agent by the framework, admin or not — it is not
+routed through the admin-only `bind_mounts:` escalation, because the agents
+that fill a disk with build caches are ordinary non-admin ones. Each agent
+sees only its own directory, never a sibling's and never the shared parent.
+
+**No second disk? Do nothing.** When `volume` does not exist the feature is a
+hard no-op: no mount, no env redirects, byte-identical compose output. A
+`scratch:` block naming a path that is not there warns on `apply` rather than
+silently pretending.
+
+**One-time cost when you turn it on:** `PYTHONUSERBASE` moves python's
+user-site, so packages an agent installed with `pip install` before the
+cutover are no longer importable and need reinstalling once. Package caches
+and browser downloads just re-populate on next use.
+
 ## Multi-Account OAuth (auth-broker)
 
 Authentication is **account-scoped and fleet-wide**, not per-agent. One

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -93,8 +93,8 @@ import { AGENT_UID_MIN, AGENT_UID_MAX, allocateAgentUid } from "./agent-uid.js";
 import { GRANTS_DB_DIRNAME, GRANTS_DB_CONTAINER_DIR } from "../vault/grants-db-path.js";
 import {
   SCRATCH_CONTAINER_DIR,
-  SCRATCH_SUBDIRS,
   agentScratchHostDir,
+  ensureAgentScratchDir,
   resolveScratchConfig,
   scratchEnv,
   scratchVolumeAvailable,
@@ -2856,16 +2856,15 @@ function emitAgentService(
     // root:root — that is the EACCES trap this feature would otherwise walk
     // straight into, because the container runs as a per-agent non-root uid.
     // Same best-effort shape as the audit / schedule.d pre-creates below.
-    // Authoritative creation + the chown to the agent uid happen at apply
-    // time (`ensureHostMountSources` in src/cli/apply.ts); this is only the
-    // guard for a compose write that didn't come through apply.
+    // Apply does this authoritatively ahead of the compose write
+    // (`ensureHostMountSources` in src/cli/apply.ts); this is the guard for a
+    // compose write that did NOT come through apply — e.g. the `agent
+    // restart` reconcile path, which shares writeComposeFile. It calls the
+    // SAME helper rather than a bare mkdir so that path can't leave a
+    // root-owned bind source behind (apply self-elevates to root, and a
+    // root:root scratch dir EACCESes every cache write from the agent uid).
     if (precreateHostDirs) {
-      try {
-        mkdirSync(scratchHostDir, { recursive: true });
-        for (const sub of SCRATCH_SUBDIRS) {
-          mkdirSync(`${scratchHostDir}/${sub}`, { recursive: true });
-        }
-      } catch { /* best-effort */ }
+      ensureAgentScratchDir(scratchHostDir, a.name);
     }
     lines.push(`      - ${scratchHostDir}:${SCRATCH_CONTAINER_DIR}:rw`);
   }

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -91,6 +91,14 @@ import { loadHostCapabilities } from "../setup/host-capabilities.js";
 import type { VoiceEngine } from "../setup/gpu-detect.js";
 import { AGENT_UID_MIN, AGENT_UID_MAX, allocateAgentUid } from "./agent-uid.js";
 import { GRANTS_DB_DIRNAME, GRANTS_DB_CONTAINER_DIR } from "../vault/grants-db-path.js";
+import {
+  SCRATCH_CONTAINER_DIR,
+  SCRATCH_SUBDIRS,
+  agentScratchHostDir,
+  resolveScratchConfig,
+  scratchEnv,
+  scratchVolumeAvailable,
+} from "./scratch.js";
 
 // UID derivation lives in agent-uid.ts (a leaf module) so scaffold.ts can
 // import it without a compose ↔ scaffold cycle (compose.ts imports
@@ -2040,6 +2048,24 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // hermetic regardless of the host's active docker context (#3648).
   const dockerSocketPath = opts.dockerSocketPath ?? DEFAULT_DOCKER_SOCKET_PATH;
 
+  // Per-agent scratch volume (see ./scratch.ts). Resolved ONCE per generate:
+  // the availability probe is a filesystem stat and must not vary between
+  // agents inside one compose file. When the operator wrote an explicit
+  // `scratch:` block but the volume isn't there, warn — silently degrading a
+  // configured knob is how a fleet ends up back at 85% full without anyone
+  // noticing. When the block is absent (the single-disk default), stay quiet.
+  const scratchCfg = resolveScratchConfig(config);
+  if (
+    scratchCfg.explicit &&
+    scratchCfg.enabled &&
+    !scratchVolumeAvailable(scratchCfg.volume)
+  ) {
+    warn(
+      `compose: scratch.volume "${scratchCfg.volume}" does not exist on this host — ` +
+      `agent caches stay on the root disk (scratch mount and cache env redirects omitted)`,
+    );
+  }
+
   // ── per-agent services ─────────────────────────────────────────────
   for (const a of describeAgents(config, opts.litellmConfirmedAgents)) {
     if (a.strippedCaps.length > 0) {
@@ -2068,6 +2094,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
       voiceEngine,
       precreateHostDirs,
       dockerSocketPath,
+      agentScratchHostDir(scratchCfg, a.name),
     );
   }
 
@@ -2174,6 +2201,13 @@ function emitAgentService(
   voiceEngine: VoiceEngine,
   precreateHostDirs: boolean,
   dockerSocketPath: string,
+  /**
+   * Host-side per-agent scratch directory, or null when the feature is off
+   * (disabled in config, or the bulk volume isn't mounted on this host).
+   * Resolved once per generate by the caller so the availability probe can't
+   * differ between agents in one file. See ./scratch.ts.
+   */
+  scratchHostDir: string | null,
 ): void {
   lines.push(`  agent-${a.name}:`);
   emitImageOrBuild(lines, "agent", imageTag, buildMode, buildContext);
@@ -2634,6 +2668,21 @@ function emitAgentService(
       env.BUZZ_PUBKEY_NAMES = petnames.map(([k, v]) => `${k}=${v}`).join(",");
     }
   }
+  // Scratch-volume cache redirects. Emitted ONLY when the scratch mount is
+  // emitted (below) — the two are one unit: env pointing at a `/scratch` that
+  // isn't mounted would break every install in the container, and a mount with
+  // no env redirects would be a silently useless empty directory.
+  //
+  // Placed BEFORE the userEnv merge (which only fills `undefined` keys), so
+  // these are authoritative the same way HOME / NPM_CONFIG_PREFIX /
+  // SWITCHROOM_* are. An operator who wants the old layout opts out with
+  // `scratch.enabled: false` rather than by shadowing individual keys — a
+  // half-redirected cache set is worse than either end state.
+  if (scratchHostDir !== null) {
+    for (const [k, v] of Object.entries(scratchEnv(SCRATCH_CONTAINER_DIR))) {
+      env[k] = v;
+    }
+  }
   // Merge operator-declared env vars from the agent's `env:` block.
   // System-managed keys (HOME, NPM_*, SWITCHROOM_*) win on collision —
   // an operator can't override the runtime contract from yaml. A
@@ -2779,6 +2828,46 @@ function emitAgentService(
     lines.push(
       `      - ${homePrefix}/.switchroom/hostd/${a.name}:/run/switchroom/hostd/${a.name}`,
     );
+  }
+  // Per-agent scratch volume — the fleet's build/package caches, moved off
+  // the root disk onto the operator's bulk device (see ./scratch.ts for the
+  // measurements and the full rationale).
+  //
+  // FRAMEWORK-INJECTED, exactly like the root-tier mount set above and the
+  // shared `skills/` mount below, and deliberately NOT routed through the
+  // operator-facing `bind_mounts:` denylist immediately below this block.
+  // That denylist is an ADMIN-ONLY escalation: `bind_mounts` throws for any
+  // agent without `admin: true`. The agents that fill a root disk with npm
+  // and uv caches are ordinary non-admin agents, so routing this through
+  // `bind_mounts:` would break the fleet for exactly the agents the change
+  // exists to fix. Neither source nor target comes from operator yaml here —
+  // the framework picks both (`<volume>/<subdir>/<agent>` → `/scratch`), and
+  // each agent sees only its OWN directory, never the shared parent.
+  //
+  // `:rw` by necessity (the whole point is that package managers write here)
+  // and exempt from the `read_only: true` root fs the same way every other
+  // bind mount is — the daemon applies it before the entrypoint runs.
+  //
+  // Null when the feature is off, which is the entire degradation story: a
+  // single-disk dev machine emits no mount, no env, and byte-identical
+  // output to before this landed.
+  if (scratchHostDir !== null) {
+    // Pre-create host-side so docker doesn't auto-create the bind source as
+    // root:root — that is the EACCES trap this feature would otherwise walk
+    // straight into, because the container runs as a per-agent non-root uid.
+    // Same best-effort shape as the audit / schedule.d pre-creates below.
+    // Authoritative creation + the chown to the agent uid happen at apply
+    // time (`ensureHostMountSources` in src/cli/apply.ts); this is only the
+    // guard for a compose write that didn't come through apply.
+    if (precreateHostDirs) {
+      try {
+        mkdirSync(scratchHostDir, { recursive: true });
+        for (const sub of SCRATCH_SUBDIRS) {
+          mkdirSync(`${scratchHostDir}/${sub}`, { recursive: true });
+        }
+      } catch { /* best-effort */ }
+    }
+    lines.push(`      - ${scratchHostDir}:${SCRATCH_CONTAINER_DIR}:rw`);
   }
   // Operator-declared extra bind-mounts (#1164). ADMIN-ONLY: emitting
   // anything for a non-admin agent is a hard error — bind_mounts is the

--- a/src/agents/scratch.test.ts
+++ b/src/agents/scratch.test.ts
@@ -28,6 +28,7 @@ import {
   SCRATCH_CONTAINER_DIR,
   SCRATCH_SUBDIRS,
   agentScratchHostDir,
+  ensureAgentScratchDir,
   ensureAgentScratchDirs,
   resolveScratchConfig,
   scratchEnv,
@@ -258,6 +259,49 @@ describe("scratch volume — host directory creation and ownership", () => {
     const tmpTarget = join(volume, DEFAULT_SCRATCH_SUBDIR, "carrie", "tmp");
     expect(existsSync(tmpTarget)).toBe(true);
     expect(scratchEnv().TMPDIR).toBe(`${SCRATCH_CONTAINER_DIR}/tmp`);
+  });
+
+  it("the single-agent form (used by the compose pre-create) chowns too — no path may create the bind source root-owned", () => {
+    const chowns: Array<[string, number, number]> = [];
+    const dir = join(volume, DEFAULT_SCRATCH_SUBDIR, "carrie");
+
+    expect(
+      ensureAgentScratchDir(dir, "carrie", (p, uid, gid) => chowns.push([p, uid, gid])),
+    ).toBe(true);
+
+    const uid = allocateAgentUid("carrie");
+    expect(chowns).toContainEqual([dir, uid, uid]);
+    for (const sub of SCRATCH_SUBDIRS) {
+      expect(existsSync(join(dir, sub))).toBe(true);
+      expect(chowns).toContainEqual([join(dir, sub), uid, uid]);
+    }
+  });
+
+  it("a compose write outside apply (precreateHostDirs) still lands the tree, not a bare mount line", () => {
+    // The `agent restart` reconcile path writes compose without going through
+    // ensureHostMountSources. If it emitted the mount without creating the
+    // source, docker would auto-create it root-owned and every cache write
+    // from the agent uid would EACCES.
+    // Point homeDir at a throwaway too: precreateHostDirs also mkdirs the
+    // operator-home mount sources, and a test must not touch a real /home.
+    const fakeHome = mkdtempSync(join(tmpdir(), "switchroom-scratch-home-"));
+    let yaml: string;
+    try {
+      yaml = generateCompose({
+        config: baseConfig({ volume }),
+        homeDir: fakeHome,
+        precreateHostDirs: true,
+        warn: () => {},
+      });
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+    const dir = join(volume, DEFAULT_SCRATCH_SUBDIR, "carrie");
+    expect(yaml).toContain(`- ${dir}:${SCRATCH_CONTAINER_DIR}:rw`);
+    expect(existsSync(dir)).toBe(true);
+    for (const sub of SCRATCH_SUBDIRS) {
+      expect(existsSync(join(dir, sub))).toBe(true);
+    }
   });
 
   it("creates nothing when there is no bulk volume", () => {

--- a/src/agents/scratch.test.ts
+++ b/src/agents/scratch.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Outcome tests for the per-agent scratch volume.
+ *
+ * Every assertion here is anchored on an observable outcome — a line in the
+ * generated compose file, an env value, a directory on disk, a chown call —
+ * rather than on a code path. Specifically:
+ *
+ *   - drop the mount line and the "non-admin agent gets it" and per-agent
+ *     isolation tests fail;
+ *   - drop or rename ONE env redirect and the redirect table test fails,
+ *     naming the variable;
+ *   - make the feature fire on a host with no bulk volume and the
+ *     degradation tests fail;
+ *   - drop the chown and the ownership test fails (via the injected seam, so
+ *     it fails on an unprivileged CI runner too);
+ *   - re-route this through `bind_mounts:` and the non-admin tests throw,
+ *     because that key is an admin-only escalation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateCompose } from "./compose.js";
+import { allocateAgentUid } from "./agent-uid.js";
+import {
+  DEFAULT_SCRATCH_SUBDIR,
+  SCRATCH_CONTAINER_DIR,
+  SCRATCH_SUBDIRS,
+  agentScratchHostDir,
+  ensureAgentScratchDirs,
+  resolveScratchConfig,
+  scratchEnv,
+} from "./scratch.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+/** Absolute path that cannot exist — the "single-disk dev machine" host. */
+const NO_SUCH_VOLUME = "/nonexistent-switchroom-bulk-volume";
+
+let volume: string;
+
+beforeEach(() => {
+  volume = mkdtempSync(join(tmpdir(), "switchroom-scratch-test-"));
+});
+
+afterEach(() => {
+  rmSync(volume, { recursive: true, force: true });
+});
+
+function baseConfig(scratch?: Record<string, unknown>): SwitchroomConfig {
+  return {
+    agents: {
+      // NOT admin, NOT root — the case the whole design exists for. carrie
+      // and clerk on the reference fleet are the biggest cache consumers and
+      // neither is admin, so a `bind_mounts:`-based implementation would
+      // throw for exactly these agents.
+      carrie: { profile: "default", claudeAccount: "default" },
+      clerk: { profile: "default", claudeAccount: "default" },
+    },
+    profiles: {},
+    defaults: {},
+    switchroom: { agents_dir: "/home/op/.switchroom/agents" },
+    telegram: { forum_chat_id: "0" },
+    ...(scratch ? { scratch } : {}),
+  } as unknown as SwitchroomConfig;
+}
+
+function gen(config: SwitchroomConfig, warn: (m: string) => void = () => {}): string {
+  return generateCompose({
+    config,
+    homeDir: "/home/op",
+    // Keep the generator from touching the host: `homeDir` alone would flip
+    // `precreateHostDirs` on and mkdir under a real /home/op.
+    precreateHostDirs: false,
+    warn,
+  });
+}
+
+/** Slice the compose text for one agent's service block. */
+function serviceBlock(yaml: string, agent: string): string {
+  const start = yaml.indexOf(`  agent-${agent}:`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const rest = yaml.slice(start + 1);
+  const next = rest.search(/\n {2}[a-z0-9-]+:\n/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+describe("scratch volume — mount injection", () => {
+  it("a NON-ADMIN agent gets the scratch bind mount (the reason this is framework-injected)", () => {
+    const yaml = gen(baseConfig({ volume }));
+    const carrie = serviceBlock(yaml, "carrie");
+
+    expect(carrie).toContain(
+      `- ${join(volume, DEFAULT_SCRATCH_SUBDIR, "carrie")}:${SCRATCH_CONTAINER_DIR}:rw`,
+    );
+    // And it did NOT arrive via the operator-facing escalation.
+    expect(baseConfig({ volume }).agents.carrie).not.toHaveProperty("bind_mounts");
+  });
+
+  it("declaring the same thing via bind_mounts on a non-admin agent still throws — the escalation was not weakened", () => {
+    const config = baseConfig({ volume });
+    (config.agents.carrie as unknown as Record<string, unknown>).bind_mounts = [
+      { source: volume, target: "/scratch" },
+    ];
+    expect(() => gen(config)).toThrow(/admin-only escalation/);
+  });
+
+  it("each agent sees only its OWN scratch dir, never a sibling's and never the shared parent", () => {
+    const yaml = gen(baseConfig({ volume }));
+    const carrie = serviceBlock(yaml, "carrie");
+    const clerk = serviceBlock(yaml, "clerk");
+
+    expect(carrie).toContain(join(volume, DEFAULT_SCRATCH_SUBDIR, "carrie"));
+    expect(carrie).not.toContain(join(volume, DEFAULT_SCRATCH_SUBDIR, "clerk"));
+    expect(clerk).toContain(join(volume, DEFAULT_SCRATCH_SUBDIR, "clerk"));
+    expect(clerk).not.toContain(join(volume, DEFAULT_SCRATCH_SUBDIR, "carrie"));
+
+    // The shared parent is never a bind source on its own.
+    expect(yaml).not.toContain(
+      `- ${join(volume, DEFAULT_SCRATCH_SUBDIR)}:${SCRATCH_CONTAINER_DIR}`,
+    );
+  });
+
+  it("honours an operator-configured subdir", () => {
+    const yaml = gen(baseConfig({ volume, subdir: "caches" }));
+    expect(yaml).toContain(
+      `- ${join(volume, "caches", "carrie")}:${SCRATCH_CONTAINER_DIR}:rw`,
+    );
+  });
+});
+
+describe("scratch volume — env redirects", () => {
+  it("every cache env var points inside the mount, so caches actually land there", () => {
+    const yaml = gen(baseConfig({ volume }));
+    const carrie = serviceBlock(yaml, "carrie");
+
+    const expected: Record<string, string> = {
+      SWITCHROOM_AGENT_SCRATCH: "/scratch",
+      XDG_CACHE_HOME: "/scratch/cache",
+      TMPDIR: "/scratch/tmp",
+      npm_config_cache: "/scratch/cache/npm",
+      BUN_INSTALL_CACHE_DIR: "/scratch/cache/bun",
+      PYTHONUSERBASE: "/scratch/python",
+      PLAYWRIGHT_BROWSERS_PATH: "/scratch/cache/ms-playwright",
+      PUPPETEER_CACHE_DIR: "/scratch/cache/puppeteer",
+    };
+    for (const [k, v] of Object.entries(expected)) {
+      expect(carrie, `missing cache redirect ${k}`).toContain(`${k}: "${v}"`);
+    }
+    // The table above IS the contract: a new redirect added to scratchEnv
+    // without a matching expectation here fails, so the test can't silently
+    // stop covering a variable.
+    expect(Object.keys(scratchEnv()).sort()).toEqual(Object.keys(expected).sort());
+  });
+
+  it("overrides the image's baked PLAYWRIGHT_BROWSERS_PATH, which otherwise keeps browsers on the root disk", () => {
+    // Anchored on the real image: Dockerfile.agent bakes the browsers path at
+    // a HOME (root-disk) location, and playwright ignores XDG_CACHE_HOME, so
+    // the umbrella redirect alone would leave ~150MB+ per version behind.
+    const dockerfile = readFileSync(
+      join(import.meta.dirname, "..", "..", "docker", "Dockerfile.agent"),
+      "utf-8",
+    );
+    const baked = /^ENV PLAYWRIGHT_BROWSERS_PATH=(.+)$/m.exec(dockerfile)?.[1];
+    expect(baked, "Dockerfile.agent no longer bakes PLAYWRIGHT_BROWSERS_PATH").toBeTruthy();
+    expect(baked).toContain("/state/agent/home");
+
+    const carrie = serviceBlock(gen(baseConfig({ volume })), "carrie");
+    expect(carrie).toContain('PLAYWRIGHT_BROWSERS_PATH: "/scratch/cache/ms-playwright"');
+    expect(carrie).not.toContain(`PLAYWRIGHT_BROWSERS_PATH: "${baked}"`);
+  });
+
+  it("leaves NPM_CONFIG_PREFIX (global install prefix, not a cache) on the persistent HOME", () => {
+    const carrie = serviceBlock(gen(baseConfig({ volume })), "carrie");
+    expect(carrie).toContain('NPM_CONFIG_PREFIX: "/state/agent/home/.npm-global"');
+  });
+
+  it("an operator env: key cannot half-shadow the redirect set", () => {
+    const config = baseConfig({ volume });
+    (config.agents.carrie as unknown as Record<string, unknown>).env = {
+      TMPDIR: "/state/agent/home/tmp",
+    };
+    const carrie = serviceBlock(gen(config), "carrie");
+    expect(carrie).toContain('TMPDIR: "/scratch/tmp"');
+    expect(carrie).not.toContain('TMPDIR: "/state/agent/home/tmp"');
+  });
+});
+
+describe("scratch volume — degradation when there is no bulk volume", () => {
+  it("emits NO mount and NO env redirect when the volume does not exist", () => {
+    const yaml = gen(baseConfig({ volume: NO_SUCH_VOLUME }));
+
+    expect(yaml).not.toContain(`:${SCRATCH_CONTAINER_DIR}:rw`);
+    expect(yaml).not.toContain(NO_SUCH_VOLUME);
+    for (const k of Object.keys(scratchEnv())) {
+      expect(yaml, `${k} leaked without a scratch mount`).not.toContain(`${k}: "/scratch`);
+    }
+    // The pre-existing HOME-cache behaviour is untouched: with no scratch
+    // volume the compose file sets NO cache env at all, so the image's baked
+    // PLAYWRIGHT_BROWSERS_PATH (Dockerfile.agent) keeps winning.
+    expect(yaml).not.toContain("PLAYWRIGHT_BROWSERS_PATH");
+  });
+
+  it("output with no bulk volume is byte-identical to output with no scratch block at all", () => {
+    expect(gen(baseConfig({ volume: NO_SUCH_VOLUME }))).toBe(gen(baseConfig()));
+  });
+
+  it("warns when an EXPLICIT scratch block names a volume that isn't there", () => {
+    const warnings: string[] = [];
+    gen(baseConfig({ volume: NO_SUCH_VOLUME }), (m) => warnings.push(m));
+    expect(warnings.join("\n")).toContain(NO_SUCH_VOLUME);
+  });
+
+  it("stays SILENT on a single-disk machine with no scratch block (the dev-machine default)", () => {
+    const warnings: string[] = [];
+    gen(baseConfig(), (m) => warnings.push(m));
+    expect(warnings.join("\n")).not.toMatch(/scratch/i);
+  });
+
+  it("enabled: false opts out even when the volume IS mounted", () => {
+    const yaml = gen(baseConfig({ volume, enabled: false }));
+    expect(yaml).not.toContain(`:${SCRATCH_CONTAINER_DIR}:rw`);
+    expect(yaml).not.toContain('SWITCHROOM_AGENT_SCRATCH');
+  });
+
+  it("a file (not a directory) at the volume path does not engage the feature", () => {
+    const cfg = resolveScratchConfig({ scratch: { volume: "/etc/hostname" } });
+    expect(agentScratchHostDir(cfg, "carrie")).toBeNull();
+  });
+});
+
+describe("scratch volume — host directory creation and ownership", () => {
+  it("creates the per-agent dir plus its subdirs, chowned to that agent's container uid", () => {
+    const chowns: Array<[string, number, number]> = [];
+    const cfg = resolveScratchConfig({ scratch: { volume } });
+
+    ensureAgentScratchDirs(cfg, ["carrie", "clerk"], (p, uid, gid) =>
+      chowns.push([p, uid, gid]),
+    );
+
+    for (const agent of ["carrie", "clerk"]) {
+      const dir = join(volume, DEFAULT_SCRATCH_SUBDIR, agent);
+      const uid = allocateAgentUid(agent);
+      expect(existsSync(dir)).toBe(true);
+      expect(chowns).toContainEqual([dir, uid, uid]);
+      for (const sub of SCRATCH_SUBDIRS) {
+        expect(existsSync(join(dir, sub))).toBe(true);
+        expect(chowns).toContainEqual([join(dir, sub), uid, uid]);
+      }
+    }
+    // Two different agents must not share a uid-owned directory.
+    expect(allocateAgentUid("carrie")).not.toBe(allocateAgentUid("clerk"));
+  });
+
+  it("TMPDIR's target directory exists after creation — a missing TMPDIR breaks mkdtemp in every toolchain", () => {
+    const cfg = resolveScratchConfig({ scratch: { volume } });
+    ensureAgentScratchDirs(cfg, ["carrie"], () => {});
+    const tmpTarget = join(volume, DEFAULT_SCRATCH_SUBDIR, "carrie", "tmp");
+    expect(existsSync(tmpTarget)).toBe(true);
+    expect(scratchEnv().TMPDIR).toBe(`${SCRATCH_CONTAINER_DIR}/tmp`);
+  });
+
+  it("creates nothing when there is no bulk volume", () => {
+    const cfg = resolveScratchConfig({ scratch: { volume: NO_SUCH_VOLUME } });
+    const chowns: string[] = [];
+    expect(ensureAgentScratchDirs(cfg, ["carrie"], (p) => chowns.push(p))).toEqual([]);
+    expect(chowns).toEqual([]);
+    expect(existsSync(NO_SUCH_VOLUME)).toBe(false);
+  });
+
+  it("refuses an agent name that could escape the volume", () => {
+    const cfg = resolveScratchConfig({ scratch: { volume } });
+    expect(agentScratchHostDir(cfg, "../../etc")).toBeNull();
+    expect(agentScratchHostDir(cfg, "/etc")).toBeNull();
+  });
+});
+
+describe("scratch volume — config resolution", () => {
+  it("defaults to the documented bulk mountpoint and subdir", () => {
+    const cfg = resolveScratchConfig({});
+    expect(cfg.volume).toBe("/mnt/bulkdata");
+    expect(cfg.subdir).toBe(DEFAULT_SCRATCH_SUBDIR);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.explicit).toBe(false);
+  });
+
+  it("marks an operator-written block as explicit so a bad path can be warned about", () => {
+    expect(resolveScratchConfig({ scratch: {} }).explicit).toBe(true);
+  });
+});

--- a/src/agents/scratch.ts
+++ b/src/agents/scratch.ts
@@ -1,0 +1,254 @@
+/**
+ * Per-agent scratch volume — relocating build/package caches off the
+ * container root disk.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Every agent's HOME is `~/.switchroom/agents/<name>/home` on the operator's
+ * ROOT disk (bind-mounted into the container at `/state/agent/home`). Every
+ * package manager an agent reaches for writes its cache under that HOME:
+ * `~/.cache/uv`, `~/.npm`, `~/.bun/install/cache`, `~/.cache/puppeteer`,
+ * `~/.cache/ms-playwright`, `~/.local/lib/pythonX.Y/site-packages`. On the
+ * reference fleet those caches were measured at ~20 GiB across the agents and
+ * pushed the root filesystem to 85% full; a manual sweep reclaimed 32 GiB and
+ * the caches regrew within hours. Sweeping does not hold — the caches have to
+ * live somewhere else.
+ *
+ * Most hosts that run a fleet have a second, large device (the reference host
+ * has 1.8 TiB at `/mnt/bulkdata`). This module gives every agent a per-agent
+ * directory on that device, bind-mounted at `/scratch` inside the container,
+ * plus the environment redirects that make the package managers actually write
+ * there.
+ *
+ * WHY NOT `bind_mounts:`
+ * ----------------------
+ * The operator-facing `bind_mounts:` key is an ADMIN-ONLY escalation —
+ * `emitAgentService` throws for any agent that declares it without
+ * `admin: true` (see the `bind_mounts is an admin-only escalation` guard in
+ * compose.ts, issue #1164). The biggest cache consumers on a real fleet are
+ * ordinary non-admin agents, so routing this through `bind_mounts:` would
+ * either break them at apply time or force a privilege grant nobody wants.
+ * The scratch mount is therefore FRAMEWORK-INJECTED, exactly like the shared
+ * `skills/` mount and the root-tier mount set: emitted by the generator itself
+ * and deliberately outside the `bind_mounts` denylist, because the framework
+ * — not the operator's yaml — chose both the source and the target.
+ *
+ * DEGRADATION
+ * -----------
+ * A dev machine has no second volume. The feature is a hard no-op when the
+ * configured volume root does not exist: no mount line, no env redirects, and
+ * agents keep using their HOME caches exactly as before. That is a
+ * per-generate probe of the real filesystem, not a config assertion.
+ */
+
+import { chownSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import type { SwitchroomConfig } from "../config/schema.js";
+import { allocateAgentUid } from "./agent-uid.js";
+
+/**
+ * Host directory that must already exist for the feature to engage — the
+ * mountpoint of the operator's bulk device. Chosen to match the documented
+ * fleet layout; override with `scratch.volume` in switchroom.yaml.
+ */
+export const DEFAULT_SCRATCH_VOLUME = "/mnt/bulkdata";
+
+/** Relative path under the volume that holds the per-agent scratch dirs. */
+export const DEFAULT_SCRATCH_SUBDIR = "switchroom/scratch";
+
+/** In-container mount target. Same for every agent (each sees only its own). */
+export const SCRATCH_CONTAINER_DIR = "/scratch";
+
+/**
+ * Subdirectories pre-created (and chowned to the agent uid) inside each
+ * agent's scratch dir at apply time.
+ *
+ * `tmp` and `python` are load-bearing: `TMPDIR` pointing at a missing
+ * directory breaks `mkdtemp` in most tooling, and pip wants `PYTHONUSERBASE`
+ * to be creatable. `cache` is the XDG root every other redirect nests under —
+ * npm/bun/playwright create their own leaf dirs, but only if the parent is
+ * traversable by the agent uid.
+ */
+export const SCRATCH_SUBDIRS = ["cache", "tmp", "python"] as const;
+
+export interface ResolvedScratchConfig {
+  enabled: boolean;
+  /** Absolute host path that must exist for the feature to engage. */
+  volume: string;
+  /** Relative path under {@link volume} holding the per-agent dirs. */
+  subdir: string;
+  /** True when the operator wrote an explicit `scratch:` block. */
+  explicit: boolean;
+}
+
+/**
+ * Resolve the `scratch:` block (or its defaults) from a parsed config.
+ *
+ * Accepts a partial config so callers that only hold a fragment (tests, the
+ * doctor probe) don't have to build a whole `SwitchroomConfig`.
+ */
+export function resolveScratchConfig(
+  config: Pick<SwitchroomConfig, "scratch"> | { scratch?: unknown },
+): ResolvedScratchConfig {
+  const raw = (config as { scratch?: Record<string, unknown> | undefined })
+    .scratch;
+  const volume =
+    typeof raw?.volume === "string" && raw.volume.length > 0
+      ? raw.volume
+      : DEFAULT_SCRATCH_VOLUME;
+  const subdir =
+    typeof raw?.subdir === "string" && raw.subdir.length > 0
+      ? raw.subdir
+      : DEFAULT_SCRATCH_SUBDIR;
+  return {
+    enabled: raw?.enabled !== false,
+    volume,
+    subdir,
+    explicit: raw !== undefined,
+  };
+}
+
+/**
+ * Is the bulk volume actually present on this machine?
+ *
+ * Probes the real filesystem — a symlink to a live directory counts (statSync
+ * follows), a dangling symlink or a plain file does not. This is the single
+ * gate that makes the whole feature a no-op on a dev box.
+ */
+export function scratchVolumeAvailable(volume: string): boolean {
+  if (!isAbsolute(volume)) return false;
+  try {
+    return existsSync(volume) && statSync(volume).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Host-side scratch directory for one agent, or null when the feature is off
+ * (disabled in config, or the volume isn't mounted on this host).
+ *
+ * `agentName` is already constrained to `[a-z0-9][a-z0-9_-]*` by the config
+ * schema, so it cannot escape the volume via `..`; the guard below is a
+ * belt-and-braces check because the return value is interpolated into a
+ * docker bind source.
+ */
+export function agentScratchHostDir(
+  cfg: ResolvedScratchConfig,
+  agentName: string,
+): string | null {
+  if (!cfg.enabled) return null;
+  if (!/^[a-z0-9][a-z0-9_-]*$/.test(agentName)) return null;
+  if (!scratchVolumeAvailable(cfg.volume)) return null;
+  return join(cfg.volume, cfg.subdir, agentName);
+}
+
+/**
+ * Create each agent's scratch directory (and its fixed subdirs) on the bulk
+ * volume, owned by that agent's container uid.
+ *
+ * OWNERSHIP IS THE POINT. Agent containers run as a deterministic per-agent
+ * non-root uid (`allocateAgentUid`, 10001–10999) on a `read_only: true` root
+ * fs. If docker auto-creates the bind source it is `root:root 0755` and every
+ * write from inside the container EACCESes — which for a cache directory
+ * means `npm install` / `uv sync` / `pip install` fail at the first write,
+ * not gracefully fall back. Worse, `apply` self-elevates to root, so even the
+ * pre-create would land root-owned without an explicit chown. Same trap and
+ * the same remedy as the per-agent `.vault-token` and audit dirs (apply.ts's
+ * `chownSync(allocateAgentUid(name))` / `alignAgentUid`'s chown sweep).
+ *
+ * Non-recursive by design: we create these directories, and everything below
+ * them is written by the agent uid itself, so a recursive sweep over a
+ * multi-gigabyte cache tree on every apply would be pure cost.
+ *
+ * Best-effort per agent: a dev host where the operator lacks CAP_CHOWN gets
+ * the directories with operator ownership rather than a failed apply. Returns
+ * the directories it created or aligned, for callers that want to report.
+ */
+export function ensureAgentScratchDirs(
+  cfg: ResolvedScratchConfig,
+  agentNames: readonly string[],
+  /**
+   * chown seam. Defaults to `chownSync`; tests inject a recorder so the
+   * ownership contract is asserted without needing CAP_CHOWN on the runner.
+   */
+  chown: (path: string, uid: number, gid: number) => void = chownSync,
+): string[] {
+  const touched: string[] = [];
+  for (const name of agentNames) {
+    const dir = agentScratchHostDir(cfg, name);
+    if (dir === null) continue;
+    try {
+      const uid = allocateAgentUid(name);
+      const paths = [dir, ...SCRATCH_SUBDIRS.map((s) => join(dir, s))];
+      for (const p of paths) {
+        mkdirSync(p, { recursive: true });
+        try {
+          chown(p, uid, uid);
+        } catch {
+          /* dev host without CAP_CHOWN — leave existing ownership */
+        }
+      }
+      touched.push(dir);
+    } catch {
+      /* best-effort: never fail an apply over a cache directory */
+    }
+  }
+  return touched;
+}
+
+/**
+ * Environment redirects that point every package manager's cache at the
+ * scratch mount. Emitted into the agent service ONLY when the mount is.
+ *
+ * Per variable:
+ *   - `SWITCHROOM_AGENT_SCRATCH` — the contract itself: how an agent, a skill,
+ *     or a sub-agent discovers it has a big scratch disk (and its absence
+ *     tells them it doesn't).
+ *   - `XDG_CACHE_HOME` — the umbrella redirect. `uv` (the single largest
+ *     offender measured), pip's HTTP cache, `go`, `deno`, and most XDG-aware
+ *     tooling derive their cache dir from it.
+ *   - `TMPDIR` — big unpack/extract temporaries. NOTE: `/tmp` in an agent is a
+ *     RAM-backed tmpfs charged against the container's `mem_limit`
+ *     (compose.ts's `tmpfs: - /tmp:size=…`), so this one is not a root-disk
+ *     saving — it moves multi-GiB unpacks off RAM and out from under the
+ *     tmpfs size ceiling, which is why an npm/bun install of a large tree
+ *     stops failing with a confusing ENOSPC.
+ *   - `npm_config_cache` — npm ignores `XDG_CACHE_HOME` and defaults to
+ *     `~/.npm`. Spelled lowercase because that is npm's canonical env form;
+ *     the existing `NPM_CONFIG_PREFIX` (a different knob — global INSTALL
+ *     prefix, deliberately left on the persistent HOME) is unaffected.
+ *   - `BUN_INSTALL_CACHE_DIR` — bun ignores XDG too, defaults to
+ *     `~/.bun/install/cache`.
+ *   - `PYTHONUSERBASE` — the user-site tree `PIP_USER=1` installs into
+ *     (`~/.local` by default). Packages, not a cache, but numpy/pandas/polars
+ *     are among the largest single consumers on the root disk. BEHAVIOUR
+ *     CHANGE: python's user-site moves with it, so packages installed before
+ *     this landed are no longer importable and must be reinstalled once.
+ *   - `PLAYWRIGHT_BROWSERS_PATH` — overrides the Dockerfile's bake of
+ *     `/state/agent/home/.cache/ms-playwright`. Safe because the boot seeding
+ *     in `profiles/_base/start.sh.hbs` reads
+ *     `${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}` — it follows
+ *     this env rather than hard-coding the HOME path.
+ *   - `PUPPETEER_CACHE_DIR` — puppeteer resolves `os.homedir()/.cache/
+ *     puppeteer` directly and does NOT honour `XDG_CACHE_HOME`, so the
+ *     umbrella redirect alone would leave its ~200 MiB Chromium downloads on
+ *     the root disk.
+ *
+ * Keys are returned unsorted; the compose emitter sorts the merged env map.
+ */
+export function scratchEnv(
+  containerDir: string = SCRATCH_CONTAINER_DIR,
+): Record<string, string> {
+  const cache = `${containerDir}/cache`;
+  return {
+    SWITCHROOM_AGENT_SCRATCH: containerDir,
+    XDG_CACHE_HOME: cache,
+    TMPDIR: `${containerDir}/tmp`,
+    npm_config_cache: `${cache}/npm`,
+    BUN_INSTALL_CACHE_DIR: `${cache}/bun`,
+    PYTHONUSERBASE: `${containerDir}/python`,
+    PLAYWRIGHT_BROWSERS_PATH: `${cache}/ms-playwright`,
+    PUPPETEER_CACHE_DIR: `${cache}/puppeteer`,
+  };
+}

--- a/src/agents/scratch.ts
+++ b/src/agents/scratch.ts
@@ -178,23 +178,40 @@ export function ensureAgentScratchDirs(
   for (const name of agentNames) {
     const dir = agentScratchHostDir(cfg, name);
     if (dir === null) continue;
-    try {
-      const uid = allocateAgentUid(name);
-      const paths = [dir, ...SCRATCH_SUBDIRS.map((s) => join(dir, s))];
-      for (const p of paths) {
-        mkdirSync(p, { recursive: true });
-        try {
-          chown(p, uid, uid);
-        } catch {
-          /* dev host without CAP_CHOWN — leave existing ownership */
-        }
-      }
-      touched.push(dir);
-    } catch {
-      /* best-effort: never fail an apply over a cache directory */
-    }
+    if (ensureAgentScratchDir(dir, name, chown)) touched.push(dir);
   }
   return touched;
+}
+
+/**
+ * Single-agent form of {@link ensureAgentScratchDirs}, for callers that
+ * already hold the resolved host directory (the compose generator's
+ * pre-create). Returns whether the tree is in place.
+ *
+ * Every creation path goes through here so none of them can create the bind
+ * source WITHOUT the chown — a root-owned scratch dir is silently unusable
+ * from inside the container.
+ */
+export function ensureAgentScratchDir(
+  dir: string,
+  agentName: string,
+  chown: (path: string, uid: number, gid: number) => void = chownSync,
+): boolean {
+  try {
+    const uid = allocateAgentUid(agentName);
+    for (const p of [dir, ...SCRATCH_SUBDIRS.map((s) => join(dir, s))]) {
+      mkdirSync(p, { recursive: true });
+      try {
+        chown(p, uid, uid);
+      } catch {
+        /* dev host without CAP_CHOWN — leave existing ownership */
+      }
+    }
+    return true;
+  } catch {
+    /* best-effort: never fail an apply over a cache directory */
+    return false;
+  }
 }
 
 /**

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -71,6 +71,10 @@ import type { VaultAclResult } from "./doctor-mcp-secrets.js";
 import { installUpdatePromptHook } from "./update-prompt-hook.js";
 import { resolveSelfInvocation, type SelfInvokeProbe } from "./self-invoke.js";
 import { allocateAgentUid } from "../agents/compose.js";
+import {
+  ensureAgentScratchDirs,
+  resolveScratchConfig,
+} from "../agents/scratch.js";
 import { LITELLM_MASTER_KEY_STATE_BASENAME } from "../litellm/external-spend.js";
 import { writeComposeFile, computeComposeContent, resolveHostSwitchroomConfigPath, resolveHostHomeForCompose } from "./write-compose.js";
 import { getProfilePath } from "../agents/profiles.js";
@@ -1308,6 +1312,19 @@ export async function ensureHostMountSources(
   for (const dir of dirs) {
     await mkdir(dir, { recursive: true });
   }
+
+  // Per-agent scratch dirs on the bulk volume (src/agents/scratch.ts). These
+  // are NOT under the operator home — they live on a second device — so they
+  // can't join the `dirs` list above. Created here, ahead of the compose
+  // write, so docker never auto-creates the bind source as root:root (which
+  // would EACCES every cache write from the non-root agent uid). No-op when
+  // the volume isn't mounted, which is the whole dev-machine degradation
+  // story. Ownership is aligned to `allocateAgentUid` inside the helper —
+  // `apply` may be running self-elevated as root here.
+  ensureAgentScratchDirs(
+    resolveScratchConfig(config),
+    Object.keys(config.agents),
+  );
 
   // The auto-unlock blob is bind-mounted at
   // `~/.switchroom/vault-auto-unlock`. If the source path is missing,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5100,6 +5100,56 @@ export const AutoReleaseCheckSchema = z.object({
     ),
 });
 
+/**
+ * Per-agent scratch volume — where build/package caches live.
+ *
+ * Every agent's HOME sits on the operator's ROOT disk, and every package
+ * manager an agent uses caches under it (`~/.cache/uv`, `~/.npm`,
+ * `~/.bun/install/cache`, `~/.cache/puppeteer`, `~/.cache/ms-playwright`,
+ * `~/.local/lib/python*`). On a busy fleet that is tens of gigabytes that
+ * regrows within hours of any manual sweep. This block points those caches at
+ * a second, larger device instead.
+ *
+ * Hard no-op when `volume` does not exist on the host: no mount, no env
+ * redirects, agents keep their HOME caches. A dev machine with one disk needs
+ * no configuration at all. See `src/agents/scratch.ts`.
+ */
+export const ScratchConfigSchema = z.object({
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      "Whether agents get a scratch mount at /scratch with their package " +
+      "caches redirected there. Default: true — but the feature only " +
+      "engages when `volume` actually exists on the host, so a single-disk " +
+      "machine is unaffected. Set false to opt out even where it does.",
+    ),
+  volume: z
+    .string()
+    .refine((v) => v.startsWith("/"), {
+      message: "scratch.volume must be an absolute host path",
+    })
+    .default("/mnt/bulkdata")
+    .describe(
+      "Absolute host path of the bulk device's mountpoint. MUST already " +
+      "exist — its presence is the single probe that turns the feature on, " +
+      "so a typo degrades to the pre-existing behaviour rather than " +
+      "quietly relocating caches somewhere that is still the root disk. " +
+      "Default: /mnt/bulkdata.",
+    ),
+  subdir: z
+    .string()
+    .refine((v) => !v.startsWith("/") && !v.split("/").includes(".."), {
+      message: "scratch.subdir must be a relative path without '..' segments",
+    })
+    .default("switchroom/scratch")
+    .describe(
+      "Relative path under `volume` holding the per-agent scratch " +
+      "directories (`<volume>/<subdir>/<agent>`). Default: " +
+      "switchroom/scratch.",
+    ),
+});
+
 export const HostControlConfigSchema = z.object({
   enabled: z
     .boolean()
@@ -5654,6 +5704,16 @@ export const SwitchroomConfigSchema = z.object({
   quota: QuotaConfigSchema.optional().describe(
     "Optional weekly/monthly USD spend budgets rendered in the session " +
     "greeting. Usage is read from ccusage at runtime; no network calls.",
+  ),
+  scratch: ScratchConfigSchema.optional().describe(
+    "Per-agent scratch volume. Relocates every agent's build/package " +
+    "caches (uv, npm, bun, playwright, puppeteer, pip user-site) off the " +
+    "root disk onto a bulk device, bind-mounted at /scratch inside each " +
+    "container. Framework-injected for EVERY agent — not routed through " +
+    "the admin-only `bind_mounts:` escalation, because the biggest cache " +
+    "consumers are ordinary non-admin agents. Omit the block to accept " +
+    "defaults; the feature is a no-op unless `scratch.volume` exists on " +
+    "the host.",
   ),
   host_control: HostControlConfigSchema.default({}).describe(
     "Host-control daemon configuration. Defaults to enabled=true since " +


### PR DESCRIPTION
## Summary

Every agent's package caches live under its HOME on the operator's **root
disk**: `~/.cache/uv`, `~/.npm`, `~/.bun/install/cache`, `~/.cache/puppeteer`,
`~/.cache/ms-playwright`, `~/.local/lib/pythonX.Y`. On the reference fleet
that reached ~20G and pushed the root filesystem to 85% full. A manual sweep
reclaimed 32G and the caches regrew within hours — sweeping does not hold.

This gives every agent a per-agent directory on the host's bulk device,
bind-mounted read-write at `/scratch`, plus the env redirects that make the
package managers actually write there.

```yaml
scratch:
  enabled: true                # default
  volume: /mnt/bulkdata        # default. Must already exist.
  subdir: switchroom/scratch   # default
```

## Why not `bind_mounts:`

`bind_mounts:` is an **admin-only escalation** — `emitAgentService` throws for
any agent that declares it without `admin: true` (`src/agents/compose.ts`,
issue #1164). The biggest cache consumers on a real fleet are ordinary
non-admin agents, so that route breaks the fleet for exactly the agents this
exists to fix.

The mount is therefore **framework-injected**, the same mechanism the
root-tier mount set and the shared `skills/` mount already use, and
deliberately outside the `bind_mounts` denylist: neither source nor target
comes from operator yaml — the framework picks both
(`<volume>/<subdir>/<agent>` → `/scratch`). Each agent sees only its own
directory, never a sibling's and never the shared parent. The `bind_mounts`
guard itself is untouched, and a test pins that it still throws for a
non-admin agent.

## Env redirects

| Variable | Value | Why it needs its own redirect |
|---|---|---|
| `SWITCHROOM_AGENT_SCRATCH` | `/scratch` | how an agent/skill discovers it has scratch space |
| `XDG_CACHE_HOME` | `/scratch/cache` | uv (the largest single offender), pip HTTP cache, most XDG tooling |
| `TMPDIR` | `/scratch/tmp` | large unpacks. NOTE: `/tmp` is a RAM-backed tmpfs charged to `mem_limit`, so this is not a root-disk saving — it moves multi-GiB unpacks off RAM and out from under the tmpfs ceiling |
| `npm_config_cache` | `/scratch/cache/npm` | npm ignores XDG (`~/.npm`) |
| `BUN_INSTALL_CACHE_DIR` | `/scratch/cache/bun` | bun ignores XDG |
| `PYTHONUSERBASE` | `/scratch/python` | the tree `PIP_USER=1` installs into |
| `PLAYWRIGHT_BROWSERS_PATH` | `/scratch/cache/ms-playwright` | **conflict found**: `Dockerfile.agent` bakes this at a HOME path and playwright ignores XDG, so the umbrella redirect alone would leave browsers on the root disk. Safe to override — `profiles/_base/start.sh.hbs:1772` seeds via `${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}`, i.e. it follows this env |
| `PUPPETEER_CACHE_DIR` | `/scratch/cache/puppeteer` | puppeteer resolves `os.homedir()/.cache` directly, ignoring XDG |

`NPM_CONFIG_PREFIX` (global *install* prefix, not a cache) deliberately stays
on the persistent HOME; a test pins that.

Emitted before the `userEnv` merge, so they are authoritative like `HOME` /
`SWITCHROOM_*`. Opting out is `scratch.enabled: false`, not shadowing
individual keys — a half-redirected cache set is worse than either end state.

## Ownership

Agent containers run as a deterministic non-root uid (10001–10999) on a
read-only rootfs. A root-owned bind source EACCESes every cache write, and
`apply` self-elevates to root, so the pre-create alone is not enough.
`ensureAgentScratchDirs` creates the dir plus its fixed subdirs and chowns
each to `allocateAgentUid(name)` — the same prior art `apply`'s `.vault-token`
chown and `alignAgentUid` use. Called from `ensureHostMountSources`, ahead of
the compose write, so docker never auto-creates the source. Non-recursive by
design: everything below is written by the agent uid itself.

## Degradation

Hard no-op when `scratch.volume` does not exist: no mount, no env, and
**byte-identical** compose output to before this landed (pinned by a test).
An explicit `scratch:` block naming a missing path warns; the single-disk
default stays silent.

## Behaviour change (one)

`PYTHONUSERBASE` moves python's user-site, so packages an agent installed with
`pip install` before the cutover need reinstalling once. Caches and browser
downloads just re-populate. Documented in `docs/configuration.md`.

## Test plan

New `src/agents/scratch.test.ts` (20 tests), outcome-anchored:

- **non-admin agent gets the mount** — fails if the mount is dropped or routed
  through `bind_mounts`
- **`bind_mounts` on a non-admin agent still throws** — the escalation was not
  weakened
- **per-agent isolation** — each service block contains its own dir and not a
  sibling's; the shared parent is never a bind source
- **env redirect table** — asserts each variable's exact value AND that
  `Object.keys(scratchEnv())` equals the expected set, so a redirect cannot be
  dropped, renamed, or added without the test failing
- **playwright override** — reads the real `Dockerfile.agent`, asserts the
  baked path is a HOME path and that compose overrides it
- **operator `env:` cannot half-shadow** the set
- **degradation** — no mount, no env, byte-identical output, warn on explicit
  misconfiguration, silence on the default, `enabled: false` opt-out, a file
  (not a dir) at the volume path does not engage
- **ownership** — dirs + subdirs created and chowned to the deterministic
  per-agent uid, via an injected chown seam so it asserts on an unprivileged
  runner too; `TMPDIR`'s target exists; nothing created when the volume is
  absent; a traversal-shaped agent name is refused

Local: `vitest run src/agents/ src/config/ src/cli/apply.test.ts
tests/write-compose.litellm-resolve.test.ts` → 59 files, 1058 passed.
`tsc --noEmit` clean. `npm run lint` clean.

## Risk

- Low for the no-volume path (byte-identical output, proven by test).
- On a host WITH the volume, first apply after this lands moves the caches:
  expect one round of re-downloads plus the `PYTHONUSERBASE` reinstall above.
- If `apply` runs inside hostd, `/mnt/bulkdata` is not mounted in that
  container, so the probe fails and the mount is omitted until an apply runs
  on the host. Follow-up if that becomes the normal path; noted here rather
  than papered over.

Job spec: `reference/jobs/survive-reboots-and-real-life.md` — a root disk at
85% and climbing is the fleet's machine misbehaving, and the failure mode
(ENOSPC mid-install, agents that can't write state) is exactly the "real life"
this job says the product must absorb without the operator babysitting it.
