### PR TITLE
fix(worktree): count nested-cwd holders as live; add report-only reap pass

### DIFF
--- a/changelog.d/4724-worktree-liveness-and-reap-report.fix.md
+++ b/changelog.d/4724-worktree-liveness-and-reap-report.fix.md
@@ -1,0 +1,27 @@
+- **worktree reaper: a process working inside a checkout counted as "free" (#4724)** —
+  The in-use probe answered with `fuser <path>` / `lsof -t <path>`, both of
+  which match the path **exactly**. A process whose cwd was a nested
+  subdirectory of a worktree — i.e. an agent actually working in the checkout —
+  was invisible to it, so the probe returned `free` for a live tree. `free` is
+  precisely what clears the reaper's third fail-safe ("an in-use probe can
+  DEFINITIVELY report the path as free"), so anything automating this would have
+  `git worktree remove --force`d live work; the same probe is the idle guard for
+  the task-tree sweep. The probe now walks procfs: a process holds the tree when
+  its **cwd is the root or any directory beneath it**, or when an open **fd**
+  resolves inside it. Because these verbs run host-side while the holders are
+  usually processes inside agent containers (same directory, different path),
+  the cwd test also walks `/proc/<pid>/cwd/..` upward comparing `(dev, ino)`,
+  which the kernel resolves in *our* namespace. A sweep that could not inspect
+  every process now reports `unavailable` (⇒ keep) rather than `free`; `lsof` is
+  invoked with `+D` and `fuser` retained as a positive-only signal.
+- **New `switchroom worktree reap-report` — report-only, deletes nothing (#4724)** —
+  Runs both classifiers on a schedule and prints what they *would* reclaim,
+  grouped per agent against a size budget (`--budget-gb`, default 5 GB, or
+  `SWITCHROOM_AGENT_TREE_BUDGET_GB`) and ordered oldest-first — the eviction
+  order a budget-driven reaper would use (RFC `agent-home-lifecycle.md` §2).
+  Only trees that already clear every safety guard are ever marked over-budget;
+  when the guards keep an agent over, the report says how much stays over rather
+  than widening eligibility. The safety default is structural, not a flag: the
+  module composes only plan-only predicates and imports no removal primitive,
+  and the verb has no `--yes`. Deleting remains the separate, explicit
+  `worktree gc --yes` / `worktree reap`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -208,6 +208,7 @@ switchroom worktree claim <repo> [--task <name>] [--agent <name>] [--json]
 switchroom worktree list [--json]
 switchroom worktree release <id> [--json]
 switchroom worktree reap [--dry-run] [--json]
+switchroom worktree reap-report [--json] [--append <file>] [--budget-gb <n>]
 ```
 
 - **`claim <repo>`** claims an isolated checkout for a repo (alias or
@@ -226,6 +227,14 @@ switchroom worktree reap [--dry-run] [--json]
 - **`reap`** removes stale / orphaned worktrees (no heartbeat for
   >10 min). `--dry-run` prints what *would* be reaped without acting.
   Always sanity-check with `--dry-run` first on a shared host.
+- **`reap-report`** is the scheduled, **report-only** pass: it runs both
+  classifiers — the claim reaper and the per-agent task-tree sweep — and
+  prints what they *would* reclaim, grouped per agent against a size
+  budget (`--budget-gb`, default 5, or `SWITCHROOM_AGENT_TREE_BUDGET_GB`)
+  and ordered oldest-first. It deletes nothing and has no `--yes`.
+  `--append <file>` writes one JSON line per run, which is how you build
+  a week of evidence that the classifiers are right before considering
+  any automatic deletion. Deleting stays a separate, explicit command.
 
 Typical flow for a non-trivial change on a shared box:
 
@@ -235,7 +244,7 @@ ID=$(switchroom worktree claim switchroom --task fix-card --agent clerk --json |
 switchroom worktree release "$ID"
 ```
 
-*Grounded in:* `src/cli/worktree.ts`, `src/worktree/{claim,release,list,reaper}.ts`.
+*Grounded in:* `src/cli/worktree.ts`, `src/worktree/{claim,release,list,reaper,reap-report,proc-liveness}.ts`.
 
 ## `switchroom web` — local monitoring dashboard
 

--- a/docs/operators/worktree-gc.md
+++ b/docs/operators/worktree-gc.md
@@ -70,6 +70,57 @@ switchroom worktree gc --purge-trash --older-than 14 --yes   # hard-delete ≥14
 Quarantine reclaims space only after `--purge-trash`; until then a quarantined
 worktree can be moved back out of the trash dir.
 
+## Is this tree in use? (the liveness probe)
+
+Every reclaim path asks one question before it touches a tree: is any live
+process sitting in it? The answer comes from `probePathInUse`
+(`src/worktree/reaper.ts` → `src/worktree/proc-liveness.ts`), which walks
+`/proc` and treats a tree as live when a process's **cwd is the tree root or
+any directory beneath it**, or when any open file descriptor points inside it.
+
+This used to be `fuser <path>` / `lsof -t <path>`. Both match the path
+**exactly**, so a process sitting in `<tree>/src/deep` — what an agent working
+in a checkout actually looks like — was reported as *free*, and the tree was
+eligible for a force-remove. Two consequences worth knowing:
+
+- **A partial sweep is never "free".** Reading another uid's
+  `/proc/<pid>/cwd` needs ptrace-read permission. Run as a uid that cannot see
+  the process holding the tree, the probe reports `unavailable` and the tree is
+  KEPT. If `switchroom worktree reap-report` shows a large
+  `could not be proven idle` count, run it as root (or as the tree's owning
+  uid) — do not read it as "nothing is holding these".
+- **Container-side holders count.** The processes that hold agent task trees
+  live inside agent containers, where the same directory has a different path.
+  The probe compares directory inodes as well as path strings, so a holder
+  inside a container is still found from the host.
+
+## Report-only pass (start here before automating anything)
+
+```bash
+switchroom worktree reap-report                       # human-readable
+switchroom worktree reap-report --json                # machine-readable
+switchroom worktree reap-report --budget-gb 5 \
+    --append /var/log/switchroom/reap-report.jsonl    # one JSON line per run
+```
+
+`reap-report` runs both classifiers — the claim reaper and the per-agent
+task-tree sweep — and prints what they *would* reclaim, grouped per agent
+against a per-agent size budget (`--budget-gb`, default 5, or
+`SWITCHROOM_AGENT_TREE_BUDGET_GB`) and ordered **oldest-first**, which is the
+eviction order a budget-driven reaper would use. A tree is only ever marked
+`over-budget` if it already cleared every safety guard; when the guards keep an
+agent over budget the report says how much stays over rather than widening
+eligibility.
+
+It **deletes nothing** and has no `--yes`. Deleting remains the separate,
+explicit `switchroom worktree gc --yes` / `switchroom worktree reap`. Run the
+report daily for a week and read the JSONL before wiring anything automatic:
+
+```cron
+# 03:40 daily — evidence only, deletes nothing
+40 3 * * *  switchroom worktree reap-report --append /var/log/switchroom/reap-report.jsonl >> /var/log/switchroom/reap-report.log 2>&1
+```
+
 ## Weekly cron (safety net)
 
 Run GC weekly so forgotten worktrees self-clean, and purge quarantined dirs

--- a/src/cli/worktree.ts
+++ b/src/cli/worktree.ts
@@ -6,12 +6,14 @@
  *   switchroom worktree release <id>
  *   switchroom worktree list [--json]
  *   switchroom worktree reap [--dry-run]
+ *   switchroom worktree reap-report [--json] [--append <file>] [--budget-gb <n>]
  *   switchroom worktree gc [--root <dir>...] [--yes] [--json]
  *   switchroom worktree gc --purge-trash [--older-than <days>] [--yes]
  */
 
 import type { Command } from "commander";
 import chalk from "chalk";
+import { appendFileSync } from "node:fs";
 import { claimWorktree } from "../worktree/claim.js";
 import { releaseWorktree } from "../worktree/release.js";
 import { listWorktrees } from "../worktree/list.js";
@@ -26,6 +28,11 @@ import {
   selectPurgeTargets,
   purgeTrash,
 } from "../worktree/gc.js";
+import {
+  agentTreeBudgetBytes,
+  buildReapReport,
+  formatReapReport,
+} from "../worktree/reap-report.js";
 
 export function registerWorktreeCommand(program: Command): void {
   const worktree = program
@@ -231,6 +238,64 @@ export function registerWorktreeCommand(program: Command): void {
         }
       }
     });
+
+  // ─── reap-report (scheduled, report-only) ────────────────────────────────
+
+  worktree
+    .command("reap-report")
+    .description(
+      "REPORT ONLY: what the reaper and the task-tree sweep WOULD reclaim.\n" +
+        "Deletes nothing — there is no --yes on this verb. Built to run from\n" +
+        "cron so a week of evidence exists before any automatic deletion is\n" +
+        "considered. Groups per agent against a size budget, oldest-first.",
+    )
+    .option("--json", "Output the raw report as JSON")
+    .option(
+      "--append <file>",
+      "Append the JSON report as one line to <file> (JSONL evidence log)",
+    )
+    .option("--budget-gb <gb>", "Per-agent task-tree budget in GB (default 5)")
+    .option("--idle-days <days>", "Idle threshold for task trees (default 14)", "14")
+    .option("--no-task-roots", "Skip the per-agent task-tree sweep")
+    .action(
+      (opts: {
+        json?: boolean;
+        append?: string;
+        budgetGb?: string;
+        idleDays: string;
+        taskRoots?: boolean;
+      }) => {
+        const parsedIdle = Number(opts.idleDays);
+        const idleDays = Number.isFinite(parsedIdle) && parsedIdle >= 0 ? parsedIdle : 14;
+        const parsedBudget = opts.budgetGb == null ? NaN : Number(opts.budgetGb);
+        const budgetBytes =
+          Number.isFinite(parsedBudget) && parsedBudget > 0
+            ? Math.round(parsedBudget * 1024 * 1024 * 1024)
+            : agentTreeBudgetBytes();
+
+        const report = buildReapReport({
+          idleDays,
+          budgetBytes,
+          taskTreeRoots: opts.taskRoots === false ? [] : undefined,
+        });
+
+        if (opts.append) {
+          try {
+            appendFileSync(opts.append, JSON.stringify(report) + "\n");
+          } catch (err) {
+            console.error(
+              chalk.yellow(`Could not append to ${opts.append}: ${(err as Error).message}`),
+            );
+          }
+        }
+
+        if (opts.json) {
+          console.log(JSON.stringify(report));
+          return;
+        }
+        console.log(formatReapReport(report));
+      },
+    );
 
   // ─── gc ─────────────────────────────────────────────────────────────────
 

--- a/src/worktree/gc.ts
+++ b/src/worktree/gc.ts
@@ -253,7 +253,7 @@ export type TaskTreeVerdict =
   | "reap"
   /** registry-claimed / stable per-repo tree / ephemeral mount → never touch. */
   | "skip-protected"
-  /** no fuser/lsof to prove it idle → treat as live, keep (fail-safe). */
+  /** nothing could prove it idle (partial procfs sweep / no tools) → keep. */
   | "skip-probe-unavailable"
   /** a live process holds the path open → keep. */
   | "skip-in-use"
@@ -329,6 +329,12 @@ export interface TaskTreeAction {
   verdict: TaskTreeVerdict;
   prSignal: PrSignal;
   idle: boolean;
+  /**
+   * Newest mtime (ms) across the tree's git-TRACKED files — the same signal
+   * `idle` is derived from, surfaced so a reporting pass can order trees
+   * oldest-first. `null` when the probe threw (⇒ treated as active).
+   */
+  newestMtimeMs: number | null;
   /** quarantine destination when this tree is actioned. */
   dest: string;
   /**
@@ -818,10 +824,13 @@ export function planGc(
 
       // Idle: newest tracked mtime older than the idle window.
       let idle = false;
+      let newestMtimeMs: number | null = null;
       try {
-        idle = (nowMs - newestMtime(dir)) / 86_400_000 >= idleDays;
+        newestMtimeMs = newestMtime(dir);
+        idle = (nowMs - newestMtimeMs) / 86_400_000 >= idleDays;
       } catch {
         idle = false; // can't tell ⇒ treat as active ⇒ keep
+        newestMtimeMs = null;
       }
 
       // Spend the probe + `gh` call only when every cheaper guard has passed
@@ -865,6 +874,7 @@ export function planGc(
         verdict,
         prSignal: sig,
         idle,
+        newestMtimeMs,
         dest: join(trash, name),
         willAct,
       });

--- a/src/worktree/proc-liveness.ts
+++ b/src/worktree/proc-liveness.ts
@@ -1,0 +1,246 @@
+/**
+ * Liveness probe: does ANY live process sit at or below a worktree path?
+ *
+ * ## Why this exists (the bug it replaces)
+ *
+ * The reaper used to answer that question with `fuser <path>` / `lsof -t <path>`.
+ * Both of those match the path **exactly**. A process whose cwd is a NESTED
+ * SUBDIRECTORY of the worktree — `<tree>/src/deep`, i.e. what an agent working
+ * in a checkout actually looks like — is invisible to them:
+ *
+ *     $ mkdir -p /tmp/tree/src/deep && (cd /tmp/tree/src/deep && sleep 60) &
+ *     $ fuser /tmp/tree            ; echo $?     # (no output)   1   ← "free"
+ *     $ fuser /tmp/tree/src/deep   ; echo $?     # 262751c       0   ← in-use
+ *
+ * `probePathInUse` therefore reported "free" for a tree an agent was actively
+ * working in, and the reaper's third fail-safe ("an in-use probe can
+ * DEFINITIVELY report the path as free") would have licensed a
+ * `git worktree remove --force` over live work.
+ *
+ * ## What replaces it
+ *
+ * On Linux we walk `/proc` ourselves and treat a process as a holder when
+ * EITHER
+ *   - its `cwd` is the tree root or any directory beneath it, or
+ *   - any of its open file descriptors resolves to a path beneath the tree.
+ *
+ * ## Two subtleties the naive version gets wrong
+ *
+ * 1. **Mount namespaces (the container/host boundary).** The claim pool and the
+ *    per-agent task trees live on the HOST (`~/.switchroom/…`), and this probe
+ *    runs host-side (`switchroom worktree reap` / `gc` are host CLI verbs; the
+ *    vault/host-home invariants keep them there). But the processes actually
+ *    holding those trees are frequently INSIDE an agent container, where the
+ *    same directory is mounted at a different path (`/state/agent/home/work/x`).
+ *    Reading `/proc/<pid>/cwd` from the host yields the path as seen in THAT
+ *    process's mount namespace, so a plain string-prefix test misses it.
+ *    We therefore also do an inode walk: `/proc/<pid>/cwd/..`, `/…/../..`, …
+ *    are resolved by the kernel in OUR view of the filesystem, so comparing
+ *    `(dev, ino)` against the tree root finds a container-side holder no matter
+ *    what its path looks like inside the container.
+ *
+ * 2. **A partial scan is not a negative.** Reading another uid's
+ *    `/proc/<pid>/cwd` needs `PTRACE_MODE_READ`; as a non-root operator most of
+ *    those fail with EACCES. Finding no holder among the processes we COULD
+ *    inspect does not prove the tree is free, so the scan reports how many
+ *    entries it could not inspect and the caller degrades to "unavailable"
+ *    (= treat as live, keep) rather than "free". Kernel threads are excluded
+ *    from that count: they have no mm (empty `cmdline`) and can never hold a
+ *    worktree.
+ */
+
+import { readdirSync, readlinkSync, realpathSync, statSync, readFileSync } from "node:fs";
+import { join, sep } from "node:path";
+
+/** Outcome of one procfs sweep. */
+export interface ProcScanResult {
+  /**
+   *   - "in-use"      — a holder was positively identified.
+   *   - "free"        — the sweep completed and found no holder. Only
+   *                     DEFINITIVE when `inaccessible === 0`.
+   *   - "unavailable" — no readable procfs (non-Linux, or /proc not mounted).
+   */
+  state: "in-use" | "free" | "unavailable";
+  /**
+   * Number of userspace processes whose cwd/fds we could not inspect
+   * (EACCES/EPERM). A "free" with a non-zero count proves nothing.
+   */
+  inaccessible: number;
+  /** Populated when `state === "in-use"`. */
+  holder?: { pid: number; kind: "cwd" | "fd"; via: "path" | "inode"; target: string };
+}
+
+export interface ProcScanOptions {
+  /** procfs mount point. Injectable so tests can drive a synthetic /proc. */
+  procRoot?: string;
+  /**
+   * Max parent hops for the namespace-proof inode walk. A worktree nested more
+   * deeply than this degrades to path matching only.
+   */
+  maxDepth?: number;
+}
+
+/** True when the path component is a pid directory. */
+function isPidDir(name: string): boolean {
+  return /^\d+$/.test(name);
+}
+
+/**
+ * `/proc/<pid>/cwd` and `/proc/<pid>/fd/<n>` links to a removed inode carry a
+ * " (deleted)" suffix. Strip it before comparing.
+ */
+function stripDeleted(target: string): string {
+  return target.endsWith(" (deleted)") ? target.slice(0, -" (deleted)".length) : target;
+}
+
+function isAtOrBelow(target: string, root: string): boolean {
+  return target === root || target.startsWith(root.endsWith(sep) ? root : root + sep);
+}
+
+/** errno of a caught fs error, or "" when it has none. */
+function errno(e: unknown): string {
+  return (e as NodeJS.ErrnoException)?.code ?? "";
+}
+
+/**
+ * A pid whose `cmdline` is empty is a kernel thread: no mm, no cwd of its own
+ * (the kernel reports `/`), so it can never hold a worktree. Excluding these
+ * keeps the `inaccessible` count honest on a host with hundreds of kthreads.
+ */
+function isKernelThread(procRoot: string, pid: string): boolean {
+  try {
+    return readFileSync(join(procRoot, pid, "cmdline")).length === 0;
+  } catch {
+    return false; // can't tell ⇒ count it as a real process (fail-safe)
+  }
+}
+
+/**
+ * Walk up from `linkPath` (a `/proc/<pid>/cwd` magic symlink) comparing
+ * `(dev, ino)` against `rootId` at every hop. The kernel resolves each `..`
+ * in OUR mount namespace, which is what makes this work for a process inside a
+ * container whose cwd STRING bears no resemblance to the host path.
+ *
+ * Returns true when the cwd is the root or a descendant of it.
+ */
+function cwdIsUnderRootByInode(
+  linkPath: string,
+  rootId: { dev: number; ino: number },
+  maxDepth: number,
+): boolean {
+  // NOTE: the `..` components are appended as raw string suffixes and never
+  // via `path.join`, which would collapse them LEXICALLY ("/proc/9/cwd/.." →
+  // "/proc/9"). We need the kernel to resolve them PHYSICALLY, through the
+  // magic symlink and up the real directory tree.
+  let suffix = "";
+  let lastDev = -1;
+  let lastIno = -1;
+  for (let hop = 0; hop <= maxDepth; hop++) {
+    let st;
+    try {
+      st = statSync(linkPath + suffix);
+    } catch {
+      return false;
+    }
+    if (st.dev === rootId.dev && st.ino === rootId.ino) return true;
+    // Reached the filesystem root of this branch: `..` is a fixed point.
+    if (st.dev === lastDev && st.ino === lastIno) return false;
+    lastDev = st.dev;
+    lastIno = st.ino;
+    suffix += "/..";
+  }
+  return false;
+}
+
+/**
+ * Scan procfs for any process holding `path` at or below the tree root.
+ *
+ * Short-circuits on the first holder found. Never throws: an unreadable procfs
+ * degrades to `"unavailable"`, which every caller must treat as "assume live".
+ */
+export function scanProcForHolders(path: string, opts: ProcScanOptions = {}): ProcScanResult {
+  const procRoot = opts.procRoot ?? "/proc";
+  const maxDepth = opts.maxDepth ?? 64;
+
+  let root: string;
+  let rootId: { dev: number; ino: number };
+  try {
+    root = realpathSync(path);
+    const st = statSync(root);
+    rootId = { dev: st.dev, ino: st.ino };
+  } catch {
+    // The tree is gone or unreadable — nothing here can prove it free.
+    return { state: "unavailable", inaccessible: 0 };
+  }
+
+  let pids: string[];
+  try {
+    pids = readdirSync(procRoot).filter(isPidDir);
+  } catch {
+    return { state: "unavailable", inaccessible: 0 };
+  }
+  if (pids.length === 0) return { state: "unavailable", inaccessible: 0 };
+
+  let inaccessible = 0;
+
+  for (const pid of pids) {
+    let blocked = false;
+
+    // ── cwd ────────────────────────────────────────────────────────────────
+    const cwdLink = join(procRoot, pid, "cwd");
+    try {
+      const target = stripDeleted(readlinkSync(cwdLink));
+      if (isAtOrBelow(target, root)) {
+        return {
+          state: "in-use",
+          inaccessible,
+          holder: { pid: Number(pid), kind: "cwd", via: "path", target },
+        };
+      }
+      // Namespace-proof fallback: the cwd STRING may be a container-internal
+      // path for the very same directory. Compare by inode instead.
+      if (cwdIsUnderRootByInode(cwdLink, rootId, maxDepth)) {
+        return {
+          state: "in-use",
+          inaccessible,
+          holder: { pid: Number(pid), kind: "cwd", via: "inode", target },
+        };
+      }
+    } catch (e) {
+      const code = errno(e);
+      // ENOENT/ESRCH: the process exited mid-scan — nothing to account for.
+      if (code === "EACCES" || code === "EPERM") blocked = true;
+    }
+
+    // ── open file descriptors ──────────────────────────────────────────────
+    // Path matching only: an fd points at a FILE, so there is no `..` walk to
+    // do and no inode of ours to compare it against. A container-side fd is
+    // consequently only caught when its path matches; the cwd walk above is
+    // the cross-namespace signal.
+    const fdDir = join(procRoot, pid, "fd");
+    try {
+      for (const fd of readdirSync(fdDir)) {
+        let target: string;
+        try {
+          target = stripDeleted(readlinkSync(join(fdDir, fd)));
+        } catch {
+          continue; // fd closed mid-scan
+        }
+        if (isAtOrBelow(target, root)) {
+          return {
+            state: "in-use",
+            inaccessible,
+            holder: { pid: Number(pid), kind: "fd", via: "path", target },
+          };
+        }
+      }
+    } catch (e) {
+      const code = errno(e);
+      if (code === "EACCES" || code === "EPERM") blocked = true;
+    }
+
+    if (blocked && !isKernelThread(procRoot, pid)) inaccessible++;
+  }
+
+  return { state: "free", inaccessible };
+}

--- a/src/worktree/reap-report.ts
+++ b/src/worktree/reap-report.ts
@@ -1,0 +1,422 @@
+/**
+ * Report-only reaper pass — evidence, never deletion.
+ *
+ * ## Why this exists
+ *
+ * The reaper (`reaper.ts`, registry claims) and the task-tree sweep
+ * (`gc.ts`, per-agent `home/work` checkouts) both know how to classify a tree
+ * as reapable. Nothing runs either on a schedule, so the fleet has no record
+ * of whether those classifiers are RIGHT — and the first time anyone finds out
+ * would be the first time something automatic deletes a checkout.
+ *
+ * This module runs both classifiers on a schedule and writes down what they
+ * WOULD do. It builds the week of evidence that has to exist before any
+ * automatic deletion is considered.
+ *
+ * ## The safety default lives here, structurally
+ *
+ * `buildReapReport` is a pure read: it composes `planReaper` and `planGc`,
+ * both of which are plan-only predicates, and it imports NO removal primitive
+ * — not `applyGc`, not `runReaper`, not `removeCheckout`, not `rm`. There is
+ * no flag on this path that deletes, because there is no code here that can.
+ * `planGc` is always called with `escapeHatch: false` so the report cannot
+ * even describe the operator's reversible-quarantine action as something it
+ * would do. Turning deletion on is a separate, deliberate change to a
+ * different code path (`switchroom worktree gc --yes` / `worktree reap`), not
+ * a flag flip on this one.
+ *
+ * ## Per-agent size budget
+ *
+ * Reporting is grouped per agent and ordered OLDEST-FIRST, so the report shows
+ * the eviction order a budget-driven reaper would use (RFC
+ * `agent-home-lifecycle.md` §2). Entries are marked `overBudget` when
+ * evicting them oldest-first is what would bring that agent back under the
+ * budget — and ONLY entries that already clear every safety guard are ever
+ * marked, so the budget can never be a reason to cross a guard. When the
+ * guards block enough that the agent stays over budget, the report says so
+ * (`stillOverBytes`) instead of widening the eligibility.
+ */
+
+import { execFileSync } from "node:child_process";
+import { sep } from "node:path";
+import { planReaper, type ReapPlanEntry, type ReaperDeps } from "./reaper.js";
+import {
+  planGc,
+  defaultRoots,
+  defaultTaskTreeRoots,
+  type GcPlan,
+  type TaskTreeAction,
+} from "./gc.js";
+
+/** Per-agent task-tree budget default (RFC §2: 5 GB). */
+export const DEFAULT_AGENT_TREE_BUDGET_BYTES = 5 * 1024 * 1024 * 1024;
+
+/** Agent label used when a tree cannot be attributed to one. */
+export const UNATTRIBUTED_AGENT = "(unattributed)";
+
+/**
+ * Resolve the per-agent budget: `SWITCHROOM_AGENT_TREE_BUDGET_GB` (a number,
+ * may be fractional), else the 5 GB default. An unparseable or negative value
+ * falls back to the default rather than silently reporting everything as over
+ * budget.
+ */
+export function agentTreeBudgetBytes(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.SWITCHROOM_AGENT_TREE_BUDGET_GB;
+  if (raw == null || raw.trim() === "") return DEFAULT_AGENT_TREE_BUDGET_BYTES;
+  const gb = Number(raw);
+  if (!Number.isFinite(gb) || gb <= 0) return DEFAULT_AGENT_TREE_BUDGET_BYTES;
+  return Math.round(gb * 1024 * 1024 * 1024);
+}
+
+/**
+ * Attribute a path to an agent: `<...>/agents/<name>/<...>` → `<name>`.
+ * Returns null when the path is not inside an agent home.
+ */
+export function agentFromPath(path: string): string | null {
+  const parts = path.split(sep);
+  const i = parts.lastIndexOf("agents");
+  if (i < 0 || i + 1 >= parts.length) return null;
+  const name = parts[i + 1];
+  return name && name !== "" ? name : null;
+}
+
+export type ReapReportSource = "claim" | "task-tree";
+
+export interface ReapReportEntry {
+  source: ReapReportSource;
+  agent: string;
+  path: string;
+  branch: string | null;
+  /** Verbatim classifier verdict (`ReapAction` or `TaskTreeVerdict`). */
+  verdict: string;
+  /** True when the classifier would reap this tree on its own guards. */
+  wouldReap: boolean;
+  /**
+   * Newest activity (ms since epoch) — heartbeat for a claim, newest tracked
+   * mtime for a task tree. `null` when it could not be determined, which the
+   * classifiers already treat as "active ⇒ keep".
+   */
+  lastActivityMs: number | null;
+  /** Whole days since `lastActivityMs`; null when that is null. */
+  idleDays: number | null;
+  sizeBytes: number;
+  /** False when sizing failed (the tree is counted as 0 bytes). */
+  sizeKnown: boolean;
+  /**
+   * True when oldest-first eviction of the guard-clear trees would have to
+   * include this one to bring the agent under budget. Never set on an entry
+   * that fails a guard.
+   */
+  overBudget: boolean;
+}
+
+export interface AgentBudgetReport {
+  agent: string;
+  budgetBytes: number;
+  totalBytes: number;
+  /** Bytes the guard-clear, over-budget entries would reclaim. */
+  reclaimableBytes: number;
+  /** Bytes still over budget after every guard-clear eviction. 0 when clear. */
+  stillOverBytes: number;
+  /** Oldest activity first. */
+  entries: ReapReportEntry[];
+}
+
+export interface ReapReport {
+  /** Always "report-only". There is no other mode on this path. */
+  mode: "report-only";
+  generatedAt: string;
+  budgetBytes: number;
+  idleDays: number;
+  agents: AgentBudgetReport[];
+  totals: {
+    candidates: number;
+    wouldReap: number;
+    wouldSkip: number;
+    bytesIfReaped: number;
+    /** Trees no probe could clear — the liveness-probe exposure, measured. */
+    probeUnavailable: number;
+  };
+  /** Count per verdict across every candidate — the classifier evidence. */
+  verdictCounts: Record<string, number>;
+}
+
+export interface ReapReportDeps {
+  /** Registry-claim plan. Default: `planReaper()`. */
+  reapPlan?: ReapPlanEntry[];
+  /** Task-tree plan. Default: `planGc(defaultRoots(), …, defaultTaskTreeRoots())`. */
+  gcPlan?: GcPlan;
+  /** Directory size in bytes; default shells `du -sk`. */
+  dirSizeBytes?: (path: string) => number;
+  nowMs?: number;
+  budgetBytes?: number;
+  idleDays?: number;
+  /** Passed through to the default `planGc` call. */
+  roots?: string[];
+  taskTreeRoots?: string[];
+  reaperDeps?: ReaperDeps;
+}
+
+/**
+ * Apparent disk usage of a directory, in bytes.
+ *
+ * `du -sk` (KiB) rather than `-sb`: BSD/macOS `du` has no `-b`. Any failure
+ * (path gone, permission denied) reports 0 with `sizeKnown: false` upstream —
+ * a size is reporting metadata, never a safety input.
+ */
+export function defaultDirSizeBytes(path: string): number {
+  const out = execFileSync("du", ["-sk", path], {
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: 8 * 1024 * 1024,
+  }).toString();
+  const kib = parseInt(out.trim().split(/\s+/)[0] ?? "", 10);
+  if (!Number.isFinite(kib)) throw new Error(`unparseable du output: ${out.trim()}`);
+  return kib * 1024;
+}
+
+function daysBetween(nowMs: number, thenMs: number): number {
+  return Math.max(0, Math.floor((nowMs - thenMs) / 86_400_000));
+}
+
+function taskTreeEntry(
+  t: TaskTreeAction,
+  nowMs: number,
+  size: (p: string) => number,
+): ReapReportEntry {
+  let sizeBytes = 0;
+  let sizeKnown = true;
+  try {
+    sizeBytes = size(t.dir);
+  } catch {
+    sizeKnown = false;
+  }
+  return {
+    source: "task-tree",
+    agent: agentFromPath(t.dir) ?? UNATTRIBUTED_AGENT,
+    path: t.dir,
+    branch: t.branch,
+    verdict: t.verdict,
+    // `willAct` under a report build is exactly `verdict === "reap"`: the
+    // report always plans with the escape hatch OFF.
+    wouldReap: t.willAct,
+    lastActivityMs: t.newestMtimeMs,
+    idleDays: t.newestMtimeMs == null ? null : daysBetween(nowMs, t.newestMtimeMs),
+    sizeBytes,
+    sizeKnown,
+    overBudget: false,
+  };
+}
+
+function claimEntry(
+  e: ReapPlanEntry,
+  nowMs: number,
+  size: (p: string) => number,
+): ReapReportEntry {
+  let sizeBytes = 0;
+  let sizeKnown = true;
+  try {
+    sizeBytes = size(e.record.path);
+  } catch {
+    sizeKnown = false;
+  }
+  const hb = Date.parse(e.record.heartbeatAt);
+  const lastActivityMs = Number.isFinite(hb) ? hb : null;
+  return {
+    source: "claim",
+    agent: e.record.ownerAgent ?? UNATTRIBUTED_AGENT,
+    path: e.record.path,
+    branch: e.record.branch,
+    verdict: e.action,
+    wouldReap: e.action === "reap" || e.action === "reap-orphan",
+    lastActivityMs,
+    idleDays: lastActivityMs == null ? null : daysBetween(nowMs, lastActivityMs),
+    sizeBytes,
+    sizeKnown,
+    overBudget: false,
+  };
+}
+
+/**
+ * Mark the oldest-first prefix of guard-clear entries whose eviction would
+ * bring the agent under budget. Mutates `entries` (already oldest-first) and
+ * returns the reclaimable / still-over figures.
+ */
+function applyBudget(
+  entries: ReapReportEntry[],
+  budgetBytes: number,
+): { totalBytes: number; reclaimableBytes: number; stillOverBytes: number } {
+  const totalBytes = entries.reduce((n, e) => n + e.sizeBytes, 0);
+  if (totalBytes <= budgetBytes) {
+    return { totalBytes, reclaimableBytes: 0, stillOverBytes: 0 };
+  }
+  let remaining = totalBytes;
+  let reclaimableBytes = 0;
+  for (const e of entries) {
+    if (remaining <= budgetBytes) break;
+    // A guard is never crossed for budget's sake: only trees the classifier
+    // already cleared are eligible for eviction.
+    if (!e.wouldReap) continue;
+    e.overBudget = true;
+    reclaimableBytes += e.sizeBytes;
+    remaining -= e.sizeBytes;
+  }
+  return {
+    totalBytes,
+    reclaimableBytes,
+    stillOverBytes: Math.max(0, remaining - budgetBytes),
+  };
+}
+
+/**
+ * Build the report. Reads only — see the module header for why deletion is
+ * structurally absent from this path rather than merely defaulted off.
+ */
+export function buildReapReport(deps: ReapReportDeps = {}): ReapReport {
+  const nowMs = deps.nowMs ?? Date.now();
+  const budgetBytes = deps.budgetBytes ?? agentTreeBudgetBytes();
+  const idleDays = deps.idleDays ?? 14;
+  const size = deps.dirSizeBytes ?? defaultDirSizeBytes;
+
+  const reapPlan = deps.reapPlan ?? planReaper(nowMs, deps.reaperDeps ?? {});
+  const gcPlan =
+    deps.gcPlan ??
+    planGc(
+      deps.roots ?? defaultRoots(),
+      {
+        dateStamp: new Date(nowMs).toISOString().slice(0, 10),
+        idleDays,
+        nowMs,
+        // Report-only: the operator escape hatch is never simulated here.
+        escapeHatch: false,
+      },
+      deps.taskTreeRoots ?? defaultTaskTreeRoots(),
+    );
+
+  const entries: ReapReportEntry[] = [
+    // A fresh claim is not a candidate for anything; excluding it keeps the
+    // report about trees the classifiers have an opinion on.
+    ...reapPlan.filter((e) => e.action !== "keep-fresh").map((e) => claimEntry(e, nowMs, size)),
+    ...gcPlan.taskTrees
+      .filter((t) => t.verdict !== "skip-protected")
+      .map((t) => taskTreeEntry(t, nowMs, size)),
+  ];
+
+  const byAgent = new Map<string, ReapReportEntry[]>();
+  for (const e of entries) {
+    const list = byAgent.get(e.agent) ?? [];
+    list.push(e);
+    byAgent.set(e.agent, list);
+  }
+
+  const agents: AgentBudgetReport[] = [...byAgent.entries()]
+    .map(([agent, list]) => {
+      // Oldest first. Unknown activity sorts LAST: the classifiers treat it as
+      // active, so it must never head an eviction order.
+      list.sort((a, b) => {
+        if (a.lastActivityMs == null && b.lastActivityMs == null) return a.path.localeCompare(b.path);
+        if (a.lastActivityMs == null) return 1;
+        if (b.lastActivityMs == null) return -1;
+        return a.lastActivityMs - b.lastActivityMs;
+      });
+      const budget = applyBudget(list, budgetBytes);
+      return {
+        agent,
+        budgetBytes,
+        totalBytes: budget.totalBytes,
+        reclaimableBytes: budget.reclaimableBytes,
+        stillOverBytes: budget.stillOverBytes,
+        entries: list,
+      };
+    })
+    .sort((a, b) => b.totalBytes - a.totalBytes || a.agent.localeCompare(b.agent));
+
+  const verdictCounts: Record<string, number> = {};
+  for (const e of entries) verdictCounts[e.verdict] = (verdictCounts[e.verdict] ?? 0) + 1;
+
+  const wouldReap = entries.filter((e) => e.wouldReap);
+  return {
+    mode: "report-only",
+    generatedAt: new Date(nowMs).toISOString(),
+    budgetBytes,
+    idleDays,
+    agents,
+    totals: {
+      candidates: entries.length,
+      wouldReap: wouldReap.length,
+      wouldSkip: entries.length - wouldReap.length,
+      bytesIfReaped: wouldReap.reduce((n, e) => n + e.sizeBytes, 0),
+      probeUnavailable: entries.filter((e) => e.verdict === "skip-probe-unavailable").length,
+    },
+    verdictCounts,
+  };
+}
+
+/** Human-readable bytes (report output only). */
+export function formatBytes(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let n = bytes;
+  let u = 0;
+  while (n >= 1024 && u < units.length - 1) {
+    n /= 1024;
+    u++;
+  }
+  return `${u === 0 ? n : n.toFixed(1)}${units[u]}`;
+}
+
+/**
+ * Render the report as the plain text a cron log wants. Deliberately states
+ * "nothing was deleted" on every run so a log tail can never be mistaken for
+ * a record of deletions.
+ */
+export function formatReapReport(report: ReapReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `worktree reap-report — REPORT ONLY, nothing was deleted (${report.generatedAt})`,
+  );
+  lines.push(
+    `budget ${formatBytes(report.budgetBytes)}/agent · idle threshold ${report.idleDays}d`,
+  );
+  lines.push(
+    `${report.totals.candidates} candidate(s): ${report.totals.wouldReap} would reap ` +
+      `(${formatBytes(report.totals.bytesIfReaped)}), ${report.totals.wouldSkip} would be kept` +
+      (report.totals.probeUnavailable > 0
+        ? ` — ${report.totals.probeUnavailable} could not be proven idle`
+        : ""),
+  );
+
+  if (report.agents.length === 0) {
+    lines.push("");
+    lines.push("No candidate worktrees found.");
+    return lines.join("\n");
+  }
+
+  for (const a of report.agents) {
+    lines.push("");
+    const over = a.totalBytes > a.budgetBytes ? ` OVER BUDGET by ${formatBytes(a.totalBytes - a.budgetBytes)}` : "";
+    lines.push(`${a.agent} — ${formatBytes(a.totalBytes)} across ${a.entries.length} tree(s)${over}`);
+    if (a.stillOverBytes > 0) {
+      lines.push(
+        `  ${formatBytes(a.stillOverBytes)} would remain over budget: the guards keep the rest.`,
+      );
+    }
+    for (const e of a.entries) {
+      const age = e.idleDays == null ? "age?" : `${e.idleDays}d`;
+      const marks = [
+        e.wouldReap ? "would-reap" : `keep:${e.verdict}`,
+        e.overBudget ? "over-budget" : null,
+        e.sizeKnown ? null : "size?",
+      ].filter(Boolean);
+      lines.push(
+        `  ${age.padStart(5)}  ${formatBytes(e.sizeBytes).padStart(8)}  ${e.source.padEnd(9)}  ` +
+          `${e.path} [${e.branch ?? "detached"}] ${marks.join(" ")}`,
+      );
+    }
+  }
+
+  const verdicts = Object.entries(report.verdictCounts).sort((a, b) => b[1] - a[1]);
+  if (verdicts.length > 0) {
+    lines.push("");
+    lines.push(`verdicts: ${verdicts.map(([v, n]) => `${v}=${n}`).join(" ")}`);
+  }
+  return lines.join("\n");
+}

--- a/src/worktree/reaper.ts
+++ b/src/worktree/reaper.ts
@@ -15,8 +15,9 @@
  *     2. the worktree has NO uncommitted changes (a hard skip — never a
  *        mere warning: we do not destroy in-flight work), AND
  *     3. an in-use probe can DEFINITIVELY report the path as free.
- *   If the in-use probe is unavailable (neither `fuser` nor `lsof` is
- *   installed) we treat the path as live and keep it — "can't prove it's
+ *   If the in-use probe cannot reach a definitive answer (no readable procfs
+ *   and no `fuser`/`lsof`, or a procfs sweep that could not inspect every
+ *   process) we treat the path as live and keep it — "can't prove it's
  *   idle" must never license a force-remove. A live claim advances its own
  *   heartbeat (see registry.touchHeartbeat, refreshed from the gateway's
  *   watch loop), so a genuinely-abandoned claim is the only thing that
@@ -39,6 +40,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { scanProcForHolders, type ProcScanResult } from "./proc-liveness.js";
 import { listRecords, deleteRecord } from "./registry.js";
 import { removeCheckout } from "./remove-checkout.js";
 import type { WorktreeRecord } from "./types.js";
@@ -50,8 +52,10 @@ export const STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
  * Result of probing whether a path is held open by a live process.
  *   - "in-use"      — a probe positively found a holder → keep the claim.
  *   - "free"        — a probe ran and found NO holder → safe to consider reap.
- *   - "unavailable" — NO probe tool is installed → we cannot tell, so the
- *                     reaper treats the path as live (fail-safe) and keeps it.
+ *   - "unavailable" — the probe could not reach a definitive answer (no
+ *                     readable procfs and no fuser/lsof, or a procfs sweep
+ *                     that could not inspect every process) → we cannot tell,
+ *                     so the reaper treats the path as live (fail-safe).
  */
 export type PathUseState = "in-use" | "free" | "unavailable";
 
@@ -93,7 +97,7 @@ export type ReapAction =
   | "keep-fresh"
   /** Stale but has uncommitted changes → preserve (never auto-delete dirty). */
   | "skip-dirty"
-  /** Stale + clean but no fuser/lsof to prove it idle → treat as live. */
+  /** Stale + clean but nothing could prove it idle → treat as live. */
   | "skip-probe-unavailable"
   /** Stale + clean but the probe positively found a holder → keep. */
   | "skip-in-use";
@@ -120,35 +124,38 @@ export function reapSkipReasonText(action: ReapAction): string {
 }
 
 /**
- * Probe whether any process holds the worktree path open.
+ * External-tool leg of the probe: `fuser` (Linux/procps), then `lsof`
+ * (macOS/BSD).
  *
- * Tries `fuser` (Linux/procps) first, then `lsof` (macOS/BSD).
+ * `lsof` is invoked with `+D` so it descends the tree — plain `lsof -t <dir>`
+ * matches the directory EXACTLY and misses a process sitting in a nested
+ * subdirectory, which is the bug this module's procfs scan exists to fix.
+ * `fuser` has no recursive mode at all, so it is kept only as a POSITIVE
+ * signal: it can say "in-use", it can never be trusted to say "free".
  *
- * Crucially, this distinguishes "the probe RAN and found nothing" (→ "free")
- * from "the probe tool is not installed" (→ "unavailable"). A missing binary
- * surfaces as a spawn `ENOENT`; a real "path not in use" surfaces as a
- * non-zero *exit* (no `ENOENT`). The reaper must never force-remove on the
- * strength of an "unavailable" result — that was the F1 data-loss hole where
- * a host without fuser/lsof reaped live worktrees.
+ * Distinguishes "the tool RAN and found nothing" (→ "free") from "the tool is
+ * not installed" (→ "unavailable"): a missing binary surfaces as a spawn
+ * `ENOENT`, a real "not in use" as a non-zero *exit*.
  */
-export function probePathInUse(path: string): PathUseState {
+export function probePathInUseWithTools(path: string): PathUseState {
   let probeRan = false;
 
   // fuser: exits 0 when the path is in use; non-zero when not; ENOENT when
-  // the binary itself is missing.
+  // the binary itself is missing. Positive-only — a non-zero exit here does
+  // NOT mark the probe as having answered, because fuser cannot see a holder
+  // in a nested subdirectory.
   try {
     execFileSync("fuser", [path], { stdio: "pipe" });
     return "in-use";
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      // fuser ran and exited non-zero → path not in use (per fuser).
-      probeRan = true;
-    }
+  } catch {
+    /* not in use per fuser, or fuser missing — either way, inconclusive. */
   }
 
-  // lsof: exits 0 with PID output when in use; exits 1 (non-ENOENT) when not.
+  // lsof +D: recurses into the tree and reports every process with an open
+  // file (cwd entries included) at or below it. Exits 0 with PID output when
+  // in use; non-zero (non-ENOENT) when not.
   try {
-    const out = execFileSync("lsof", ["-t", path], {
+    const out = execFileSync("lsof", ["-t", "+D", path], {
       stdio: ["ignore", "pipe", "ignore"],
     })
       .toString()
@@ -157,12 +164,62 @@ export function probePathInUse(path: string): PathUseState {
     if (out.length > 0) return "in-use";
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      // lsof ran and found nothing (exit 1) → not in use (per lsof).
+      // lsof ran and found nothing → not in use (per lsof).
       probeRan = true;
     }
   }
 
   return probeRan ? "free" : "unavailable";
+}
+
+/** Injectable seams for `probePathInUse` (tests / host portability). */
+export interface ProbeDeps {
+  scanProc?: (path: string) => ProcScanResult;
+  probeTools?: (path: string) => PathUseState;
+}
+
+/**
+ * Probe whether any process holds the worktree path open — AT OR BELOW the
+ * tree root.
+ *
+ * Primary mechanism is the procfs scan (`scanProcForHolders`): it matches a
+ * process whose cwd is any directory beneath the tree, and any open fd into
+ * the tree, including across a container mount namespace. See
+ * `proc-liveness.ts` for the failure it fixes — `fuser`/`lsof -t` match the
+ * path exactly, so both reported "free" for a tree an agent was working in.
+ *
+ * Resolution order, safety-first:
+ *   1. procfs found a holder                      → "in-use"
+ *   2. procfs swept EVERY process, found none     → "free"   (definitive)
+ *   3. procfs sweep was PARTIAL (some processes
+ *      unreadable) or procfs is absent            → fall back to the tools;
+ *      a tool hit is still "in-use", but a tool MISS after a partial sweep is
+ *      "unavailable", never "free" — we could not inspect every process and
+ *      the tools cannot see a nested holder, so nothing here proves the tree
+ *      is idle.
+ *
+ * Consequence worth knowing before automating deletion: run as a uid that
+ * cannot read other users' `/proc/<pid>/cwd` (i.e. not the tree owner and not
+ * root), this returns "unavailable" for a tree it cannot clear — the reaper
+ * keeps it. That is the intended posture ("can't prove it's idle" must never
+ * license a force-remove, per this module's fail-safe contract), and the
+ * report-only pass (`reap-report.ts`) surfaces the count so the exposure is
+ * measurable before anyone turns on deletion.
+ */
+export function probePathInUse(path: string, deps: ProbeDeps = {}): PathUseState {
+  const scanProc = deps.scanProc ?? ((p: string) => scanProcForHolders(p));
+  const probeTools = deps.probeTools ?? probePathInUseWithTools;
+
+  const scan = scanProc(path);
+  if (scan.state === "in-use") return "in-use";
+  if (scan.state === "free" && scan.inaccessible === 0) return "free";
+
+  const tool = probeTools(path);
+  if (tool === "in-use") return "in-use";
+  // Partial procfs sweep: a tool miss cannot upgrade it to "free".
+  if (scan.state === "free") return "unavailable";
+  // No procfs at all (non-Linux): the tools are the only evidence there is.
+  return tool;
 }
 
 /**
@@ -261,7 +318,7 @@ export function planReaper(nowMs?: number, deps: ReaperDeps = {}): ReapPlanEntry
     }
 
     // Fail-safe 2: only reap when the path is DEFINITIVELY free. Both
-    // "in-use" and "unavailable" (no fuser/lsof to prove idleness) mean we
+    // "in-use" and "unavailable" (nothing could prove idleness) mean we
     // cannot show the worktree is dead → keep it.
     const use = probeInUse(record.path);
     if (use === "unavailable") {
@@ -270,7 +327,8 @@ export function planReaper(nowMs?: number, deps: ReaperDeps = {}): ReapPlanEntry
         action: "skip-probe-unavailable",
         message:
           `[worktree-reaper] SKIPPED stale worktree — in-use probe ` +
-          `unavailable (neither fuser nor lsof installed); treating as ` +
+          `could not prove the path idle (no readable procfs, no ` +
+          `fuser/lsof, or a partial procfs sweep); treating as ` +
           `live: id=${record.id} path=${record.path}`,
       });
       continue;

--- a/tests/worktree.proc-liveness.test.ts
+++ b/tests/worktree.proc-liveness.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Liveness-probe outcome tests.
+ *
+ * The headline case is the REGRESSION test: a process whose cwd is a NESTED
+ * SUBDIRECTORY of a worktree must classify the worktree as live. Against the
+ * pre-fix probe (`fuser <path>` / `lsof -t <path>`, both exact-match) that test
+ * fails — the probe returns "free" and the reaper would force-remove a tree an
+ * agent is working in.
+ *
+ * The synthetic-procfs tests drive `scanProcForHolders` against a fake `/proc`
+ * built out of real symlinks, which is how the cross-mount-namespace and
+ * partial-sweep behaviours are pinned without needing containers or root.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { probePathInUse, probePathInUseWithTools } from "../src/worktree/reaper.js";
+import { scanProcForHolders } from "../src/worktree/proc-liveness.js";
+
+/** Wait until `pred()` is true or the deadline passes. */
+async function until(pred: () => boolean, timeoutMs = 5000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return pred();
+}
+
+describe("worktree liveness probe", () => {
+  let tmpDir: string;
+  const children: ChildProcess[] = [];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sw-liveness-"));
+  });
+
+  afterEach(() => {
+    for (const c of children.splice(0)) {
+      try {
+        c.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── The regression: nested cwd ────────────────────────────────────────────
+
+  const linuxOnly = process.platform === "linux" ? it : it.skip;
+
+  linuxOnly(
+    "classifies a tree as in-use when a process cwd is a NESTED SUBDIRECTORY",
+    async () => {
+      const tree = join(tmpDir, "tree");
+      const nested = join(tree, "src", "deep");
+      mkdirSync(nested, { recursive: true });
+
+      // A live process sitting in the nested subdir — exactly what an agent
+      // working inside a checkout looks like.
+      const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 60000)"], {
+        cwd: nested,
+        stdio: "ignore",
+      });
+      children.push(child);
+      expect(await until(() => child.pid != null && !child.killed)).toBe(true);
+      // Give the kernel a beat to publish /proc/<pid>.
+      expect(await until(() => existsSync(`/proc/${child.pid}`))).toBe(true);
+
+      // The OUTCOME that matters: the tree root must be reported live, so the
+      // reaper's third fail-safe can never clear it.
+      expect(probePathInUse(tree)).toBe("in-use");
+
+      // And the reason the old probe missed it, pinned explicitly: the
+      // external tools answer about the exact path only.
+      expect(probePathInUseWithTools(tree)).not.toBe("in-use");
+    },
+  );
+
+  linuxOnly("classifies a tree as in-use when a process holds an fd inside it", async () => {
+    const tree = join(tmpDir, "fdtree");
+    mkdirSync(join(tree, "sub"), { recursive: true });
+    const file = join(tree, "sub", "held.txt");
+    writeFileSync(file, "x");
+
+    // This very process holds the fd — no child needed, and /proc/self is
+    // always readable.
+    const fd = openSync(file, "r");
+    try {
+      expect(probePathInUse(tree)).toBe("in-use");
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  linuxOnly("reports a genuinely unheld tree as free", () => {
+    const tree = join(tmpDir, "idle");
+    mkdirSync(join(tree, "src"), { recursive: true });
+    // Running as a uid that can inspect every process this yields "free";
+    // otherwise the partial-sweep guard downgrades to "unavailable". Both are
+    // safe; what must never happen is a false "in-use".
+    expect(["free", "unavailable"]).toContain(probePathInUse(tree));
+  });
+
+  // ── Synthetic procfs: mechanisms that need a controlled /proc ─────────────
+
+  /** Build a fake procfs entry with a cwd symlink (and optional fds). */
+  function fakeProc(
+    root: string,
+    entries: { pid: string; cwd?: string; fds?: string[]; cmdline?: string }[],
+  ): string {
+    mkdirSync(root, { recursive: true });
+    for (const e of entries) {
+      const dir = join(root, e.pid);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "cmdline"), e.cmdline ?? "node\0");
+      if (e.cwd) symlinkSync(e.cwd, join(dir, "cwd"));
+      if (e.fds) {
+        mkdirSync(join(dir, "fd"), { recursive: true });
+        e.fds.forEach((target, i) => symlinkSync(target, join(dir, "fd", String(i + 3))));
+      }
+    }
+    return root;
+  }
+
+  it("finds a holder whose cwd path is a container-internal alias of the tree", () => {
+    // A process inside an agent container sees the worktree at a different
+    // path than the host does. Its /proc/<pid>/cwd STRING therefore shares no
+    // prefix with the host path — only the inode walk can match it.
+    const tree = join(tmpDir, "host", "tree");
+    mkdirSync(join(tree, "src", "deep"), { recursive: true });
+    const alias = join(tmpDir, "state-agent"); // stands in for the container view
+    symlinkSync(join(tmpDir, "host"), alias);
+
+    const procRoot = fakeProc(join(tmpDir, "proc"), [
+      { pid: "4242", cwd: join(alias, "tree", "src", "deep") },
+    ]);
+
+    const scan = scanProcForHolders(tree, { procRoot });
+    expect(scan.state).toBe("in-use");
+    expect(scan.holder?.via).toBe("inode");
+    expect(scan.holder?.pid).toBe(4242);
+  });
+
+  it("reports free (definitive) when every process is inspectable and none holds the tree", () => {
+    const tree = join(tmpDir, "tree");
+    mkdirSync(tree, { recursive: true });
+    const other = join(tmpDir, "elsewhere");
+    mkdirSync(other, { recursive: true });
+
+    const procRoot = fakeProc(join(tmpDir, "proc"), [{ pid: "7", cwd: other }]);
+    const scan = scanProcForHolders(tree, { procRoot });
+    expect(scan).toMatchObject({ state: "free", inaccessible: 0 });
+  });
+
+  it("a partial sweep never resolves to free, even when the tools say free", () => {
+    const tree = join(tmpDir, "tree");
+    mkdirSync(tree, { recursive: true });
+    expect(
+      probePathInUse(tree, {
+        scanProc: () => ({ state: "free", inaccessible: 3 }),
+        probeTools: () => "free",
+      }),
+    ).toBe("unavailable");
+  });
+
+  // Root can read every /proc entry, so the EACCES accounting can only be
+  // observed as a non-root uid. The decision rule it feeds is pinned above,
+  // unconditionally.
+  const nonRootOnly = (process.getuid?.() ?? 0) === 0 ? it.skip : it;
+
+  nonRootOnly("counts a process it cannot inspect as uninspectable", () => {
+    const tree = join(tmpDir, "tree");
+    mkdirSync(tree, { recursive: true });
+    const procRoot = fakeProc(join(tmpDir, "proc"), [{ pid: "9", cwd: tmpDir }]);
+    const blocked = join(procRoot, "11");
+    mkdirSync(blocked, { recursive: true });
+    writeFileSync(join(blocked, "cmdline"), "node\0");
+    symlinkSync(tmpDir, join(blocked, "cwd"));
+    // 0o000 makes both the cwd readlink and the fd readdir fail with EACCES.
+    chmodSync(blocked, 0o000);
+    try {
+      const scan = scanProcForHolders(tree, { procRoot });
+      expect(scan).toMatchObject({ state: "free", inaccessible: 1 });
+    } finally {
+      chmodSync(blocked, 0o755);
+    }
+  });
+
+  it("a tool hit still wins after a partial sweep", () => {
+    const tree = join(tmpDir, "tree");
+    mkdirSync(tree, { recursive: true });
+    expect(
+      probePathInUse(tree, {
+        scanProc: () => ({ state: "free", inaccessible: 2 }),
+        probeTools: () => "in-use",
+      }),
+    ).toBe("in-use");
+  });
+
+  it("falls through to the tools verbatim when there is no procfs at all", () => {
+    const tree = join(tmpDir, "tree");
+    mkdirSync(tree, { recursive: true });
+    expect(
+      probePathInUse(tree, {
+        scanProc: () => ({ state: "unavailable", inaccessible: 0 }),
+        probeTools: () => "free",
+      }),
+    ).toBe("free");
+    expect(
+      probePathInUse(tree, {
+        scanProc: () => ({ state: "unavailable", inaccessible: 0 }),
+        probeTools: () => "unavailable",
+      }),
+    ).toBe("unavailable");
+  });
+
+  it("kernel threads are not counted as uninspectable", () => {
+    const tree = join(tmpDir, "tree");
+    mkdirSync(tree, { recursive: true });
+    // Empty cmdline + no cwd link ⇒ a kthread-shaped entry. It must not
+    // poison the sweep into "partial".
+    const procRoot = join(tmpDir, "proc");
+    mkdirSync(join(procRoot, "2"), { recursive: true });
+    writeFileSync(join(procRoot, "2", "cmdline"), "");
+    const scan = scanProcForHolders(tree, { procRoot });
+    expect(scan).toMatchObject({ state: "free", inaccessible: 0 });
+  });
+
+  it("treats a vanished tree as unavailable, never free", () => {
+    const scan = scanProcForHolders(join(tmpDir, "does-not-exist"), {
+      procRoot: join(tmpDir, "proc"),
+    });
+    expect(scan.state).toBe("unavailable");
+  });
+});

--- a/tests/worktree.reap-report.test.ts
+++ b/tests/worktree.reap-report.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Report-only reaper pass — outcome tests.
+ *
+ * The invariants under test are: nothing on this path deletes anything, the
+ * per-agent budget orders evictions oldest-first, and the budget can never
+ * promote a tree that fails a safety guard.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { listRecords, writeRecord } from "../src/worktree/registry.js";
+import { STALE_THRESHOLD_MS, type ReapPlanEntry } from "../src/worktree/reaper.js";
+import type { GcPlan, TaskTreeAction } from "../src/worktree/gc.js";
+import {
+  agentFromPath,
+  agentTreeBudgetBytes,
+  buildReapReport,
+  formatReapReport,
+  DEFAULT_AGENT_TREE_BUDGET_BYTES,
+  UNATTRIBUTED_AGENT,
+} from "../src/worktree/reap-report.js";
+
+const NOW = Date.parse("2026-08-01T00:00:00.000Z");
+const DAY = 86_400_000;
+const GB = 1024 * 1024 * 1024;
+
+function taskTree(over: Partial<TaskTreeAction> & { dir: string }): TaskTreeAction {
+  return {
+    shape: "clone",
+    ownerRepo: null,
+    branch: "task/x",
+    verdict: "reap",
+    prSignal: "merged",
+    idle: true,
+    newestMtimeMs: NOW - 30 * DAY,
+    dest: "/trash/x",
+    willAct: true,
+    ...over,
+  };
+}
+
+function gcPlan(taskTrees: TaskTreeAction[]): GcPlan {
+  return {
+    roots: [],
+    taskTreeRoots: [],
+    trashDir: "/trash",
+    orphans: [],
+    registered: [],
+    taskTrees,
+    reposToPrune: [],
+    skipped: [],
+  };
+}
+
+/** `<home>/agents/<agent>/home/work/<slug>` — the real task-tree shape. */
+function treePath(agent: string, slug: string): string {
+  return join("/srv", ".switchroom", "agents", agent, "home", "work", slug);
+}
+
+describe("worktree reap-report", () => {
+  it("attributes a task tree to its agent, and falls back cleanly", () => {
+    expect(agentFromPath(treePath("klanker", "fix-3019"))).toBe("klanker");
+    expect(agentFromPath("/home/op/code/switchroom-x")).toBeNull();
+  });
+
+  it("orders each agent's trees oldest-first", () => {
+    const report = buildReapReport({
+      nowMs: NOW,
+      reapPlan: [],
+      dirSizeBytes: () => 1024,
+      gcPlan: gcPlan([
+        taskTree({ dir: treePath("klanker", "newer"), newestMtimeMs: NOW - 20 * DAY }),
+        taskTree({ dir: treePath("klanker", "oldest"), newestMtimeMs: NOW - 90 * DAY }),
+        taskTree({ dir: treePath("klanker", "middle"), newestMtimeMs: NOW - 45 * DAY }),
+      ]),
+    });
+
+    const agent = report.agents.find((a) => a.agent === "klanker");
+    expect(agent?.entries.map((e) => e.path)).toEqual([
+      treePath("klanker", "oldest"),
+      treePath("klanker", "middle"),
+      treePath("klanker", "newer"),
+    ]);
+    expect(agent?.entries.map((e) => e.idleDays)).toEqual([90, 45, 20]);
+  });
+
+  it("sorts a tree with unknown activity LAST, never at the head of the eviction order", () => {
+    const report = buildReapReport({
+      nowMs: NOW,
+      reapPlan: [],
+      dirSizeBytes: () => 1024,
+      gcPlan: gcPlan([
+        taskTree({ dir: treePath("a", "unknown"), newestMtimeMs: null }),
+        taskTree({ dir: treePath("a", "old"), newestMtimeMs: NOW - 60 * DAY }),
+      ]),
+    });
+    expect(report.agents[0]!.entries.map((e) => e.path)).toEqual([
+      treePath("a", "old"),
+      treePath("a", "unknown"),
+    ]);
+  });
+
+  it("marks only as many oldest trees over-budget as it takes to get under budget", () => {
+    const report = buildReapReport({
+      nowMs: NOW,
+      budgetBytes: 5 * GB,
+      reapPlan: [],
+      dirSizeBytes: () => 2 * GB, // 4 trees × 2 GB = 8 GB against a 5 GB budget
+      gcPlan: gcPlan([
+        taskTree({ dir: treePath("klanker", "t1"), newestMtimeMs: NOW - 10 * DAY }),
+        taskTree({ dir: treePath("klanker", "t2"), newestMtimeMs: NOW - 20 * DAY }),
+        taskTree({ dir: treePath("klanker", "t3"), newestMtimeMs: NOW - 30 * DAY }),
+        taskTree({ dir: treePath("klanker", "t4"), newestMtimeMs: NOW - 40 * DAY }),
+      ]),
+    });
+
+    const agent = report.agents[0]!;
+    expect(agent.totalBytes).toBe(8 * GB);
+    // 8 GB − 2 evictions × 2 GB = 4 GB ≤ 5 GB, so exactly the two oldest.
+    expect(agent.entries.filter((e) => e.overBudget).map((e) => e.path)).toEqual([
+      treePath("klanker", "t4"),
+      treePath("klanker", "t3"),
+    ]);
+    expect(agent.reclaimableBytes).toBe(4 * GB);
+    expect(agent.stillOverBytes).toBe(0);
+  });
+
+  it("never marks a guard-blocked tree over-budget, and says how much stays over", () => {
+    const report = buildReapReport({
+      nowMs: NOW,
+      budgetBytes: 1 * GB,
+      reapPlan: [],
+      dirSizeBytes: () => 2 * GB,
+      gcPlan: gcPlan([
+        // The oldest tree is dirty — the budget must not promote it.
+        taskTree({
+          dir: treePath("klanker", "dirty"),
+          newestMtimeMs: NOW - 90 * DAY,
+          verdict: "skip-dirty",
+          willAct: false,
+        }),
+        taskTree({
+          dir: treePath("klanker", "inuse"),
+          newestMtimeMs: NOW - 80 * DAY,
+          verdict: "skip-in-use",
+          willAct: false,
+        }),
+        taskTree({ dir: treePath("klanker", "clean"), newestMtimeMs: NOW - 10 * DAY }),
+      ]),
+    });
+
+    const agent = report.agents[0]!;
+    const overBudget = agent.entries.filter((e) => e.overBudget);
+    expect(overBudget.map((e) => e.path)).toEqual([treePath("klanker", "clean")]);
+    // 6 GB total − 2 GB reclaimable = 4 GB, i.e. 3 GB still over a 1 GB budget.
+    expect(agent.stillOverBytes).toBe(3 * GB);
+    expect(formatReapReport(report)).toContain("would remain over budget");
+  });
+
+  it("counts verdicts and the unprovable-idle exposure across both sources", () => {
+    const claim = (id: string, action: ReapPlanEntry["action"]): ReapPlanEntry => ({
+      record: {
+        id,
+        repo: "/repo",
+        repoName: "switchroom",
+        branch: `task/${id}`,
+        path: `/srv/.switchroom/worktree-checkouts/${id}`,
+        createdAt: new Date(NOW - STALE_THRESHOLD_MS * 4).toISOString(),
+        heartbeatAt: new Date(NOW - STALE_THRESHOLD_MS * 3).toISOString(),
+        ownerAgent: "klanker",
+      },
+      action,
+      message: "",
+    });
+
+    const report = buildReapReport({
+      nowMs: NOW,
+      reapPlan: [
+        claim("keep", "keep-fresh"), // excluded: not a candidate
+        claim("c1", "skip-probe-unavailable"),
+        claim("c2", "reap"),
+      ],
+      dirSizeBytes: () => 1024,
+      gcPlan: gcPlan([
+        taskTree({ dir: treePath("klanker", "t1"), verdict: "skip-probe-unavailable", willAct: false }),
+        taskTree({ dir: treePath("klanker", "t2") }),
+        // Protected trees are never candidates.
+        taskTree({ dir: treePath("klanker", "stable"), verdict: "skip-protected", willAct: false }),
+      ]),
+    });
+
+    expect(report.totals.candidates).toBe(4);
+    expect(report.totals.wouldReap).toBe(2);
+    expect(report.totals.wouldSkip).toBe(2);
+    expect(report.totals.probeUnavailable).toBe(2);
+    expect(report.verdictCounts["skip-protected"]).toBeUndefined();
+    expect(report.verdictCounts["keep-fresh"]).toBeUndefined();
+  });
+
+  it("labels an unattributable tree instead of dropping it", () => {
+    const report = buildReapReport({
+      nowMs: NOW,
+      reapPlan: [],
+      dirSizeBytes: () => 1024,
+      gcPlan: gcPlan([taskTree({ dir: "/home/op/code/switchroom-stray" })]),
+    });
+    expect(report.agents[0]!.agent).toBe(UNATTRIBUTED_AGENT);
+  });
+
+  it("counts a tree whose size cannot be measured as 0 bytes, flagged, not skipped", () => {
+    const report = buildReapReport({
+      nowMs: NOW,
+      reapPlan: [],
+      dirSizeBytes: () => {
+        throw new Error("du: permission denied");
+      },
+      gcPlan: gcPlan([taskTree({ dir: treePath("a", "t1") })]),
+    });
+    const entry = report.agents[0]!.entries[0]!;
+    expect(entry.sizeKnown).toBe(false);
+    expect(entry.sizeBytes).toBe(0);
+    expect(report.totals.candidates).toBe(1);
+  });
+
+  it("resolves the budget from env, falling back to the default on garbage", () => {
+    expect(agentTreeBudgetBytes({} as NodeJS.ProcessEnv)).toBe(DEFAULT_AGENT_TREE_BUDGET_BYTES);
+    expect(agentTreeBudgetBytes({ SWITCHROOM_AGENT_TREE_BUDGET_GB: "2" } as NodeJS.ProcessEnv)).toBe(2 * GB);
+    expect(agentTreeBudgetBytes({ SWITCHROOM_AGENT_TREE_BUDGET_GB: "-3" } as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_AGENT_TREE_BUDGET_BYTES,
+    );
+    expect(agentTreeBudgetBytes({ SWITCHROOM_AGENT_TREE_BUDGET_GB: "banana" } as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_AGENT_TREE_BUDGET_BYTES,
+    );
+  });
+
+  it("says report-only, and says nothing was deleted", () => {
+    const report = buildReapReport({
+      nowMs: NOW,
+      reapPlan: [],
+      dirSizeBytes: () => 0,
+      gcPlan: gcPlan([]),
+    });
+    expect(report.mode).toBe("report-only");
+    expect(formatReapReport(report)).toContain("nothing was deleted");
+  });
+});
+
+// ── The safety default: a report pass leaves the disk and registry alone ────
+
+describe("worktree reap-report — deletes nothing", () => {
+  let tmpDir: string;
+  const origEnv = process.env.SWITCHROOM_WORKTREE_DIR;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sw-reap-report-"));
+    process.env.SWITCHROOM_WORKTREE_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (origEnv === undefined) delete process.env.SWITCHROOM_WORKTREE_DIR;
+    else process.env.SWITCHROOM_WORKTREE_DIR = origEnv;
+  });
+
+  it("leaves a would-reap orphan record and a would-reap tree on disk untouched", () => {
+    // A stale registry claim whose tree exists AND a task tree the classifier
+    // says it would reap. A real reap pass would delete both; the report pass
+    // must leave every byte in place.
+    const treeDir = join(tmpDir, "checkouts", "stale01");
+    mkdirSync(treeDir, { recursive: true });
+    writeFileSync(join(treeDir, "file.txt"), "work");
+    writeRecord({
+      id: "stale01",
+      repo: "/repo",
+      repoName: "switchroom",
+      branch: "task/stale01",
+      path: treeDir,
+      createdAt: new Date(Date.now() - STALE_THRESHOLD_MS * 4).toISOString(),
+      heartbeatAt: new Date(Date.now() - STALE_THRESHOLD_MS * 3).toISOString(),
+      ownerAgent: "klanker",
+    });
+
+    const taskDir = join(tmpDir, "agents", "klanker", "home", "work", "fix-1");
+    mkdirSync(taskDir, { recursive: true });
+    writeFileSync(join(taskDir, "keep.txt"), "task work");
+
+    const report = buildReapReport({
+      // Real planReaper (reads the registry above), synthetic gc plan so the
+      // test does not shell out to git/gh.
+      reaperDeps: { probeInUse: () => "free", hasUncommittedChanges: () => false },
+      gcPlan: gcPlan([taskTree({ dir: taskDir })]),
+      dirSizeBytes: () => 4096,
+    });
+
+    expect(report.totals.wouldReap).toBeGreaterThanOrEqual(2);
+    // Outcome: everything still there.
+    expect(existsSync(join(treeDir, "file.txt"))).toBe(true);
+    expect(existsSync(join(taskDir, "keep.txt"))).toBe(true);
+    expect(listRecords().map((r) => r.id)).toEqual(["stale01"]);
+  });
+});


### PR DESCRIPTION
## Summary

Two changes to the worktree reclaim subsystem, one correctness fix and one
evidence-gathering mode.

**1. The liveness probe missed nested holders (`src/worktree/reaper.ts:134`
on `main`).** `probePathInUse` answered with `fuser <path>` then
`lsof -t <path>`. Both match the path **exactly**, so a process whose cwd is a
nested subdirectory of a worktree — i.e. an agent working inside a checkout —
was reported `free`. Reproduced on `main`:

```
$ mkdir -p /tmp/tree/src/deep && (cd /tmp/tree/src/deep && sleep 60) &
$ fuser /tmp/tree          ; echo $?     # (no output)   1   ← "free"
$ fuser /tmp/tree/src/deep ; echo $?     # 262751c       0   ← in-use
```

`free` is exactly what clears the reaper's third fail-safe ("an in-use probe
can DEFINITIVELY report the path as free"), so any automation built on this
probe would `git worktree remove --force` live work. The same probe is the
idle guard for the task-tree sweep (`gc.ts:834`).

The probe now walks procfs (`src/worktree/proc-liveness.ts`): a process is a
holder when its **cwd is the tree root or any directory beneath it**, or when
any **open fd** resolves inside the tree. Two subtleties handled explicitly:

- **Container/host boundary.** These verbs run host-side, but the processes
  holding agent task trees run inside agent containers where the same
  directory has a different path, so `readlink /proc/<pid>/cwd` from the host
  returns a path that shares no prefix with the host path. We therefore also
  walk `/proc/<pid>/cwd`, `/proc/<pid>/cwd/..`, … comparing `(dev, ino)`
  against the tree root — the kernel resolves those in *our* mount namespace,
  so a container-side holder is found regardless of its internal path.
- **A partial sweep is not a negative.** Reading another uid's
  `/proc/<pid>/cwd` needs ptrace-read permission. If any userspace process
  could not be inspected, the probe returns `unavailable` (⇒ treat as live,
  keep) rather than `free`. Kernel threads are excluded from that count.
  `lsof` is now invoked with `+D` (recursive); `fuser` is kept as a
  positive-only signal since it has no recursive mode.

**2. `switchroom worktree reap-report` — scheduled, report-only.** Runs both
classifiers (the claim reaper and the per-agent task-tree sweep) and prints
what they *would* reclaim: grouped per agent against a size budget
(`--budget-gb`, default 5 GB, or `SWITCHROOM_AGENT_TREE_BUDGET_GB`), ordered
**oldest-first**, which is the eviction order a budget-driven reaper would
use. Only trees that already clear every safety guard are ever marked
`over-budget`; when the guards keep an agent over budget the report says how
much stays over rather than widening eligibility.

## Why

RFC `reference/rfcs/agent-home-lifecycle.md` §2 — the deterministic task-tree
reaper and its per-agent size budget. §4 (gc coverage) has landed; §2's
periodic pass had not. The point of shipping the *report* first is that
nothing in the fleet has ever measured whether these classifiers are right,
and the first time anyone would find out is the first time something
automatic deletes a checkout. This builds a week of evidence first.

**Where the safety default lives:** it is structural, not a flag.
`src/worktree/reap-report.ts` composes only plan-only predicates (`planReaper`,
`planGc`) and imports no removal primitive — not `applyGc`, not `runReaper`,
not `removeCheckout`. `planGc` is always called with `escapeHatch: false`.
The CLI verb has no `--yes`. There is no scheduled deletion anywhere in this
PR; deleting stays the separate, explicit `worktree gc --yes` / `worktree
reap`.

## Test plan

- `tests/worktree.proc-liveness.test.ts` — the regression test spawns a real
  process with its cwd in a nested subdirectory and asserts the tree is
  classified `in-use`. **It fails against the unfixed probe**: run on
  `origin/main`'s `reaper.ts` it reports `expected 'free' to be 'in-use'`;
  it passes on this branch. Plus fd holders, the cross-namespace inode walk
  (synthetic procfs built from real symlinks), the partial-sweep →
  `unavailable` rule, kernel-thread exclusion, and a vanished tree.
- `tests/worktree.reap-report.test.ts` — oldest-first ordering, unknown-age
  entries sorted last, the budget marking exactly the oldest prefix needed,
  the budget never promoting a guard-blocked tree (`stillOverBytes` instead),
  unattributed trees labelled not dropped, and an end-to-end outcome test
  that a report pass over a would-reap claim + a would-reap task tree leaves
  every file and registry record on disk.
- `./node_modules/.bin/vitest run tests/worktree.{reaper,gc,proc-liveness,reap-report}.test.ts`
  → 111 passed, 1 skipped (the skip is the non-root EACCES accounting case;
  its decision rule is pinned unconditionally).
- `bun run lint` clean end to end (`tsc --noEmit` included).

## Risk

- **Reapability on a host where the probe cannot see every process.** Run as
  a uid that can't read the holder's `/proc/<pid>/cwd`, trees now resolve
  `unavailable` and are KEPT where `fuser` previously said `free`. That is
  the module's stated contract ("can't prove it's idle" must never license a
  force-remove) and it fails toward preservation; the report surfaces the
  count (`could not be proven idle`) so the exposure is measurable. Documented
  in `docs/operators/worktree-gc.md`.
- **Probe cost.** One `readlink` + one `readdir` per pid, short-circuiting on
  the first holder; the inode walk only runs when the path test misses.
- `TaskTreeAction` gains `newestMtimeMs` (the signal `idle` was already
  derived from) so the report can order oldest-first. Additive.

*Job spec:* `reference/jobs/give-each-agent-its-own-workspace.md` — "Orphan
cleanup / reaping: abandoned trees are reaped, not accumulated", under its
Durability clause that a dirty or live tree is never reset on the agent's
behalf. This PR is the guard half of that: it stops the classifier from
calling a live tree dead, and it measures the classifier before anything acts
on it.