### PR TITLE
build(claude-cli): bump the pinned Claude CLI to 2.1.233

### DIFF
--- a/changelog.d/4729-claude-cli-2.1.233.build.md
+++ b/changelog.d/4729-claude-cli-2.1.233.build.md
@@ -1,0 +1,7 @@
+- **claude-cli: bump the pinned Claude CLI to 2.1.233 (#4729)** — all three
+  lockstep pins (`docker/Dockerfile.base`, `docker/Dockerfile.hindsight`,
+  `dependencies.json`) move 2.1.229 → 2.1.233. Upstream never published
+  2.1.230. The nightly `claude@latest` canary had not yet seen 2.1.233, so the
+  flag contract was run manually against a real 2.1.233 binary instead; the
+  behavioural check (manual DM + group round-trip) is still required before a
+  fleet roll.

--- a/dependencies.json
+++ b/dependencies.json
@@ -5,7 +5,7 @@
     "node": "22.22.2"
   },
   "claude": {
-    "cli": "2.1.229"
+    "cli": "2.1.233"
   },
   "playwright_mcp": "0.0.71",
   "hindsight": {

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.229
+ARG CLAUDE_CODE_VERSION=2.1.233
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -119,7 +119,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.229
+ARG CLAUDE_CODE_VERSION=2.1.233
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 


### PR DESCRIPTION
Bumps the pinned Claude CLI from **2.1.229 → 2.1.233**, per `docs/operators/claude-cli-updates.md`.

Note on the sequence: **2.1.230 was never published.** npm shows `… 2.1.228, 2.1.229, 2.1.231, 2.1.232, 2.1.233`. 2.1.233 published 2026-08-14T18:50Z.

## The three lockstep pins

| Location | Field | Value |
|---|---|---|
| `docker/Dockerfile.base:157` | `ARG CLAUDE_CODE_VERSION=` | `2.1.233` |
| `docker/Dockerfile.hindsight:122` | `ARG CLAUDE_CODE_VERSION=` | `2.1.233` |
| `dependencies.json:8` | `.claude.cli` | `2.1.233` |

```
$ npm run lint:claude-cli-lockstep
check-claude-cli-lockstep: OK — all three pins agree (2.1.233).
```

## ⚠️ The canary has NOT validated 2.1.233

`ci-claude-latest-canary` last ran **2026-08-14T07:51Z green** — that is **before 2.1.233 existed** (published 18:50Z the same day). So step 1 of the routine procedure ("check the canary") is **not satisfied by an existing run**. This PR is being opened on a manual contract check instead, not on canary coverage. Do not read the green canary badge as coverage for this version.

What was actually verified locally, in place of the canary:

```
$ PATH=<2.1.233-prefix>/bin:$PATH npx vitest run tests/claude-cli-contract.test.ts --reporter=verbose
✓ reports a version (2.1.233 (Claude Code))
✓ --help still documents every flag switchroom's agent boot depends on
✓ exposes the `mcp` subcommand (switchroom wires MCP servers)
↓ skips cleanly when claude is not installed (normal CI job)   [inverse self-skip guard — expected]
Tests  3 passed | 1 skipped (4)
```

The flag contract **ran** (it did not self-skip) against a real, locally-installed 2.1.233 binary. `tests/doctor-claude-cli.test.ts` — 34 passed. `npm run lint` clean.

That still only proves the binary installs, runs, and keeps every flag agent-boot needs. It proves **nothing** about turn behaviour. The behavioural gate (`ci-uat`) is still unwired, so the manual canary in step 6 of the operator doc is mandatory before any fleet roll.

## Behavioural changes in 232/233 — investigated

These are the ones that can break switchroom without failing a single CI check.

### 1. Todo/task tools removed on newer models — **low risk, one soft degradation**

`TaskCreate/Get/Update/List` and `TodoWrite` are gone on Sonnet 5 / Opus 4.8 / Fable 5 "and newer models" unless `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` is set. That env var **is present in the 2.1.233 binary** (confirmed by strings), so the escape hatch is real.

The whole fleet runs affected models. Repo audit:

- `src/agents/scaffold.ts:1533` (`DEFAULT_READ_ONLY_PREAPPROVED_TOOLS`) and `:2876` (`ALL_BUILTIN_TOOLS`) list `TodoWrite`. **Harmless** — a name in an allow-list that no longer resolves to a tool is inert; `ALL_BUILTIN_TOOLS` only drives `tools.allow: [all]` expansion.
- `telegram-plugin/tool-labels.ts:238-242`, `permission-title.ts:274`, `hooks/tool-label-pretool.mjs:209,259-261` — label/title cases for these tools. **Harmless** — dead switch arms.
- **`src/agents/in-flight.ts` — the one real degradation.** Signal 1 of the busy-detector is `<agentDir>/.claude/tasks/<session>/*.json`, described at `in-flight.ts:7-8` as "files written by Claude Code for each TodoWrite/Task-tool record". With the todo tools gone, that signal goes permanently cold. It is **not** a break: `detectInFlight` is "any one positive ⇒ busy" and signals 2 (session transcript `.jsonl` mtime) and 3 (sub-agent transcripts) still fire, and the transcript signal is the dominant one for an in-progress turn. Effect is reduced sensitivity in `waitUntilIdle` / restart-safety, not a false idle during an active turn.
- **No prompt template, skill, or profile in the repo instructs an agent to use `TodoWrite`.**

**Recommendation: do NOT set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` in compose.** Nothing in switchroom depends on these tools for correctness, and keeping them off removes a tool call per turn. Per the brief, no compose change is made in this PR either way — flagging for the merge decision.

### 2. Nested git repos no longer inherit trust from a parent — **confirmed upstream, switchroom NOT exposed on the boot path**

The change is real and I located it in the 2.1.233 bundle. Trust resolution is now:

```js
function Dnd(e,t){ let r=resolve(t), n=gitRoot(r), o=n!==null?normalize(resolve(n)):null; return Pnd(e,r,o) }
function Pnd(e,t,r){ let n=normalize(t); while(true){
  if(!(r===null||n===r||n.startsWith(r+"/"))) return false;      // ← walk is now BOUNDED by the enclosing git root
  if(e.projects?.[n]?.hasTrustDialogAccepted) return true;
  if(n===r) return false; … } }
```

The ancestor walk stops at the enclosing **git repo root** instead of continuing to `/`. Exactly as described.

Why switchroom is safe today, verified rather than assumed:

- `start.sh` does `cd "<agentDir>"` then `exec claude` (interactive, not `-p`). `src/setup/onboarding.ts:264-269` pre-trusts **exactly `resolve(agentDir)`**, and the trust check tests that exact key *before* the ancestor walk (`RM_()`: `if(e.projects?.[t]?.hasTrustDialogAccepted) return true;` precedes `Dnd`). Exact match wins — the walk never runs for the main session.
- `<agentDir>` is **not a git repo and has no git ancestor** (verified on a live agent home: `git rev-parse` → `fatal: not a git repository … up to mount point`). So even the fallback walk is unbounded there.
- The boot `--add-dir ~/.switchroom/fleet` (`src/cli/apply.ts:1458`) targets a directory that is likewise not a git repo — unchanged by this.
- `Task`-tool sub-agents run **in the parent process at the parent's cwd**, so a worker checkout under `~/work/<name>/` never triggers a fresh cwd trust check.

**Residual exposure (not a blocker, worth a follow-up issue):** the walk-bounding *does* bite any flow that gives a claude process a cwd inside a nested checkout, or `/add-dir`s one — e.g. `~/work/<name>/repo` (a git repo whose own root is itself) previously inherited trust from `<agentDir>`; now it resolves `n === r` on the first iteration and returns `false`. `<agentDir>/workspace` (git-init'ed at `src/agents/scaffold.ts:3268`) is the same shape. Nothing in the tree does that today. If we ever add it, the dir needs its own `projects[]` entry — `RM_()` also short-circuits on `CLAUDE_CODE_SANDBOXED`, and `src/agents/inject.ts:189` already blocks `/add-dir` on injected turns.

### 3. Sub-agent forking on by default — **known shape, one cosmetic risk**

switchroom already models forks explicitly: `telegram-plugin/hooks/subagent-tracker-pretool.mjs:380` special-cases `subagent_type === 'fork'` (F3: a fork inherits the parent's model and ignores `tool_input.model`, so the dispatch-time model seed is suppressed). So fork dispatches are handled, not novel.

The risk is the *background* half. Line 401 records `background: input.run_in_background === true ? 1 : 0`. If 232+ runs non-teammate spawns in the background by default **without** setting `run_in_background: true` in `tool_input`, the worker card mislabels a background worker as foreground. That is a rendering inaccuracy on the activity card, not a lost worker — the subagent-watcher tracks the transcript independently. Flagging; not fixed here.

### 4. Cross-session messaging (`@`-mention by session name, `SendMessage` to a bare name without a confirm step, accept/hold/refuse config)

Twelve agents share this host. This is the same class as the 2.1.166 cross-session-messaging hardening the operator doc calls out at step 6 as invisible to the build checks. **Not verifiable by CI** — it needs the manual DM + group round-trip against the test bot before any fleet roll. No repo change required to land the pin.

## Scope

Pin bump only. Per the brief, no compose/env change and no behavioural fix is bundled here — items 1 and 3 above are reported for a separate decision.

Do **not** auto-merge — merge decision is the operator's.
