### PR TITLE
fix(compose): attribute a defaulted-verdict voice-sidecar removal

### DIFF
--- a/changelog.d/4735-attribute-voice-sidecar-drop.fix.md
+++ b/changelog.d/4735-attribute-voice-sidecar-drop.fix.md
@@ -1,0 +1,1 @@
+- **compose: a `voice-sidecar` removal caused by a defaulted (missing/unreadable/malformed) host-capabilities verdict is now attributed as a warning in the apply report, instead of appearing as a bare `services removed: voice-sidecar` line that reads as intent (#4735)**

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -87,7 +87,7 @@ import { isClaudeModel } from "../../telegram-plugin/gateway/model-command.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { resolveTimezone } from "../config/timezone.js";
 import { getBundledSkillsPoolDir } from "./reconcile-default-skills.js";
-import { loadHostCapabilities } from "../setup/host-capabilities.js";
+import { resolveVoiceEngine } from "../setup/host-capabilities.js";
 import type { VoiceEngine } from "../setup/gpu-detect.js";
 import { AGENT_UID_MIN, AGENT_UID_MAX, allocateAgentUid } from "./agent-uid.js";
 import { GRANTS_DB_DIRNAME, GRANTS_DB_CONTAINER_DIR } from "../vault/grants-db-path.js";
@@ -526,7 +526,7 @@ export interface ComposeGeneratorOptions {
    * INJECTABLE so the compose-generator stays pure and the snapshot tests
    * can exercise BOTH branches without shelling out to real hardware. When
    * omitted, the generator reads the persisted verdict from
-   * `loadHostCapabilities()` (defaulting to `cloud` if no verdict file
+   * `resolveVoiceEngine()` (defaulting to `cloud` if no verdict file
    * exists yet), so production callers Just Work without threading it.
    */
   voiceEngine?: VoiceEngine;
@@ -1469,7 +1469,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // when no verdict file exists — fail-safe: never emit a GPU service on a
   // host we haven't confirmed has a usable GPU.
   const voiceEngine: VoiceEngine =
-    opts.voiceEngine ?? loadHostCapabilities()?.voice.engine ?? "cloud";
+    opts.voiceEngine ?? resolveVoiceEngine().engine;
 
   // Resolve the host's analytics distinct ID once per generator call. The
   // CLI persists this at ~/.switchroom/analytics-id (see

--- a/src/agents/singleton-reconcile.ts
+++ b/src/agents/singleton-reconcile.ts
@@ -32,7 +32,7 @@ import { readFileSync } from "node:fs";
 
 import { parse as parseYaml } from "yaml";
 
-import { loadHostCapabilities } from "../setup/host-capabilities.js";
+import { resolveVoiceEngine } from "../setup/host-capabilities.js";
 import { composeEnvFileArgs } from "./compose-env.js";
 
 /**
@@ -77,7 +77,7 @@ export type SingletonService = (typeof SINGLETON_SERVICES)[number];
 export function resolveSingletonServices(
   voiceEngine?: "local" | "cloud",
 ): SingletonService[] {
-  const engine = voiceEngine ?? loadHostCapabilities()?.voice.engine ?? "cloud";
+  const engine = voiceEngine ?? resolveVoiceEngine().engine;
   return engine === "local"
     ? [...CORE_SINGLETON_SERVICES, VOICE_SIDECAR_SERVICE]
     : [...CORE_SINGLETON_SERVICES];

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -76,7 +76,7 @@ import {
   resolveScratchConfig,
 } from "../agents/scratch.js";
 import { LITELLM_MASTER_KEY_STATE_BASENAME } from "../litellm/external-spend.js";
-import { writeComposeFile, computeComposeContent, resolveHostSwitchroomConfigPath, resolveHostHomeForCompose } from "./write-compose.js";
+import { writeComposeFile, computeComposeContent, parseComposeServiceNames, resolveHostSwitchroomConfigPath, resolveHostHomeForCompose } from "./write-compose.js";
 import { getProfilePath } from "../agents/profiles.js";
 import { detectInstallType } from "./install-detect.js";
 import {
@@ -2284,25 +2284,13 @@ export async function probeVaultProvisioning(
   };
 }
 
-/** Parse the top-level service names out of a generated compose YAML. */
-export function parseComposeServiceNames(compose: string): string[] {
-  const lines = compose.split("\n");
-  const names: string[] = [];
-  let inServices = false;
-  for (const line of lines) {
-    if (/^services:\s*$/.test(line)) {
-      inServices = true;
-      continue;
-    }
-    // A new top-level key (column 0, non-space) ends the services block.
-    if (inServices && /^\S/.test(line)) break;
-    if (!inServices) continue;
-    // Service entries are keyed at exactly two-space indent: `  <name>:`.
-    const m = /^ {2}([A-Za-z0-9_.-]+):\s*$/.exec(line);
-    if (m) names.push(m[1]);
-  }
-  return names;
-}
+/**
+ * Parse the top-level service names out of a generated compose YAML.
+ *
+ * Re-exported from `write-compose.ts`, which needs the same parse to attribute
+ * a dropped `voice-sidecar` and cannot import from here (cycle).
+ */
+export { parseComposeServiceNames };
 
 export interface ApplyDryRunResult {
   /** Conditions that would make a real apply exit non-zero. */
@@ -2472,6 +2460,13 @@ export async function runApplyDryRun(
     }
     if (removedServices.length > 0) {
       info.push(`compose: services removed: ${removedServices.join(", ")}.`);
+    }
+    // An unattributed `services removed: voice-sidecar` reads as intent. When
+    // the removal is only a defaulted verdict, say so — and as a WARNING, not
+    // an info line, because the operator is about to delete a running service
+    // on evidence switchroom does not actually have.
+    if (computed.voiceSidecarDrop) {
+      warnings.push(`compose: ${computed.voiceSidecarDrop.message}`);
     }
     if (previousImageTag !== null && !composeChanged) {
       info.push(`compose: no change (would be byte-identical to the current file).`);

--- a/src/cli/write-compose.ts
+++ b/src/cli/write-compose.ts
@@ -25,6 +25,13 @@ import { resolveImageTag, resolveRelease, type ReleaseBlockShape } from "../conf
 import { isDockerRuntime } from "../runtime-mode.js";
 import { resolveOperatorUid } from "./operator-uid.js";
 import { resolveAgentConfig } from "../config/merge.js";
+import { VOICE_SIDECAR_SERVICE } from "../agents/singleton-reconcile.js";
+import {
+  resolveVoiceEngine,
+  isDefaultedVoiceEngine,
+  type VoiceEngineReason,
+  type VoiceEngineResolution,
+} from "../setup/host-capabilities.js";
 
 /** Minimal structural view of a broker structured-get result (see
  *  src/vault/broker/client.ts `getViaBrokerStructured`). We branch on `kind`
@@ -319,6 +326,86 @@ export interface ComputeComposeResult {
   previous: string | null;
   /** The agent image tag previously on disk (for drift logging), or null. */
   previousImageTag: string | null;
+  /**
+   * Set when this generation DROPS an already-emitted `voice-sidecar` because
+   * the voice verdict was defaulted rather than read. Null on every other
+   * path — including a genuine `cloud` verdict, a fresh install with no
+   * previous compose, and any run that keeps the service.
+   */
+  voiceSidecarDrop: VoiceSidecarDrop | null;
+}
+
+/** Why an already-emitted `voice-sidecar` is about to disappear. */
+export interface VoiceSidecarDrop {
+  reason: VoiceEngineReason;
+  /** The verdict path that was attempted. */
+  path: string;
+  /** One-line explanation from the read; empty for `no-verdict`. */
+  detail: string;
+  /** Operator-facing one-liner, identical on every surface. */
+  message: string;
+}
+
+/** Parse the top-level service names out of a generated compose YAML. */
+export function parseComposeServiceNames(compose: string): string[] {
+  const lines = compose.split("\n");
+  const names: string[] = [];
+  let inServices = false;
+  for (const line of lines) {
+    if (/^services:\s*$/.test(line)) {
+      inServices = true;
+      continue;
+    }
+    // A new top-level key (column 0, non-space) ends the services block.
+    if (inServices && /^\S/.test(line)) break;
+    if (!inServices) continue;
+    // Service entries are keyed at exactly two-space indent: `  <name>:`.
+    const m = /^ {2}([A-Za-z0-9_.-]+):\s*$/.exec(line);
+    if (m) names.push(m[1]);
+  }
+  return names;
+}
+
+/**
+ * Build the operator-facing line for a defaulted voice verdict that costs a
+ * running service. Exported so the dry-run report and the write path render
+ * byte-identical text.
+ */
+export function voiceSidecarDropMessage(r: VoiceEngineResolution): string {
+  const why = r.reason === "no-verdict"
+    ? `no verdict file at ${r.path}`
+    : `the verdict at ${r.path} is ${r.reason} — ${r.detail}`;
+  return (
+    `voice-sidecar is being REMOVED because ${why}, so the voice engine ` +
+    "defaulted to `cloud`. This host is not known to lack a GPU — switchroom " +
+    "could not tell. Re-run `switchroom setup` to re-probe before applying, or " +
+    "confirm the removal is intended."
+  );
+}
+
+/**
+ * Decide whether this generation silently drops a running `voice-sidecar`.
+ *
+ * Only fires when ALL of: a previous compose exists and declared the service,
+ * the new content does not, and the engine was DEFAULTED rather than read from
+ * a verdict. A genuine `cloud` verdict is a deliberate operator state and stays
+ * quiet; a fresh install has no previous compose and stays quiet too.
+ */
+export function detectVoiceSidecarDrop(
+  previous: string | null,
+  content: string,
+  resolution: VoiceEngineResolution,
+): VoiceSidecarDrop | null {
+  if (!isDefaultedVoiceEngine(resolution)) return null;
+  if (previous === null) return null;
+  if (!parseComposeServiceNames(previous).includes(VOICE_SIDECAR_SERVICE)) return null;
+  if (parseComposeServiceNames(content).includes(VOICE_SIDECAR_SERVICE)) return null;
+  return {
+    reason: resolution.reason,
+    path: resolution.path,
+    detail: resolution.detail,
+    message: voiceSidecarDropMessage(resolution),
+  };
 }
 
 /**
@@ -361,10 +448,17 @@ export async function computeComposeContent(
   // injection so a key-less agent never boots a dead proxy route (#litellm).
   const litellmConfirmedAgents = await resolveLiteLLMConfirmedAgents(opts.config, previous);
 
+  // Resolve the voice verdict ONCE here and inject it, rather than letting
+  // generateCompose read it again: the drop attribution below must describe
+  // the verdict the emitted compose was actually built from, not a second read
+  // that could disagree with it.
+  const voiceResolution = resolveVoiceEngine();
+
   const content = generateCompose({
     config: opts.config,
     imageTag,
     litellmConfirmedAgents,
+    voiceEngine: voiceResolution.engine,
     buildMode: opts.buildMode ?? "pull",
     buildContext: opts.buildContext,
     // Bake the operator's HOST HOME absolute path into volume sources (avoids
@@ -392,7 +486,27 @@ export async function computeComposeContent(
 
   const previousImageTag = previous ? (AGENT_IMAGE_TAG_RE.exec(previous)?.[1] ?? null) : null;
 
-  return { content, imageTag, previous, previousImageTag };
+  // A defaulted verdict that costs a RUNNING service is the one place the
+  // reader's deliberate silence on `absent` is wrong. Warn once per process,
+  // on every caller of this seam (real apply, dry-run, `agent restart`'s
+  // reconcile, doctor drift) — and return it so callers can render it in
+  // their own report format instead of scraping stderr.
+  const voiceSidecarDrop = detectVoiceSidecarDrop(previous, content, voiceResolution);
+  if (voiceSidecarDrop && !_warnedVoiceDrop) {
+    _warnedVoiceDrop = true;
+    process.stderr.write(`[switchroom] WARNING: ${voiceSidecarDrop.message}\n`);
+  }
+
+  return { content, imageTag, previous, previousImageTag, voiceSidecarDrop };
+}
+
+/** One-time guard for the voice-sidecar drop warning (mirrors the
+ *  host-capabilities reader's own once-per-process memo). */
+let _warnedVoiceDrop = false;
+
+/** Test seam: reset the one-time drop warning. */
+export function _resetVoiceSidecarDropWarning(): void {
+  _warnedVoiceDrop = false;
 }
 
 /** Suffix of the compose backup file. */

--- a/src/setup/host-capabilities.ts
+++ b/src/setup/host-capabilities.ts
@@ -257,3 +257,66 @@ export function loadHostCapabilities(): HostCapabilities | null {
   warnDegradedHostCapabilities(read);
   return read.caps;
 }
+
+/** Why {@link resolveVoiceEngine} answered the way it did. */
+export type VoiceEngineReason =
+  /** A readable verdict file said so — the only NON-default answer. */
+  | "verdict"
+  /** `ENOENT` — never probed, or the wrong HOME. Defaulted to `cloud`. */
+  | "no-verdict"
+  /** Present but unreadable (`EACCES`/…). Defaulted to `cloud`. */
+  | "unreadable"
+  /** Present but not a capabilities document. Defaulted to `cloud`. */
+  | "malformed";
+
+/** The voice-engine verdict plus HOW it was reached. */
+export interface VoiceEngineResolution {
+  engine: VoiceEngine;
+  reason: VoiceEngineReason;
+  /** The verdict path that was attempted, for operator-actionable messages. */
+  path: string;
+  /** One-line human explanation. Empty for `verdict` / `no-verdict`. */
+  detail: string;
+}
+
+/** True when the engine was DEFAULTED rather than read from a verdict. */
+export function isDefaultedVoiceEngine(r: VoiceEngineResolution): boolean {
+  return r.reason !== "verdict";
+}
+
+/**
+ * Resolve the voice engine, reporting whether it came from a verdict or from
+ * the fail-safe default.
+ *
+ * Callers used to do `loadHostCapabilities()?.voice.engine ?? "cloud"`, which
+ * is exactly the collapse {@link loadHostCapabilities}'s own docstring warns
+ * against: it cannot tell "this host has no GPU" from "we could not tell", and
+ * for the voice sidecar that difference is a service being REMOVED from the
+ * generated compose. `absent` stays quiet at the reader layer by design (a
+ * fresh install is indistinguishable from a wrong HOME there) — so the reason
+ * is returned instead, and the one call site where a default is destructive
+ * (dropping an already-emitted `voice-sidecar`) attributes it. See
+ * `computeComposeContent`.
+ */
+export function resolveVoiceEngine(): VoiceEngineResolution {
+  const read = readHostCapabilities();
+  warnDegradedHostCapabilities(read);
+  if (read.status === "ok" && read.caps) {
+    return {
+      engine: read.caps.voice.engine,
+      reason: "verdict",
+      path: read.path,
+      detail: "",
+    };
+  }
+  // `ok` with a null `caps` violates HostCapabilitiesRead's own contract, so
+  // it is not a real state — fold it in with `malformed`: either way the
+  // document could not be used and the engine below is a DEFAULT, not a read.
+  const reason: VoiceEngineReason =
+    read.status === "absent"
+      ? "no-verdict"
+      : read.status === "unreadable"
+        ? "unreadable"
+        : "malformed";
+  return { engine: "cloud", reason, path: read.path, detail: read.detail };
+}

--- a/tests/voice-sidecar-drop-attribution.test.ts
+++ b/tests/voice-sidecar-drop-attribution.test.ts
@@ -16,7 +16,7 @@
  * at a fresh tmpdir — never the operator's real `~/.switchroom/`.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -26,23 +26,38 @@ import {
   hostCapabilitiesPath,
 } from "../src/setup/host-capabilities.js";
 import {
+  computeComposeContent,
   detectVoiceSidecarDrop,
   parseComposeServiceNames,
+  _resetVoiceSidecarDropWarning,
 } from "../src/cli/write-compose.js";
+import { runApplyDryRun } from "../src/cli/apply.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
 
 let home: string;
 let prevHome: string | undefined;
+let prevHostHome: string | undefined;
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "switchroom-voicedrop-"));
   prevHome = process.env.HOME;
+  prevHostHome = process.env.SWITCHROOM_HOST_HOME;
   process.env.HOME = home;
+  // The compose generator's host-home resolver THROWS inside a container when
+  // this is unset (the 2026-06-23 poison guard), which would turn the wiring
+  // tests below into a `compose generation:` blocker instead of exercising the
+  // drop path. Pin it at the same tmp home so the test is identical on a host
+  // shell and in CI's container.
+  process.env.SWITCHROOM_HOST_HOME = home;
   resetHostCapabilitiesWarnings();
+  _resetVoiceSidecarDropWarning();
 });
 
 afterEach(() => {
   if (prevHome === undefined) delete process.env.HOME;
   else process.env.HOME = prevHome;
+  if (prevHostHome === undefined) delete process.env.SWITCHROOM_HOST_HOME;
+  else process.env.SWITCHROOM_HOST_HOME = prevHostHome;
   rmSync(home, { recursive: true, force: true });
 });
 
@@ -110,6 +125,40 @@ describe("resolveVoiceEngine — reports HOW the engine was decided", () => {
     expect(isDefaultedVoiceEngine(r)).toBe(true);
     // The path is what makes the message actionable.
     expect(r.path).toBe(hostCapabilitiesPath());
+  });
+
+  // `unreadable` is the LOUD trigger the reader singles out (a root-owned 0600
+  // file in a uid-1000 home): the file is there and we were denied, which is
+  // NOT "no GPU" and NOT "malformed bytes" — each points the operator at a
+  // different fix. Root bypasses mode bits, so this can only run unprivileged.
+  const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  it.skipIf(asRoot)(
+    "an unreadable verdict is distinguishable from malformed — different fix",
+    () => {
+      mkdirSync(join(home, ".switchroom"), { recursive: true });
+      writeFileSync(hostCapabilitiesPath(), "{}");
+      chmodSync(hostCapabilitiesPath(), 0o000);
+      const r = resolveVoiceEngine();
+      expect(r.engine).toBe("cloud");
+      expect(r.reason).toBe("unreadable");
+      expect(isDefaultedVoiceEngine(r)).toBe(true);
+      expect(r.detail).not.toBe("");
+    },
+  );
+
+  // The EACCES case above cannot run as root, and CI is not the only place
+  // this suite runs. A directory in the way of the path is the same
+  // `unreadable` fact (EISDIR) and is uid-independent, so the branch is never
+  // left wholly unexercised — without one of these, a typo folding
+  // `unreadable` into `malformed` ships, and the operator is told to fix the
+  // file's BYTES when the actual fix is its PERMISSIONS.
+  it("a verdict path blocked by a directory is unreadable, not malformed", () => {
+    mkdirSync(hostCapabilitiesPath(), { recursive: true });
+    const r = resolveVoiceEngine();
+    expect(r.engine).toBe("cloud");
+    expect(r.reason).toBe("unreadable");
+    expect(isDefaultedVoiceEngine(r)).toBe(true);
+    expect(r.detail).not.toBe("");
   });
 
   it("a malformed verdict defaults to cloud and is distinguishable from absent", () => {
@@ -183,5 +232,148 @@ describe("parseComposeServiceNames — the single parse both surfaces use", () =
       "clerk",
       "voice-sidecar",
     ]);
+  });
+});
+
+/**
+ * The helpers above are pure and would all stay green if the WIRING that
+ * carries their answer to the operator were deleted — the `voiceSidecarDrop`
+ * field on `computeComposeContent`'s result and the `warnings.push` in
+ * `runApplyDryRun`. These drive the real seam end to end instead: a config in,
+ * an `ApplyDryRunResult` out, asserting the operator-visible OUTCOME (which
+ * REPORT BUCKET the attribution lands in), not that a helper was called.
+ */
+describe("apply --dry-run — the attribution reaches the operator's report", () => {
+  /** Minimal config that generates a compose with one agent. */
+  function config(): SwitchroomConfig {
+    return { agents: { clerk: { purpose: "test agent" } }, defaults: {} } as unknown as SwitchroomConfig;
+  }
+
+  /** Seed a previous on-disk compose that DOES declare the sidecar. */
+  function seedPreviousCompose(content = WITH_SIDECAR): string {
+    mkdirSync(join(home, ".switchroom"), { recursive: true });
+    const composePath = join(home, ".switchroom", "docker-compose.yml");
+    writeFileSync(composePath, content);
+    return composePath;
+  }
+
+  /** Run the dry-run against a seeded compose, with docker detection stubbed. */
+  async function dryRun(composePath: string) {
+    return runApplyDryRun(
+      config(),
+      { outPath: composePath },
+      { writeOut: () => {}, writeErr: () => {}, detectComposeV2: () => null },
+    );
+  }
+
+  it("warns (not info, not blocking) when a defaulted verdict drops a running sidecar", async () => {
+    const composePath = seedPreviousCompose();
+    // No host-capabilities.json in this HOME → `no-verdict` → engine defaults
+    // to cloud → the regenerated compose has no voice-sidecar.
+    const res = await dryRun(composePath);
+
+    const attributed = res.warnings.filter((w) => w.includes("voice-sidecar is being REMOVED"));
+    expect(attributed).toHaveLength(1);
+    // Actionable: names the verdict path, and refuses the GPU-absence framing
+    // that conflation is the whole bug.
+    expect(attributed[0]).toContain(hostCapabilitiesPath());
+    expect(attributed[0]).toContain("could not tell");
+
+    // The removal itself is deliberately UN-GATED — attributing it must not
+    // start failing an apply that used to succeed.
+    expect(res.blocking.filter((b) => b.includes("voice-sidecar"))).toEqual([]);
+    expect(res.wouldSucceed).toBe(true);
+
+    // And it must not be demoted into the info stream, where it reads as an
+    // intended change alongside the unattributed `services removed:` line.
+    expect(res.info.filter((i) => i.includes("is being REMOVED"))).toEqual([]);
+    expect(res.removedServices).toContain("voice-sidecar");
+  });
+
+  it("stays quiet on a genuine cloud verdict — the same removal, deliberately", async () => {
+    writeVerdict("cloud");
+    const composePath = seedPreviousCompose();
+    const res = await dryRun(composePath);
+
+    // Same observable removal…
+    expect(res.removedServices).toContain("voice-sidecar");
+    // …but no attribution anywhere, because the operator's own verdict said so.
+    // Without this, "always warn" would satisfy the test above.
+    expect(res.warnings.filter((w) => w.includes("voice-sidecar"))).toEqual([]);
+    expect(res.blocking.filter((b) => b.includes("voice-sidecar"))).toEqual([]);
+  });
+
+  it("stays quiet when the previous compose never had the sidecar", async () => {
+    const composePath = seedPreviousCompose(WITHOUT_SIDECAR);
+    const res = await dryRun(composePath);
+
+    expect(res.removedServices).not.toContain("voice-sidecar");
+    expect(res.warnings.filter((w) => w.includes("voice-sidecar"))).toEqual([]);
+  });
+});
+
+describe("computeComposeContent — the drop is returned AND warned once", () => {
+  /** Seed a previous compose declaring the sidecar; return its path. */
+  function seed(): string {
+    mkdirSync(join(home, ".switchroom"), { recursive: true });
+    const composePath = join(home, ".switchroom", "docker-compose.yml");
+    writeFileSync(composePath, WITH_SIDECAR);
+    return composePath;
+  }
+
+  async function compute(composePath: string) {
+    return computeComposeContent({
+      config: { agents: { clerk: { purpose: "test agent" } }, defaults: {} } as unknown as SwitchroomConfig,
+      composePath,
+      buildMode: "pull",
+      buildContext: undefined,
+    });
+  }
+
+  it("emits the stderr warning exactly ONCE per process, not per caller", async () => {
+    const composePath = seed();
+    const captured: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    process.stderr.write = ((chunk: any, ...rest: any[]) => {
+      captured.push(String(chunk));
+      return original(chunk, ...(rest as []));
+    }) as typeof process.stderr.write;
+    try {
+      // Every caller of this seam (apply, dry-run, `agent restart`'s
+      // reconcile, doctor drift) hits it in one process; the operator must
+      // not be spammed, but must still get it back structurally each time.
+      const first = await compute(composePath);
+      const second = await compute(composePath);
+      expect(first.voiceSidecarDrop).not.toBeNull();
+      expect(second.voiceSidecarDrop).not.toBeNull();
+      expect(
+        captured.filter((c) => c.includes("voice-sidecar is being REMOVED")),
+      ).toHaveLength(1);
+    } finally {
+      process.stderr.write = original;
+    }
+  });
+
+  it("_resetVoiceSidecarDropWarning re-arms the once-guard for the next process", async () => {
+    const composePath = seed();
+    await compute(composePath);
+    _resetVoiceSidecarDropWarning();
+
+    const captured: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    process.stderr.write = ((chunk: any, ...rest: any[]) => {
+      captured.push(String(chunk));
+      return original(chunk, ...(rest as []));
+    }) as typeof process.stderr.write;
+    try {
+      await compute(composePath);
+      expect(
+        captured.filter((c) => c.includes("voice-sidecar is being REMOVED")),
+      ).toHaveLength(1);
+    } finally {
+      process.stderr.write = original;
+    }
   });
 });

--- a/tests/voice-sidecar-drop-attribution.test.ts
+++ b/tests/voice-sidecar-drop-attribution.test.ts
@@ -1,0 +1,187 @@
+/**
+ * A defaulted voice verdict must never remove `voice-sidecar` silently.
+ *
+ * The bug: both voice gates read the verdict through `loadHostCapabilities()`,
+ * whose own docstring says to prefer `readHostCapabilities` "anywhere the null
+ * would silently become a behaviour change". Dropping an already-emitted
+ * service from the fleet compose is exactly such a change, and `absent` is
+ * deliberately quiet at the reader layer — so a moved/lost
+ * `host-capabilities.json` deleted a running GPU service and the operator's
+ * only signal was an unattributed `compose: services removed: voice-sidecar.`
+ *
+ * These assert the OUTCOME the operator gets (a reason naming the verdict path,
+ * on a defaulted read only), not that a particular helper was called.
+ *
+ * Isolation: `resolveStatePath` derives from `process.env.HOME`, so HOME points
+ * at a fresh tmpdir — never the operator's real `~/.switchroom/`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  resolveVoiceEngine,
+  isDefaultedVoiceEngine,
+  resetHostCapabilitiesWarnings,
+  hostCapabilitiesPath,
+} from "../src/setup/host-capabilities.js";
+import {
+  detectVoiceSidecarDrop,
+  parseComposeServiceNames,
+} from "../src/cli/write-compose.js";
+
+let home: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "switchroom-voicedrop-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = home;
+  resetHostCapabilitiesWarnings();
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+/** Write a verdict file with the given engine. */
+function writeVerdict(engine: "local" | "cloud"): void {
+  const path = hostCapabilitiesPath();
+  mkdirSync(join(home, ".switchroom"), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify({
+      version: 1,
+      voice: {
+        gpuPresent: engine === "local",
+        containerToolkit: engine === "local",
+        engine,
+        detectedAt: "2026-06-30T21:10:45.000Z",
+      },
+    }),
+  );
+}
+
+/** Write bytes that are readable but are not a capabilities document. */
+function writeGarbageVerdict(): void {
+  mkdirSync(join(home, ".switchroom"), { recursive: true });
+  writeFileSync(hostCapabilitiesPath(), '{"version":1}');
+}
+
+const WITH_SIDECAR = [
+  "services:",
+  "  clerk:",
+  "    image: ghcr.io/switchroom/switchroom-agent:v1",
+  "  voice-sidecar:",
+  "    image: ghcr.io/switchroom/switchroom-voice:v1",
+  "",
+].join("\n");
+
+const WITHOUT_SIDECAR = [
+  "services:",
+  "  clerk:",
+  "    image: ghcr.io/switchroom/switchroom-agent:v1",
+  "",
+].join("\n");
+
+describe("resolveVoiceEngine — reports HOW the engine was decided", () => {
+  it("a readable local verdict is a read, not a default", () => {
+    writeVerdict("local");
+    const r = resolveVoiceEngine();
+    expect(r.engine).toBe("local");
+    expect(r.reason).toBe("verdict");
+    expect(isDefaultedVoiceEngine(r)).toBe(false);
+  });
+
+  it("a readable cloud verdict is a read, not a default", () => {
+    writeVerdict("cloud");
+    const r = resolveVoiceEngine();
+    expect(r.engine).toBe("cloud");
+    expect(r.reason).toBe("verdict");
+    expect(isDefaultedVoiceEngine(r)).toBe(false);
+  });
+
+  it("an absent verdict defaults to cloud and says so", () => {
+    const r = resolveVoiceEngine();
+    expect(r.engine).toBe("cloud");
+    expect(r.reason).toBe("no-verdict");
+    expect(isDefaultedVoiceEngine(r)).toBe(true);
+    // The path is what makes the message actionable.
+    expect(r.path).toBe(hostCapabilitiesPath());
+  });
+
+  it("a malformed verdict defaults to cloud and is distinguishable from absent", () => {
+    writeGarbageVerdict();
+    const r = resolveVoiceEngine();
+    expect(r.engine).toBe("cloud");
+    expect(r.reason).toBe("malformed");
+    expect(isDefaultedVoiceEngine(r)).toBe(true);
+    expect(r.detail).not.toBe("");
+  });
+});
+
+describe("detectVoiceSidecarDrop — fires only when a default costs a service", () => {
+  it("attributes the removal when the verdict file is missing", () => {
+    const drop = detectVoiceSidecarDrop(
+      WITH_SIDECAR,
+      WITHOUT_SIDECAR,
+      resolveVoiceEngine(),
+    );
+    expect(drop).not.toBeNull();
+    expect(drop!.reason).toBe("no-verdict");
+    // The operator must be told WHERE to look and that this is not a
+    // GPU-absence finding — that conflation is the bug.
+    expect(drop!.message).toContain(hostCapabilitiesPath());
+    expect(drop!.message).toContain("REMOVED");
+    expect(drop!.message).toContain("could not tell");
+  });
+
+  it("attributes the removal when the verdict file is unusable", () => {
+    writeGarbageVerdict();
+    const drop = detectVoiceSidecarDrop(
+      WITH_SIDECAR,
+      WITHOUT_SIDECAR,
+      resolveVoiceEngine(),
+    );
+    expect(drop).not.toBeNull();
+    expect(drop!.reason).toBe("malformed");
+    expect(drop!.message).toContain("malformed");
+  });
+
+  it("stays quiet on a genuine cloud verdict — that removal is intended", () => {
+    writeVerdict("cloud");
+    expect(
+      detectVoiceSidecarDrop(WITH_SIDECAR, WITHOUT_SIDECAR, resolveVoiceEngine()),
+    ).toBeNull();
+  });
+
+  it("stays quiet on a fresh install with no previous compose", () => {
+    expect(
+      detectVoiceSidecarDrop(null, WITHOUT_SIDECAR, resolveVoiceEngine()),
+    ).toBeNull();
+  });
+
+  it("stays quiet when the previous compose never had the sidecar", () => {
+    expect(
+      detectVoiceSidecarDrop(WITHOUT_SIDECAR, WITHOUT_SIDECAR, resolveVoiceEngine()),
+    ).toBeNull();
+  });
+
+  it("stays quiet when the sidecar survives the regeneration", () => {
+    writeVerdict("local");
+    expect(
+      detectVoiceSidecarDrop(WITH_SIDECAR, WITH_SIDECAR, resolveVoiceEngine()),
+    ).toBeNull();
+  });
+});
+
+describe("parseComposeServiceNames — the single parse both surfaces use", () => {
+  it("extracts top-level service keys only", () => {
+    expect(parseComposeServiceNames(WITH_SIDECAR)).toEqual([
+      "clerk",
+      "voice-sidecar",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

A defaulted voice-engine verdict can delete a running `voice-sidecar` from the generated compose with no explanation. This makes the removal self-attributing, and only when it is actually a default.

- `resolveVoiceEngine()` (new, `src/setup/host-capabilities.ts`) returns the engine **plus how it was decided** — `verdict` | `no-verdict` | `unreadable` | `malformed` — over the honest `readHostCapabilities()` primitive.
- Both voice gates (`src/agents/compose.ts`, `src/agents/singleton-reconcile.ts`) now use it instead of `loadHostCapabilities()?.voice.engine ?? "cloud"`.
- `computeComposeContent` resolves the verdict **once** and passes that same resolution into `generateCompose`, so the attribution can never disagree with the compose actually emitted.
- `detectVoiceSidecarDrop` fires only when a default costs a service: previous compose had the sidecar, new one does not, engine was defaulted. `apply --dry-run` surfaces it as a **warning**, not an info line.
- `parseComposeServiceNames` moved from `apply.ts` to `write-compose.ts` (apply imports write-compose, so the reverse would be a cycle) and is re-exported for existing callers.

## Why

`loadHostCapabilities()`'s own docstring says to prefer `readHostCapabilities` "anywhere the null would silently become a behaviour change". Dropping a running GPU service out of the fleet compose is exactly such a change, and it was reading through the lossy wrapper.

Worse, the loudest safety net does not cover the most likely trigger: `isDegradedHostCapabilitiesRead()` returns false for `absent`, deliberately — at the reader layer a wrong `HOME` (sudo, a container) is indistinguishable from a fresh install. So a moved or lost `host-capabilities.json` warned *nothing* while the apply report said only:

```
compose: services removed: voice-sidecar.
```

which reads as intent. That is the failure mode `reference/jobs/restart-and-know-what-im-running.md:52` names outright — *"Lying by omission: tools silently disabled and quietly dropped"* — and `:22`, *"The worst outcome is a silent respawn that comes back subtly different."*

This does not make `absent` loud at the reader layer (that design is correct). It returns the reason instead, and attributes it at the one call site where the default is destructive.

## Test plan

New `tests/voice-sidecar-drop-attribution.test.ts` — 11 tests, asserting the operator-visible outcome, not that a helper was called:

- `resolveVoiceEngine` reports `verdict` for a readable `local` **and** a readable `cloud` verdict; `no-verdict` when absent; `malformed` when the bytes are not a capabilities document — each with the right engine and `isDefaultedVoiceEngine`.
- `detectVoiceSidecarDrop` fires on `no-verdict` and on `malformed`, and the message contains the verdict path, `REMOVED`, and `could not tell`.
- Stays null on a genuine `cloud` verdict (intended removal), on a fresh install (`previous === null`), when the previous compose never had the sidecar, and when the sidecar survives.

Isolation follows the shared-state discipline: `HOME` is pointed at an `mkdtempSync` dir, never `~/.switchroom/`.

Local runs, all green:

```
tests/voice-sidecar-drop-attribution.test.ts            11 passed
src/setup/host-capabilities.test.ts
src/cli/apply.test.ts
src/agents/singleton-reconcile.test.ts
tests/docker/compose-generator.test.ts                  282 passed | 1 skipped
npm run lint                                            exit 0
```

## Risk

Low, and deliberately narrow.

- **No behaviour change to which engine is chosen.** `resolveVoiceEngine().engine` is the same value the old expression produced in every state; only the surrounding metadata is new.
- **The new warning cannot fire on a correct host.** It requires a defaulted verdict *and* an existing compose that had the sidecar *and* a regenerated one that does not. A genuine `cloud` verdict removes the sidecar as silently as before.
- `parseComposeServiceNames` is moved, not rewritten, and is still exported from `apply.ts`, so no external caller breaks.

Found while validating v0.21.13 on the live fleet: an `apply --dry-run` from a context with a non-host `HOME` reported `services removed: voice-sidecar` with no hint that the verdict had simply not been found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)