### PR TITLE
memory: pin the hindsight shim's REST route contract to /openapi.json

### DIFF
--- a/changelog.d/pin-the-hindsight-shim-s-rest-route-contract-to.feat.md
+++ b/changelog.d/pin-the-hindsight-shim-s-rest-route-contract-to.feat.md
@@ -1,0 +1,13 @@
+- **memory: pin the hindsight shim's REST route contract to /openapi.json** —
+  design-v2.md §2.5's engine version pin, previously "not built": the
+  hindsight-mcp-shim's five synthesized tools (`deactivate_directive`,
+  `reactivate_directive`, `search_knowledge_pages`, `get_knowledge_page`,
+  `get_knowledge_tree`) are REST calls that `tools/list`'s existing contract
+  check can never see move. The shim now fetches `/openapi.json` and, when a
+  route is CONFIRMED missing, rejects that tool's call loudly before ever
+  attempting the doomed REST request — consistent with the shim's existing
+  anti-silent-drop guard. An unreachable/malformed spec degrades to
+  "proceed" rather than blocking every synthesized tool on a flaky probe.
+  `switchroom doctor` gains a matching contract probe: fail rows when a
+  synthesized tool's route is missing, and a row comparing the live
+  engine's declared version against the pin.

--- a/changelog.d/pin-the-hindsight-shim-s-rest-route-contract-to.feat.md
+++ b/changelog.d/pin-the-hindsight-shim-s-rest-route-contract-to.feat.md
@@ -10,4 +10,8 @@
   "proceed" rather than blocking every synthesized tool on a flaky probe.
   `switchroom doctor` gains a matching contract probe: fail rows when a
   synthesized tool's route is missing, and a row comparing the live
-  engine's declared version against the pin.
+  engine's declared version against the pin. Adversarial review: doctor now
+  emits a `warn` row (not silence) when the engine is reachable but
+  `/openapi.json` is not, and `ShimContractPin` gained a short negative/
+  positive cache TTL so a permanently-missing (or later-restored) route no
+  longer re-pays the fetch timeout on every synthesized call forever.

--- a/src/cli/doctor-hindsight-shim-contract.ts
+++ b/src/cli/doctor-hindsight-shim-contract.ts
@@ -1,0 +1,174 @@
+/**
+ * `switchroom doctor` section for the hindsight-mcp-shim's REST contract —
+ * design-v2.md §2.5's "engine version pin ... and a doctor contract probe",
+ * called out as "not built" ("a grep of the shipped shim finds no
+ * `/openapi.json` reference"). This file is that probe.
+ *
+ * Three things a healthy shim needs; here is doctor's existing coverage of
+ * each, and what this file adds:
+ *
+ *   1. **The 32 backend MCP tools resolve.** Already covered by
+ *      `classifyToolContract` (`doctor-memory.ts`), driven off a live
+ *      `tools/list` and wired into `doctor.ts` as the "hindsight contract:
+ *      <tool>" rows. NOT duplicated here.
+ *   2. **The five SHIM-SYNTHESIZED tools' REST routes are present.** These
+ *      tools (`deactivate_directive`, `reactivate_directive`,
+ *      `search_knowledge_pages`, `get_knowledge_page`, `get_knowledge_tree`)
+ *      are REST, not MCP — `tools/list` can never see one of their routes
+ *      move. This was the gap: nothing in doctor previously read
+ *      `/openapi.json`, so a route rename/removal underneath one of these
+ *      tools was invisible until an agent's live call failed.
+ *   3. **The live engine's declared version matches the pin.** Read from
+ *      `/openapi.json`'s `info.version` (design-v2.md §2.5, "E-01's
+ *      method") rather than `/version` (already `classifyHindsightVersionSkew`'s
+ *      job), so this row is grounded in the SAME document the route check
+ *      reads rather than a second probe that could disagree with the first.
+ *
+ * Classifiers are pure and take an already-fetched `OpenApiSpec`, so they are
+ * testable without a live server. The wrapper does the one fetch and is
+ * best-effort like every other live doctor probe in this file's siblings.
+ */
+import { compareApiVersion } from "../memory/hindsight-repair.js";
+import {
+  fetchHindsightOpenApi,
+  missingRoutesForTool,
+  SYNTHESIZED_ROUTE_TOOL_NAMES,
+  type OpenApiSpec,
+} from "../memory/hindsight-shim-contract.js";
+import { HINDSIGHT_MIN_API_VERSION } from "../memory/hindsight-tools.js";
+import type { CheckResult } from "./doctor-memory.js";
+
+/** Shared name prefix for every row this file produces. */
+export const SHIM_CONTRACT_CHECK_PREFIX = "hindsight shim contract";
+
+/**
+ * Pure: classify one synthesized tool's route presence in an already-fetched
+ * spec. `null` means every route the tool depends on is present — the
+ * caller omits the row rather than emitting a per-tool `ok`, matching
+ * `classifyToolContract`'s "only report drift" idiom.
+ */
+export function classifySynthesizedToolRoute(
+  spec: OpenApiSpec,
+  toolName: string,
+): CheckResult | null {
+  const missing = missingRoutesForTool(spec, toolName);
+  if (missing.length === 0) return null;
+  const routeList = missing
+    .map((r) => `${r.method.toUpperCase()} ${r.path}`)
+    .join(", ");
+  return {
+    name: `${SHIM_CONTRACT_CHECK_PREFIX}: ${toolName}`,
+    status: "fail",
+    detail:
+      `the live engine's /openapi.json no longer declares [${routeList}] — ` +
+      `the REST route(s) '${toolName}' is synthesized over. Every call to ` +
+      `this tool will now be loud-rejected by the shim's contract preflight ` +
+      `(ShimContractPin.preflight in hindsight-mcp-shim.ts) rather than ` +
+      `silently returning nothing, but the tool is effectively dead until ` +
+      `this is fixed.`,
+    fix:
+      "If the engine renamed/moved the route, update SYNTHESIZED_TOOL_ROUTES " +
+      "(src/memory/hindsight-shim-contract.ts) and the corresponding " +
+      "DirectiveAdmin/KnowledgeAdmin call to match. If the engine now " +
+      "registers this capability as a real MCP tool, retire the synthesis " +
+      "instead — see the retirement seam in withSynthesizedTools " +
+      "(src/cli/hindsight-mcp-shim.ts).",
+  };
+}
+
+/**
+ * Pure: classify the live engine's declared version (`/openapi.json`'s
+ * `info.version`) against the floor the shim's route contract is pinned to.
+ * Shape mirrors `classifyHindsightVersionSkew` (older/equal/newer →
+ * fail/ok/warn) but is a DELIBERATELY SEPARATE row, scoped to the same
+ * document the route rows above read — see this file's header for why
+ * `/openapi.json`, not `/version`, is the source here.
+ */
+export function classifyShimContractVersion(spec: OpenApiSpec): CheckResult {
+  const name = `${SHIM_CONTRACT_CHECK_PREFIX}: version`;
+  const live = spec.info?.version;
+  if (typeof live !== "string" || live.length === 0) {
+    return {
+      name,
+      status: "warn",
+      detail:
+        "/openapi.json has no info.version — cannot confirm the shim's " +
+        "REST route contract is pinned to a known engine version.",
+    };
+  }
+  const cmp = compareApiVersion(live, HINDSIGHT_MIN_API_VERSION);
+  if (cmp === 0) {
+    return {
+      name,
+      status: "ok",
+      detail: `/openapi.json info.version ${live} matches the pinned ${HINDSIGHT_MIN_API_VERSION}`,
+    };
+  }
+  if (cmp < 0) {
+    return {
+      name,
+      status: "fail",
+      detail:
+        `/openapi.json info.version ${live} is OLDER than the pinned ` +
+        `${HINDSIGHT_MIN_API_VERSION} — the REST route contract the five ` +
+        `synthesized tools depend on may not exist on this server.`,
+      fix:
+        "Same remediation as the `hindsight version` check: update the " +
+        "pinned image, or deliberately re-pin HINDSIGHT_MIN_API_VERSION to " +
+        "this older version.",
+    };
+  }
+  return {
+    name,
+    status: "warn",
+    detail:
+      `/openapi.json info.version ${live} is NEWER than the pinned ` +
+      `${HINDSIGHT_MIN_API_VERSION} — the engine may have grown a native ` +
+      `MCP tool that makes one of the five synthesized tools obsolete; ` +
+      `re-check the retirement seam (withSynthesizedTools, ` +
+      `hindsight-mcp-shim.ts).`,
+  };
+}
+
+/**
+ * Pure: assemble every row for an already-fetched spec — the version row,
+ * one row per synthesized tool with a route problem, and a single rollup
+ * `ok` row when every synthesized route is present (never one `ok` row per
+ * tool — same "report drift, not health" idiom as `classifyToolContract`).
+ */
+export function classifyHindsightShimContract(spec: OpenApiSpec): CheckResult[] {
+  const results: CheckResult[] = [classifyShimContractVersion(spec)];
+  const routeRows = SYNTHESIZED_ROUTE_TOOL_NAMES.map((tool) =>
+    classifySynthesizedToolRoute(spec, tool),
+  ).filter((r): r is CheckResult => r !== null);
+  if (routeRows.length === 0) {
+    results.push({
+      name: `${SHIM_CONTRACT_CHECK_PREFIX}: routes`,
+      status: "ok",
+      detail: `all ${SYNTHESIZED_ROUTE_TOOL_NAMES.length} synthesized tools' REST routes are present in /openapi.json`,
+    });
+  } else {
+    results.push(...routeRows);
+  }
+  return results;
+}
+
+/**
+ * Best-effort live wrapper: fetch `/openapi.json` and classify it.
+ *
+ * An unreachable/malformed spec produces NO rows at all — same idiom as
+ * `classifyHindsightVersionSkew`'s "live === null → return null" and
+ * `checkHindsightContainerHealth`'s "not a local container → return []":
+ * reachability itself is already `hindsight` TCP-reach / `hindsight /health`
+ * / `hindsight version`'s job in `doctor.ts`, and a second red row for the
+ * exact same outage would be noise, not signal.
+ */
+export async function runHindsightShimContractCheck(
+  mcpUrl: string,
+  opts: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<CheckResult[]> {
+  const origin = mcpUrl.replace(/\/mcp\/?$/, "").replace(/\/$/, "");
+  const spec = await fetchHindsightOpenApi(origin, opts);
+  if (!spec) return [];
+  return classifyHindsightShimContract(spec);
+}

--- a/src/cli/doctor-hindsight-shim-contract.ts
+++ b/src/cli/doctor-hindsight-shim-contract.ts
@@ -156,12 +156,21 @@ export function classifyHindsightShimContract(spec: OpenApiSpec): CheckResult[] 
 /**
  * Best-effort live wrapper: fetch `/openapi.json` and classify it.
  *
- * An unreachable/malformed spec produces NO rows at all — same idiom as
- * `classifyHindsightVersionSkew`'s "live === null → return null" and
- * `checkHindsightContainerHealth`'s "not a local container → return []":
- * reachability itself is already `hindsight` TCP-reach / `hindsight /health`
- * / `hindsight version`'s job in `doctor.ts`, and a second red row for the
- * exact same outage would be noise, not signal.
+ * `doctor.ts` only ever reaches this call AFTER its own TCP-reach + "speaking
+ * Hindsight MCP" probe has already passed (both early-return the whole
+ * `checkHindsight*` pass otherwise) — so by the time this function runs,
+ * total-outage reachability is a settled fact, not something this row needs
+ * to re-establish. That means a null spec here is NOT the same "second red
+ * row for the same outage" case `classifyHindsightVersionSkew`'s
+ * `live === null → return null` idiom exists to avoid: it can only mean the
+ * engine answered MCP but does not serve `/openapi.json` (docs disabled, a
+ * proxy stripping the route, a build with the OpenAPI route pulled) — which
+ * silently switches the route-drift guard AND `ShimContractPin.preflight`'s
+ * loud pre-flight off, with nothing else in doctor able to notice. Emitting
+ * `[]` here made that exact failure mode invisible: the anti-silent-drop
+ * guard would itself go dark, and the only symptom was the ABSENCE of an
+ * `ok` rollup row, which nobody scans for. Emit a `warn` row instead so the
+ * gap is a row to read, not a row to notice is missing.
  */
 export async function runHindsightShimContractCheck(
   mcpUrl: string,
@@ -169,6 +178,30 @@ export async function runHindsightShimContractCheck(
 ): Promise<CheckResult[]> {
   const origin = mcpUrl.replace(/\/mcp\/?$/, "").replace(/\/$/, "");
   const spec = await fetchHindsightOpenApi(origin, opts);
-  if (!spec) return [];
+  if (!spec) {
+    return [
+      {
+        name: `${SHIM_CONTRACT_CHECK_PREFIX}: routes`,
+        status: "warn",
+        detail:
+          `the engine is reachable but /openapi.json did not return a usable ` +
+          `spec — the shim contract guard is INACTIVE: neither this doctor ` +
+          `check nor ShimContractPin's loud call-time preflight (` +
+          `hindsight-mcp-shim.ts) can detect a route rename/removal under the ` +
+          `five synthesized tools (deactivate_directive, reactivate_directive, ` +
+          `search_knowledge_pages, get_knowledge_page, get_knowledge_tree) ` +
+          `right now. Calls degrade to "unknown, proceed" and a route drop ` +
+          `would surface as a bare failed REST call instead of a named refusal.`,
+        fix:
+          "Confirm /openapi.json is served at the engine's origin (FastAPI " +
+          "serves it by default; check for `docs_url`/`openapi_url` disabled " +
+          "in the engine's startup config, or a reverse proxy stripping the " +
+          "route). If OpenAPI docs are deliberately disabled in production, " +
+          "this warning is expected and the route contract is unverifiable " +
+          "by design — the REST layer's own error handling remains the " +
+          "backstop for the five synthesized tools.",
+      },
+    ];
+  }
   return classifyHindsightShimContract(spec);
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -55,6 +55,7 @@ import { findUnmanagedHindsightEnvKeys } from "../setup/hindsight-perf-defaults.
 import { findUnknownMemoryKeys, type MemoryTier } from "../config/memory-key-drift.js";
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
 import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, checkHindsightVersion, classifyConsolidationBacklog, classifyAsyncOpQueue, classifyDirectiveCount, classifyBankConfigReachability } from "./doctor-memory.js";
+import { runHindsightShimContractCheck } from "./doctor-hindsight-shim-contract.js";
 import { checkAgentRecallHealth } from "./doctor-recall-health.js";
 import { checkHnswPartialIndexes } from "./doctor-hnsw-index.js";
 import { checkObservationScopeSaturation } from "./doctor-observation-scopes.js";
@@ -1844,6 +1845,16 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   // and three whole MCP tools reachable by nobody. This is the other direction.
   const versionRow = await checkHindsightVersion(url);
   if (versionRow) results.push(versionRow);
+
+  // Shim contract probe (design-v2.md §2.5, "the pin is not built"): the
+  // two checks above cover the 32 backend MCP tools and the /version scalar.
+  // Neither can see the five shim-SYNTHESIZED tools' underlying REST routes
+  // (deactivate_directive, reactivate_directive, search_knowledge_pages,
+  // get_knowledge_page, get_knowledge_tree) — those are plain REST calls
+  // `tools/list` never touches. Read /openapi.json and diff it against the
+  // route contract those five tools depend on, so a renamed/removed route
+  // surfaces here instead of at an agent's next live call.
+  results.push(...(await runHindsightShimContractCheck(url)));
 
   // Consumer probe (#1245): broker-fed hindsight needs an
   // `auth.consumers[]` entry + a bound per-consumer socket. Replaces

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -93,6 +93,7 @@ import {
   type KnowledgeNode,
 } from "../memory/hindsight-knowledge-admin.js";
 import { redact } from "../secret-detect/redact.js";
+import { ShimContractPin } from "../memory/hindsight-shim-contract.js";
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 
 // ─── Protocol constants ───────────────────────────────────────────────────
@@ -1373,6 +1374,32 @@ export class HindsightShim {
   }
 
   /**
+   * Lazily built, per-instance memoized probe of the live engine's
+   * `/openapi.json` — the engine version pin design-v2.md §2.5 named as
+   * owed (see `../memory/hindsight-shim-contract.ts`'s module header for the
+   * full rationale). Built the same way as {@link directiveAdmin} /
+   * {@link knowledgeAdmin} — same `apiBaseUrl` derivation, same injected
+   * `fetchImpl` — so a test that stubs one stubs all three consistently.
+   *
+   * Never fetched from `initializeResult()` or any other startup path: the
+   * shim's foundational rule is that `initialize` always succeeds regardless
+   * of backend state, and this probe is best-effort exactly like
+   * `directiveAdmin`/`knowledgeAdmin` are — it only ever runs lazily, on the
+   * first synthesized call.
+   */
+  private contractPinCache: ShimContractPin | null = null;
+
+  private get contractPin(): ShimContractPin {
+    if (!this.contractPinCache) {
+      this.contractPinCache = new ShimContractPin(
+        this.opts.apiBaseUrl ?? this.opts.url.replace(/\/mcp\/?$/, ""),
+        this.opts.fetchImpl ? { fetchImpl: this.opts.fetchImpl } : {},
+      );
+    }
+    return this.contractPinCache;
+  }
+
+  /**
    * Answer a shim-synthesized tool locally. Never touches the upstream MCP
    * session.
    *
@@ -1424,6 +1451,13 @@ export class HindsightShim {
           "there is no bank to pin it to.",
       );
     }
+    // Route-contract preflight (engine version pin, design-v2.md §2.5): a
+    // CONFIRMED-missing route fails loudly here, before the doomed REST call
+    // is even attempted. An unreachable/malformed /openapi.json is treated
+    // as "unknown" and falls through unchanged — see ShimContractPin's
+    // header for why that direction is the safe one.
+    const preflight = await this.contractPin.preflight(name);
+    if (!preflight.ok) return fail(preflight.text);
     try {
       const text = await this.runSynthesized(name, clean);
       return { content: [{ type: "text", text }], isError: false };

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -1386,6 +1386,18 @@ export class HindsightShim {
    * of backend state, and this probe is best-effort exactly like
    * `directiveAdmin`/`knowledgeAdmin` are — it only ever runs lazily, on the
    * first synthesized call.
+   *
+   * `negativeCacheMs`/`positiveCacheMs` (adversarial review on #4739):
+   * without a negative TTL, an engine with no `/openapi.json` made EVERY
+   * synthesized call re-pay up to `OPENAPI_FETCH_TIMEOUT_MS` (3s) on the
+   * tool-call latency path, forever. 30s bounds that tax to at most one
+   * timeout per 30s of wall-clock regardless of call volume, while still
+   * clearing within a session once the engine comes back — no restart
+   * needed. 5 minutes on the positive side means a route restored by a
+   * mid-session engine upgrade (rare, but the alternative is a stuck
+   * rejection lying about "the shim confirmed the route is gone" until the
+   * shim restarts) is re-checked well inside a typical session rather than
+   * requiring one.
    */
   private contractPinCache: ShimContractPin | null = null;
 
@@ -1393,7 +1405,11 @@ export class HindsightShim {
     if (!this.contractPinCache) {
       this.contractPinCache = new ShimContractPin(
         this.opts.apiBaseUrl ?? this.opts.url.replace(/\/mcp\/?$/, ""),
-        this.opts.fetchImpl ? { fetchImpl: this.opts.fetchImpl } : {},
+        {
+          ...(this.opts.fetchImpl ? { fetchImpl: this.opts.fetchImpl } : {}),
+          negativeCacheMs: 30_000,
+          positiveCacheMs: 5 * 60_000,
+        },
       );
     }
     return this.contractPinCache;

--- a/src/memory/hindsight-shim-contract.ts
+++ b/src/memory/hindsight-shim-contract.ts
@@ -167,25 +167,95 @@ export async function fetchHindsightOpenApi(
  * Loud pre-flight for one synthesized tool call, lazily fetching and
  * memoizing `/openapi.json` for the process lifetime of one shim instance.
  *
- * A FAILED fetch is deliberately NOT cached as failure: the next
- * synthesized call retries, so a backend that was briefly unreachable at
- * the first call does not wedge every later call into permanent "unknown"
- * for the rest of the session — the same per-call-retry philosophy
- * `UpstreamClient` applies to the upstream MCP session.
+ * A FAILED fetch is deliberately NOT cached as PERMANENT failure: a backend
+ * that was briefly unreachable at the first call must not wedge every later
+ * call into permanent "unknown" for the rest of the session — the same
+ * per-call-retry philosophy `UpstreamClient` applies to the upstream MCP
+ * session. But "not permanent" does not mean "never cached" either: against
+ * an engine that genuinely has no `/openapi.json` (docs disabled, an old
+ * build), every synthesized call was re-paying up to `OPENAPI_FETCH_TIMEOUT_MS`
+ * on the tool-call latency path, forever, with no way for the outage to ever
+ * resolve. `negativeCacheMs` (opt-in — `0`/unset preserves the original
+ * always-retry behaviour exactly, which is what the tests below pin) bounds
+ * that tax with a SHORT TTL: long enough to skip the immediate next few
+ * calls' timeout, short enough that a transient outage still clears within
+ * one session rather than needing a shim restart. See `hindsight-mcp-shim.ts`
+ * for the production TTL and the reasoning behind that specific number.
+ *
+ * The same age-check mechanism also plugs the mirror-image staleness case: a
+ * SUCCESSFUL fetch was previously memoized for the whole process lifetime,
+ * so a route missing at the first call but restored by a mid-session engine
+ * upgrade stayed rejected — with `preflight`'s own error text claiming "the
+ * shim confirmed the route is gone", which by then was false — until the
+ * shim was restarted. `positiveCacheMs` (opt-in, same `0`/unset-disables
+ * default) ages the successful cache out too, so a later call re-fetches and
+ * can recover without a restart.
  */
 export class ShimContractPin {
   private cached: OpenApiSpec | null = null;
+  private cachedAt: number | null = null;
+  private failedAt: number | null = null;
 
   constructor(
     private readonly apiBaseUrl: string,
-    private readonly opts: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+    private readonly opts: {
+      fetchImpl?: typeof fetch;
+      timeoutMs?: number;
+      /**
+       * How long a FAILED `/openapi.json` fetch is negative-cached before the
+       * next call retries. `0` or unset (the default) disables negative
+       * caching entirely — every call retries immediately, matching this
+       * module's original behaviour byte-for-byte.
+       */
+      negativeCacheMs?: number;
+      /**
+       * How long a SUCCESSFUL `/openapi.json` fetch is cached before the next
+       * call re-fetches. `0` or unset (the default) memoizes for the process
+       * lifetime — this module's original behaviour byte-for-byte.
+       */
+      positiveCacheMs?: number;
+      /** Injectable clock for tests. Defaults to `Date.now`. */
+      now?: () => number;
+    } = {},
   ) {}
 
-  /** The cached/fetched spec, or null if `/openapi.json` has never been reachable. */
+  private now(): number {
+    return this.opts.now ? this.opts.now() : Date.now();
+  }
+
+  /**
+   * The cached/fetched spec, or null when `/openapi.json` is not currently
+   * known-reachable (never fetched successfully, or the last attempt failed
+   * and — with `negativeCacheMs` set — is still within its negative-cache
+   * window).
+   */
   async spec(): Promise<OpenApiSpec | null> {
-    if (this.cached) return this.cached;
+    const positiveCacheMs = this.opts.positiveCacheMs ?? 0;
+    if (this.cached) {
+      const stale =
+        positiveCacheMs > 0 &&
+        this.cachedAt !== null &&
+        this.now() - this.cachedAt >= positiveCacheMs;
+      if (!stale) return this.cached;
+      this.cached = null;
+      this.cachedAt = null;
+    }
+    const negativeCacheMs = this.opts.negativeCacheMs ?? 0;
+    if (
+      negativeCacheMs > 0 &&
+      this.failedAt !== null &&
+      this.now() - this.failedAt < negativeCacheMs
+    ) {
+      return null;
+    }
     const fetched = await fetchHindsightOpenApi(this.apiBaseUrl, this.opts);
-    if (fetched) this.cached = fetched;
+    if (fetched) {
+      this.cached = fetched;
+      this.cachedAt = this.now();
+      this.failedAt = null;
+    } else if (negativeCacheMs > 0) {
+      this.failedAt = this.now();
+    }
     return fetched;
   }
 

--- a/src/memory/hindsight-shim-contract.ts
+++ b/src/memory/hindsight-shim-contract.ts
@@ -1,0 +1,228 @@
+/**
+ * Engine version pin + REST route contract for the hindsight-mcp-shim's
+ * SYNTHESIZED tools (`deactivate_directive`, `reactivate_directive`,
+ * `search_knowledge_pages`, `get_knowledge_page`, `get_knowledge_tree`) —
+ * the piece design-v2.md §2.5 named as owed and never built ("a grep of the
+ * shipped shim finds no `/openapi.json` reference, so the pin is not built").
+ *
+ * ## Why `/openapi.json` and not `/version`
+ *
+ * `/version` (already consumed by `doctor-memory.ts`'s
+ * `classifyHindsightVersionSkew`) returns a single `api_version` scalar and
+ * nothing about which REST routes exist. That check protects the MCP
+ * `tools/list` contract (`classifyToolContract` / `EXPECTED_HINDSIGHT_TOOLS`)
+ * — but the five tools this module cares about are NOT MCP tools at all.
+ * They are hand-rolled REST calls (`DirectiveAdmin` PATCHing
+ * `/directives/{id}`, `KnowledgeAdmin` GETing the `/knowledge-base/*`
+ * surface) that exist only because the pinned image's MCP surface has no
+ * directive-update or knowledge tool (see the header comments of
+ * `hindsight-directive-admin.ts` / `hindsight-knowledge-admin.ts`). A
+ * `tools/list` diff can never notice one of those REST routes moving,
+ * because it never looks at REST at all. `/openapi.json` is the one live
+ * document that actually enumerates REST paths + methods, so it is the only
+ * honest ground truth for this contract (design-v2.md §2.5, "E-01's
+ * method").
+ *
+ * ## Fail-loud, not fail-hard
+ *
+ * The shim's own rule (`hindsight-mcp-shim.ts`'s module header,
+ * `synthesizedCall`) is that a synthesized tool must fail LOUDLY at call
+ * time, never degrade quietly. `ShimContractPin.preflight` extends that rule
+ * to route drift: when `/openapi.json` PROVES a synthesized tool's
+ * underlying route is gone, the call is rejected before it ever reaches the
+ * REST layer, naming the missing route(s) — instead of a bare 404 the model
+ * has to interpret unaided.
+ *
+ * It deliberately does NOT crash the shim at startup, and does NOT block a
+ * call just because the probe itself failed: `initialize` must always
+ * succeed with the backend down or old — that is the entire reason the shim
+ * exists (see `hindsight-mcp-shim.ts`'s header) — and an unreachable or
+ * malformed `/openapi.json` degrades to "unknown, proceed" so the REST layer
+ * remains the backstop (it already answers its own honest `isError` on a
+ * down/wrong backend). Only a CONFIRMED-missing route is rejected pre-flight;
+ * everything else is unchanged behaviour.
+ */
+
+/** The subset of an OpenAPI 3 document this module reads. */
+export interface OpenApiSpec {
+  info?: { version?: string };
+  paths?: Record<string, Record<string, unknown> | undefined>;
+}
+
+/** Timeout for the `/openapi.json` fetch. Short: never worth blocking a call on. */
+export const OPENAPI_FETCH_TIMEOUT_MS = 3_000;
+
+/** One REST route + method a synthesized tool's implementation depends on. */
+export interface RouteRequirement {
+  /** Path exactly as `/openapi.json` spells it (e.g. `{bank_id}` placeholders). */
+  path: string;
+  method: string;
+}
+
+/**
+ * The REST route(s) each synthesized tool's implementation actually calls.
+ * MUST mirror `DirectiveAdmin`'s and `KnowledgeAdmin`'s real request paths —
+ * kept here, not derived from those classes, so drift between "what the code
+ * calls" and "what this module checks" is a reviewable diff. The same
+ * discipline `FALLBACK_TOOL_TABLE` documents for the MCP surface
+ * (`hindsight-mcp-shim.ts`).
+ *
+ * `deactivate_directive`/`reactivate_directive` both need the LIST route too
+ * (`DirectiveAdmin.list()`/`.resolve()` — every deactivate/reactivate reads
+ * the full directive list first to resolve a name to an id) as well as the
+ * PATCH route that actually flips `is_active`.
+ */
+export const SYNTHESIZED_TOOL_ROUTES: Record<string, RouteRequirement[]> = {
+  deactivate_directive: [
+    { path: "/v1/default/banks/{bank_id}/directives", method: "get" },
+    {
+      path: "/v1/default/banks/{bank_id}/directives/{directive_id}",
+      method: "patch",
+    },
+  ],
+  reactivate_directive: [
+    { path: "/v1/default/banks/{bank_id}/directives", method: "get" },
+    {
+      path: "/v1/default/banks/{bank_id}/directives/{directive_id}",
+      method: "patch",
+    },
+  ],
+  search_knowledge_pages: [
+    {
+      path: "/v1/default/banks/{bank_id}/knowledge-base/search",
+      method: "get",
+    },
+  ],
+  get_knowledge_page: [
+    {
+      path: "/v1/default/banks/{bank_id}/knowledge-base/pages/{page_id}",
+      method: "get",
+    },
+  ],
+  get_knowledge_tree: [
+    {
+      path: "/v1/default/banks/{bank_id}/knowledge-base/tree",
+      method: "get",
+    },
+  ],
+};
+
+/** Names of every synthesized tool with a pinned route requirement. */
+export const SYNTHESIZED_ROUTE_TOOL_NAMES = Object.keys(SYNTHESIZED_TOOL_ROUTES);
+
+/** Pure, no network: true when `spec` declares `route.method` on `route.path`. */
+export function openApiHasRoute(spec: OpenApiSpec, route: RouteRequirement): boolean {
+  const methods = spec.paths?.[route.path];
+  if (!methods || typeof methods !== "object") return false;
+  return Object.prototype.hasOwnProperty.call(methods, route.method.toLowerCase());
+}
+
+/**
+ * Pure: which of `toolName`'s required routes are missing from `spec`.
+ * Empty array = every route present (or `toolName` has no pinned
+ * requirement at all, e.g. it isn't a synthesized tool).
+ */
+export function missingRoutesForTool(
+  spec: OpenApiSpec,
+  toolName: string,
+): RouteRequirement[] {
+  const required = SYNTHESIZED_TOOL_ROUTES[toolName];
+  if (!required) return [];
+  return required.filter((r) => !openApiHasRoute(spec, r));
+}
+
+/**
+ * Best-effort: GET `<apiBaseUrl>/openapi.json`. Returns null on any failure
+ * — unreachable, non-200, unparseable JSON, or a body with no `paths`
+ * object. Callers decide what "unknown" means; every current caller
+ * degrades rather than blocking (see the module header).
+ */
+export async function fetchHindsightOpenApi(
+  apiBaseUrl: string,
+  opts: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<OpenApiSpec | null> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const base = apiBaseUrl.replace(/\/+$/, "");
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    opts.timeoutMs ?? OPENAPI_FETCH_TIMEOUT_MS,
+  );
+  try {
+    const res = await doFetch(`${base}/openapi.json`, { signal: controller.signal });
+    if (!res.ok) return null;
+    const body = (await res.json()) as OpenApiSpec | null;
+    if (!body || typeof body !== "object" || typeof body.paths !== "object") {
+      return null;
+    }
+    return body;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Loud pre-flight for one synthesized tool call, lazily fetching and
+ * memoizing `/openapi.json` for the process lifetime of one shim instance.
+ *
+ * A FAILED fetch is deliberately NOT cached as failure: the next
+ * synthesized call retries, so a backend that was briefly unreachable at
+ * the first call does not wedge every later call into permanent "unknown"
+ * for the rest of the session — the same per-call-retry philosophy
+ * `UpstreamClient` applies to the upstream MCP session.
+ */
+export class ShimContractPin {
+  private cached: OpenApiSpec | null = null;
+
+  constructor(
+    private readonly apiBaseUrl: string,
+    private readonly opts: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+  ) {}
+
+  /** The cached/fetched spec, or null if `/openapi.json` has never been reachable. */
+  async spec(): Promise<OpenApiSpec | null> {
+    if (this.cached) return this.cached;
+    const fetched = await fetchHindsightOpenApi(this.apiBaseUrl, this.opts);
+    if (fetched) this.cached = fetched;
+    return fetched;
+  }
+
+  /**
+   * `ok: true` — the call may proceed — when the route is confirmed
+   * present, OR when the contract could not be checked at all (spec
+   * unreachable/malformed: the REST layer is still the backstop and answers
+   * its own honest error, exactly as it did before this module existed).
+   *
+   * `ok: false`, with the missing routes named, ONLY when `/openapi.json`
+   * was successfully read and PROVES the route is gone — the one case a bare
+   * REST call cannot distinguish from a transient 404.
+   */
+  async preflight(
+    toolName: string,
+  ): Promise<{ ok: true } | { ok: false; text: string }> {
+    const spec = await this.spec();
+    if (!spec) return { ok: true };
+    const missing = missingRoutesForTool(spec, toolName);
+    if (missing.length === 0) return { ok: true };
+    const engineVersion = spec.info?.version ?? "unknown";
+    const routeList = missing
+      .map((r) => `${r.method.toUpperCase()} ${r.path}`)
+      .join(", ");
+    return {
+      ok: false,
+      text:
+        `${toolName} is unavailable: the live Hindsight engine (api_version ` +
+        `${engineVersion}) no longer exposes the REST route(s) this tool is ` +
+        `synthesized over: ${routeList}. This is not a silent empty result — ` +
+        `the shim confirmed the route is gone and is refusing the call rather ` +
+        `than guessing. If the engine renamed/moved the route, this tool's ` +
+        `implementation needs updating; if the engine now ships this ` +
+        `capability as a real MCP tool, the synthesis should be retired (see ` +
+        `the retirement seam in withSynthesizedTools, hindsight-mcp-shim.ts). ` +
+        `\`switchroom doctor\`'s hindsight shim contract rows carry the same ` +
+        `finding fleet-wide.`,
+    };
+  }
+}

--- a/tests/doctor-hindsight-shim-contract.test.ts
+++ b/tests/doctor-hindsight-shim-contract.test.ts
@@ -10,8 +10,14 @@
  *                       rollup `ok` row, not five
  *   • version skew   — older/equal/newer against the pin must classify as
  *                       fail/ok/warn respectively
- *   • quiet on outage — an unreachable /openapi.json must produce NO rows
- *                       (reachability is another check's job), not a fail
+ *   • guard-inactive is loud — by the point `doctor.ts` calls this check,
+ *                       reachability (TCP + speaking MCP) is already an
+ *                       established fact, so a null spec here can only mean
+ *                       the route-drift guard itself is unable to run; that
+ *                       must be a `warn` row an operator can read, never `[]`
+ *                       (adversarial review on #4739 — the prior `[]` made
+ *                       the guard's own failure indistinguishable from a
+ *                       healthy fleet)
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { createServer, type Server } from "node:http";
@@ -152,7 +158,14 @@ describe("runHindsightShimContractCheck", () => {
     expect(rows.every((r) => r.status === "ok")).toBe(true);
   });
 
-  it("returns NO rows when /openapi.json is unreachable — reachability is a different check's job", async () => {
+  it("THE GUARD, FINDING 1: a warn row — not silence — when /openapi.json is unreachable", async () => {
+    // Regression guard for the adversarial-review finding on #4739: doctor
+    // only reaches this check after its own TCP-reach + "speaking MCP" probe
+    // already passed, so a null spec here means the route-drift guard AND
+    // ShimContractPin's call-time preflight are both now unable to detect
+    // drift — an anti-silent-drop guard failing silently. `[]` made that
+    // invisible (only the ABSENCE of an ok row hinted at it); this must
+    // instead be a `warn` row naming the actual consequence.
     const dead = createServer();
     await new Promise<void>((r) => dead.listen(0, "127.0.0.1", r));
     const port = (dead.address() as { port: number }).port;
@@ -161,6 +174,13 @@ describe("runHindsightShimContractCheck", () => {
       `http://127.0.0.1:${port}/mcp/`,
       { timeoutMs: 300 },
     );
-    expect(rows).toEqual([]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("warn");
+    expect(rows[0].name).toBe(`${SHIM_CONTRACT_CHECK_PREFIX}: routes`);
+    // Must name the actual consequence (guard inactive), not just "fetch
+    // failed" — an operator scanning doctor output needs to know WHAT is
+    // silently unprotected, not just that one probe didn't come back.
+    expect(rows[0].detail).toContain("INACTIVE");
+    expect(rows[0].detail.toLowerCase()).toContain("preflight");
   });
 });

--- a/tests/doctor-hindsight-shim-contract.test.ts
+++ b/tests/doctor-hindsight-shim-contract.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Outcome tests for the `switchroom doctor` hindsight-shim contract probe
+ * (src/cli/doctor-hindsight-shim-contract.ts) — design-v2.md §2.5's "a
+ * doctor contract probe ... not built", now built.
+ *
+ * Each guard fails on the specific defect it exists for:
+ *   • route drift    — a synthesized tool's route missing from /openapi.json
+ *                       must produce a `fail` row naming the tool AND route
+ *   • no false alarm — a fully-present contract must produce exactly one
+ *                       rollup `ok` row, not five
+ *   • version skew   — older/equal/newer against the pin must classify as
+ *                       fail/ok/warn respectively
+ *   • quiet on outage — an unreachable /openapi.json must produce NO rows
+ *                       (reachability is another check's job), not a fail
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+
+import {
+  classifyHindsightShimContract,
+  classifyShimContractVersion,
+  classifySynthesizedToolRoute,
+  runHindsightShimContractCheck,
+  SHIM_CONTRACT_CHECK_PREFIX,
+} from "../src/cli/doctor-hindsight-shim-contract.js";
+import type { OpenApiSpec } from "../src/memory/hindsight-shim-contract.js";
+import { HINDSIGHT_MIN_API_VERSION } from "../src/memory/hindsight-tools.js";
+
+function fullSpec(version = HINDSIGHT_MIN_API_VERSION): OpenApiSpec {
+  return {
+    info: { version },
+    paths: {
+      "/v1/default/banks/{bank_id}/directives": { get: {}, post: {} },
+      "/v1/default/banks/{bank_id}/directives/{directive_id}": {
+        get: {},
+        patch: {},
+        delete: {},
+      },
+      "/v1/default/banks/{bank_id}/knowledge-base/search": { get: {} },
+      "/v1/default/banks/{bank_id}/knowledge-base/pages/{page_id}": { get: {} },
+      "/v1/default/banks/{bank_id}/knowledge-base/tree": { get: {} },
+    },
+  };
+}
+
+describe("classifySynthesizedToolRoute", () => {
+  it("null (no row) when every route the tool needs is present", () => {
+    expect(classifySynthesizedToolRoute(fullSpec(), "get_knowledge_tree")).toBeNull();
+  });
+
+  it("fail row naming the tool and the exact missing route", () => {
+    const spec = fullSpec();
+    delete spec.paths!["/v1/default/banks/{bank_id}/knowledge-base/tree"];
+    const row = classifySynthesizedToolRoute(spec, "get_knowledge_tree");
+    expect(row?.status).toBe("fail");
+    expect(row?.name).toBe(`${SHIM_CONTRACT_CHECK_PREFIX}: get_knowledge_tree`);
+    expect(row?.detail).toContain(
+      "GET /v1/default/banks/{bank_id}/knowledge-base/tree",
+    );
+    expect(row?.fix).toBeTruthy();
+  });
+});
+
+describe("classifyShimContractVersion", () => {
+  it("ok when the live version matches the pin exactly", () => {
+    const row = classifyShimContractVersion(fullSpec(HINDSIGHT_MIN_API_VERSION));
+    expect(row.status).toBe("ok");
+  });
+
+  it("fail when the live version is OLDER than the pin", () => {
+    const row = classifyShimContractVersion(fullSpec("0.1.0"));
+    expect(row.status).toBe("fail");
+    expect(row.detail).toContain("OLDER");
+    expect(row.fix).toBeTruthy();
+  });
+
+  it("warn when the live version is NEWER than the pin", () => {
+    const row = classifyShimContractVersion(fullSpec("99.0.0"));
+    expect(row.status).toBe("warn");
+    expect(row.detail).toContain("NEWER");
+  });
+
+  it("warn when the spec has no info.version", () => {
+    const row = classifyShimContractVersion({ paths: {} });
+    expect(row.status).toBe("warn");
+  });
+});
+
+describe("classifyHindsightShimContract", () => {
+  it("a fully-present contract at the pinned version produces exactly one route rollup ok row plus one version ok row — never five", () => {
+    const rows = classifyHindsightShimContract(fullSpec());
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.status)).toEqual(["ok", "ok"]);
+    expect(rows.find((r) => r.name.endsWith(": routes"))).toBeTruthy();
+    expect(rows.find((r) => r.name.endsWith(": version"))).toBeTruthy();
+  });
+
+  it("THE GUARD: a dropped route surfaces as a fail row, not silence", () => {
+    const spec = fullSpec();
+    delete spec.paths!["/v1/default/banks/{bank_id}/knowledge-base/pages/{page_id}"];
+    const rows = classifyHindsightShimContract(spec);
+    const failRows = rows.filter((r) => r.status === "fail");
+    expect(failRows).toHaveLength(1);
+    expect(failRows[0].name).toBe(`${SHIM_CONTRACT_CHECK_PREFIX}: get_knowledge_page`);
+    // The clean rollup row must NOT appear once there is real drift.
+    expect(rows.find((r) => r.name.endsWith(": routes") && r.status === "ok")).toBeUndefined();
+  });
+
+  it("multiple dropped routes each get their own named row", () => {
+    const spec = fullSpec();
+    delete spec.paths!["/v1/default/banks/{bank_id}/knowledge-base/tree"];
+    delete spec.paths!["/v1/default/banks/{bank_id}/directives/{directive_id}"];
+    const rows = classifyHindsightShimContract(spec);
+    const names = rows.filter((r) => r.status === "fail").map((r) => r.name);
+    expect(names).toContain(`${SHIM_CONTRACT_CHECK_PREFIX}: get_knowledge_tree`);
+    expect(names).toContain(`${SHIM_CONTRACT_CHECK_PREFIX}: deactivate_directive`);
+    expect(names).toContain(`${SHIM_CONTRACT_CHECK_PREFIX}: reactivate_directive`);
+  });
+});
+
+// ─── live wrapper against a real HTTP server ───────────────────────────────
+
+async function startOpenApiServer(
+  respond: (res: import("node:http").ServerResponse) => void,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    if (req.url === "/openapi.json") return respond(res);
+    res.writeHead(404).end();
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  return {
+    url: `http://127.0.0.1:${port}/mcp/`,
+    close: () => new Promise((r) => server.close(() => r())),
+  };
+}
+
+describe("runHindsightShimContractCheck", () => {
+  let srv: { url: string; close: () => Promise<void> } | null = null;
+  afterEach(async () => {
+    await srv?.close();
+    srv = null;
+  });
+
+  it("returns the classified rows for a reachable spec", async () => {
+    srv = await startOpenApiServer((res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(fullSpec()));
+    });
+    const rows = await runHindsightShimContractCheck(srv.url);
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.status === "ok")).toBe(true);
+  });
+
+  it("returns NO rows when /openapi.json is unreachable — reachability is a different check's job", async () => {
+    const dead = createServer();
+    await new Promise<void>((r) => dead.listen(0, "127.0.0.1", r));
+    const port = (dead.address() as { port: number }).port;
+    await new Promise<void>((r) => dead.close(() => r()));
+    const rows = await runHindsightShimContractCheck(
+      `http://127.0.0.1:${port}/mcp/`,
+      { timeoutMs: 300 },
+    );
+    expect(rows).toEqual([]);
+  });
+});

--- a/tests/hindsight-mcp-shim-contract-preflight.test.ts
+++ b/tests/hindsight-mcp-shim-contract-preflight.test.ts
@@ -1,0 +1,208 @@
+/**
+ * End-to-end outcome test for the shim's route-contract preflight
+ * (design-v2.md §2.5's "engine version pin") wired into
+ * `HindsightShim.synthesizedCall` (src/cli/hindsight-mcp-shim.ts), driven
+ * through the real `tools/call` JSON-RPC path against a REST mock that
+ * serves BOTH `/openapi.json` and the knowledge-base endpoints.
+ *
+ * This is the guard the task called for explicitly: "one that fails if a
+ * synthesized tool's route vanishes and the shim stays quiet". Without the
+ * preflight wired in, `search_knowledge_pages` against a REST 404 answers
+ * `isError:true` too — but for the WRONG reason (a bare "HTTP 404"), and
+ * critically the request still reaches the server. This test asserts BOTH
+ * that the call fails loudly with the missing route named AND that the
+ * request never left the shim — proving the rejection happens at the
+ * contract layer, not as an incidental REST failure.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { HindsightShim } from "../src/cli/hindsight-mcp-shim.js";
+
+const BANK = "agent-own-bank";
+const KNOWLEDGE_SEARCH_PATH =
+  "/v1/default/banks/{bank_id}/knowledge-base/search";
+const KNOWLEDGE_TREE_PATH = "/v1/default/banks/{bank_id}/knowledge-base/tree";
+const DIRECTIVES_PATH = "/v1/default/banks/{bank_id}/directives";
+const DIRECTIVE_ITEM_PATH = "/v1/default/banks/{bank_id}/directives/{directive_id}";
+const KNOWLEDGE_PAGE_PATH =
+  "/v1/default/banks/{bank_id}/knowledge-base/pages/{page_id}";
+
+interface Mock {
+  baseUrl: string;
+  server: Server;
+  seen: { method: string; path: string }[];
+  /** Paths present in the /openapi.json this server answers. Mutate to drift the spec. */
+  presentPaths: Set<string>;
+  close: () => Promise<void>;
+}
+
+function fullOpenApiPaths(): Set<string> {
+  return new Set([
+    DIRECTIVES_PATH,
+    DIRECTIVE_ITEM_PATH,
+    KNOWLEDGE_SEARCH_PATH,
+    KNOWLEDGE_PAGE_PATH,
+    KNOWLEDGE_TREE_PATH,
+  ]);
+}
+
+async function startMock(): Promise<Mock> {
+  const state: Mock = {
+    baseUrl: "",
+    server: undefined as unknown as Server,
+    seen: [],
+    presentPaths: fullOpenApiPaths(),
+    close: async () => undefined,
+  };
+  const server = createServer((req, res) => {
+    req.on("data", () => undefined);
+    req.on("end", () => {
+      const path = req.url ?? "";
+      state.seen.push({ method: req.method ?? "", path });
+      const send = (status: number, payload: unknown) => {
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify(payload));
+      };
+
+      if (path === "/openapi.json") {
+        const paths: Record<string, Record<string, unknown>> = {};
+        const methodsFor = (p: string): Record<string, unknown> => {
+          if (p === DIRECTIVES_PATH) return { get: {}, post: {} };
+          if (p === DIRECTIVE_ITEM_PATH) return { get: {}, patch: {}, delete: {} };
+          return { get: {} };
+        };
+        for (const p of state.presentPaths) paths[p] = methodsFor(p);
+        return send(200, { info: { version: "0.9.0" }, paths });
+      }
+
+      const [rawPath, rawQuery] = path.split("?");
+      const query = new URLSearchParams(rawQuery ?? "");
+      const m =
+        /^\/v1\/default\/banks\/([^/]+)\/knowledge-base\/(tree|search)$/.exec(
+          rawPath,
+        );
+      if (m && decodeURIComponent(m[1]) === BANK) {
+        if (m[2] === "search") {
+          const q = query.get("q") ?? "";
+          if (q.length === 0) return send(422, { detail: "q too short" });
+          return send(200, {
+            results: [
+              {
+                id: "pg-1",
+                name: "A page",
+                snippet: "hit",
+                score: 0.9,
+              },
+            ],
+            total: 1,
+          });
+        }
+        return send(200, { roots: [] });
+      }
+      return send(404, { detail: "not found" });
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  state.baseUrl = `http://127.0.0.1:${port}`;
+  state.server = server;
+  state.close = () => new Promise((r) => server.close(() => r()));
+  return state;
+}
+
+async function withShim<T>(
+  mock: Mock,
+  fn: (shim: HindsightShim) => Promise<T>,
+): Promise<T> {
+  const cacheDir = mkdtempSync(join(tmpdir(), "shim-contract-preflight-"));
+  try {
+    return await fn(
+      new HindsightShim({
+        // /mcp/ on the mock 404s — the synthesized path never touches it.
+        url: `${mock.baseUrl}/mcp/`,
+        bankId: BANK,
+        cacheDir,
+        toolsListTimeoutMs: 500,
+        logger: () => undefined,
+      }),
+    );
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+}
+
+async function callTool(
+  shim: HindsightShim,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ isError: boolean; text: string }> {
+  const res = (await shim.handle({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name, arguments: args },
+  })) as { result: { isError: boolean; content: { text: string }[] } };
+  return { isError: res.result.isError, text: res.result.content[0].text };
+}
+
+let mock: Mock;
+beforeEach(async () => {
+  mock = await startMock();
+});
+afterEach(async () => {
+  await mock.close();
+});
+
+describe("route-contract preflight, end to end through tools/call", () => {
+  it("baseline: succeeds normally when the live spec has every route", async () => {
+    await withShim(mock, async (shim) => {
+      const result = await callTool(shim, "search_knowledge_pages", {
+        query: "hit",
+      });
+      expect(result.isError).toBe(false);
+      expect(
+        mock.seen.some(
+          (r) =>
+            r.method === "GET" &&
+            r.path.includes(`/knowledge-base/search`),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it(
+    "THE GUARD: when /openapi.json drops the search route, the call fails " +
+      "LOUDLY naming the missing route, and the REST search endpoint is " +
+      "NEVER hit — proving the shim did not just stay quiet",
+    async () => {
+      mock.presentPaths.delete(KNOWLEDGE_SEARCH_PATH);
+      await withShim(mock, async (shim) => {
+        const result = await callTool(shim, "search_knowledge_pages", {
+          query: "hit",
+        });
+        expect(result.isError).toBe(true);
+        expect(result.text).toContain("search_knowledge_pages");
+        expect(result.text).toContain("GET " + KNOWLEDGE_SEARCH_PATH);
+        // The whole point: this is a REFUSAL, not an attempted call that
+        // happened to fail. If the shim regressed to "try anyway", this
+        // request would show up in `seen` as a 422/200 against the mock.
+        expect(
+          mock.seen.some((r) => r.path.includes("/knowledge-base/search")),
+        ).toBe(false);
+      });
+    },
+  );
+
+  it("a route drop on ONE synthesized tool does not block a sibling tool", async () => {
+    mock.presentPaths.delete(KNOWLEDGE_SEARCH_PATH);
+    await withShim(mock, async (shim) => {
+      const tree = await callTool(shim, "get_knowledge_tree", {});
+      expect(tree.isError).toBe(false);
+    });
+  });
+
+});

--- a/tests/hindsight-shim-contract.test.ts
+++ b/tests/hindsight-shim-contract.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Outcome tests for the shim's engine-version pin + REST route contract
+ * (src/memory/hindsight-shim-contract.ts) — design-v2.md §2.5's "the pin is
+ * not built", now built.
+ *
+ * Each guard is written so it fails on the specific defect it exists for:
+ *   • route presence   — a route that IS in /openapi.json must never be
+ *                         reported missing (false alarm)
+ *   • route absence     — a route the live spec does NOT declare must be
+ *                         reported missing, by name, for the RIGHT tool
+ *   • degrade-not-block — an unreachable/malformed /openapi.json must let
+ *                         calls proceed (preflight ok:true), never freeze
+ *                         every synthesized tool on a flaky probe
+ *   • retry-after-fail  — a first FAILED fetch must not be cached as
+ *                         failure; the next call gets a fresh attempt
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+
+import {
+  fetchHindsightOpenApi,
+  missingRoutesForTool,
+  openApiHasRoute,
+  ShimContractPin,
+  SYNTHESIZED_ROUTE_TOOL_NAMES,
+  SYNTHESIZED_TOOL_ROUTES,
+  type OpenApiSpec,
+} from "../src/memory/hindsight-shim-contract.js";
+
+// ─── the live route set this whole module exists to protect ───────────────
+
+/** The exact shape confirmed live against a running hindsight 0.9.0. */
+function fullOpenApiSpec(): OpenApiSpec {
+  return {
+    info: { version: "0.9.0" },
+    paths: {
+      "/v1/default/banks/{bank_id}/directives": { get: {}, post: {} },
+      "/v1/default/banks/{bank_id}/directives/{directive_id}": {
+        get: {},
+        patch: {},
+        delete: {},
+      },
+      "/v1/default/banks/{bank_id}/knowledge-base/search": { get: {} },
+      "/v1/default/banks/{bank_id}/knowledge-base/pages/{page_id}": { get: {} },
+      "/v1/default/banks/{bank_id}/knowledge-base/tree": { get: {} },
+    },
+  };
+}
+
+describe("route table sanity", () => {
+  it("every synthesized tool with a call-path has a pinned route requirement", () => {
+    // Guards SYNTHESIZED_TOOL_ROUTES from silently losing a tool.
+    expect(SYNTHESIZED_ROUTE_TOOL_NAMES.sort()).toEqual(
+      [
+        "deactivate_directive",
+        "reactivate_directive",
+        "search_knowledge_pages",
+        "get_knowledge_page",
+        "get_knowledge_tree",
+      ].sort(),
+    );
+  });
+
+  it("every pinned route resolves against the live-confirmed full spec", () => {
+    const spec = fullOpenApiSpec();
+    for (const tool of SYNTHESIZED_ROUTE_TOOL_NAMES) {
+      expect(missingRoutesForTool(spec, tool), tool).toEqual([]);
+    }
+  });
+});
+
+describe("openApiHasRoute", () => {
+  it("true when the method is declared on the path", () => {
+    const spec = fullOpenApiSpec();
+    expect(
+      openApiHasRoute(spec, {
+        path: "/v1/default/banks/{bank_id}/knowledge-base/tree",
+        method: "get",
+      }),
+    ).toBe(true);
+  });
+
+  it("false when the path exists but the method does not", () => {
+    const spec: OpenApiSpec = {
+      paths: { "/v1/default/banks/{bank_id}/directives/{directive_id}": { get: {} } },
+    };
+    expect(
+      openApiHasRoute(spec, {
+        path: "/v1/default/banks/{bank_id}/directives/{directive_id}",
+        method: "patch",
+      }),
+    ).toBe(false);
+  });
+
+  it("false when the path is absent entirely", () => {
+    const spec: OpenApiSpec = { paths: {} };
+    expect(
+      openApiHasRoute(spec, {
+        path: "/v1/default/banks/{bank_id}/knowledge-base/tree",
+        method: "get",
+      }),
+    ).toBe(false);
+  });
+
+  it("method match is case-insensitive against the requirement table", () => {
+    const spec: OpenApiSpec = {
+      paths: { "/x": { GET: {} } as unknown as Record<string, unknown> },
+    };
+    // openapi.json always lowercases methods; this proves we don't silently
+    // false-negative if a future spec generator changes case.
+    expect(openApiHasRoute(spec, { path: "/x", method: "get" })).toBe(false);
+    const lower: OpenApiSpec = { paths: { "/x": { get: {} } } };
+    expect(openApiHasRoute(lower, { path: "/x", method: "get" })).toBe(true);
+  });
+});
+
+describe("missingRoutesForTool", () => {
+  it("reports the PATCH route missing when the directive PATCH route is dropped", () => {
+    const spec = fullOpenApiSpec();
+    delete spec.paths!["/v1/default/banks/{bank_id}/directives/{directive_id}"];
+    const missing = missingRoutesForTool(spec, "deactivate_directive");
+    expect(missing).toEqual(
+      SYNTHESIZED_TOOL_ROUTES.deactivate_directive.filter(
+        (r) => r.path === "/v1/default/banks/{bank_id}/directives/{directive_id}",
+      ),
+    );
+  });
+
+  it("reports the knowledge search route missing without touching unrelated tools", () => {
+    const spec = fullOpenApiSpec();
+    delete spec.paths!["/v1/default/banks/{bank_id}/knowledge-base/search"];
+    expect(missingRoutesForTool(spec, "search_knowledge_pages")).toHaveLength(1);
+    expect(missingRoutesForTool(spec, "get_knowledge_page")).toEqual([]);
+    expect(missingRoutesForTool(spec, "get_knowledge_tree")).toEqual([]);
+    expect(missingRoutesForTool(spec, "deactivate_directive")).toEqual([]);
+  });
+
+  it("a tool with no pinned requirement (e.g. a real backend tool name) is never 'missing'", () => {
+    expect(missingRoutesForTool(fullOpenApiSpec(), "recall")).toEqual([]);
+  });
+});
+
+// ─── fetchHindsightOpenApi against a real HTTP server ──────────────────────
+
+async function startOpenApiServer(
+  respond: (res: import("node:http").ServerResponse) => void,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    if (req.url === "/openapi.json") return respond(res);
+    res.writeHead(404).end();
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise((r) => server.close(() => r())),
+  };
+}
+
+describe("fetchHindsightOpenApi", () => {
+  it("returns the parsed spec on a 200 with a paths object", async () => {
+    const srv = await startOpenApiServer((res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(fullOpenApiSpec()));
+    });
+    try {
+      const spec = await fetchHindsightOpenApi(srv.url);
+      expect(spec?.info?.version).toBe("0.9.0");
+      expect(Object.keys(spec?.paths ?? {})).toHaveLength(5);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("returns null on a non-200", async () => {
+    const srv = await startOpenApiServer((res) => {
+      res.writeHead(500).end("boom");
+    });
+    try {
+      expect(await fetchHindsightOpenApi(srv.url)).toBeNull();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("returns null on a body with no paths object (malformed spec)", async () => {
+    const srv = await startOpenApiServer((res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ info: { version: "0.9.0" } }));
+    });
+    try {
+      expect(await fetchHindsightOpenApi(srv.url)).toBeNull();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("returns null when the server is unreachable", async () => {
+    const srv = createServer();
+    await new Promise<void>((r) => srv.listen(0, "127.0.0.1", r));
+    const port = (srv.address() as { port: number }).port;
+    await new Promise<void>((r) => srv.close(() => r()));
+    expect(
+      await fetchHindsightOpenApi(`http://127.0.0.1:${port}`, { timeoutMs: 300 }),
+    ).toBeNull();
+  });
+});
+
+// ─── ShimContractPin.preflight — the loud-vs-degrade decision itself ──────
+
+describe("ShimContractPin.preflight", () => {
+  let srv: { url: string; close: () => Promise<void> };
+  let spec: OpenApiSpec;
+
+  beforeEach(async () => {
+    spec = fullOpenApiSpec();
+    srv = await startOpenApiServer((res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(spec));
+    });
+  });
+  afterEach(async () => {
+    await srv.close();
+  });
+
+  it("ok:true when every route the tool needs is present", async () => {
+    const pin = new ShimContractPin(srv.url);
+    const result = await pin.preflight("get_knowledge_tree");
+    expect(result.ok).toBe(true);
+  });
+
+  it("THE CORE GUARD: ok:false, naming the exact missing route, once the live spec drops it", async () => {
+    delete spec.paths!["/v1/default/banks/{bank_id}/knowledge-base/tree"];
+    const pin = new ShimContractPin(srv.url);
+    const result = await pin.preflight("get_knowledge_tree");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.text).toContain("get_knowledge_tree");
+      expect(result.text).toContain(
+        "GET /v1/default/banks/{bank_id}/knowledge-base/tree",
+      );
+      // Must read as a deliberate refusal, not a silent/empty result — this is
+      // the exact anti-silent-drop wording the task requires.
+      expect(result.text.toLowerCase()).toContain("not");
+    }
+  });
+
+  it("does not cross-contaminate: dropping one tool's route leaves a sibling tool ok", async () => {
+    delete spec.paths!["/v1/default/banks/{bank_id}/knowledge-base/search"];
+    const pin = new ShimContractPin(srv.url);
+    expect((await pin.preflight("search_knowledge_pages")).ok).toBe(false);
+    expect((await pin.preflight("get_knowledge_tree")).ok).toBe(true);
+    expect((await pin.preflight("deactivate_directive")).ok).toBe(true);
+  });
+
+  it("degrades to ok:true (does not block) when /openapi.json is unreachable", async () => {
+    await srv.close();
+    const pin = new ShimContractPin(srv.url, { timeoutMs: 300 });
+    expect((await pin.preflight("get_knowledge_tree")).ok).toBe(true);
+  });
+
+  it("memoizes a SUCCESSFUL fetch — one request serves every subsequent preflight", async () => {
+    let hits = 0;
+    const counting = await startOpenApiServer((res) => {
+      hits += 1;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(fullOpenApiSpec()));
+    });
+    try {
+      const pin = new ShimContractPin(counting.url);
+      await pin.preflight("get_knowledge_tree");
+      await pin.preflight("search_knowledge_pages");
+      await pin.preflight("deactivate_directive");
+      expect(hits).toBe(1);
+    } finally {
+      await counting.close();
+    }
+  });
+
+  it("does NOT cache a FAILED fetch — a later call gets a fresh attempt", async () => {
+    let hits = 0;
+    let up = false;
+    const flaky = await startOpenApiServer((res) => {
+      hits += 1;
+      if (!up) {
+        res.writeHead(503).end();
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(fullOpenApiSpec()));
+    });
+    try {
+      const pin = new ShimContractPin(flaky.url, { timeoutMs: 500 });
+      expect((await pin.preflight("get_knowledge_tree")).ok).toBe(true); // degraded
+      expect(hits).toBe(1);
+      up = true;
+      await pin.preflight("get_knowledge_tree");
+      expect(hits).toBe(2); // retried, not stuck on the first failure forever
+    } finally {
+      await flaky.close();
+    }
+  });
+});

--- a/tests/hindsight-shim-contract.test.ts
+++ b/tests/hindsight-shim-contract.test.ts
@@ -300,4 +300,128 @@ describe("ShimContractPin.preflight", () => {
       await flaky.close();
     }
   });
+
+  // ── FINDING 2 (adversarial review, #4739): negativeCacheMs bounds the
+  //    re-fetch tax on a permanently-missing /openapi.json without
+  //    recreating the poisoned-cache problem the test above guards against.
+  describe("negativeCacheMs — bounds the re-fetch tax, still recovers", () => {
+    it("skips the network fetch entirely while within the negative-cache TTL", async () => {
+      let hits = 0;
+      let clock = 0;
+      const down = await startOpenApiServer((res) => {
+        hits += 1;
+        res.writeHead(503).end();
+      });
+      try {
+        const pin = new ShimContractPin(down.url, {
+          timeoutMs: 500,
+          negativeCacheMs: 10_000,
+          now: () => clock,
+        });
+        expect((await pin.preflight("get_knowledge_tree")).ok).toBe(true); // degraded
+        expect(hits).toBe(1); // paid the one real fetch
+
+        // Repeated calls well inside the TTL must NOT re-pay the fetch —
+        // this is the specific cost FINDING 2 exists to bound. Without the
+        // fix, each of these would independently re-pay up to
+        // OPENAPI_FETCH_TIMEOUT_MS on the tool-call latency path.
+        clock += 1_000;
+        await pin.preflight("get_knowledge_tree");
+        clock += 1_000;
+        await pin.preflight("search_knowledge_pages");
+        clock += 1_000;
+        await pin.preflight("deactivate_directive");
+        expect(hits).toBe(1); // still just the one fetch — this is the guard
+      } finally {
+        await down.close();
+      }
+    });
+
+    it("retries once the negative-cache TTL has expired — an outage still clears without a restart", async () => {
+      let hits = 0;
+      let up = false;
+      let clock = 0;
+      const flaky = await startOpenApiServer((res) => {
+        hits += 1;
+        if (!up) {
+          res.writeHead(503).end();
+          return;
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(fullOpenApiSpec()));
+      });
+      try {
+        const pin = new ShimContractPin(flaky.url, {
+          timeoutMs: 500,
+          negativeCacheMs: 10_000,
+          now: () => clock,
+        });
+        expect((await pin.preflight("get_knowledge_tree")).ok).toBe(true); // degraded
+        expect(hits).toBe(1);
+
+        // Still within the TTL: no re-fetch, even though the backend is
+        // actually back up by now — proves the cache is genuinely gating
+        // the call, not incidentally not firing.
+        up = true;
+        clock += 5_000;
+        await pin.preflight("get_knowledge_tree");
+        expect(hits).toBe(1);
+
+        // Past the TTL: the next call must retry and recover — this is the
+        // "not sticky forever" half of FINDING 2, same guarantee the
+        // no-negative-cache test above pins for the TTL-disabled default.
+        clock += 6_000; // total elapsed since the failure: 11s > 10s TTL
+        const recovered = await pin.preflight("get_knowledge_tree");
+        expect(hits).toBe(2);
+        expect(recovered.ok).toBe(true); // route present again — no longer degraded-unknown, genuinely confirmed
+      } finally {
+        await flaky.close();
+      }
+    });
+  });
+
+  // ── Third case folded in from the same TTL mechanism: a route restored by
+  //    a mid-session engine upgrade must not stay rejected until restart.
+  describe("positiveCacheMs — a successful spec ages out and can recover a restored route", () => {
+    it("re-fetches after the positive-cache TTL and un-rejects a route the engine restored", async () => {
+      let hits = 0;
+      let restored = false;
+      let clock = 0;
+      const upgrading = await startOpenApiServer((res) => {
+        hits += 1;
+        const spec = fullOpenApiSpec();
+        if (!restored) {
+          delete spec.paths!["/v1/default/banks/{bank_id}/knowledge-base/tree"];
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(spec));
+      });
+      try {
+        const pin = new ShimContractPin(upgrading.url, {
+          positiveCacheMs: 10_000,
+          now: () => clock,
+        });
+        const first = await pin.preflight("get_knowledge_tree");
+        expect(first.ok).toBe(false); // route genuinely missing
+        expect(hits).toBe(1);
+
+        // Within the TTL, the stale-missing spec stays memoized — no
+        // re-fetch yet, even though the engine has since restored the route.
+        restored = true;
+        clock += 5_000;
+        const stillCached = await pin.preflight("get_knowledge_tree");
+        expect(stillCached.ok).toBe(false);
+        expect(hits).toBe(1);
+
+        // Past the TTL, the cache ages out, the route is re-checked, and the
+        // call recovers WITHOUT a shim restart.
+        clock += 6_000; // total elapsed: 11s > 10s TTL
+        const recovered = await pin.preflight("get_knowledge_tree");
+        expect(recovered.ok).toBe(true);
+        expect(hits).toBe(2);
+      } finally {
+        await upgrading.close();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements the piece design-v2.md §2.5 named as owed and never built ("a
grep of the shipped shim finds no `/openapi.json` reference, so the pin is
not built"): the engine version pin plus doctor contract probe for the
hindsight-mcp-shim's five **synthesized** tools.

- `deactivate_directive`, `reactivate_directive`, `search_knowledge_pages`,
  `get_knowledge_page`, `get_knowledge_tree` are hand-rolled REST calls
  (`DirectiveAdmin` / `KnowledgeAdmin`), not MCP tools — the engine's own
  `/mcp` never registers them (32 backend tools, 0 knowledge tools). The
  existing `classifyToolContract` diff (`tools/list` vs
  `EXPECTED_HINDSIGHT_TOOLS`) can therefore never notice one of their REST
  routes moving or disappearing — it never looks at REST at all.
- `src/memory/hindsight-shim-contract.ts` is new: `SYNTHESIZED_TOOL_ROUTES`
  pins the exact `{path, method}` pairs each synthesized tool depends on
  (confirmed live against a running 0.9.0 engine's `/openapi.json`), and
  `ShimContractPin` fetches + memoizes the spec and answers a per-tool
  `preflight()`.
- Wired into `HindsightShim.synthesizedCall` (`src/cli/hindsight-mcp-shim.ts`):
  when `/openapi.json` PROVES a route is gone, the call is rejected loudly
  — naming the missing route — **before** the doomed REST call is even
  attempted. This extends the shim's existing anti-silent-drop guard
  (`synthesizedCall`'s unknown-arg rejection) to route drift.
- `src/cli/doctor-hindsight-shim-contract.ts` is new, wired into
  `switchroom doctor` right after the existing `hindsight contract` /
  `hindsight version` rows: a `fail` row per synthesized tool with a
  missing route, and a `hindsight shim contract: version` row comparing
  `/openapi.json`'s `info.version` against `HINDSIGHT_MIN_API_VERSION`.

### Behaviour on version/contract mismatch — explicit choice

**No hard startup crash.** The shim's foundational invariant is that
`initialize` always succeeds regardless of backend state — that is the
entire reason the shim exists (see its module header). This preflight
follows the same rule: it is lazily fetched on the first synthesized call,
never during `initialize()`, and an unreachable or malformed
`/openapi.json` degrades to "proceed" (the REST layer remains the
backstop, exactly as it already was) rather than blocking every
synthesized tool on a probe that might itself be flaky. Only a
**confirmed**-missing route — `/openapi.json` fetched successfully and the
route is provably absent — is rejected, and the rejection is scoped to
that one tool, not the whole shim. This is the "least surprising
behaviour" call the task asked me to make explicit where §2.5 was silent
on it.

A failed fetch is **not** cached as failure — the next synthesized call
retries, so a backend that was briefly unreachable doesn't wedge every
later call into permanent "unknown" for the session.

### What I could not implement as written from §2.5

§2.5 (and §5, migration step 2) describes "a doctor contract probe
**against a throwaway bank**". I implemented a static `/openapi.json`
schema-presence check instead — non-mutating, no bank created/exercised/
torn down. This matches the task's own literal wording for the doctor
requirement ("the 5 synthesized ones have their routes present") and
avoids `doctor` (documented elsewhere in this codebase as a read-only
diagnostic — see `hindsight-repair.ts`'s header: "`doctor` is a read-only
diagnostic and must stay that way") acquiring a live-bank side effect. I
could not find an elaboration of "throwaway bank" beyond that one phrase —
the design doc cites "E-01's method" but E-01 itself lives in a separate
evidence-ledger file this repo does not contain. Flagging this rather than
guessing at what a throwaway-bank exercise should create/assert/clean up.

## Test plan

- [x] `vitest run tests/hindsight-shim-contract.test.ts
  tests/hindsight-mcp-shim-contract-preflight.test.ts
  tests/doctor-hindsight-shim-contract.test.ts tests/hindsight-mcp-shim.test.ts
  tests/hindsight-directive-admin.test.ts tests/hindsight-knowledge-admin.test.ts
  tests/memory.hindsight-contract.fixture.test.ts
  tests/memory.hindsight-iserror-guard.test.ts` — 190 passed
- [x] `vitest run tests/doctor.test.ts tests/cli.doctor.hindsight-consumer.test.ts
  tests/cli.doctor.memory-health.test.ts tests/cli.doctor.memory.test.ts` —
  146 passed, 2 skipped (no regression)
- [x] `tsc --noEmit` clean
- [x] `npm run lint` — full lint suite clean, including
  `check-changelog-entry` (fragment staged) and `check-mutation-coverage`
- [x] The load-bearing guard test
  (`hindsight-mcp-shim-contract-preflight.test.ts`, "THE GUARD") drives a
  real `tools/call` for `search_knowledge_pages` against a mock REST server
  whose `/openapi.json` has the search route removed, and asserts BOTH
  `isError:true` naming the missing route AND that the REST search endpoint
  was **never hit** — proving this is a refusal at the contract layer, not
  an incidental REST failure the shim happened to also report

🤖 Generated with [Claude Code](https://claude.com/claude-code)