### PR TITLE
feat(hindsight): log injected directive IDs on recall_log rows

### DIFF
--- a/changelog.d/0000-log-injected-directive-ids.feat.md
+++ b/changelog.d/0000-log-injected-directive-ids.feat.md
@@ -1,0 +1,12 @@
+- **hindsight: log injected directive IDs on `recall_log` rows (#0000)**
+
+  Memory-redesign step 1 (probes/instrumentation, no behaviour change):
+  `state/recall_log.jsonl` now carries `directive_ids`, the ids of the
+  directives actually injected into `<active_directives>` this turn (the
+  post-cap head-slice, in priority order), alongside the existing
+  `directive_count`/`directives_omitted` volume fields. `null` on a cache-hit
+  row, matching those two fields. Makes directive exposure — including
+  "never once injected" — queryable before any change to what gets
+  injected. `injected_score_min/median/max` (per-memory recall-quality
+  telemetry) and the `recall.py` scores-API comment (E-24) were already
+  correct on `main` — no change needed there.

--- a/changelog.d/4738-log-injected-directive-ids.feat.md
+++ b/changelog.d/4738-log-injected-directive-ids.feat.md
@@ -1,4 +1,4 @@
-- **hindsight: log injected directive IDs on `recall_log` rows (#0000)**
+- **hindsight: log injected directive IDs on `recall_log` rows (#4738)**
 
   Memory-redesign step 1 (probes/instrumentation, no behaviour change):
   `state/recall_log.jsonl` now carries `directive_ids`, the ids of the

--- a/vendor/hindsight-memory/scripts/lib/directives.py
+++ b/vendor/hindsight-memory/scripts/lib/directives.py
@@ -241,6 +241,24 @@ def count_omitted_directives(directives: list, max_directives: int = MAX_DIRECTI
     return max(0, len(directives) - max_directives)
 
 
+def injected_directive_ids(directives: list, max_directives: int = MAX_DIRECTIVES) -> list:
+    """The `id`s of the directives `format_active_directives_block` would
+    actually INJECT (the `[:max_directives]` head-slice), in the same
+    priority-descending order the block renders them.
+
+    Read-only / additive instrumentation (step 1 of the memory redesign,
+    E-45 recommendation (b)): today a recall_log row records only
+    `directive_count` (how many were fetched) and `directives_omitted` (how
+    many were dropped by the cap), never WHICH directives actually reached
+    the prompt. This makes exposure queryable — e.g. "which directives have
+    never once been injected" — without touching what gets injected. Skips
+    any directive dict missing a truthy `id` rather than raising, so a
+    malformed entry can't take recall telemetry down.
+    """
+    truncated = directives[:max_directives] if directives else []
+    return [d["id"] for d in truncated if isinstance(d, dict) and d.get("id")]
+
+
 def format_active_directives_block(directives: list, max_directives: int = MAX_DIRECTIVES) -> Optional[str]:
     """Format directives into the <active_directives> block string.
 

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -77,6 +77,7 @@ from lib.directives import (
     count_omitted_directives,
     fetch_active_directives_cached,
     format_active_directives_block,
+    injected_directive_ids,
 )
 from lib.gateway_ipc import extract_chat_id_from_prompt, extract_topic_from_prompt, extract_user_from_prompt, update_placeholder
 from lib.parallel_recall import run_parallel
@@ -1900,6 +1901,10 @@ def main():
                 "directive_count": None,
                 # No directives block is built on a cache hit.
                 "directives_omitted": None,
+                # Same reason — a cache hit replays a formatted context
+                # block, not a fetched directive list, so there is nothing
+                # to derive the injected id set from this turn.
+                "directive_ids": None,
                 "demoted_count": 0,
                 # #3837 score-floor fields, present for a uniformly queryable
                 # schema. A cache hit replays a formatted context block, not a
@@ -2620,6 +2625,15 @@ def main():
         # never reached the agent. >0 here means the bank is over cap and the
         # doctor's directive-count check will be FAILing too.
         "directives_omitted": count_omitted_directives(directives),
+        # Switchroom memory-redesign step 1 (E-45 recommendation (b)) — WHICH
+        # directives actually reached the prompt this turn, in the same
+        # priority-descending order `format_active_directives_block` rendered
+        # them. `directive_count`/`directives_omitted` above are volume-only
+        # (how many fetched, how many the cap dropped); this is the queryable
+        # record of identity, so directive exposure — including "never once
+        # injected" — is measurable before any change to what gets injected.
+        # Purely additive: does not change `directives_block` composition.
+        "directive_ids": injected_directive_ids(directives),
         "demoted_count": demoted_count,
         # Switchroom #3837 — score-floor telemetry, deliberately alongside the
         # `injected_score_*` fields below: those are what the floor was derived

--- a/vendor/hindsight-memory/scripts/tests/test_directives.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directives.py
@@ -28,6 +28,7 @@ from lib.directives import (  # noqa: E402
     fetch_active_directives,
     fetch_active_directives_cached,
     format_active_directives_block,
+    injected_directive_ids,
     invalidate_directives_cache,
     parse_active_directives_block,
     rule_already_captured,
@@ -259,6 +260,51 @@ class FormatActiveDirectivesBlockTests(unittest.TestCase):
         self.assertNotIn("more, omitted", format_active_directives_block(under))
         # Honours a custom cap the same way the formatter does.
         self.assertEqual(count_omitted_directives(directives, max_directives=5), total - 5)
+
+    def test_injected_directive_ids_matches_the_rendered_block(self):
+        """Memory-redesign step 1 (E-45 recommendation (b)): the id list
+        `recall.py` puts on the recall_log row must name exactly the
+        directives `format_active_directives_block` actually rendered —
+        not the full fetched set, and in the same priority order."""
+        total = MAX_DIRECTIVES + 4
+        directives = [
+            _directive(f"d{i}", f"c{i}", priority=total - i) for i in range(total)
+        ]
+        with patch("sys.stderr", new=StringIO()):
+            out = format_active_directives_block(directives)
+        ids = injected_directive_ids(directives)
+        self.assertEqual(len(ids), MAX_DIRECTIVES)
+        # Real, concrete values — the head-slice in priority order, not a
+        # placeholder or a count.
+        self.assertEqual(ids, [f"id-d{i}" for i in range(MAX_DIRECTIVES)])
+        # Every injected id is actually present in the rendered block...
+        for i in range(MAX_DIRECTIVES):
+            self.assertIn(f"d{i}: c{i}", out)
+        # ...and the omitted tail's ids are excluded.
+        for i in range(MAX_DIRECTIVES, total):
+            self.assertNotIn(f"id-d{i}", ids)
+            self.assertNotIn(f"d{i}: c{i}", out)
+
+    def test_injected_directive_ids_under_cap_returns_all(self):
+        directives = [_directive(f"d{i}", f"c{i}", priority=5 - i) for i in range(3)]
+        self.assertEqual(injected_directive_ids(directives), ["id-d0", "id-d1", "id-d2"])
+
+    def test_injected_directive_ids_empty_list(self):
+        self.assertEqual(injected_directive_ids([]), [])
+
+    def test_injected_directive_ids_skips_malformed_entries(self):
+        directives = [
+            _directive("good", "content", priority=9),
+            {"priority": 5},  # no id — must not crash or contribute a None
+            "not-a-dict",
+        ]
+        self.assertEqual(injected_directive_ids(directives), ["id-good"])
+
+    def test_injected_directive_ids_honours_custom_cap(self):
+        directives = [_directive(f"d{i}", f"c{i}", priority=10 - i) for i in range(5)]
+        self.assertEqual(
+            injected_directive_ids(directives, max_directives=2), ["id-d0", "id-d1"]
+        )
 
     def test_no_warning_when_nothing_is_truncated(self):
         directives = [_directive("only", "single", priority=5)]

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -470,6 +470,59 @@ class RecallTelemetryLogTests(unittest.TestCase):
         self.assertIsNone(e["injected_score_median"])
         self.assertIsNone(e["injected_score_max"])
 
+    def test_logs_injected_directive_ids(self):
+        """Memory-redesign step 1 (E-45 recommendation (b)): the recall_log
+        row must name WHICH directives were injected, not just how many.
+        `directive_count` alone can't answer "which directives were never
+        once injected" — this makes that queryable.
+        """
+        directives = [
+            _directive("first", "content one", priority=10),
+            _directive("second", "content two", priority=5),
+        ]
+        client = _FakeClient(directives=directives, memories=[])
+        _run_main_with(client)
+        e = self._read_log()[0]
+        self.assertEqual(e["directive_count"], 2)
+        self.assertEqual(e["directive_ids"], ["id-first", "id-second"])
+
+    def test_directive_ids_preserve_priority_order_across_more_than_a_few(self):
+        """Real values across several directives, in the rendered priority
+        order — not just a two-item happy path."""
+        directives = [
+            _directive(f"d{i}", f"c{i}", priority=10 - i) for i in range(6)
+        ]
+        client = _FakeClient(directives=directives, memories=[])
+        _run_main_with(client)
+        e = self._read_log()[0]
+        self.assertEqual(e["directive_count"], 6)
+        self.assertEqual(
+            e["directive_ids"],
+            ["id-d0", "id-d1", "id-d2", "id-d3", "id-d4", "id-d5"],
+        )
+
+    def test_directive_ids_null_on_cache_hit(self):
+        """A cache hit replays a formatted context block, not a fetched
+        directive list — `directive_ids` must be null (schema-uniform with
+        `directive_count`/`directives_omitted`), never a stale prior value.
+
+        Forces the cache-HIT branch directly (rather than relying on a
+        second `main()` call actually persisting a cache entry — the
+        integration harness patches `write_state` to a no-op, so
+        `_cache_store` never lands between calls)."""
+        client = _FakeClient(directives=[_directive("only", "content", priority=5)], memories=[])
+        with patch.object(recall, "_cache_lookup", return_value="[Hindsight] cached context"), \
+                patch.dict(os.environ, {"HINDSIGHT_RECALL_CACHE_TTL_SECS": "300"}):
+            _run_main_with(client)
+        entries = self._read_log()
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertTrue(e["cache_hit"])
+        self.assertIsNone(e["directive_ids"])
+        # Schema-uniform with the fields it mirrors.
+        self.assertIsNone(e["directive_count"])
+        self.assertIsNone(e["directives_omitted"])
+
     def test_no_log_when_plugin_data_unset(self):
         # If CLAUDE_PLUGIN_DATA isn't set, the writer no-ops silently —
         # we don't want a stray log file in the working directory.


### PR DESCRIPTION
## Summary

Step 1 of the switchroom memory redesign (design-v2.md §5 step 1(c)) — additive instrumentation only, **zero behaviour change**. This turns directive exposure into a measurable quantity before any injection/cap change lands (E-45 recommendation (b)):

- **`directive_ids` on every `recall_log.jsonl` row.** Today a row records `directive_count` (how many were fetched) and `directives_omitted` (how many the `MAX_DIRECTIVES` cap dropped), but never *which* directives actually reached the prompt. Added `injected_directive_ids()` in `vendor/hindsight-memory/scripts/lib/directives.py` — the pure counterpart of the existing `count_omitted_directives()`, returning the ids of the post-cap head-slice (what `format_active_directives_block` actually renders) in priority order. Wired into both `_write_recall_log` call sites in `recall.py`: real ids on a fresh recall, `null` on a cache hit (matching the existing `directive_count`/`directives_omitted` null-on-cache-hit convention, since no directives block is built on a cache hit).

## Already shipped on `main` — verified, not touched

The task also asked for two other step-1 items. Both are already implemented and correct on `origin/main`, so no change was needed:

- **Per-memory injected score aggregates (E-85).** `injected_score_min/median/max` already land on every `recall_log` row via `_injected_score_stats()` (`recall.py:531`), covered by `tests/test_recall_min_score.py` and `tests/test_recall_integration.py`.
- **Stale scores comment (E-24, `recall.py:344-345` per the ticket).** The line anchor has drifted (confirmed via `grep`), and the comment itself was already corrected in commit `70d29067` ("Deleted the stale 'Hindsight's HTTP API does not return similarity scores' comment... and rewrote the #475 gate rationale"). `grep -rn similarity vendor/hindsight-memory/scripts/` returns nothing relevant on `main` today.

## Test plan

- [x] `vendor/hindsight-memory/scripts/tests/test_directives.py` — 5 new unit tests for `injected_directive_ids()`: matches the rendered block's head-slice (real ids, real priority order), under-cap returns all, empty list, skips malformed/id-less entries, honours a custom cap.
- [x] `vendor/hindsight-memory/scripts/tests/test_recall_integration.py` — 3 new end-to-end tests against `recall.main()`: `directive_ids` appears with real values on a fresh recall, preserves priority order across several directives, and is `null` (not stale/omitted) on a forced cache hit.
- [x] `python3 -m unittest discover` in `vendor/hindsight-memory/scripts` — **1079 tests, OK** (required `python-ok` check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)