### PR TITLE
fix(worktree-gc): discover agent checkouts wherever they actually live

### DIFF
--- a/changelog.d/4726-gc-widen-agent-checkout-discovery.fix.md
+++ b/changelog.d/4726-gc-widen-agent-checkout-discovery.fix.md
@@ -1,0 +1,36 @@
+- **worktree gc: the sweeper looked in two directories nobody uses (#4726)** —
+  The fleet root disk hit 85% full with **41 stale git checkouts** scattered
+  across agent homes, and the existing sweeper caught almost none of them.
+  `defaultTaskTreeRoots()` scanned exactly two subdirectories per agent —
+  `home/work` and `home/workspace` — while the real litter sat at
+  `<agent>/home/sr-4638`, `<agent>/home/tmp-build/switchroom`,
+  `<agent>/home/.cache/sr-review`, `<agent>/.work4481/repo`,
+  `<agent>/worktrees/<slug>` and `<agent>/scratchwork/switchroom`. The
+  classifier was never broken; it was aimed at a convention nobody follows.
+  `discoverAgentCheckouts()` now walks each agent's directory and hands `gc`
+  every checkout it finds, wherever the agent put it. The walk is bounded by
+  construction — depth 4 below the agent dir, a package-manager/build prune
+  list, a 50 000-directory visit budget, symlinks never followed, and a hard
+  stop at each checkout boundary so a tree's own `node_modules`, nested
+  submodules and nested linked worktrees are never mistaken for independent
+  trees. Measured on the reference fleet (37 agents, 52 GiB of agent homes):
+  **1 450 `readdir` calls, 32 ms**, 77 checkouts found. Pass `--no-discover` for the old root-only behaviour;
+  `home/work` and `home/workspace` coverage is unioned in and unchanged.
+- **worktree gc: three new guards, because a wider net catches precious things (#4726)** —
+  Widening WHERE gc looks relaxes nothing about WHAT it may reap, but it does
+  put trees in front of the classifier that were previously out of reach, so
+  the precious/disposable line is now drawn explicitly: an agent's own durable
+  furniture (`<agent>/workspace`, `<agent>/home/workspace`, and the stable
+  per-repo tree `<agent>/work/<slug>`) is never a candidate; a checkout parked
+  on a **trunk** branch (`main`/`master`/`trunk`/`develop`) is a reference
+  clone and is `skip-protected` without spending a `gh` call; and a
+  **`.switchroom-keep`** marker file in any checkout protects it
+  unconditionally. A repo whose `origin` is not switchroom's was, and remains,
+  reported `not-ours` and left alone.
+- **worktree gc: two quarantined trees with the same basename collided (#4726)** —
+  The quarantine destination was `<trash>/<basename>`, which two agents could
+  already produce for one dated trash dir (`home/work/switchroom` is not a
+  unique name); widened discovery makes it routine — the incident layout alone
+  carries three `switchroom` and two `repo` basenames. `mv` would have nested
+  the second tree inside the first and lost which agent it came from.
+  Destinations now disambiguate with a stable SHA-1 prefix of the source path.

--- a/src/cli/worktree.ts
+++ b/src/cli/worktree.ts
@@ -23,6 +23,7 @@ import {
   applyGc,
   defaultRoots,
   defaultTaskTreeRoots,
+  defaultTaskTreeDirs,
   trashRoot,
   listTrashEntries,
   selectPurgeTargets,
@@ -323,6 +324,10 @@ export function registerWorktreeCommand(program: Command): void {
       [] as string[],
     )
     .option("--no-task-roots", "Skip the per-agent task-tree sweep entirely")
+    .option(
+      "--no-discover",
+      "Skip widened discovery of checkouts outside home/work + home/workspace",
+    )
     .option("--idle-days <days>", "Idle threshold for task trees (default 14)", "14")
     .option(
       "--reclaim-dirty",
@@ -337,6 +342,7 @@ export function registerWorktreeCommand(program: Command): void {
         root: string[];
         taskRoot: string[];
         taskRoots?: boolean;
+        discover?: boolean;
         idleDays: string;
         reclaimDirty?: boolean;
         yes?: boolean;
@@ -378,6 +384,12 @@ export function registerWorktreeCommand(program: Command): void {
             : opts.taskRoot.length > 0
               ? opts.taskRoot
               : defaultTaskTreeRoots();
+        // Widened discovery (2026-08 disk incident): find checkouts wherever
+        // agents actually put them, not only under the two blessed roots.
+        const taskTreeDirs =
+          opts.taskRoots === false || opts.discover === false || opts.taskRoot.length > 0
+            ? []
+            : defaultTaskTreeDirs();
         const parsedIdle = Number(opts.idleDays);
         const idleDays = Number.isFinite(parsedIdle) && parsedIdle >= 0 ? parsedIdle : 14;
         const dateStamp = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
@@ -385,6 +397,7 @@ export function registerWorktreeCommand(program: Command): void {
           roots,
           { dateStamp, idleDays, escapeHatch: opts.reclaimDirty },
           taskTreeRoots,
+          taskTreeDirs,
         );
         const toRemove = plan.registered.filter((r) => r.verdict === "remove");
         const taskReap = plan.taskTrees.filter((t) => t.willAct);

--- a/src/worktree/gc.ts
+++ b/src/worktree/gc.ts
@@ -32,6 +32,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   existsSync,
   readFileSync,
@@ -248,6 +249,45 @@ export function isStablePerRepoBranch(branch: string | null): boolean {
   return !!branch && /^agent\/[^/]+\/main$/.test(branch);
 }
 
+/**
+ * True for a checkout parked on a TRUNK branch — a reference clone, not a
+ * disposable task tree.
+ *
+ * This guard is what makes widened discovery (see `discoverAgentCheckouts`)
+ * safe. Before it, the only thing standing between the sweep and a long-lived
+ * reference clone such as `overlord/home/switchroom-clone` was the PR probe
+ * happening to answer `none` for the branch `main` — a preservation that
+ * depended on a NETWORK CALL to `gh` and on GitHub never having a PR whose
+ * head branch is literally `main`. Narrow roots hid that: a reference clone
+ * was never under `home/work` in the first place. Once the scanner finds
+ * checkouts wherever agents actually put them, the distinction has to be
+ * structural.
+ *
+ * A task tree by construction sits on its own task branch (that is the whole
+ * point of a task tree); a tree on trunk is either a reference clone, a
+ * scratch build of `main`, or something an agent means to keep. All three are
+ * cheap to keep and expensive to get wrong, so trunk ⇒ never reaped.
+ */
+export function isReferenceCheckoutBranch(branch: string | null): boolean {
+  return !!branch && ["main", "master", "trunk", "develop"].includes(branch);
+}
+
+/**
+ * Marker file an agent or the operator drops in a checkout to declare it
+ * durable. Its presence makes the tree `skip-protected` unconditionally.
+ *
+ * Every other precious/disposable signal is INFERRED, and inference cannot be
+ * complete: the reference clone `overlord/home/switchroom-clone` sits on a
+ * local scratch branch (`review-merge`, upstream `origin/main`) — neither
+ * trunk nor a reserved path. It survives the sweep today only because that
+ * branch has no PR (`prSignal: "none"` -> `skip-unmerged`) and because it is
+ * touched often enough to stay inside the idle window. Both are true, and both
+ * are accidents. This marker is the deterministic escape valve:
+ * `touch .switchroom-keep` and the tree is off-limits regardless of branch,
+ * age, or PR state — a mechanism, not a heuristic.
+ */
+export const KEEP_MARKER = ".switchroom-keep";
+
 export type TaskTreeVerdict =
   /** clean + pushed + idle + (merged|closed) PR + provably free → reclaim. */
   | "reap"
@@ -271,6 +311,10 @@ export type TaskTreeVerdict =
 export interface TaskTreeClassifyInput {
   isRegistryClaimed: boolean;
   isStablePerRepoTree: boolean;
+  /** Checkout parked on a trunk branch — a reference clone. Never reaped. */
+  isReferenceCheckout?: boolean;
+  /** `.switchroom-keep` present — operator/agent declared it durable. */
+  isKeepMarked?: boolean;
   isEphemeralPath: boolean;
   clean: boolean;
   pushed: PushState;
@@ -286,7 +330,13 @@ export interface TaskTreeClassifyInput {
  * live or dirty-and-in-use tree can never be quarantined.
  */
 export function classifyTaskTree(i: TaskTreeClassifyInput): TaskTreeVerdict {
-  if (i.isRegistryClaimed || i.isStablePerRepoTree || i.isEphemeralPath) {
+  if (
+    i.isRegistryClaimed ||
+    i.isStablePerRepoTree ||
+    i.isReferenceCheckout ||
+    i.isKeepMarked ||
+    i.isEphemeralPath
+  ) {
     return "skip-protected";
   }
   // In-use guards come first: a tree a live process holds is never eligible for
@@ -365,6 +415,8 @@ export interface SkippedDir {
 export interface GcPlan {
   roots: string[];
   taskTreeRoots: string[];
+  /** Explicit task-tree candidate dirs (widened discovery). */
+  taskTreeDirs: string[];
   trashDir: string;
   orphans: OrphanAction[];
   registered: RegisteredAction[];
@@ -545,6 +597,34 @@ function defaultNewestTrackedMtimeMs(
   return newest || Date.now();
 }
 
+/**
+ * Allocate a COLLISION-FREE quarantine destination under `trash` for `dir`.
+ *
+ * The quarantine dest used to be `join(trash, basename(dir))`. That was
+ * already latently wrong across agents (two agents can both own a
+ * `home/work/switchroom`), and widened discovery makes it acute: the incident
+ * layout alone contains three `switchroom` and two `repo` basenames. Two
+ * quarantines in the same dated trash dir would then race for one path — `mv`
+ * would nest the second INSIDE the first, and the operator loses the ability
+ * to tell which agent a recovered tree came from.
+ *
+ * The disambiguator is the SHA-1 of the absolute source path, so it is stable
+ * across runs (a re-run of a dry-run prints the same dest) and short enough to
+ * stay readable. `used` is mutated so one planner run stays internally
+ * consistent.
+ */
+export function allocateTrashDest(trash: string, dir: string, used: Set<string>): string {
+  const name = basename(dir);
+  if (!used.has(name)) {
+    used.add(name);
+    return join(trash, name);
+  }
+  const suffix = createHash("sha1").update(resolve(dir)).digest("hex").slice(0, 8);
+  const unique = `${name}-${suffix}`;
+  used.add(unique);
+  return join(trash, unique);
+}
+
 /** Default trash root. Override via SWITCHROOM_WORKTREE_TRASH for tests. */
 export function trashRoot(): string {
   return resolve(
@@ -566,11 +646,16 @@ export function trashRoot(): string {
  *                       carry different semantics (all tree shapes, the
  *                       `work/` carve-out, the pushed + idle guards, and
  *                       merged-OR-closed eligibility).
+ * @param taskTreeDirs   EXPLICIT task-tree candidate directories, from widened
+ *                       discovery (`discoverAgentCheckouts`). Unioned with the
+ *                       subdirs of `taskTreeRoots` and de-duplicated, so the
+ *                       pre-existing root-based behaviour is unchanged.
  */
 export function planGc(
   roots: string[],
   deps: GcDeps = {},
   taskTreeRoots: string[] = [],
+  taskTreeDirs: string[] = [],
 ): GcPlan {
   const exists = deps.existsSync ?? existsSync;
   const readDir = deps.readDir ?? ((p: string) => readdirSync(p));
@@ -616,6 +701,8 @@ export function planGc(
 
   const orphans: OrphanAction[] = [];
   const skipped: SkippedDir[] = [];
+  // Quarantine basenames already handed out this run (see allocateTrashDest).
+  const usedTrashNames = new Set<string>();
   const ownerRepos = new Set<string>(); // validated repos discovered via orphans
 
   // ── Phase A: orphan attribution + quarantine plan ──
@@ -672,7 +759,7 @@ export function planGc(
       // Orphan ⇔ the admin dir the pointer references is gone. If it still
       // exists the worktree is live/registered → handled by Phase B.
       if (exists(ptr)) continue;
-      orphans.push({ dir, owner: repoRoot, dest: join(trash, name) });
+      orphans.push({ dir, owner: repoRoot, dest: allocateTrashDest(trash, dir, usedTrashNames) });
     }
   }
 
@@ -724,6 +811,17 @@ export function planGc(
   // carve-out is achieved structurally (these roots never reach the blanket
   // `looksLikeAgentWorktree` skip) and all three tree shapes are covered.
   const taskTrees: TaskTreeAction[] = [];
+  // Candidates = immediate subdirs of each blessed root (legacy behaviour)
+  // UNION the explicitly discovered checkouts (widened discovery), keyed by
+  // resolved path so a directory reachable both ways is classified once.
+  const candidates: string[] = [];
+  const seenCandidate = new Set<string>();
+  const pushCandidate = (dir: string) => {
+    const key = resolve(dir);
+    if (seenCandidate.has(key)) return;
+    seenCandidate.add(key);
+    candidates.push(dir);
+  };
   for (const root of taskTreeRoots) {
     if (!exists(root)) continue;
     let entries: string[];
@@ -732,158 +830,166 @@ export function planGc(
     } catch {
       continue;
     }
-    for (const name of entries) {
-      const dir = join(root, name);
-      if (isEphemeralPath(dir)) continue;
-      const dotGit = join(dir, ".git");
-      if (!exists(dotGit)) continue; // not a git tree — leave it
-      let shape: TaskTreeShape;
-      try {
-        shape = stat(dotGit).isDirectory() ? "clone" : "worktree";
-      } catch {
-        continue;
-      }
+    for (const name of entries) pushCandidate(join(root, name));
+  }
+  for (const d of taskTreeDirs) pushCandidate(d);
 
-      // Safety gate: only ever touch a checkout of the canonical switchroom
-      // repo. `git -C <dir> remote get-url origin` works for worktree AND clone.
-      // A FAILED probe is not a negative answer. Both keep the tree, but only
-      // the negative answer means "we looked and it isn't ours"; the failure
-      // means the tree is unreadable and needs the operator's attention.
-      let remoteOk = false;
-      let remoteError: string | null = null;
-      try {
-        remoteOk = isSwitchroomRemote(exec("git", gitArgs(dir, "remote", "get-url", "origin")));
-      } catch (e) {
-        remoteError = describeExecFailure(e);
-      }
-      if (remoteError) {
-        skipped.push({ dir, reason: `git probe failed, kept: ${remoteError}`, kind: "probe-failed" });
-        continue;
-      }
-      if (!remoteOk) {
-        skipped.push({ dir, reason: "not a switchroom task tree", kind: "not-ours" });
-        continue;
-      }
-
-      // Owner repo (for post-reclaim `worktree prune`) — worktree shape only.
-      let ownerRepo: string | null = null;
-      if (shape === "worktree") {
-        try {
-          const ptr = parseGitdirPointer(readFile(dotGit));
-          if (ptr) ownerRepo = repoRootFromWorktreeGitdir(ptr);
-        } catch {
-          ownerRepo = null;
-        }
-      }
-
-      // Branch / detached HEAD.
-      let branch: string | null = null;
-      let detached = false;
-      try {
-        const b = exec("git", gitArgs(dir, "rev-parse", "--abbrev-ref", "HEAD")).trim();
-        if (b === "HEAD") detached = true;
-        else branch = b;
-      } catch {
-        detached = true; // can't read HEAD ⇒ treat as detached ⇒ unpushed ⇒ keep
-      }
-
-      const claimedWt = claimed.has(resolve(dir));
-      const stableTree = isStablePerRepoBranch(branch);
-      const ephemeral = isEphemeralPath(dir);
-      const protectedTree = claimedWt || stableTree || ephemeral;
-
-      // Effective cleanliness (build noise tolerated; anything else ⇒ dirty).
-      let clean = false;
-      try {
-        clean = isEffectivelyClean(exec("git", gitArgs(dir, "status", "--porcelain")).split("\n"));
-      } catch {
-        clean = false; // can't inspect ⇒ assume dirty ⇒ keep
-      }
-
-      // Push state: uncommitted-clean does NOT imply pushed.
-      let upstream: string | null = null;
-      let aheadCount = 0;
-      if (!detached) {
-        try {
-          upstream =
-            exec("git", gitArgs(dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")).trim() ||
-            null;
-        } catch {
-          upstream = null;
-        }
-        if (upstream) {
-          try {
-            aheadCount = parseInt(exec("git", gitArgs(dir, "rev-list", "--count", "@{upstream}..HEAD")).trim(), 10);
-            if (!Number.isFinite(aheadCount)) aheadCount = -1;
-          } catch {
-            aheadCount = -1; // count failed ⇒ error ⇒ keep
-          }
-        }
-      }
-      const pushed = pushStateFrom({ detached, upstream, aheadCount });
-
-      // Idle: newest tracked mtime older than the idle window.
-      let idle = false;
-      let newestMtimeMs: number | null = null;
-      try {
-        newestMtimeMs = newestMtime(dir);
-        idle = (nowMs - newestMtimeMs) / 86_400_000 >= idleDays;
-      } catch {
-        idle = false; // can't tell ⇒ treat as active ⇒ keep
-        newestMtimeMs = null;
-      }
-
-      // Spend the probe + `gh` call only when every cheaper guard has passed
-      // (mirrors Phase B). classifyTaskTree checks in-use/clean/pushed/idle
-      // before the PR signal, so an uncalled `error`/`unavailable` is only ever
-      // consulted when an earlier guard has already decided the verdict.
-      let inUse: PathUseState = "unavailable";
-      let sig: PrSignal = "error";
-      if (!protectedTree) {
-        inUse = probeInUse(dir);
-        if (inUse === "free" && clean && pushed === "pushed" && idle && branch) {
-          sig = prSignal(dir, branch);
-        }
-      }
-
-      const verdict = classifyTaskTree({
-        isRegistryClaimed: claimedWt,
-        isStablePerRepoTree: stableTree,
-        isEphemeralPath: ephemeral,
-        clean,
-        pushed,
-        prSignal: sig,
-        idle,
-        inUse,
-      });
-
-      // Automatic reap, OR — under the operator escape hatch — an IDLE
-      // dirty/unpushed tree (reversible quarantine; never a live/in-use one,
-      // since those resolve to skip-in-use before skip-dirty/skip-unpushed).
-      const willAct =
-        verdict === "reap" ||
-        (escapeHatch && idle && (verdict === "skip-dirty" || verdict === "skip-unpushed"));
-
-      if (willAct && ownerRepo) reposToPrune.add(ownerRepo);
-
-      taskTrees.push({
-        dir,
-        shape,
-        ownerRepo,
-        branch,
-        verdict,
-        prSignal: sig,
-        idle,
-        newestMtimeMs,
-        dest: join(trash, name),
-        willAct,
-      });
+  for (const dir of candidates) {
+    if (isEphemeralPath(dir)) continue;
+    const dotGit = join(dir, ".git");
+    if (!exists(dotGit)) continue; // not a git tree — leave it
+    let shape: TaskTreeShape;
+    try {
+      shape = stat(dotGit).isDirectory() ? "clone" : "worktree";
+    } catch {
+      continue;
     }
+
+    // Safety gate: only ever touch a checkout of the canonical switchroom
+    // repo. `git -C <dir> remote get-url origin` works for worktree AND clone.
+    // A FAILED probe is not a negative answer. Both keep the tree, but only
+    // the negative answer means "we looked and it isn't ours"; the failure
+    // means the tree is unreadable and needs the operator's attention.
+    let remoteOk = false;
+    let remoteError: string | null = null;
+    try {
+      remoteOk = isSwitchroomRemote(exec("git", gitArgs(dir, "remote", "get-url", "origin")));
+    } catch (e) {
+      remoteError = describeExecFailure(e);
+    }
+    if (remoteError) {
+      skipped.push({ dir, reason: `git probe failed, kept: ${remoteError}`, kind: "probe-failed" });
+      continue;
+    }
+    if (!remoteOk) {
+      skipped.push({ dir, reason: "not a switchroom task tree", kind: "not-ours" });
+      continue;
+    }
+
+    // Owner repo (for post-reclaim `worktree prune`) — worktree shape only.
+    let ownerRepo: string | null = null;
+    if (shape === "worktree") {
+      try {
+        const ptr = parseGitdirPointer(readFile(dotGit));
+        if (ptr) ownerRepo = repoRootFromWorktreeGitdir(ptr);
+      } catch {
+        ownerRepo = null;
+      }
+    }
+
+    // Branch / detached HEAD.
+    let branch: string | null = null;
+    let detached = false;
+    try {
+      const b = exec("git", gitArgs(dir, "rev-parse", "--abbrev-ref", "HEAD")).trim();
+      if (b === "HEAD") detached = true;
+      else branch = b;
+    } catch {
+      detached = true; // can't read HEAD ⇒ treat as detached ⇒ unpushed ⇒ keep
+    }
+
+    const claimedWt = claimed.has(resolve(dir));
+    const stableTree = isStablePerRepoBranch(branch);
+    const referenceCheckout = isReferenceCheckoutBranch(branch);
+    const keepMarked = exists(join(dir, KEEP_MARKER));
+    const ephemeral = isEphemeralPath(dir);
+    const protectedTree =
+      claimedWt || stableTree || referenceCheckout || keepMarked || ephemeral;
+
+    // Effective cleanliness (build noise tolerated; anything else ⇒ dirty).
+    let clean = false;
+    try {
+      clean = isEffectivelyClean(exec("git", gitArgs(dir, "status", "--porcelain")).split("\n"));
+    } catch {
+      clean = false; // can't inspect ⇒ assume dirty ⇒ keep
+    }
+
+    // Push state: uncommitted-clean does NOT imply pushed.
+    let upstream: string | null = null;
+    let aheadCount = 0;
+    if (!detached) {
+      try {
+        upstream =
+          exec("git", gitArgs(dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")).trim() ||
+          null;
+      } catch {
+        upstream = null;
+      }
+      if (upstream) {
+        try {
+          aheadCount = parseInt(exec("git", gitArgs(dir, "rev-list", "--count", "@{upstream}..HEAD")).trim(), 10);
+          if (!Number.isFinite(aheadCount)) aheadCount = -1;
+        } catch {
+          aheadCount = -1; // count failed ⇒ error ⇒ keep
+        }
+      }
+    }
+    const pushed = pushStateFrom({ detached, upstream, aheadCount });
+
+    // Idle: newest tracked mtime older than the idle window.
+    let idle = false;
+    let newestMtimeMs: number | null = null;
+    try {
+      newestMtimeMs = newestMtime(dir);
+      idle = (nowMs - newestMtimeMs) / 86_400_000 >= idleDays;
+    } catch {
+      idle = false; // can't tell ⇒ treat as active ⇒ keep
+      newestMtimeMs = null;
+    }
+
+    // Spend the probe + `gh` call only when every cheaper guard has passed
+    // (mirrors Phase B). classifyTaskTree checks in-use/clean/pushed/idle
+    // before the PR signal, so an uncalled `error`/`unavailable` is only ever
+    // consulted when an earlier guard has already decided the verdict.
+    let inUse: PathUseState = "unavailable";
+    let sig: PrSignal = "error";
+    if (!protectedTree) {
+      inUse = probeInUse(dir);
+      if (inUse === "free" && clean && pushed === "pushed" && idle && branch) {
+        sig = prSignal(dir, branch);
+      }
+    }
+
+    const verdict = classifyTaskTree({
+      isRegistryClaimed: claimedWt,
+      isStablePerRepoTree: stableTree,
+      isReferenceCheckout: referenceCheckout,
+      isKeepMarked: keepMarked,
+      isEphemeralPath: ephemeral,
+      clean,
+      pushed,
+      prSignal: sig,
+      idle,
+      inUse,
+    });
+
+    // Automatic reap, OR — under the operator escape hatch — an IDLE
+    // dirty/unpushed tree (reversible quarantine; never a live/in-use one,
+    // since those resolve to skip-in-use before skip-dirty/skip-unpushed).
+    const willAct =
+      verdict === "reap" ||
+      (escapeHatch && idle && (verdict === "skip-dirty" || verdict === "skip-unpushed"));
+
+    if (willAct && ownerRepo) reposToPrune.add(ownerRepo);
+
+    taskTrees.push({
+      dir,
+      shape,
+      ownerRepo,
+      branch,
+      verdict,
+      prSignal: sig,
+      idle,
+      newestMtimeMs,
+      dest: allocateTrashDest(trash, dir, usedTrashNames),
+      willAct,
+    });
   }
 
   return {
     roots,
     taskTreeRoots,
+    taskTreeDirs,
     trashDir: trash,
     orphans,
     registered,
@@ -1081,4 +1187,211 @@ export function defaultTaskTreeRoots(): string[] {
     }
   }
   return roots;
+}
+
+// ── widened discovery — find checkouts where agents ACTUALLY put them ───────
+//
+// `defaultTaskTreeRoots()` above scans exactly two subdirectories per agent
+// (`home/work`, `home/workspace`). The 2026-08 disk incident (root disk 85%
+// full) turned up 41 stale checkouts across the fleet and only a handful were
+// under either root. The real litter was:
+//
+//   <agent>/home/sr-4638              direct child of home/, ad-hoc name
+//   <agent>/home/tmp-build/switchroom nested one level deeper
+//   <agent>/home/.cache/sr-review     inside a DOT directory
+//   <agent>/.work4481/repo            dot directory outside home/ entirely
+//   <agent>/worktrees/b3-…            a sibling of home/, not under it
+//   <agent>/scratchwork/switchroom    outside home/
+//
+// The classifier was never broken — it was aimed at a convention nobody
+// follows. Discovery therefore walks the agent directory itself, bounded, and
+// hands `planGc` explicit candidate DIRECTORIES rather than blessed roots.
+
+/**
+ * Directory names never descended into during discovery.
+ *
+ * Two categories, both load-bearing for the cost bound:
+ *   - `.git` — descending it would treat `.git/modules/<sub>` and
+ *     `.git/worktrees/<name>` admin dirs as independent checkouts. It is also
+ *     the single largest object count on disk.
+ *   - package-manager caches and build output — thousands of directories with
+ *     zero chance of holding a task checkout.
+ *
+ * `.cache` is deliberately ABSENT: the incident found a real stale checkout at
+ * `overlord/home/.cache/sr-review`. Its cost is bounded by the depth cap
+ * instead (measured below), not by a name prune.
+ */
+export const DISCOVERY_PRUNE_DIRS: ReadonlySet<string> = new Set([
+  ".git",
+  "node_modules",
+  ".npm",
+  ".bun",
+  ".cargo",
+  ".rustup",
+  ".nvm",
+  ".pnpm-store",
+  ".yarn",
+  ".venv",
+  "venv",
+  "site-packages",
+  "__pycache__",
+  ".pyenv",
+  ".gradle",
+  ".m2",
+  ".claude",
+  ".local",
+  "target",
+  "dist",
+  ".next",
+  // `~/.cache/uv/sdists-v9/**` contains thousands of unpacked source dists,
+  // many of which carry a real `.git`.
+  "uv",
+  // An agent's `tmp/` is owned by the SEPARATE tmp reaper (`tmp-reaper.ts`,
+  // `switchroom reap-stale-workdirs`). Two reapers racing for the same
+  // directories is worse than either alone, and the reference fleet has live
+  // harness fixtures there (`klanker/tmp/sr-a4b-*/a4b/workspace`). Note this
+  // prunes the exact name `tmp` only: `home/tmp-build/switchroom` was real
+  // incident litter and is still discovered.
+  "tmp",
+]);
+
+/**
+ * True for a directory that must never be descended into during discovery.
+ *
+ * Beyond the fixed name list, `*.git` is pruned by SHAPE: that is the bare-repo
+ * convention (`switchroom.git/`), and a bare repo's internal `worktrees/<name>`
+ * admin directories would otherwise be walked and could be mistaken for
+ * independent checkouts — the same failure the `.git` prune exists to stop, one
+ * layout removed.
+ */
+export function isPrunedDiscoveryDir(name: string): boolean {
+  return DISCOVERY_PRUNE_DIRS.has(name) || name.endsWith(".git");
+}
+
+/**
+ * Paths under an agent directory that are the agent's own durable furniture,
+ * never a disposable task tree. Relative to `<agentsDir>/<agent>`.
+ *
+ * `work` (and its immediate children) is the STABLE per-repo tree documented
+ * at `defaultTaskTreeRoots` — deliberately never scanned. `home/workspace` is
+ * the agent's own workspace: `defaultTaskTreeRoots` scans its CHILDREN as task
+ * trees, but the workspace directory itself, if it is a checkout, is the
+ * agent's and not litter.
+ */
+function reservedAgentPath(relParts: string[]): "container" | "tree" | null {
+  const rel = relParts.join("/");
+  // Containers: never a candidate themselves, but always walked THROUGH — a
+  // stray `.git` in an agent's HOME must not blind the walk to everything
+  // below it.
+  if (rel === "" || rel === "home") return "container";
+  // The agent's own workspace, both spellings seen on the reference fleet:
+  // `<agent>/workspace` (a switchroom checkout on `master`, the host-side
+  // agent workspace) and `<agent>/home/workspace` (whose CHILDREN are the
+  // legacy task-tree root). The directories themselves are durable furniture.
+  if (rel === "workspace") return "tree";
+  if (rel === "home/workspace") return "container";
+  // <agent>/work and <agent>/work/<slug> — the stable per-repo tree
+  // (`defaultTaskTreeRoots` documents it as deliberately not scanned).
+  // Reserved AND terminal: nothing inside it is independent litter.
+  if (relParts[0] === "work" && relParts.length <= 2) return "tree";
+  return null;
+}
+
+export interface DiscoverDeps {
+  readDir?: (p: string) => { name: string; isDirectory: () => boolean; isSymbolicLink: () => boolean }[];
+  existsSync?: (p: string) => boolean;
+  /** Max directory depth below each agent directory. Default 4. */
+  maxDepth?: number;
+  /** Hard ceiling on directories VISITED, fleet-wide. Default 50_000. */
+  maxVisits?: number;
+}
+
+/**
+ * Discover every git checkout under each agent's directory.
+ *
+ * Bounded by construction:
+ *   - **depth** — `maxDepth` levels below `<agentsDir>/<agent>` (default 4;
+ *     the deepest real litter found in the incident was at depth 3).
+ *   - **prune** — `DISCOVERY_PRUNE_DIRS`, plus symlinks (never followed, so a
+ *     symlink loop cannot hang the walk and a symlinked-in project cannot be
+ *     mistaken for the agent's own litter).
+ *   - **short-circuit** — a directory containing `.git` is recorded as a
+ *     candidate and NOT descended into. That is what keeps a checkout's own
+ *     `node_modules`, nested submodules, and nested linked worktrees out of
+ *     the walk: a nested worktree inside a checkout is part of that checkout's
+ *     tree and must never be reaped as an independent one.
+ *   - **visit budget** — `maxVisits` directories fleet-wide, so a pathological
+ *     home cannot turn a GC dry-run into an unbounded traversal.
+ *
+ * Reserved agent furniture (`isReservedAgentPath`) is descended into but never
+ * itself emitted. Everything emitted still runs the full `planGc` Phase C
+ * guard gauntlet — switchroom-origin, trunk-branch, claimed, in-use, dirty,
+ * unpushed, idle, PR state — before anything is reclaimed. Discovery widens
+ * WHERE we look; it relaxes nothing about WHAT may be reaped.
+ */
+export function discoverAgentCheckouts(
+  agentsDir: string,
+  deps: DiscoverDeps = {},
+): string[] {
+  const readDir =
+    deps.readDir ?? ((p: string) => readdirSync(p, { withFileTypes: true }));
+  const exists = deps.existsSync ?? existsSync;
+  const maxDepth = deps.maxDepth ?? 4;
+  const maxVisits = deps.maxVisits ?? 50_000;
+
+  let agents: { name: string; isDirectory: () => boolean; isSymbolicLink: () => boolean }[];
+  try {
+    agents = readDir(agentsDir);
+  } catch {
+    return [];
+  }
+
+  const found: string[] = [];
+  let visits = 0;
+
+  for (const agent of agents.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!agent.isDirectory() || agent.isSymbolicLink()) continue;
+    const agentRoot = join(agentsDir, agent.name);
+    // Breadth-first so the shallow, likely candidates are found before a deep
+    // pathological subtree can exhaust the visit budget.
+    const queue: { dir: string; rel: string[] }[] = [{ dir: agentRoot, rel: [] }];
+    while (queue.length) {
+      const { dir, rel } = queue.shift()!;
+      if (visits >= maxVisits) return found;
+      visits++;
+
+      const reserved = reservedAgentPath(rel);
+      if (reserved === "tree") continue; // stable per-repo tree — stop here
+      // A `.git` entry (file OR directory) marks a checkout. Record it and do
+      // not descend: everything below belongs to that checkout.
+      if (reserved !== "container" && exists(join(dir, ".git"))) {
+        found.push(dir);
+        continue;
+      }
+      if (rel.length >= maxDepth) continue;
+
+      let kids: { name: string; isDirectory: () => boolean; isSymbolicLink: () => boolean }[];
+      try {
+        kids = readDir(dir);
+      } catch {
+        continue; // unreadable (cross-uid, EACCES) — nothing to discover here
+      }
+      for (const k of kids) {
+        if (!k.isDirectory() || k.isSymbolicLink()) continue;
+        if (isPrunedDiscoveryDir(k.name)) continue;
+        queue.push({ dir: join(dir, k.name), rel: [...rel, k.name] });
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Default explicit task-tree CANDIDATES — every git checkout discovered under
+ * `~/.switchroom/agents/<name>/`. Complements (does not replace)
+ * `defaultTaskTreeRoots()`: `planGc` unions the two and de-duplicates, so the
+ * pre-existing `home/work` / `home/workspace` behaviour is preserved exactly.
+ */
+export function defaultTaskTreeDirs(deps: DiscoverDeps = {}): string[] {
+  return discoverAgentCheckouts(join(homedir(), ".switchroom", "agents"), deps);
 }

--- a/src/worktree/reap-report.ts
+++ b/src/worktree/reap-report.ts
@@ -44,6 +44,7 @@ import {
   planGc,
   defaultRoots,
   defaultTaskTreeRoots,
+  defaultTaskTreeDirs,
   type GcPlan,
   type TaskTreeAction,
 } from "./gc.js";
@@ -154,6 +155,8 @@ export interface ReapReportDeps {
   /** Passed through to the default `planGc` call. */
   roots?: string[];
   taskTreeRoots?: string[];
+  /** Explicit task-tree candidates (widened discovery). Default: discovered. */
+  taskTreeDirs?: string[];
   reaperDeps?: ReaperDeps;
 }
 
@@ -290,6 +293,7 @@ export function buildReapReport(deps: ReapReportDeps = {}): ReapReport {
         escapeHatch: false,
       },
       deps.taskTreeRoots ?? defaultTaskTreeRoots(),
+      deps.taskTreeDirs ?? defaultTaskTreeDirs(),
     );
 
   const entries: ReapReportEntry[] = [

--- a/src/worktree/reap-report.ts
+++ b/src/worktree/reap-report.ts
@@ -293,7 +293,9 @@ export function buildReapReport(deps: ReapReportDeps = {}): ReapReport {
         escapeHatch: false,
       },
       deps.taskTreeRoots ?? defaultTaskTreeRoots(),
-      deps.taskTreeDirs ?? defaultTaskTreeDirs(),
+      // Explicit roots mean the caller has scoped the sweep (and tests inject
+      // them for hermeticity) — do not widen out from under them.
+      deps.taskTreeDirs ?? (deps.taskTreeRoots ? [] : defaultTaskTreeDirs()),
     );
 
   const entries: ReapReportEntry[] = [

--- a/tests/worktree.gc.discovery.test.ts
+++ b/tests/worktree.gc.discovery.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Widened task-tree discovery — the 2026-08 fleet disk incident.
+ *
+ * The root disk hit 85% full with 41 stale git checkouts scattered across
+ * agent homes. `defaultTaskTreeRoots()` scanned exactly two subdirectories per
+ * agent (`home/work`, `home/workspace`) and therefore missed almost all of
+ * them. The classifier was never broken — it was aimed at a convention nobody
+ * follows.
+ *
+ * The fixture below is the REAL layout observed in that incident (dot
+ * directories, nested `repo/` children, a checkout outside `home/` entirely,
+ * plus a reference clone that the manual sweep deliberately preserved). The
+ * assertions are outcomes: which directories the scanner returns and which
+ * verdict the planner reaches — not which code path ran.
+ *
+ * These tests fail on unmodified `gc.ts`: `discoverAgentCheckouts` does not
+ * exist there, and the root-based scan cannot reach any of the dot-directory
+ * or outside-`home/` litter no matter how it is invoked.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  discoverAgentCheckouts,
+  isPrunedDiscoveryDir,
+  planGc,
+  classifyTaskTree,
+  isReferenceCheckoutBranch,
+  allocateTrashDest,
+  KEEP_MARKER,
+  type GcDeps,
+  type TaskTreeClassifyInput,
+} from "../src/worktree/gc.js";
+
+// ── fixture: the real incident layout ───────────────────────────────────────
+
+/** Checkout paths, relative to `<agentsDir>`, exactly as found on the fleet. */
+const LITTER = [
+  "klanker/home/sr-4638", //              direct child of home/, ad-hoc name
+  "klanker/home/srwork",
+  "klanker/home/review-4432-klanker",
+  "klanker/home/wt-benchdrop-647877",
+  "klanker/home/tmp-build/switchroom", // nested one level deeper
+  "klanker/home/voiceout-work/switchroom",
+  "overlord/home/r5repro2",
+  "overlord/home/sr-secreview",
+  "overlord/.work4481/repo", //           DOT dir, outside home/ entirely
+  "overlord/worktrees/b3-overlay-eacces", // sibling of home/, not under it
+  "overlord/home/.cache/sr-review", //    inside a DOT directory
+  "overlord/home/ovl-changelog-fix/repo",
+  "overlord/home/wt-vault-4486",
+  "gymbro/scratchwork/switchroom", //     outside home/
+  "carrie/home/switchroom-work",
+  "clerk/home/switchroom-pr",
+  // the two roots the pre-incident scanner did cover — must not regress
+  "klanker/home/work/fix-3333",
+  "klanker/home/workspace/sr-2771",
+];
+
+/** Checkouts that must be SPARED. */
+const PRECIOUS = [
+  "overlord/home/switchroom-clone", // reference clone (manual sweep kept it)
+  "carrie/home/ProductOS", //          a real project repo the agent owns
+  "overlord/workspace", //             the agent's own host-side workspace
+  "overlord/home/workspace", //        the agent's own workspace dir
+  "overlord/work/switchroom", //       the STABLE per-repo tree
+];
+
+/** Directories that exist but are NOT checkouts (walked through, never emitted). */
+const NOISE_DIRS = [
+  "overlord/home/.cache/uv/sdists-v9/editable/pkg", // pruned by name (`uv`)
+  "overlord/home/node_modules/left-pad", //           pruned by name
+  "klanker/home/work/fix-3333/node_modules/react", // inside a checkout
+  "klanker/home/work/fix-3333/.git/worktrees/x", //   .git internals
+  "overlord/home/a/b/c/d/e/f/deep-checkout", //       past the depth cap
+  "klanker/tmp/sr-a4b-xyz/a4b/workspace", //          the tmp reaper owns tmp/
+  "overlord/home/mirrors/switchroom.git/worktrees/w", // bare-repo admin dir
+];
+
+let AGENTS: string;
+
+function mkCheckout(rel: string, gitIsDir = true) {
+  const dir = join(AGENTS, rel);
+  mkdirSync(dir, { recursive: true });
+  if (gitIsDir) mkdirSync(join(dir, ".git"), { recursive: true });
+  else writeFileSync(join(dir, ".git"), "gitdir: /owner/.git/worktrees/x\n");
+}
+
+beforeAll(() => {
+  AGENTS = mkdtempSync(join(tmpdir(), "gc-discovery-"));
+  for (const rel of LITTER) mkCheckout(rel, !rel.includes("wt-"));
+  for (const rel of PRECIOUS) mkCheckout(rel);
+  for (const rel of NOISE_DIRS) mkCheckout(rel);
+  mkCheckout("overlord/home/a/b/c/d/e/f/deep-checkout");
+  // a symlink loop — the walk must not follow it and must not hang
+  mkdirSync(join(AGENTS, "klanker/home/loopsrc"), { recursive: true });
+  try {
+    symlinkSync(join(AGENTS, "klanker"), join(AGENTS, "klanker/home/loopsrc/back"));
+  } catch {
+    /* platforms without symlink perms — the rest of the fixture still holds */
+  }
+});
+
+afterAll(() => {
+  rmSync(AGENTS, { recursive: true, force: true });
+});
+
+const relOf = (abs: string) => abs.slice(AGENTS.length + 1);
+
+describe("discoverAgentCheckouts — finds the incident litter", () => {
+  it("finds EVERY stale checkout from the real incident layout", () => {
+    const found = discoverAgentCheckouts(AGENTS).map(relOf);
+    for (const rel of LITTER) expect(found).toContain(rel);
+  });
+
+  it("finds the litter the two blessed roots structurally could not reach", () => {
+    // This is the regression that caused the incident: every one of these sits
+    // outside `home/work` and `home/workspace`, so NO invocation of the
+    // root-based scanner can produce them.
+    const found = discoverAgentCheckouts(AGENTS).map(relOf);
+    expect(found).toContain("overlord/.work4481/repo"); //          dot dir, outside home/
+    expect(found).toContain("overlord/home/.cache/sr-review"); //   inside a dot dir
+    expect(found).toContain("gymbro/scratchwork/switchroom"); //    outside home/
+    expect(found).toContain("overlord/worktrees/b3-overlay-eacces");
+    expect(found).toContain("klanker/home/sr-4638"); //             direct child of home/
+    expect(found).toContain("overlord/home/ovl-changelog-fix/repo"); // nested repo/ child
+  });
+
+  it("does not regress the pre-existing home/work + home/workspace coverage", () => {
+    const found = discoverAgentCheckouts(AGENTS).map(relOf);
+    expect(found).toContain("klanker/home/work/fix-3333");
+    expect(found).toContain("klanker/home/workspace/sr-2771");
+  });
+});
+
+describe("discoverAgentCheckouts — spares what must be spared", () => {
+  it("never emits the agent's own durable furniture", () => {
+    const found = discoverAgentCheckouts(AGENTS).map(relOf);
+    // `<agent>/workspace` and `<agent>/home/workspace` are the agent's own
+    // workspace; `<agent>/work/<slug>` is the STABLE per-repo tree.
+    expect(found).not.toContain("overlord/workspace");
+    expect(found).not.toContain("overlord/home/workspace");
+    expect(found).not.toContain("overlord/work/switchroom");
+    expect(found).not.toContain("overlord/work");
+    expect(found).not.toContain("overlord/home");
+    expect(found).not.toContain("overlord");
+  });
+
+  it("stops at a checkout boundary — nested node_modules and .git are never candidates", () => {
+    const found = discoverAgentCheckouts(AGENTS).map(relOf);
+    for (const f of found) {
+      expect(f).not.toContain("/node_modules");
+      expect(f).not.toContain("/.git/");
+      expect(f.endsWith("/.git")).toBe(false);
+    }
+  });
+
+  it("prunes package-manager caches by name and honours the depth cap", () => {
+    const found = discoverAgentCheckouts(AGENTS).map(relOf);
+    expect(found.some((f) => f.includes("/uv/"))).toBe(false);
+    // depth 7 below the agent dir, past the default cap of 4
+    expect(found).not.toContain("overlord/home/a/b/c/d/e/f/deep-checkout");
+    // ...and IS found once the cap is lifted, proving the cap is what excluded it
+    const deep = discoverAgentCheckouts(AGENTS, { maxDepth: 8 }).map(relOf);
+    expect(deep).toContain("overlord/home/a/b/c/d/e/f/deep-checkout");
+  });
+
+  it("leaves <agent>/tmp to the separate tmp reaper", () => {
+    // `klanker/tmp/...` is pruned; `klanker/home/tmp-build/switchroom` is NOT
+    // — the prune is the exact name, not a prefix.
+    const found = discoverAgentCheckouts(AGENTS).map(relOf);
+    expect(found.some((f) => f.startsWith("klanker/tmp/"))).toBe(false);
+    expect(found).toContain("klanker/home/tmp-build/switchroom");
+  });
+
+  it("never descends a bare repo's internal worktrees/ admin dir", () => {
+    const found = discoverAgentCheckouts(AGENTS).map(relOf);
+    expect(found.some((f) => f.includes(".git/"))).toBe(false);
+    expect(isPrunedDiscoveryDir("switchroom.git")).toBe(true);
+    expect(isPrunedDiscoveryDir("tmp")).toBe(true);
+    expect(isPrunedDiscoveryDir("tmp-build")).toBe(false);
+  });
+
+  it("does not follow symlinks (a loop terminates)", () => {
+    const found = discoverAgentCheckouts(AGENTS).map(relOf);
+    expect(found.some((f) => f.includes("loopsrc/back"))).toBe(false);
+  });
+
+  it("honours the visit budget instead of walking unbounded", () => {
+    const budgeted = discoverAgentCheckouts(AGENTS, { maxVisits: 5 });
+    const full = discoverAgentCheckouts(AGENTS);
+    expect(budgeted.length).toBeLessThan(full.length);
+  });
+});
+
+// ── planGc integration: discovered dirs go through the FULL guard gauntlet ──
+//
+// Uses INJECTED deps over synthetic absolute paths rather than the on-disk
+// fixture: `isEphemeralPath` (gc.ts) refuses `/tmp`, `/state` and `/host`
+// outright, so a real temp-dir fixture would be skipped before any classifier
+// ran. The paths mirror the incident layout exactly.
+
+describe("planGc — discovered candidates are classified, precious ones spared", () => {
+  const NOW = 1_700_000_000_000;
+  const SR = "https://github.com/switchroom/switchroom.git\n";
+  const A = "/agents";
+
+  const DISCOVERED = [
+    `${A}/overlord/.work4481/repo`,
+    `${A}/overlord/home/.cache/sr-review`,
+    `${A}/overlord/home/ovl-changelog-fix/repo`,
+    `${A}/overlord/worktrees/b3-overlay-eacces`,
+    `${A}/gymbro/scratchwork/switchroom`,
+    `${A}/klanker/home/tmp-build/switchroom`,
+    `${A}/klanker/home/voiceout-work/switchroom`,
+    `${A}/klanker/home/sr-4638`,
+    `${A}/klanker/home/work/fix-3333`,
+    `${A}/overlord/home/switchroom-clone`,
+    `${A}/carrie/home/ProductOS`,
+  ];
+  const LITTER_DIRS = DISCOVERED.slice(0, 9);
+
+  interface Over {
+    remote?: string;
+    branch?: string;
+    keep?: boolean;
+  }
+
+  function deps(overrides: Record<string, Over> = {}): GcDeps {
+    return {
+      dateStamp: "2026-08-15",
+      idleDays: 14,
+      nowMs: NOW,
+      probeInUse: () => "free",
+      newestTrackedMtimeMs: () => NOW - 60 * 86_400_000,
+      existsSync: (p: string) => {
+        if (p.endsWith(`/${KEEP_MARKER}`)) {
+          return overrides[p.slice(0, -(KEEP_MARKER.length + 1))]?.keep === true;
+        }
+        if (p.endsWith("/.git")) return DISCOVERED.includes(p.slice(0, -5));
+        return DISCOVERED.includes(p);
+      },
+      readDir: (p: string) => {
+        throw new Error("unexpected readDir " + p);
+      },
+      stat: () => ({ isDirectory: () => true }), // every fixture tree is a clone
+      exec: (_file: string, args: string[]) => {
+        const dir = args[args.indexOf("-C") + 1]!;
+        const o = overrides[dir] ?? {};
+        if (args.includes("remote")) return o.remote ?? SR;
+        if (args.includes("status")) return "";
+        if (args.includes("@{upstream}")) return "origin/x\n";
+        if (args.includes("rev-list")) return "0\n";
+        if (args.includes("rev-parse")) return `${o.branch ?? "feat/x"}\n`;
+        throw new Error("unexpected exec " + args.join(" "));
+      },
+      prSignal: () => "merged",
+    };
+  }
+
+  const byDir = (overrides: Record<string, Over> = {}, roots: string[] = []) => {
+    const plan = planGc([], deps(overrides), roots, DISCOVERED);
+    return { plan, trees: new Map(plan.taskTrees.map((t) => [t.dir, t])) };
+  };
+
+  it("reaps the dot-directory litter the old roots could not see", () => {
+    const { trees } = byDir();
+    for (const dir of LITTER_DIRS) {
+      expect(trees.get(dir)?.verdict, dir).toBe("reap");
+      expect(trees.get(dir)?.willAct, dir).toBe(true);
+    }
+  });
+
+  it("spares a project repo the agent owns — its origin is not switchroom's", () => {
+    const dir = `${A}/carrie/home/ProductOS`;
+    const { plan, trees } = byDir({ [dir]: { remote: "git@github.com:acme/ProductOS.git\n" } });
+    expect(trees.has(dir)).toBe(false);
+    expect(plan.skipped.find((s) => s.dir === dir)?.kind).toBe("not-ours");
+  });
+
+  it("spares a reference clone carrying the .switchroom-keep marker", () => {
+    const dir = `${A}/overlord/home/switchroom-clone`;
+    const { trees } = byDir({ [dir]: { branch: "review-merge", keep: true } });
+    expect(trees.get(dir)?.verdict).toBe("skip-protected");
+    expect(trees.get(dir)?.willAct).toBe(false);
+  });
+
+  it("spares a reference clone parked on trunk, without spending a gh probe on it", () => {
+    const dir = `${A}/overlord/home/switchroom-clone`;
+    const probed: string[] = [];
+    const plan = planGc(
+      [],
+      { ...deps({ [dir]: { branch: "main" } }), prSignal: (r: string) => (probed.push(r), "merged") },
+      [],
+      DISCOVERED,
+    );
+    const t = plan.taskTrees.find((x) => x.dir === dir);
+    expect(t?.verdict).toBe("skip-protected");
+    expect(t?.willAct).toBe(false);
+    expect(probed).not.toContain(dir);
+    expect(plan.taskTrees.filter((x) => x.willAct).length).toBeGreaterThan(0);
+  });
+
+  it("de-duplicates a directory reachable via BOTH a blessed root and discovery", () => {
+    const root = `${A}/klanker/home/work`;
+    const plan = planGc(
+      [],
+      {
+        ...deps(),
+        existsSync: (p: string) =>
+          p === root ||
+          (p.endsWith(`/${KEEP_MARKER}`)
+            ? false
+            : p.endsWith("/.git")
+              ? DISCOVERED.includes(p.slice(0, -5))
+              : DISCOVERED.includes(p)),
+        readDir: (p: string) => (p === root ? ["fix-3333"] : []),
+      },
+      [root],
+      DISCOVERED,
+    );
+    expect(plan.taskTrees.filter((t) => t.dir === `${root}/fix-3333`).length).toBe(1);
+  });
+
+  it("gives every quarantined tree a DISTINCT destination", () => {
+    const { plan } = byDir();
+    const acting = plan.taskTrees.filter((t) => t.willAct);
+    // the layout alone carries three `switchroom` and two `repo` basenames
+    expect(acting.length).toBeGreaterThan(3);
+    const dests = acting.map((t) => t.dest);
+    expect(new Set(dests).size).toBe(dests.length);
+  });
+
+  it("records the discovered candidates on the plan", () => {
+    const { plan } = byDir();
+    expect(plan.taskTreeDirs).toEqual(DISCOVERED);
+  });
+});
+
+// ── pure guards ─────────────────────────────────────────────────────────────
+
+describe("precious-vs-disposable guards (pure)", () => {
+  const base: TaskTreeClassifyInput = {
+    isRegistryClaimed: false,
+    isStablePerRepoTree: false,
+    isEphemeralPath: false,
+    clean: true,
+    pushed: "pushed",
+    prSignal: "merged",
+    idle: true,
+    inUse: "free",
+  };
+
+  it("an otherwise-reapable tree IS reaped (the guards are not blanket)", () => {
+    expect(classifyTaskTree(base)).toBe("reap");
+  });
+
+  it("a trunk-branch checkout is protected", () => {
+    expect(classifyTaskTree({ ...base, isReferenceCheckout: true })).toBe("skip-protected");
+    for (const b of ["main", "master", "trunk", "develop"]) {
+      expect(isReferenceCheckoutBranch(b), b).toBe(true);
+    }
+    for (const b of ["feat/x", "fix/4638", "review-merge", null]) {
+      expect(isReferenceCheckoutBranch(b), String(b)).toBe(false);
+    }
+  });
+
+  it("a .switchroom-keep marked tree is protected", () => {
+    expect(classifyTaskTree({ ...base, isKeepMarked: true })).toBe("skip-protected");
+  });
+
+  it("allocateTrashDest never collides on equal basenames", () => {
+    const used = new Set<string>();
+    const a = allocateTrashDest("/trash", "/agents/x/home/w1/repo", used);
+    const b = allocateTrashDest("/trash", "/agents/y/home/w2/repo", used);
+    expect(a).toBe("/trash/repo");
+    expect(b).not.toBe(a);
+    // stable across runs
+    expect(allocateTrashDest("/trash", "/agents/y/home/w2/repo", new Set(["repo"]))).toBe(b);
+  });
+});


### PR DESCRIPTION
## The incident

The fleet root disk hit 85% full. **41 stale git checkouts** were found scattered across agent homes; the existing sweeper caught almost none of them.

Root cause, verified in real source: `defaultTaskTreeRoots()` (`src/worktree/gc.ts:1068` at `4a4ed83c`) scans exactly two subdirectories per agent — `home/work` and `home/workspace`. The actual litter (relative to `~/.switchroom/agents/`):

```
klanker/home/sr-4638              direct child of home/, ad-hoc name
klanker/home/tmp-build/switchroom nested one level deeper
overlord/home/.cache/sr-review    inside a DOT directory
overlord/.work4481/repo           dot dir, outside home/ entirely
overlord/worktrees/b3-overlay-…   sibling of home/, not under it
gymbro/scratchwork/switchroom     outside home/
```

**The classifier was never broken — it was aimed at a convention nobody follows.**

## Part A — widen detection

`discoverAgentCheckouts()` walks each agent's directory and hands `planGc` every checkout it finds, wherever the agent put it. It is unioned with (not a replacement for) the two blessed roots, de-duplicated by resolved path, so pre-existing `home/work` / `home/workspace` behaviour is unchanged.

**Bounded by construction — and measured, not asserted:**

| bound | value |
|---|---|
| depth | 4 below the agent dir (deepest real litter was 3) |
| prune | `.git`, `*.git` (bare repos), `node_modules`, `.npm`, `.bun`, `.cargo`, `.yarn`, `.venv`, `uv`, `tmp`, `.claude`, `.local`, `target`, `dist`, … |
| checkout boundary | a directory with `.git` is recorded and **never descended** |
| symlinks | never followed (a loop terminates) |
| visit budget | 50 000 directories fleet-wide |

Measured on the reference fleet (**37 agents, 52 GiB of agent homes**): **1 450 `readdir` calls, 32 ms, 77 checkouts found**. For comparison, an unbounded `find` over the same tree visits **176 436** directories.

`.cache` is deliberately **not** pruned — `overlord/home/.cache/sr-review` was real litter. `tmp` **is** pruned because `tmp-reaper.ts` already owns it and two reapers racing the same directories is worse than either alone; note that prunes the exact name only, so `home/tmp-build/switchroom` is still found.

## The disposable-vs-precious rule

Widening WHERE gc looks relaxes nothing about WHAT it may reap — every discovered tree still runs the full Phase C gauntlet (switchroom origin → claimed → in-use → clean → pushed → idle 14d → PR merged/closed). But it puts trees in front of the classifier that were previously unreachable, so the line is now drawn explicitly:

1. **Reserved agent furniture is never a candidate** — `<agent>/workspace`, `<agent>/home/workspace`, and the stable per-repo tree `<agent>/work/<slug>` (`src/repos/agent-worktree.ts:5`). Structural, not inferred.
2. **Origin must be switchroom's** — unchanged (`isSwitchroomRemote`). A project repo an agent legitimately owns reports `not-ours` and is left alone.
3. **A trunk-branch checkout is a reference clone** — `main`/`master`/`trunk`/`develop` ⇒ `skip-protected`, with no `gh` call spent.
4. **`.switchroom-keep` protects any checkout unconditionally** — the deterministic escape valve, because inference cannot be complete. Concretely: `overlord/home/switchroom-clone`, the reference clone today's manual sweep deliberately preserved, sits on a local scratch branch (`review-merge`, upstream `origin/main`) — **neither trunk nor a reserved path**. It survives today only because that branch has no PR (`prSignal: none` ⇒ `skip-unmerged`) and because it stays inside the idle window. Both are true; both are accidents. A marker file is a mechanism.

## Also fixed — a latent quarantine collision

The quarantine destination was `join(trash, basename(dir))`. Two agents could already produce one path for one dated trash dir; under discovery it is routine (the incident layout alone carries three `switchroom` and two `repo` basenames). `mv` would have nested the second tree inside the first and lost which agent it came from. `allocateTrashDest()` disambiguates with a stable SHA-1 prefix of the source path.

## Tests

`tests/worktree.gc.discovery.test.ts` (21 tests) builds an on-disk fixture reproducing the real layout — dot dirs, nested `repo/` children, a checkout outside `home/`, a bare repo's `worktrees/` admin dir, a symlink loop, a checkout past the depth cap — and asserts outcomes: which paths come back and which verdict the planner reaches.

**They fail on unmodified `gc.ts`: 17 of 21 fail** (`git stash -- src/` then re-run). The 2 that pass by design are the controls — `classifyTaskTree(base) === "reap"` must hold on both sides, otherwise the guard tests prove nothing.

## Local verification

- `vitest run tests/worktree.gc.discovery.test.ts` — 21 passed
- Scoped worktree/reaper suites (12 files) — **204 passed, 1 skipped, 0 failed**
- `npm run lint` — **exit 0**, including `check-changelog-entry: OK` and `check-mutation-coverage`

## Part B — investigated, recommend a SEPARATE PR

Widening detection treats the symptom; agents pick ad-hoc paths because nothing hands them one. Two findings that change the shape of the fix:

- **#4723's scratch mount is not the answer, and the briefing's premise about it is wrong.** `/scratch` is backed by `/mnt/bulkdata/switchroom/scratch/<agent>` — a **different device, outside `~/.switchroom/agents/`** (`src/agents/scratch.ts`, `DEFAULT_SCRATCH_VOLUME`). It is a *cache* relocation (`XDG_CACHE_HOME`, `TMPDIR`, `npm_config_cache`, …) and a **hard no-op when the bulk volume is absent**. So (a) it cannot be the canonical checkout location, because on a host without the volume it does not exist and workers would fall straight back to ad-hoc paths, and (b) checkouts placed there would be invisible to this PR's scanner — Part B done naively re-opens the hole Part A just closed. This also means the walk never touches the bulk volume, so that cost worry does not apply.
- **The real gap is guidance, not storage.** `profiles/_shared/dev-protocol.md.hbs:10` tells workers "remove worktrees when done, don't orphan them" but **never names a directory**. There is no env var, no template variable, and no verb that answers "where do I put a task checkout?". `home/work` is already the de-facto answer and already gc's root — it mostly needs advertising.

Recommendation: a separate PR that (1) emits an always-present `SWITCHROOM_AGENT_TASKDIR` from `compose.ts`, (2) names it in `dev-protocol.md.hbs`, and (3) optionally adds a `worktree` verb to allocate one. That spans compose + profiles + CLI, and item 3 collides with in-flight verb work in `src/cli/worktree.ts`. It should not ride on this diff, and Part A works without it.

## Coordination

`src/cli/worktree.ts` is touched by **13 added lines** (one import, one `--no-discover` flag, one option type, the default wiring) to stay out of the way of the concurrent verb work in that file. `src/cli/doctor.ts` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)