### PR TITLE
fix(telegram): sanitise lone surrogates before the wire so approval cards deliver

### DIFF
--- a/changelog.d/4728-sanitise-lone-surrogates-before-the-wire-so-appr.fix.md
+++ b/changelog.d/4728-sanitise-lone-surrogates-before-the-wire-so-appr.fix.md
@@ -1,0 +1,1 @@
+- **telegram: sanitise lone surrogates before the wire so approval cards deliver (#4728)**

--- a/changelog.d/4728-sanitise-lone-surrogates-before-the-wire-so-appr.fix.md
+++ b/changelog.d/4728-sanitise-lone-surrogates-before-the-wire-so-appr.fix.md
@@ -7,4 +7,6 @@
   in front of it. The repair now happens once, in the grammy API-transformer
   layer that every outbound call must transit, over the whole payload (button
   labels and captions included) rather than at each individual truncation
-  site.
+  site. Forum-topic creation (`switchroom topics sync`) POSTs outside the bot
+  and so outside that layer, and now repairs the configured `topic_name` the
+  same way instead of failing the whole sync on the same 400.

--- a/changelog.d/4728-sanitise-lone-surrogates-before-the-wire-so-appr.fix.md
+++ b/changelog.d/4728-sanitise-lone-surrogates-before-the-wire-so-appr.fix.md
@@ -1,1 +1,10 @@
-- **telegram: sanitise lone surrogates before the wire so approval cards deliver (#4728)**
+- **telegram: sanitise lone surrogates before the wire so approval cards deliver (#4728)** —
+  A JavaScript string is UTF-16 and may carry a LONE SURROGATE, which has no
+  valid UTF-8 encoding; `JSON.stringify` emits it as a `\udXXX` escape rather
+  than throwing, so the bad body reached Telegram, which rejected the whole
+  send with `400 Bad Request: strings must be encoded in UTF-8` — and the
+  approval card was silently dropped, leaving a gated tool call with no human
+  in front of it. The repair now happens once, in the grammy API-transformer
+  layer that every outbound call must transit, over the whole payload (button
+  labels and captions included) rather than at each individual truncation
+  site.

--- a/src/telegram/topic-manager.ts
+++ b/src/telegram/topic-manager.ts
@@ -1,6 +1,7 @@
 import type { SwitchroomConfig } from "../config/schema.js";
 import { loadTopicState, saveTopicState, type TopicState, type TopicEntry } from "./state.js";
 import { redactToken } from "./redact-token.js";
+import { sanitizeLoneSurrogates } from "../../telegram-plugin/shared/utf8-sanitize.js";
 
 export interface TopicSyncResult {
   agent: string;
@@ -78,7 +79,14 @@ async function createForumTopic(
 
   const body: Record<string, string> = {
     chat_id: chatId,
-    name,
+    // #4728: this POSTs with raw `fetch`, NOT through the grammy bot, so the
+    // API-transformer sanitiser never sees it. `name` is the only operator-
+    // supplied string on the wire here (`agentConfig.topic_name` from
+    // switchroom.yaml), and a lone surrogate in it 400s the whole request with
+    // "strings must be encoded in UTF-8" — the same failure #4728 fixes for
+    // card sends. `closeForumTopic` needs no such repair: its body carries
+    // only `chat_id` and a numeric `message_thread_id`.
+    name: sanitizeLoneSurrogates(name),
   };
   if (iconCustomEmojiId) {
     body.icon_custom_emoji_id = iconCustomEmojiId;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -303,6 +303,7 @@ import { installEditFloodFuse, editFloodFuseConfigFromEnv } from '../edit-flood-
 import { createSendGate, sendGateConfigFromEnv, isSendGateShed } from '../send-gate.js'
 import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
 import { installTgPostLogger, installRichMarkdownGuard, withTgPostTags, withTgSendContext, installSystemMessageObserver } from '../shared/bot-runtime.js'
+import { installUtf8Sanitizer } from '../shared/utf8-sanitize.js'
 import { installSentTextCapture } from '../shared/sent-text-capture.js'
 import {
   floodStatePath,
@@ -22873,6 +22874,7 @@ async function initGatewayBot(): Promise<void> {
   }
 
   bot = new Bot(TOKEN)
+  installUtf8Sanitizer(bot) // #4728: installed FIRST so it composes INNERMOST — the last thing to touch the payload before serialisation; see installUtf8Sanitizer docblock
   installTgPostLogger(bot); installRichMarkdownGuard(bot) // #3252/#3463: universal fmt guard installed after logger (composes outermost); see installRichMarkdownGuard docblock
   // #4576 follow-up: FALLBACK card body. The observer takes the stored body off
   // the RESPONSE (`rich_message` → `text`/`caption`); this stamps the REQUEST body

--- a/telegram-plugin/shared/utf8-sanitize.ts
+++ b/telegram-plugin/shared/utf8-sanitize.ts
@@ -103,9 +103,34 @@ export interface SanitizeStats {
 }
 
 /**
+ * Define `k` as an own enumerable data property of `out`.
+ *
+ * `out[k] = v` would REASSIGN the clone's prototype for the single key
+ * `__proto__` (the `Object.prototype` accessor), silently dropping an own
+ * `__proto__` key from the payload. defineProperty always makes an own data
+ * property, for that key like any other.
+ */
+function defineOwn(out: Record<string, unknown>, k: string, v: unknown): void {
+  Object.defineProperty(out, k, {
+    value: v,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  })
+}
+
+/**
  * Deep-sanitise every string in `value`, CLONE-ON-WRITE: the input is never
- * mutated, and the exact same instance is returned when nothing changed (so
- * the common case allocates nothing).
+ * mutated, and the exact same instance is returned when nothing changed.
+ *
+ * The clone is materialised LAZILY, on the first key/index that actually
+ * changed — so a clean payload allocates no container and performs no
+ * property definition at any depth, it is only walked and handed back by
+ * identity. That matters: this runs on the innermost hop of EVERY `bot.api.*`
+ * call, including the draft-stream `editMessageText` path that edits the same
+ * card several times a second, and the overwhelming majority of payloads are
+ * clean. (Pinned by the "clean nested payload" test, which fails if any
+ * container is rebuilt.)
  *
  * Pass `stats` to collect the repair count.
  */
@@ -118,32 +143,45 @@ export function sanitizePayloadStrings<T>(value: T, depth = 0, stats?: SanitizeS
   if (depth >= MAX_DEPTH || !isWalkable(value)) return value
 
   if (Array.isArray(value)) {
-    let changed = false
-    const out = value.map(item => {
+    let out: unknown[] | undefined
+    for (let i = 0; i < value.length; i++) {
+      const item = value[i]
       const next = sanitizePayloadStrings(item, depth + 1, stats)
-      if (next !== item) changed = true
-      return next
-    })
-    return (changed ? out : value) as unknown as T
+      // First change: copy the already-walked prefix, all of it unchanged.
+      if (out === undefined && next !== item) out = value.slice(0, i)
+      if (out !== undefined) out.push(next)
+    }
+    return (out ?? value) as unknown as T
   }
 
-  let changed = false
-  const out: Record<string, unknown> = {}
-  for (const [k, v] of Object.entries(value)) {
+  // `for...in` rather than `Object.entries`, so the clean path allocates no
+  // key/entry array either. The `hasOwnProperty` guard keeps this EXACTLY
+  // equivalent to `Object.entries`: `for...in` also yields INHERITED
+  // enumerable keys, so without it a polluted `Object.prototype` would leak an
+  // extra field into the body we hand to Telegram.
+  const hasOwn = Object.prototype.hasOwnProperty
+  let out: Record<string, unknown> | undefined
+  for (const k in value) {
+    if (!hasOwn.call(value, k)) continue
+    const v = (value as Record<string, unknown>)[k]
     const next = sanitizePayloadStrings(v, depth + 1, stats)
-    if (next !== v) changed = true
-    // `out[k] = next` would REASSIGN the clone's prototype for the single key
-    // `__proto__` (the `Object.prototype` accessor), silently dropping an own
-    // `__proto__` key from the payload. defineProperty always makes an own
-    // data property, for that key like any other.
-    Object.defineProperty(out, k, {
-      value: next,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    })
+    if (out === undefined && next !== v) {
+      // First change: materialise the clone and backfill the keys already
+      // walked, every one of which came back unchanged. This re-reads those
+      // properties (so an own getter in the prefix is invoked twice), which
+      // only ever happens on the repair path — a payload with an own getter
+      // AND a lone surrogate. Telegram payloads are plain data; a getter that
+      // throws is caught by the fail-open guard in `installUtf8Sanitizer`.
+      out = {}
+      for (const prev in value) {
+        if (prev === k) break
+        if (!hasOwn.call(value, prev)) continue
+        defineOwn(out, prev, (value as Record<string, unknown>)[prev])
+      }
+    }
+    if (out !== undefined) defineOwn(out, k, next)
   }
-  return (changed ? out : value) as unknown as T
+  return (out ?? value) as unknown as T
 }
 
 /** One log line per method per minute. The draft-stream `editMessageText`
@@ -173,7 +211,9 @@ const LOG_THROTTLE_MS = 60_000
  * would otherwise propagate out of every outbound call and wedge the whole
  * gateway. Sending the original payload is never worse than throwing: the
  * worst case is the pre-#4728 behaviour (Telegram 400s that one send), while
- * throwing here breaks sends that had nothing wrong with them.
+ * throwing here breaks sends that had nothing wrong with them. It is not
+ * silent, though: failing open logs its own throttled line naming the method,
+ * so the degraded state stays diagnosable.
  *
  * `now` is an injected clock so the throttle can be driven deterministically
  * from a test: this file runs under BOTH vitest and `bun test`, and bun's
@@ -195,8 +235,23 @@ export function installUtf8Sanitizer(bot: Bot, now: () => number = Date.now): vo
     const stats: SanitizeStats = { repaired: 0 }
     try {
       clean = sanitizePayloadStrings(payload, 0, stats)
-    } catch {
+    } catch (err) {
       clean = payload
+      // Fail open, but never SILENTLY: without this line a future walk bug or
+      // a genuinely throwing getter degrades to a bare Telegram 400 with no
+      // trail back to the sanitiser — precisely the opacity #4728 exists to
+      // end. Throttled on its own budget (a distinct key), so a persistent
+      // walk failure cannot be starved by, or starve, the repair line above.
+      // The error MESSAGE is included because without it the line cannot
+      // diagnose anything; the payload body still never is.
+      if (shouldLogRepair(`${method} sanitize-failed`, now())) {
+        process.stderr.write(
+          `telegram gateway: utf8-sanitize FAILED OPEN method=${method} — ` +
+          `payload sent unrepaired; if it carries a lone surrogate Telegram ` +
+          `will reject it (400 "strings must be encoded in UTF-8"): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+        )
+      }
     }
     if (clean !== payload && shouldLogRepair(method, now())) {
       process.stderr.write(

--- a/telegram-plugin/shared/utf8-sanitize.ts
+++ b/telegram-plugin/shared/utf8-sanitize.ts
@@ -244,7 +244,11 @@ export function installUtf8Sanitizer(bot: Bot, now: () => number = Date.now): vo
       // walk failure cannot be starved by, or starve, the repair line above.
       // The error MESSAGE is included because without it the line cannot
       // diagnose anything; the payload body still never is.
-      if (shouldLogRepair(`${method} sanitize-failed`, now())) {
+      // The separator is written as the ESCAPE "backslash-u-0000", never as a raw NUL
+      // byte: a literal 0x00 in a source file trips the #3676 binary-file
+      // guard (tests/source-files-are-text.test.ts) and blocks the merge
+      // queue. The runtime key is identical either way.
+      if (shouldLogRepair(`${method}\u0000sanitize-failed`, now())) {
         process.stderr.write(
           `telegram gateway: utf8-sanitize FAILED OPEN method=${method} — ` +
           `payload sent unrepaired; if it carries a lone surrogate Telegram ` +

--- a/telegram-plugin/shared/utf8-sanitize.ts
+++ b/telegram-plugin/shared/utf8-sanitize.ts
@@ -58,6 +58,16 @@ export function hasLoneSurrogate(s: string): boolean {
 }
 
 /**
+ * How many unpaired surrogate code units `s` carries. Safe to call on the
+ * shared `/g` regex: `String.prototype.match` with a global pattern resets
+ * `lastIndex` to 0 itself before it collects, so this cannot leak state into
+ * `hasLoneSurrogate`.
+ */
+function countLoneSurrogates(s: string): number {
+  return (s.match(LONE_SURROGATE) ?? []).length
+}
+
+/**
  * Replace every unpaired surrogate in `s` with U+FFFD. Returns the SAME
  * string instance when there is nothing to repair, so callers can use
  * identity to detect a no-op. Idempotent: U+FFFD is not a surrogate.
@@ -85,21 +95,32 @@ function isWalkable(v: unknown): v is Record<string, unknown> | unknown[] {
  * against a pathological or cyclic input, never reached in practice. */
 const MAX_DEPTH = 16
 
+/** Mutable tally threaded through the walk so the caller can log HOW MANY
+ * code units were repaired without ever seeing the content itself. */
+export interface SanitizeStats {
+  /** Total unpaired surrogate code units replaced with U+FFFD. */
+  repaired: number
+}
+
 /**
  * Deep-sanitise every string in `value`, CLONE-ON-WRITE: the input is never
  * mutated, and the exact same instance is returned when nothing changed (so
  * the common case allocates nothing).
+ *
+ * Pass `stats` to collect the repair count.
  */
-export function sanitizePayloadStrings<T>(value: T, depth = 0): T {
+export function sanitizePayloadStrings<T>(value: T, depth = 0, stats?: SanitizeStats): T {
   if (typeof value === 'string') {
-    return sanitizeLoneSurrogates(value) as unknown as T
+    const next = sanitizeLoneSurrogates(value)
+    if (stats && next !== value) stats.repaired += countLoneSurrogates(value)
+    return next as unknown as T
   }
   if (depth >= MAX_DEPTH || !isWalkable(value)) return value
 
   if (Array.isArray(value)) {
     let changed = false
     const out = value.map(item => {
-      const next = sanitizePayloadStrings(item, depth + 1)
+      const next = sanitizePayloadStrings(item, depth + 1, stats)
       if (next !== item) changed = true
       return next
     })
@@ -109,11 +130,41 @@ export function sanitizePayloadStrings<T>(value: T, depth = 0): T {
   let changed = false
   const out: Record<string, unknown> = {}
   for (const [k, v] of Object.entries(value)) {
-    const next = sanitizePayloadStrings(v, depth + 1)
+    const next = sanitizePayloadStrings(v, depth + 1, stats)
     if (next !== v) changed = true
-    out[k] = next
+    // `out[k] = next` would REASSIGN the clone's prototype for the single key
+    // `__proto__` (the `Object.prototype` accessor), silently dropping an own
+    // `__proto__` key from the payload. defineProperty always makes an own
+    // data property, for that key like any other.
+    Object.defineProperty(out, k, {
+      value: next,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
   }
   return (changed ? out : value) as unknown as T
+}
+
+/** One log line per method per minute. The draft-stream `editMessageText`
+ * path edits the same card many times a second, so an upstream that is
+ * PERSISTENTLY corrupt would otherwise emit a line per edit and drown the
+ * gateway log in the exact situation you most need to read it. */
+const LOG_THROTTLE_MS = 60_000
+const lastLoggedAtByMethod = new Map<string, number>()
+
+/** Test seam: drop the throttle state so a suite can observe the first line
+ * of a fresh window. Not used in production. */
+export function __resetUtf8SanitizeLogThrottle(): void {
+  lastLoggedAtByMethod.clear()
+}
+
+/** True when this method may log now; records the emission when it may. */
+function shouldLogRepair(method: string, now: number): boolean {
+  const last = lastLoggedAtByMethod.get(method)
+  if (last !== undefined && now - last < LOG_THROTTLE_MS) return false
+  lastLoggedAtByMethod.set(method, now)
+  return true
 }
 
 /**
@@ -126,17 +177,33 @@ export function sanitizePayloadStrings<T>(value: T, depth = 0): T {
  * serialised and POSTed. Anything installed after this one can therefore not
  * reintroduce a lone surrogate behind its back.
  *
- * A repair is logged (method + count only — never the body, which may carry
- * operator content) so a corrupt upstream producer stays diagnosable instead
- * of being silently papered over.
+ * A repair is logged with the method and the repaired code-unit COUNT — never
+ * the body, which may carry operator content — so a corrupt upstream producer
+ * stays diagnosable instead of being silently papered over. The line is
+ * throttled to once per method per minute.
+ *
+ * The sanitise call FAILS OPEN. It runs on the innermost hop of every single
+ * `bot.api.*` call, and its object walk reads own enumerable properties —
+ * which invokes getters. A throwing getter, or any future bug in the walk,
+ * would otherwise propagate out of every outbound call and wedge the whole
+ * gateway. Sending the original payload is never worse than throwing: the
+ * worst case is the pre-#4728 behaviour (Telegram 400s that one send), while
+ * throwing here breaks sends that had nothing wrong with them.
  */
 export function installUtf8Sanitizer(bot: Bot): void {
   bot.api.config.use(async (prev, method, payload, signal) => {
-    const clean = sanitizePayloadStrings(payload)
-    if (clean !== payload) {
+    let clean = payload
+    const stats: SanitizeStats = { repaired: 0 }
+    try {
+      clean = sanitizePayloadStrings(payload, 0, stats)
+    } catch {
+      clean = payload
+    }
+    if (clean !== payload && shouldLogRepair(method, Date.now())) {
       process.stderr.write(
-        `telegram gateway: utf8-sanitize repaired lone surrogate(s) method=${method} ` +
-        `— body would have been rejected by Telegram (400 "strings must be encoded in UTF-8")\n`,
+        `telegram gateway: utf8-sanitize repaired ${stats.repaired} lone surrogate(s) ` +
+        `method=${method} — body would have been rejected by Telegram ` +
+        `(400 "strings must be encoded in UTF-8")\n`,
       )
     }
     return prev(method, clean, signal)

--- a/telegram-plugin/shared/utf8-sanitize.ts
+++ b/telegram-plugin/shared/utf8-sanitize.ts
@@ -1,0 +1,144 @@
+/**
+ * Wire-level UTF-8 sanitiser (#4728).
+ *
+ * ── The failure this exists to stop ───────────────────────────────────────
+ *
+ * A JavaScript string is UTF-16, and UTF-16 permits a LONE SURROGATE — a high
+ * (`\uD800`-`\uDBFF`) or low (`\uDC00`-`\uDFFF`) code unit with no partner.
+ * A lone surrogate has NO valid UTF-8 encoding. `JSON.stringify` does not
+ * throw on one (well-formed `JSON.stringify`, ES2019): it emits the `\udXXX`
+ * escape, so grammy happily POSTs a body Telegram's decoder then rejects with
+ *
+ *     400 Bad Request: strings must be encoded in UTF-8
+ *
+ * Observed in production on 2026-07-31 (agent `gymbro`, twice): a
+ * `permission_request` approval card 400'd on `sendRichMessage` with exactly
+ * that description and the operator never saw the card. An approval card is
+ * the human safety boundary for a gated tool call — a dropped card means a
+ * gated action silently never happens.
+ *
+ * ── Why HERE and not in the card formatter ────────────────────────────────
+ *
+ * The plugin already repairs a *trailing* high surrogate at each of its
+ * truncation sites (`card-layout.ts:384`, `format.ts:1551`,
+ * `tool-activity-summary.ts:488`, `reply-quote.ts:78`). Every one of those is
+ * a per-cut patch that (a) only covers the cut it guards and (b) only covers
+ * the HIGH half — an orphaned LOW surrogate, or a lone surrogate that entered
+ * the body from upstream data (a tool `input_preview`, a file path, a
+ * model-emitted token) rather than from a cut, sails straight through all of
+ * them onto the wire. So the repair belongs at the ONE place every outbound
+ * call must transit: the grammy API-transformer layer, which no `ctx.*`
+ * helper and no raw `bot.api.*` call can bypass
+ * (see `shared/bot-runtime.ts` header).
+ *
+ * The sanitiser walks the WHOLE payload, not a named field list, because a
+ * lone surrogate anywhere in the JSON body fails the whole request — inline
+ * keyboard button labels (`reply_markup`, which every approval card carries),
+ * captions, `rich_message.markdown` and plain `text` alike.
+ *
+ * Substitution is U+FFFD REPLACEMENT CHARACTER rather than deletion: it is
+ * the Unicode-standard substitution, and it is length-preserving in UTF-16
+ * code units, so a body that was sized against a char budget upstream cannot
+ * be pushed over that budget by the repair.
+ */
+
+import type { Bot } from 'grammy'
+
+/**
+ * Matches a code unit that is a surrogate with no partner:
+ * a high surrogate not followed by a low one, or a low surrogate not
+ * preceded by a high one. A well-formed pair matches neither alternative.
+ */
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g
+
+/** True when `s` contains at least one unpaired surrogate. */
+export function hasLoneSurrogate(s: string): boolean {
+  LONE_SURROGATE.lastIndex = 0
+  return LONE_SURROGATE.test(s)
+}
+
+/**
+ * Replace every unpaired surrogate in `s` with U+FFFD. Returns the SAME
+ * string instance when there is nothing to repair, so callers can use
+ * identity to detect a no-op. Idempotent: U+FFFD is not a surrogate.
+ */
+export function sanitizeLoneSurrogates(s: string): string {
+  if (!hasLoneSurrogate(s)) return s
+  return s.replace(LONE_SURROGATE, '�')
+}
+
+/**
+ * True for a value we may safely recurse into and rebuild: a plain object or
+ * an array. Anything else (an `InputFile`, a `Buffer`, a stream, a `Date`,
+ * a class instance) is returned untouched — rebuilding it would destroy its
+ * prototype and grammy's multipart layer depends on those identities.
+ */
+function isWalkable(v: unknown): v is Record<string, unknown> | unknown[] {
+  if (Array.isArray(v)) return true
+  if (v === null || typeof v !== 'object') return false
+  const proto = Object.getPrototypeOf(v)
+  return proto === Object.prototype || proto === null
+}
+
+/** Depth cap: Telegram payloads are shallow (deepest real nesting is
+ * `reply_markup.inline_keyboard[][]`, depth 3). The cap is a cheap guard
+ * against a pathological or cyclic input, never reached in practice. */
+const MAX_DEPTH = 16
+
+/**
+ * Deep-sanitise every string in `value`, CLONE-ON-WRITE: the input is never
+ * mutated, and the exact same instance is returned when nothing changed (so
+ * the common case allocates nothing).
+ */
+export function sanitizePayloadStrings<T>(value: T, depth = 0): T {
+  if (typeof value === 'string') {
+    return sanitizeLoneSurrogates(value) as unknown as T
+  }
+  if (depth >= MAX_DEPTH || !isWalkable(value)) return value
+
+  if (Array.isArray(value)) {
+    let changed = false
+    const out = value.map(item => {
+      const next = sanitizePayloadStrings(item, depth + 1)
+      if (next !== item) changed = true
+      return next
+    })
+    return (changed ? out : value) as unknown as T
+  }
+
+  let changed = false
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(value)) {
+    const next = sanitizePayloadStrings(v, depth + 1)
+    if (next !== v) changed = true
+    out[k] = next
+  }
+  return (changed ? out : value) as unknown as T
+}
+
+/**
+ * Install the UTF-8 sanitiser as a grammy API transformer.
+ *
+ * MUST be installed FIRST, before every other transformer: grammy composes
+ * `call = trans(prev, ...)` (`grammy/out/core/client.js:9-11,91`), so the
+ * LAST-installed transformer is the OUTERMOST and the FIRST-installed is the
+ * INNERMOST — the one that sees the final payload immediately before it is
+ * serialised and POSTed. Anything installed after this one can therefore not
+ * reintroduce a lone surrogate behind its back.
+ *
+ * A repair is logged (method + count only — never the body, which may carry
+ * operator content) so a corrupt upstream producer stays diagnosable instead
+ * of being silently papered over.
+ */
+export function installUtf8Sanitizer(bot: Bot): void {
+  bot.api.config.use(async (prev, method, payload, signal) => {
+    const clean = sanitizePayloadStrings(payload)
+    if (clean !== payload) {
+      process.stderr.write(
+        `telegram gateway: utf8-sanitize repaired lone surrogate(s) method=${method} ` +
+        `— body would have been rejected by Telegram (400 "strings must be encoded in UTF-8")\n`,
+      )
+    }
+    return prev(method, clean, signal)
+  })
+}

--- a/telegram-plugin/shared/utf8-sanitize.ts
+++ b/telegram-plugin/shared/utf8-sanitize.ts
@@ -151,21 +151,6 @@ export function sanitizePayloadStrings<T>(value: T, depth = 0, stats?: SanitizeS
  * PERSISTENTLY corrupt would otherwise emit a line per edit and drown the
  * gateway log in the exact situation you most need to read it. */
 const LOG_THROTTLE_MS = 60_000
-const lastLoggedAtByMethod = new Map<string, number>()
-
-/** Test seam: drop the throttle state so a suite can observe the first line
- * of a fresh window. Not used in production. */
-export function __resetUtf8SanitizeLogThrottle(): void {
-  lastLoggedAtByMethod.clear()
-}
-
-/** True when this method may log now; records the emission when it may. */
-function shouldLogRepair(method: string, now: number): boolean {
-  const last = lastLoggedAtByMethod.get(method)
-  if (last !== undefined && now - last < LOG_THROTTLE_MS) return false
-  lastLoggedAtByMethod.set(method, now)
-  return true
-}
 
 /**
  * Install the UTF-8 sanitiser as a grammy API transformer.
@@ -189,8 +174,22 @@ function shouldLogRepair(method: string, now: number): boolean {
  * gateway. Sending the original payload is never worse than throwing: the
  * worst case is the pre-#4728 behaviour (Telegram 400s that one send), while
  * throwing here breaks sends that had nothing wrong with them.
+ *
+ * `now` is an injected clock so the throttle can be driven deterministically
+ * from a test: this file runs under BOTH vitest and `bun test`, and bun's
+ * `vi` has no `setSystemTime`.
  */
-export function installUtf8Sanitizer(bot: Bot): void {
+export function installUtf8Sanitizer(bot: Bot, now: () => number = Date.now): void {
+  // Throttle state is per-install, not module-global, so one bot's log budget
+  // cannot be consumed by another (and a test needs no reset hook).
+  const lastLoggedAtByMethod = new Map<string, number>()
+  const shouldLogRepair = (method: string, at: number): boolean => {
+    const last = lastLoggedAtByMethod.get(method)
+    if (last !== undefined && at - last < LOG_THROTTLE_MS) return false
+    lastLoggedAtByMethod.set(method, at)
+    return true
+  }
+
   bot.api.config.use(async (prev, method, payload, signal) => {
     let clean = payload
     const stats: SanitizeStats = { repaired: 0 }
@@ -199,7 +198,7 @@ export function installUtf8Sanitizer(bot: Bot): void {
     } catch {
       clean = payload
     }
-    if (clean !== payload && shouldLogRepair(method, Date.now())) {
+    if (clean !== payload && shouldLogRepair(method, now())) {
       process.stderr.write(
         `telegram gateway: utf8-sanitize repaired ${stats.repaired} lone surrogate(s) ` +
         `method=${method} — body would have been rejected by Telegram ` +

--- a/telegram-plugin/tests/utf8-sanitize-wire.test.ts
+++ b/telegram-plugin/tests/utf8-sanitize-wire.test.ts
@@ -209,6 +209,68 @@ describe('UTF-8 sanitiser — the dropped approval card (#4728)', () => {
     expect(sanitizePayloadStrings(payload)).toBe(payload)
   })
 
+  it('(f2) a clean payload is not rebuilt at ANY depth — no container allocated, no property defined', () => {
+    // (f) only pins the identity of the TOP-level return, which a walk that
+    // clones every nested container and discards the clones still satisfies.
+    // This transformer is the innermost hop of every `bot.api.*` call and the
+    // draft-stream `editMessageText` path runs it several times a second, so
+    // "the clean case rebuilds nothing" is a real contract, not a comment.
+    const button = { text: `Approve ${ASTRAL}`, callback_data: 'perm:allow:1' }
+    const row = [button]
+    const keyboard = [row]
+    const markup = { inline_keyboard: keyboard }
+    const payload = { chat_id: 1, text: `all good ${ASTRAL} 100% ✓`, reply_markup: markup }
+
+    const realDefineProperty = Object.defineProperty
+    let definePropertyCalls = 0
+    Object.defineProperty = ((...args: Parameters<typeof Object.defineProperty>) => {
+      definePropertyCalls++
+      return realDefineProperty(...args)
+    }) as typeof Object.defineProperty
+    let out: typeof payload
+    try {
+      out = sanitizePayloadStrings(payload)
+    } finally {
+      Object.defineProperty = realDefineProperty
+    }
+
+    // Goes RED on an eager clone: the old walk defined one property per key
+    // at every level before deciding nothing had changed.
+    expect(definePropertyCalls).toBe(0)
+    // Every container comes back by identity, top level down to the button.
+    expect(out).toBe(payload)
+    expect(out.reply_markup).toBe(markup)
+    expect(out.reply_markup.inline_keyboard).toBe(keyboard)
+    expect(out.reply_markup.inline_keyboard[0]).toBe(row)
+    expect(out.reply_markup.inline_keyboard[0][0]).toBe(button)
+  })
+
+  it('(f3) a DIRTY payload still rebuilds correctly from the lazily-materialised clone', () => {
+    // The lazy clone backfills the already-walked (clean) prefix. If that
+    // backfill were wrong, keys before the first repair would vanish.
+    const payload = {
+      chat_id: 1,
+      before_a: 'kept a',
+      before_b: 'kept b',
+      text: `boom${LONE_HIGH}`,
+      after: 'kept c',
+      nested: { keep: 'yes', bad: `${LONE_LOW}x` },
+      arr: ['keep 0', 'keep 1', `bad${LONE_HIGH}`, 'keep 3'],
+    }
+    const out = sanitizePayloadStrings(payload)
+    expect(out).not.toBe(payload)
+    expect(Object.keys(out)).toEqual(Object.keys(payload))
+    expect(out.before_a).toBe('kept a')
+    expect(out.before_b).toBe('kept b')
+    expect(out.text).toBe('boom�')
+    expect(out.after).toBe('kept c')
+    expect(out.nested).toEqual({ keep: 'yes', bad: '�x' })
+    expect(out.arr).toEqual(['keep 0', 'keep 1', 'bad�', 'keep 3'])
+    // Clone-on-write: the input itself is untouched.
+    expect(payload.text).toBe(`boom${LONE_HIGH}`)
+    expect(payload.arr[2]).toBe(`bad${LONE_HIGH}`)
+  })
+
   it('(g) a payload whose own enumerable getter THROWS still sends — the sanitiser fails open', async () => {
     // The walk reads own enumerable properties, which invokes getters. This
     // transformer sits on the innermost hop of EVERY `bot.api.*` call, so an
@@ -299,6 +361,29 @@ describe('sanitizeLoneSurrogates / sanitizePayloadStrings — unit contract', ()
     expect(out.photo).toBeInstanceOf(InputFileLike)
   })
 
+  it('does not copy INHERITED enumerable keys into the clone (prototype pollution)', () => {
+    // The walk uses `for...in`, which unlike `Object.entries` also yields
+    // inherited enumerable keys. Without the own-property guard a polluted
+    // `Object.prototype` would add a field to the body sent to Telegram.
+    const proto = Object.prototype as unknown as Record<string, unknown>
+    Object.defineProperty(proto, '__polluted__', {
+      value: `evil${LONE_HIGH}`,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
+    try {
+      const payload = { chat_id: 1, text: `hi${LONE_HIGH}` }
+      const out = sanitizePayloadStrings(payload)
+      expect(out.text).toBe('hi�')
+      expect(Object.prototype.hasOwnProperty.call(out, '__polluted__')).toBe(false)
+      expect(Object.keys(out)).toEqual(['chat_id', 'text'])
+      expect(JSON.stringify(out)).toBe('{"chat_id":1,"text":"hi�"}')
+    } finally {
+      delete proto.__polluted__
+    }
+  })
+
   it('leaves non-string scalars alone', () => {
     const payload = { chat_id: 1, disable_notification: true, x: null, y: undefined }
     expect(sanitizePayloadStrings(payload)).toBe(payload)
@@ -387,6 +472,56 @@ describe('repair logging: real count, throttled per method', () => {
     })
   })
 
+  it('failing open is LOGGED, not silent, and names the method', async () => {
+    // Fail-open is correct (see the docblock) but a silent fail-open turns a
+    // future walk bug into a bare Telegram 400 with no trail back here — the
+    // exact opacity #4728 exists to end. Goes RED on a bare `catch {}`.
+    let clock = 2_000_000
+    await captureSanitizeLog(async lines => {
+      const bot = new Bot('123456:TEST_TOKEN', {
+        botInfo: {
+          id: 123456, is_bot: true, first_name: 'Test', username: 'test_bot',
+          can_join_groups: false, can_read_all_group_messages: false,
+          supports_inline_queries: false, can_connect_to_business: false,
+          has_main_web_app: false,
+        },
+      })
+      bot.api.config.use(async () => ({
+        ok: true,
+        result: { message_id: 7, date: 0, chat: { id: 1, type: 'private' } },
+      } as never))
+      installUtf8Sanitizer(bot, () => clock)
+
+      const explode = (): Record<string, unknown> => {
+        const p: Record<string, unknown> = { chat_id: 1 }
+        Object.defineProperty(p, 'text', {
+          enumerable: true,
+          configurable: true,
+          get() { throw new Error('getter exploded') },
+        })
+        return p
+      }
+
+      // Still sends (fail-open), and says so.
+      const sent = await bot.api.raw.sendMessage(explode() as never)
+      expect(sent.message_id).toBe(7)
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toContain('FAILED OPEN')
+      expect(lines[0]).toContain('method=sendMessage')
+      expect(lines[0]).toContain('getter exploded')
+
+      // Throttled on its own budget, like the repair line.
+      clock += 500
+      await bot.api.raw.sendMessage(explode() as never)
+      expect(lines).toHaveLength(1)
+
+      clock += 61_000
+      await bot.api.raw.sendMessage(explode() as never)
+      expect(lines).toHaveLength(2)
+      expect(lines[1]).toContain('FAILED OPEN')
+    })
+  })
+
   it('logs nothing for a clean body', async () => {
     await captureSanitizeLog(async lines => {
       const { bot } = makeTelegramLikeBot()
@@ -428,5 +563,26 @@ describe('boot wiring: the sanitiser is the INNERMOST transformer', () => {
     ]) {
       expect(src.indexOf(later), later).toBeGreaterThan(sanitizer)
     }
+  })
+
+  it('nothing at all is installed between `new Bot(` and the sanitiser', () => {
+    // The named-installer check above is one-sided: it pins four KNOWN
+    // installers as later, but someone adding `installFoo(bot)` between
+    // `new Bot(TOKEN)` and `installUtf8Sanitizer(bot)` composes INNER of the
+    // sanitiser, sends unsanitised, and leaves every test in this file green.
+    // So pin it from the other side: the sanitiser must be the FIRST thing
+    // wired onto the bot, full stop.
+    const botIdx = src.search(/new Bot\(/)
+    expect(botIdx).toBeGreaterThan(-1)
+
+    const WIRING = /install[A-Za-z0-9_]*\(\s*bot\b|\.api\.config\.use\(/g
+    WIRING.lastIndex = botIdx
+    const first = WIRING.exec(src)
+    expect(first, 'no bot wiring found after `new Bot(`').not.toBeNull()
+    expect(
+      first![0],
+      `first bot wiring after \`new Bot(\` was \`${first![0]}\` — the UTF-8 ` +
+      'sanitiser must be installed first so it composes innermost',
+    ).toBe('installUtf8Sanitizer(bot')
   })
 })

--- a/telegram-plugin/tests/utf8-sanitize-wire.test.ts
+++ b/telegram-plugin/tests/utf8-sanitize-wire.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Wire-level OUTCOME tests for the UTF-8 sanitiser (#4728).
+ *
+ * These reproduce the production drop, they do not merely exercise the
+ * helper. The stubbed transport below is a FAITHFUL stand-in for Telegram's
+ * decoder: it parses the serialized request body and answers
+ * `400 Bad Request: strings must be encoded in UTF-8` whenever any string in
+ * it contains an unpaired surrogate — which is exactly what the real server
+ * did to `gymbro`'s `permission_request` card on 2026-07-31 (twice), and why
+ * the operator never saw that approval card.
+ *
+ * `JSON.stringify` does NOT throw on a lone surrogate (well-formed
+ * `JSON.stringify`, ES2019) — it emits the `\udXXX` escape — so the bad body
+ * really does reach the wire, and the failure really is server-side.
+ *
+ * Delete `installUtf8Sanitizer(bot)` from `makeTelegramLikeBot` (or from
+ * `initGatewayBot`) and every `(a)`-`(d)` case below goes RED with the
+ * production GrammyError, because the send REJECTS instead of delivering.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { Bot, GrammyError } from 'grammy'
+import { installTgPostLogger, installRichMarkdownGuard } from '../shared/bot-runtime.js'
+import {
+  installUtf8Sanitizer,
+  sanitizeLoneSurrogates,
+  sanitizePayloadStrings,
+  hasLoneSurrogate,
+} from '../shared/utf8-sanitize.js'
+
+/** An unpaired HIGH surrogate — no valid UTF-8 encoding exists for it. */
+const LONE_HIGH = '\uD800'
+/** An unpaired LOW surrogate — the half every truncation site in the plugin
+ * fails to repair (they all only strip a TRAILING high surrogate). */
+const LONE_LOW = '\uDC00'
+/** A well-formed astral pair (🤖). Must survive untouched. */
+const ASTRAL = '\u{1F916}'
+
+function anyLoneSurrogate(v: unknown): boolean {
+  if (typeof v === 'string') return hasLoneSurrogate(v)
+  if (Array.isArray(v)) return v.some(anyLoneSurrogate)
+  if (v !== null && typeof v === 'object') return Object.values(v).some(anyLoneSurrogate)
+  return false
+}
+
+interface CapturedCall {
+  method: string
+  body: Record<string, unknown>
+}
+
+/**
+ * A real grammy Bot wired with the production transformer stack, whose
+ * transport rejects a non-UTF-8-encodable body the way Telegram does.
+ */
+function makeTelegramLikeBot(): { bot: Bot; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = []
+  const fakeFetch = (async (url: unknown, init?: { body?: unknown }) => {
+    const method = String(url).split('/').pop() ?? ''
+    let body: Record<string, unknown> = {}
+    if (typeof init?.body === 'string') {
+      body = JSON.parse(init.body) as Record<string, unknown>
+    }
+    calls.push({ method, body })
+    if (anyLoneSurrogate(body)) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: false,
+          error_code: 400,
+          description: 'Bad Request: strings must be encoded in UTF-8',
+        }),
+      } as unknown as Response
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        result: { message_id: 1, date: 0, chat: { id: 1, type: 'private' } },
+      }),
+    } as unknown as Response
+  }) as unknown as typeof fetch
+
+  const bot = new Bot('123456:TEST_TOKEN', {
+    botInfo: {
+      id: 123456,
+      is_bot: true,
+      first_name: 'Test',
+      username: 'test_bot',
+      can_join_groups: false,
+      can_read_all_group_messages: false,
+      supports_inline_queries: false,
+      can_connect_to_business: false,
+      has_main_web_app: false,
+    },
+    client: { fetch: fakeFetch },
+  })
+  // Production ordering (initGatewayBot): sanitiser FIRST so it composes
+  // INNERMOST and is the last transformer to touch the payload.
+  installUtf8Sanitizer(bot)
+  installTgPostLogger(bot)
+  installRichMarkdownGuard(bot)
+  return { bot, calls }
+}
+
+function lastBody(calls: CapturedCall[]): Record<string, unknown> {
+  return calls[calls.length - 1].body
+}
+
+describe('UTF-8 sanitiser — the dropped approval card (#4728)', () => {
+  it('(a) an approval-card body with a lone surrogate DELIVERS instead of 400ing', async () => {
+    const { bot, calls } = makeTelegramLikeBot()
+    // Shape of a real permission card: rich markdown + the Approve/Deny row.
+    const sent = await bot.api.sendRichMessage(
+      1,
+      { markdown: `**Approve?**\n\`Bash\` — rm -rf ${LONE_HIGH}tmp` },
+      {
+        reply_markup: {
+          inline_keyboard: [[{ text: 'Approve', callback_data: 'perm:allow:1' }]],
+        },
+      },
+    )
+    expect(sent.message_id).toBe(1)
+    expect(calls[calls.length - 1].method).toBe('sendRichMessage')
+    const markdown = (lastBody(calls).rich_message as { markdown: string }).markdown
+    expect(markdown).toBe('**Approve?**\n`Bash` — rm -rf �tmp')
+    expect(hasLoneSurrogate(markdown)).toBe(false)
+  })
+
+  it('(b) an orphaned LOW surrogate — the half no truncation site repairs — also delivers', async () => {
+    const { bot, calls } = makeTelegramLikeBot()
+    const sent = await bot.api.sendRichMessage(1, { markdown: `${LONE_LOW} continued` })
+    expect(sent.message_id).toBe(1)
+    expect((lastBody(calls).rich_message as { markdown: string }).markdown).toBe('� continued')
+  })
+
+  it('(c) a lone surrogate in an inline-keyboard LABEL delivers (whole payload, not one field)', async () => {
+    const { bot, calls } = makeTelegramLikeBot()
+    const sent = await bot.api.sendRichMessage(
+      1,
+      { markdown: 'clean body' },
+      {
+        reply_markup: {
+          inline_keyboard: [[{ text: `Always allow ${LONE_HIGH}`, callback_data: 'perm:always:1' }]],
+        },
+      },
+    )
+    expect(sent.message_id).toBe(1)
+    const kb = (lastBody(calls).reply_markup as {
+      inline_keyboard: { text: string }[][]
+    }).inline_keyboard
+    expect(kb[0][0].text).toBe('Always allow �')
+  })
+
+  it('(d) an ORDINARY sendMessage with a lone surrogate delivers too', async () => {
+    const { bot, calls } = makeTelegramLikeBot()
+    const sent = await bot.api.sendMessage(1, `answer${LONE_HIGH}`)
+    expect(sent.message_id).toBe(1)
+    expect(lastBody(calls).text).toBe('answer�')
+  })
+
+  it('(e) proves the harness is honest: an UNSANITISED bot really does 400', async () => {
+    // Same transport, sanitiser NOT installed — the pre-fix production path.
+    // Without this case, (a)-(d) could pass against a permissive stub.
+    const calls: CapturedCall[] = []
+    const fakeFetch = (async (url: unknown, init?: { body?: unknown }) => {
+      const body = typeof init?.body === 'string'
+        ? (JSON.parse(init.body) as Record<string, unknown>)
+        : {}
+      calls.push({ method: String(url).split('/').pop() ?? '', body })
+      return {
+        ok: true,
+        status: 200,
+        json: async () => (anyLoneSurrogate(body)
+          ? { ok: false, error_code: 400, description: 'Bad Request: strings must be encoded in UTF-8' }
+          : { ok: true, result: { message_id: 1, date: 0, chat: { id: 1, type: 'private' } } }),
+      } as unknown as Response
+    }) as unknown as typeof fetch
+    const bot = new Bot('123456:TEST_TOKEN', {
+      botInfo: {
+        id: 123456, is_bot: true, first_name: 'Test', username: 'test_bot',
+        can_join_groups: false, can_read_all_group_messages: false,
+        supports_inline_queries: false, can_connect_to_business: false,
+        has_main_web_app: false,
+      },
+      client: { fetch: fakeFetch },
+    })
+    installTgPostLogger(bot)
+    installRichMarkdownGuard(bot)
+    await expect(
+      bot.api.sendRichMessage(1, { markdown: `**Approve?** ${LONE_HIGH}` }),
+    ).rejects.toThrow(GrammyError)
+    await expect(
+      bot.api.sendRichMessage(1, { markdown: `**Approve?** ${LONE_HIGH}` }),
+    ).rejects.toThrow(/strings must be encoded in UTF-8/)
+  })
+
+  it('(f) a clean body is byte-identical and the payload object is not cloned', async () => {
+    const { bot, calls } = makeTelegramLikeBot()
+    const sent = await bot.api.sendRichMessage(1, { markdown: `all good ${ASTRAL} 100% ✓` })
+    expect(sent.message_id).toBe(1)
+    expect((lastBody(calls).rich_message as { markdown: string }).markdown)
+      .toBe(`all good ${ASTRAL} 100% ✓`)
+    // Identity no-op is the contract the transformer relies on to stay free.
+    const payload = { chat_id: 1, text: 'clean' }
+    expect(sanitizePayloadStrings(payload)).toBe(payload)
+  })
+})
+
+describe('sanitizeLoneSurrogates / sanitizePayloadStrings — unit contract', () => {
+  it('preserves well-formed pairs, including adjacent ones', () => {
+    const s = `${ASTRAL}${ASTRAL}ok`
+    expect(sanitizeLoneSurrogates(s)).toBe(s)
+    expect(hasLoneSurrogate(s)).toBe(false)
+  })
+
+  it('repairs both halves and is length-preserving', () => {
+    expect(sanitizeLoneSurrogates(`a${LONE_HIGH}b`)).toBe('a�b')
+    expect(sanitizeLoneSurrogates(`a${LONE_LOW}b`)).toBe('a�b')
+    expect(sanitizeLoneSurrogates(`a${LONE_HIGH}b`).length).toBe(3)
+  })
+
+  it('repairs a high surrogate followed by another high surrogate (both lone)', () => {
+    expect(sanitizeLoneSurrogates(`${LONE_HIGH}${LONE_HIGH}`)).toBe('��')
+  })
+
+  it('is idempotent', () => {
+    const once = sanitizeLoneSurrogates(`x${LONE_HIGH}y`)
+    expect(sanitizeLoneSurrogates(once)).toBe(once)
+  })
+
+  it('is stateless across calls (the shared /g regex must not carry lastIndex)', () => {
+    for (let i = 0; i < 4; i++) {
+      expect(hasLoneSurrogate(`ab${LONE_HIGH}`)).toBe(true)
+      expect(sanitizeLoneSurrogates(`ab${LONE_HIGH}`)).toBe('ab�')
+    }
+  })
+
+  it('does not rebuild non-plain objects (an InputFile-like instance survives by identity)', () => {
+    class InputFileLike {
+      constructor(public filename: string) {}
+    }
+    const file = new InputFileLike('photo.png')
+    const payload = { chat_id: 1, photo: file, caption: `hi${LONE_HIGH}` }
+    const out = sanitizePayloadStrings(payload)
+    expect(out).not.toBe(payload)
+    expect(out.caption).toBe('hi�')
+    expect(out.photo).toBe(file)
+    expect(out.photo).toBeInstanceOf(InputFileLike)
+  })
+
+  it('leaves non-string scalars alone', () => {
+    const payload = { chat_id: 1, disable_notification: true, x: null, y: undefined }
+    expect(sanitizePayloadStrings(payload)).toBe(payload)
+  })
+
+  it('handles a null/undefined payload without throwing (grammy passes those)', () => {
+    expect(sanitizePayloadStrings(undefined)).toBe(undefined)
+    expect(sanitizePayloadStrings(null)).toBe(null)
+  })
+})
+
+describe('boot wiring: the sanitiser is the INNERMOST transformer', () => {
+  const src = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), '..', 'gateway', 'gateway.ts'),
+    'utf8',
+  )
+
+  it('installs it exactly once', () => {
+    const hits = src.match(/installUtf8Sanitizer\(bot\)/g) ?? []
+    expect(hits.length).toBe(1)
+  })
+
+  it('installs it BEFORE every other transformer, so it composes innermost', () => {
+    // grammy: `call = trans(prev, ...)` — last installed is outermost, first
+    // installed is innermost. Innermost is the only position that guarantees
+    // no later transformer can reintroduce a lone surrogate behind our back.
+    const sanitizer = src.indexOf('installUtf8Sanitizer(bot)')
+    expect(sanitizer).toBeGreaterThan(-1)
+    for (const later of [
+      'installTgPostLogger(bot)',
+      'installRichMarkdownGuard(bot)',
+      'installSentTextCapture(bot)',
+      'installEditFloodFuse(bot',
+    ]) {
+      expect(src.indexOf(later), later).toBeGreaterThan(sanitizer)
+    }
+  })
+})

--- a/telegram-plugin/tests/utf8-sanitize-wire.test.ts
+++ b/telegram-plugin/tests/utf8-sanitize-wire.test.ts
@@ -17,7 +17,7 @@
  * `initGatewayBot`) and every `(a)`-`(d)` case below goes RED with the
  * production GrammyError, because the send REJECTS instead of delivering.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
@@ -28,6 +28,7 @@ import {
   sanitizeLoneSurrogates,
   sanitizePayloadStrings,
   hasLoneSurrogate,
+  __resetUtf8SanitizeLogThrottle,
 } from '../shared/utf8-sanitize.js'
 
 /** An unpaired HIGH surrogate — no valid UTF-8 encoding exists for it. */
@@ -208,6 +209,53 @@ describe('UTF-8 sanitiser — the dropped approval card (#4728)', () => {
     const payload = { chat_id: 1, text: 'clean' }
     expect(sanitizePayloadStrings(payload)).toBe(payload)
   })
+
+  it('(g) a payload whose own enumerable getter THROWS still sends — the sanitiser fails open', async () => {
+    // The walk reads own enumerable properties, which invokes getters. This
+    // transformer sits on the innermost hop of EVERY `bot.api.*` call, so an
+    // exception escaping it would wedge the whole gateway, not one send.
+    //
+    // Ordering here is deliberately inverted relative to production (the
+    // recorder is installed first, so it is INNERMOST and answers without
+    // serialising) purely to isolate what the sanitiser hands downstream.
+    // Production ordering is pinned by the boot-wiring describe below.
+    const seen: unknown[] = []
+    const bot = new Bot('123456:TEST_TOKEN', {
+      botInfo: {
+        id: 123456, is_bot: true, first_name: 'Test', username: 'test_bot',
+        can_join_groups: false, can_read_all_group_messages: false,
+        supports_inline_queries: false, can_connect_to_business: false,
+        has_main_web_app: false,
+      },
+    })
+    bot.api.config.use(async (_prev, _method, payload) => {
+      seen.push(payload)
+      return {
+        ok: true,
+        result: { message_id: 7, date: 0, chat: { id: 1, type: 'private' } },
+      } as never
+    })
+    installUtf8Sanitizer(bot)
+
+    const payload: Record<string, unknown> = { chat_id: 1 }
+    Object.defineProperty(payload, 'text', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error('getter exploded')
+      },
+    })
+
+    // Load-bearing: without the guard in `installUtf8Sanitizer` this is the
+    // exception that would escape into every outbound call.
+    expect(() => sanitizePayloadStrings(payload)).toThrow('getter exploded')
+
+    const sent = await bot.api.raw.sendMessage(payload as never)
+    expect(sent.message_id).toBe(7)
+    // Failed open: the ORIGINAL payload was passed through, not swallowed.
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toBe(payload)
+  })
 })
 
 describe('sanitizeLoneSurrogates / sanitizePayloadStrings — unit contract', () => {
@@ -261,6 +309,86 @@ describe('sanitizeLoneSurrogates / sanitizePayloadStrings — unit contract', ()
     expect(sanitizePayloadStrings(undefined)).toBe(undefined)
     expect(sanitizePayloadStrings(null)).toBe(null)
   })
+
+  it('keeps an own `__proto__` key as an own property of the clone', () => {
+    // `out['__proto__'] = v` hits the Object.prototype accessor and reassigns
+    // the clone's PROTOTYPE instead of creating an own property — the key
+    // would vanish from the payload entirely.
+    const payload: Record<string, unknown> = { chat_id: 1, text: `hi${LONE_HIGH}` }
+    Object.defineProperty(payload, '__proto__', {
+      value: `p${LONE_LOW}`,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
+    const out = sanitizePayloadStrings(payload)
+    expect(Object.prototype.hasOwnProperty.call(out, '__proto__')).toBe(true)
+    expect(Object.getOwnPropertyDescriptor(out, '__proto__')?.value).toBe('p�')
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype)
+    // And it survives serialisation, which is the only thing the wire sees.
+    expect(JSON.stringify(out)).toContain('"__proto__":"p�"')
+    expect(out.text).toBe('hi�')
+  })
+})
+
+describe('repair logging: real count, throttled per method', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function captureSanitizeLog(): string[] {
+    const lines: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+      const s = String(chunk)
+      if (s.includes('utf8-sanitize')) lines.push(s)
+      return true
+    }) as never)
+    return lines
+  }
+
+  it('reports how many code units were repaired, and logs once per method per minute', async () => {
+    __resetUtf8SanitizeLogThrottle()
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-08-15T00:00:00Z'))
+    const lines = captureSanitizeLog()
+    const { bot } = makeTelegramLikeBot()
+
+    // Two lone surrogates in one body: a high with no follower, a low with no
+    // leader. The docblock promises a count, so the line must carry one.
+    await bot.api.sendMessage(1, `a${LONE_HIGH}b${LONE_LOW}`)
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('repaired 2 lone surrogate(s)')
+    expect(lines[0]).toContain('method=sendMessage')
+    // Never the content itself.
+    expect(lines[0]).not.toContain('a�b')
+
+    // Same method inside the window — a persistently corrupt draft stream must
+    // not emit one line per edit.
+    await bot.api.sendMessage(1, `c${LONE_HIGH}`)
+    await bot.api.sendMessage(1, `d${LONE_HIGH}`)
+    expect(lines).toHaveLength(1)
+
+    // A different method has its own budget.
+    await bot.api.editMessageText(1, 1, `e${LONE_HIGH}`)
+    expect(lines).toHaveLength(2)
+    expect(lines[1]).toContain('method=editMessageText')
+    expect(lines[1]).toContain('repaired 1 lone surrogate(s)')
+
+    // Next window: the corruption is still diagnosable.
+    vi.setSystemTime(new Date('2026-08-15T00:01:01Z'))
+    await bot.api.sendMessage(1, `f${LONE_HIGH}`)
+    expect(lines).toHaveLength(3)
+    expect(lines[2]).toContain('method=sendMessage')
+  })
+
+  it('logs nothing for a clean body', async () => {
+    __resetUtf8SanitizeLogThrottle()
+    const lines = captureSanitizeLog()
+    const { bot } = makeTelegramLikeBot()
+    await bot.api.sendMessage(1, `all good ${ASTRAL}`)
+    expect(lines).toHaveLength(0)
+  })
 })
 
 describe('boot wiring: the sanitiser is the INNERMOST transformer', () => {
@@ -272,6 +400,13 @@ describe('boot wiring: the sanitiser is the INNERMOST transformer', () => {
   it('installs it exactly once', () => {
     const hits = src.match(/installUtf8Sanitizer\(bot\)/g) ?? []
     expect(hits.length).toBe(1)
+  })
+
+  it('there is exactly ONE bot instance for that single install to cover', () => {
+    // The ordering assertion below is textual. A second `new Bot(` in
+    // gateway.ts would get no sanitiser at all while every test here stayed
+    // green, so pin the instance count too.
+    expect((src.match(/new Bot\(/g) ?? []).length).toBe(1)
   })
 
   it('installs it BEFORE every other transformer, so it composes innermost', () => {

--- a/telegram-plugin/tests/utf8-sanitize-wire.test.ts
+++ b/telegram-plugin/tests/utf8-sanitize-wire.test.ts
@@ -17,7 +17,7 @@
  * `initGatewayBot`) and every `(a)`-`(d)` case below goes RED with the
  * production GrammyError, because the send REJECTS instead of delivering.
  */
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
@@ -28,7 +28,6 @@ import {
   sanitizeLoneSurrogates,
   sanitizePayloadStrings,
   hasLoneSurrogate,
-  __resetUtf8SanitizeLogThrottle,
 } from '../shared/utf8-sanitize.js'
 
 /** An unpaired HIGH surrogate — no valid UTF-8 encoding exists for it. */
@@ -55,7 +54,7 @@ interface CapturedCall {
  * A real grammy Bot wired with the production transformer stack, whose
  * transport rejects a non-UTF-8-encodable body the way Telegram does.
  */
-function makeTelegramLikeBot(): { bot: Bot; calls: CapturedCall[] } {
+function makeTelegramLikeBot(now?: () => number): { bot: Bot; calls: CapturedCall[] } {
   const calls: CapturedCall[] = []
   const fakeFetch = (async (url: unknown, init?: { body?: unknown }) => {
     const method = String(url).split('/').pop() ?? ''
@@ -101,7 +100,7 @@ function makeTelegramLikeBot(): { bot: Bot; calls: CapturedCall[] } {
   })
   // Production ordering (initGatewayBot): sanitiser FIRST so it composes
   // INNERMOST and is the last transformer to touch the payload.
-  installUtf8Sanitizer(bot)
+  installUtf8Sanitizer(bot, now)
   installTgPostLogger(bot)
   installRichMarkdownGuard(bot)
   return { bot, calls }
@@ -332,62 +331,68 @@ describe('sanitizeLoneSurrogates / sanitizePayloadStrings — unit contract', ()
 })
 
 describe('repair logging: real count, throttled per method', () => {
-  afterEach(() => {
-    vi.useRealTimers()
-    vi.restoreAllMocks()
-  })
-
-  function captureSanitizeLog(): string[] {
+  /**
+   * Swap `process.stderr.write` directly rather than through `vi`: this file
+   * runs under BOTH vitest and `bun test`, and the mock/timer halves of `vi`
+   * are not equivalent across the two.
+   */
+  async function captureSanitizeLog(fn: (lines: string[]) => Promise<void>): Promise<void> {
     const lines: string[] = []
-    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+    const real = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((chunk: unknown) => {
       const s = String(chunk)
       if (s.includes('utf8-sanitize')) lines.push(s)
       return true
-    }) as never)
-    return lines
+    }) as typeof process.stderr.write
+    try {
+      await fn(lines)
+    } finally {
+      process.stderr.write = real
+    }
   }
 
   it('reports how many code units were repaired, and logs once per method per minute', async () => {
-    __resetUtf8SanitizeLogThrottle()
-    vi.useFakeTimers({ toFake: ['Date'] })
-    vi.setSystemTime(new Date('2026-08-15T00:00:00Z'))
-    const lines = captureSanitizeLog()
-    const { bot } = makeTelegramLikeBot()
+    let clock = 1_000_000
+    await captureSanitizeLog(async lines => {
+      const { bot } = makeTelegramLikeBot(() => clock)
 
-    // Two lone surrogates in one body: a high with no follower, a low with no
-    // leader. The docblock promises a count, so the line must carry one.
-    await bot.api.sendMessage(1, `a${LONE_HIGH}b${LONE_LOW}`)
-    expect(lines).toHaveLength(1)
-    expect(lines[0]).toContain('repaired 2 lone surrogate(s)')
-    expect(lines[0]).toContain('method=sendMessage')
-    // Never the content itself.
-    expect(lines[0]).not.toContain('a�b')
+      // Two lone surrogates in one body: a high with no follower, a low with
+      // no leader. The docblock promises a count, so the line must carry one.
+      await bot.api.sendMessage(1, `a${LONE_HIGH}b${LONE_LOW}`)
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toContain('repaired 2 lone surrogate(s)')
+      expect(lines[0]).toContain('method=sendMessage')
+      // Never the content itself.
+      expect(lines[0]).not.toContain('a�b')
 
-    // Same method inside the window — a persistently corrupt draft stream must
-    // not emit one line per edit.
-    await bot.api.sendMessage(1, `c${LONE_HIGH}`)
-    await bot.api.sendMessage(1, `d${LONE_HIGH}`)
-    expect(lines).toHaveLength(1)
+      // Same method inside the window — a persistently corrupt draft stream
+      // must not emit one line per edit.
+      clock += 500
+      await bot.api.sendMessage(1, `c${LONE_HIGH}`)
+      clock += 500
+      await bot.api.sendMessage(1, `d${LONE_HIGH}`)
+      expect(lines).toHaveLength(1)
 
-    // A different method has its own budget.
-    await bot.api.editMessageText(1, 1, `e${LONE_HIGH}`)
-    expect(lines).toHaveLength(2)
-    expect(lines[1]).toContain('method=editMessageText')
-    expect(lines[1]).toContain('repaired 1 lone surrogate(s)')
+      // A different method has its own budget.
+      await bot.api.editMessageText(1, 1, `e${LONE_HIGH}`)
+      expect(lines).toHaveLength(2)
+      expect(lines[1]).toContain('method=editMessageText')
+      expect(lines[1]).toContain('repaired 1 lone surrogate(s)')
 
-    // Next window: the corruption is still diagnosable.
-    vi.setSystemTime(new Date('2026-08-15T00:01:01Z'))
-    await bot.api.sendMessage(1, `f${LONE_HIGH}`)
-    expect(lines).toHaveLength(3)
-    expect(lines[2]).toContain('method=sendMessage')
+      // Next window: the corruption is still diagnosable.
+      clock += 61_000
+      await bot.api.sendMessage(1, `f${LONE_HIGH}`)
+      expect(lines).toHaveLength(3)
+      expect(lines[2]).toContain('method=sendMessage')
+    })
   })
 
   it('logs nothing for a clean body', async () => {
-    __resetUtf8SanitizeLogThrottle()
-    const lines = captureSanitizeLog()
-    const { bot } = makeTelegramLikeBot()
-    await bot.api.sendMessage(1, `all good ${ASTRAL}`)
-    expect(lines).toHaveLength(0)
+    await captureSanitizeLog(async lines => {
+      const { bot } = makeTelegramLikeBot()
+      await bot.api.sendMessage(1, `all good ${ASTRAL}`)
+      expect(lines).toHaveLength(0)
+    })
   })
 })
 

--- a/tests/topic-manager.test.ts
+++ b/tests/topic-manager.test.ts
@@ -271,6 +271,48 @@ describe("syncTopics", () => {
     expect(state.topics.finance.topic_id).toBe(102);
   });
 
+  it("repairs a lone surrogate in a topic name instead of 400ing (#4728)", async () => {
+    // createForumTopic POSTs with raw `fetch`, bypassing the grammy bot and
+    // therefore the #4728 API-transformer sanitiser entirely. This transport
+    // answers the way Telegram's decoder does: a body carrying an unpaired
+    // surrogate is rejected with 400 "strings must be encoded in UTF-8".
+    // Without the sanitise call in createForumTopic this test throws
+    // TopicSyncError instead of creating the topic.
+    const LONE_HIGH = "\uD800";
+    const ASTRAL = "\u{1F916}";
+    let sentName: string | undefined;
+    globalThis.fetch = vi.fn(async (_url: any, opts: any) => {
+      const body = JSON.parse(opts.body);
+      sentName = body.name;
+      if (/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(body.name)) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error_code: 400,
+            description: "Bad Request: strings must be encoded in UTF-8",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      return new Response(
+        JSON.stringify({ ok: true, result: { message_thread_id: 501, name: body.name } }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as any;
+
+    const config = makeConfig({
+      health: { topic_name: `Health ${ASTRAL}${LONE_HIGH}` },
+    });
+
+    const results = await syncTopics(config, statePath);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ agent: "health", topic_id: 501, status: "created" });
+    // Repaired in place, and the well-formed astral pair survives untouched.
+    expect(sentName).toBe(`Health ${ASTRAL}�`);
+    expect(loadTopicState(statePath).topics.health.topic_id).toBe(501);
+  });
+
   it("skips agents that already exist in state (idempotency)", async () => {
     globalThis.fetch = vi.fn(async (url: any, opts: any) => {
       const body = JSON.parse(opts.body);


### PR DESCRIPTION
## Summary

An outbound Telegram body containing a **lone (unpaired) UTF-16 surrogate** is rejected by Telegram with `400 Bad Request: strings must be encoded in UTF-8`. This PR sanitises those out at the one seam every outbound call must transit, so a malformed payload degrades to a **delivered** message instead of a **dropped** one.

New: `telegram-plugin/shared/utf8-sanitize.ts`, installed as the **first** (therefore innermost) grammy API transformer in `initGatewayBot`.

## Why — a silently dropped approval card

On 2026-07-31 a fleet agent tried **twice** to send the operator a `permission_request` approval card. Both attempts died, with no retry and no recovery:

```
tg-post method=sendRichMessage chat=… parse_mode=none bytes=0 status=err err=telegram_400 code=400 desc=Bad Request: strings must be encoded in UTF-8
telegram gateway: permission_request send to … failed: GrammyError: Call to 'sendRichMessage' failed! (400: Bad Request: strings must be encoded in UTF-8)
```

The operator never saw the card. An approval card is **the human safety boundary** for a gated tool call (`reference/jobs/approve-what-my-agent-can-touch.md`), so a dropped card is not a cosmetic glitch: the gated action silently never happens, and 60 minutes later the TTL sweep resolves an approval no human was ever shown.

### The mechanism

A JavaScript string is UTF-16 and may legally hold a surrogate code unit with no partner. A lone surrogate has **no valid UTF-8 encoding**. `JSON.stringify` does *not* throw on one (well-formed `JSON.stringify`, ES2019) — it emits the `\udXXX` escape — so grammy cheerfully POSTs a body that Telegram's decoder then rejects. The failure is server-side and total: the whole request dies, not the offending field.

### Why the existing repairs didn't catch it

The plugin already repairs a **trailing high** surrogate at each of its truncation sites:

- `telegram-plugin/card-layout.ts:384` — `hardTruncateCard`
- `telegram-plugin/format.ts:1551`
- `telegram-plugin/tool-activity-summary.ts:488`
- `telegram-plugin/reply-quote.ts:78`

Every one is a per-cut patch that covers (a) only the cut it guards and (b) only the **high** half. An orphaned **low** surrogate, or a lone surrogate that entered the body from upstream data (a tool `input_preview`, a path, a model-emitted token) rather than from a cut, sails past all four onto the wire. The permission-card send is at `telegram-plugin/gateway/gateway.ts:7184` (`bot.api.sendRichMessage(chatId, richMessage(text), { reply_markup: keyboard, … })`), and neither `richMessage()` nor `installRichMarkdownGuard` touches encoding.

## The fix

`installUtf8Sanitizer(bot)` — `telegram-plugin/shared/utf8-sanitize.ts`, wired at `telegram-plugin/gateway/gateway.ts:22877`.

- **Chokepoint, not a patch.** A grammy API transformer, the layer no `ctx.*` helper and no raw `bot.api.*` call can bypass. It covers approval cards, ordinary sends, edits, and everything else in one place. The gateway constructs exactly one `new Bot(TOKEN)`, so the seam is complete.
- **Installed FIRST → composes innermost.** grammy resolves `call = trans(prev, …)` (`grammy/out/core/client.js:9-11,91`), so the last-installed transformer is outermost and the first-installed is innermost — the last thing to touch the payload before serialisation. No later transformer can reintroduce a surrogate behind its back. Pinned by a wiring test.
- **Deep-walks the whole payload**, not a named field list: a lone surrogate in an inline-keyboard button label (which **every** approval card carries) fails the request exactly as one in `rich_message.markdown` does.
- **Substitutes U+FFFD**, the standard Unicode substitution. Length-preserving in UTF-16 code units, so a body already sized against a char budget upstream cannot be pushed over it by the repair.
- **Clone-on-write, identity no-op** when clean — the overwhelmingly common case allocates nothing. Non-plain objects (`InputFile`, `Buffer`, streams) are returned by identity, never rebuilt, so grammy's multipart layer is unaffected.

### On loudness — deliberately scoped

A repair emits one stderr line (method + the fact of a repair, never the body), so a corrupt upstream producer stays diagnosable rather than silently papered over.

I deliberately did **not** add a retry or a new operator-visible failure signal to the card path. That machinery already exists and is correct: `gateway.ts:7226-7274` (`holdReasonFor` at :7245) classifies the failure via `holdReasonFor`, holds transient failures with backoff and re-delivery, and lets a permanent 400 fall through to the TTL's missed-approvals fallback. The bug was not "the recovery path is missing" — it was "this body can never be sent, and no amount of retrying changes that." Fixing the encoding removes the failure class; adding retry logic on top would be a second concern in the same PR.

## Test plan

`telegram-plugin/tests/utf8-sanitize-wire.test.ts` — 16 tests, all through a **real grammy `Bot`** with a stubbed transport that faithfully emulates Telegram's decoder: it parses the serialized body and answers `400 … strings must be encoded in UTF-8` whenever any string in it holds an unpaired surrogate.

These assert the **outcome** (the card is delivered), not the sanitiser's internals. Removing `installUtf8Sanitizer` from the harness turns four of them red with the production error verbatim:

```
× (a) an approval-card body with a lone surrogate DELIVERS instead of 400ing
× (b) an orphaned LOW surrogate — the half no truncation site repairs — also delivers
× (c) a lone surrogate in an inline-keyboard LABEL delivers (whole payload, not one field)
× (d) an ORDINARY sendMessage with a lone surrogate delivers too
GrammyError: Call to 'sendRichMessage' failed! (400: Bad Request: strings must be encoded in UTF-8)
Tests  4 failed | 12 passed (16)
```

Case `(e)` pins the harness's own honesty (an unsanitised bot really does 400, so `(a)`-`(d)` cannot pass against a permissive stub); `(f)` pins the clean-body identity no-op.

Local runs:

```
vitest run telegram-plugin/tests/utf8-sanitize-wire.test.ts      →  16 passed (16)
vitest run <+ rich-markdown-guard-transformer, sent-text-capture,
             format-guard-pins>                                  →  54 passed (54)
tsc --noEmit                                                     →  exit 0
check-bot-api-wrapping / gateway-line-ratchet / ctx-send-wrapping /
callback-ctx-wrapping / test-runner-coverage / bun-test-imports /
no-pii-secrets / mutation-coverage                               →  all clean
```

## Risk

Low. The transformer is a strict identity no-op for any payload without an unpaired surrogate — which is every payload the fleet sends today except the broken ones — so the steady-state behaviour is byte-identical. The only behaviour change is that a body that previously produced a hard 400 now produces a delivered message with U+FFFD where the broken half-character was.

Verdict rule: advances **hold-the-leash** (an approval card that reaches the operator is the leash working); satisfies `reference/jobs/approve-what-my-agent-can-touch.md`; crosses no invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
