### PR TITLE
feat(hindsight): periodic VACUUM + measured conditional REINDEX in maintenance

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -107,6 +107,13 @@ jobs:
               - 'docker/Dockerfile.auth-broker'
               - 'src/auth/broker/**'
               - 'tests/docker/**'
+              # tests/docker/hindsight-maintenance.test.ts reads this script
+              # with readFileSync and spawns it — neither is an import, so
+              # vitest's module-graph tracing (`--changed` in ci-tests-core)
+              # cannot reach the suite from a script-only edit. Listed here so
+              # the vacuum/reindex/alarm guards actually run for exactly the
+              # change they exist to police.
+              - 'docker/hindsight-maintenance.sh'
               - '.github/workflows/docker-e2e.yml'
             # The hindsight image is NOT built by build-images.sh — it is the
             # pinned upstream image plus baked patches. It gets its own job

--- a/changelog.d/4742-hindsight-vacuum-conditional-reindex.feat.md
+++ b/changelog.d/4742-hindsight-vacuum-conditional-reindex.feat.md
@@ -1,0 +1,20 @@
+- **hindsight: periodic `VACUUM (ANALYZE)` and measured conditional `REINDEX` (#4742)**
+
+  The hindsight maintenance loop now runs a throttled whole-database
+  `VACUUM (ANALYZE)` (default every 6h, `vacuumdb -j 4 --analyze` where
+  available) and a weekly, measurement-gated
+  `REINDEX INDEX CONCURRENTLY` sweep. Postgres' cumulative stats do not
+  survive a container recreate on this deployment — `stats_reset` is NULL
+  and `last_autovacuum` empty for every table minutes after a roll — so
+  autovacuum's dead-tuple trigger keeps restarting from zero and can go
+  unfired for long stretches. The payoff is the visibility map, not disk:
+  three hot tables measured 35.1% / 25.2% / 86.3% all-visible before a
+  manual vacuum and 99.0% / 100% / 99.2% after a 25-second run, and a low
+  all-visible fraction forces heap fetches instead of index-only scans.
+  The reindex rebuilds only btree indexes whose measured
+  `avg_leaf_density` is below 70% (hnsw/bm25 indexes are excluded from
+  the catalog query — `pgstatindex` errors on them and a rebuild is not a
+  bloat fix), always CONCURRENTLY, guarded on free disk, capped at 3 per
+  tick with the skipped count logged, and never in the same tick as the
+  vacuum. `VACUUM FULL` is never issued. Off-switchable with
+  `SWITCHROOM_HINDSIGHT_VACUUM=0` / `SWITCHROOM_HINDSIGHT_REINDEX=0`.

--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -3,7 +3,8 @@
 # entrypoint's background loop (so it executes alongside a live pg,
 # unlike the entrypoint body which runs before start-all.sh boots pg).
 #
-# Three best-effort jobs, all idempotent and safe to run on every tick:
+# Best-effort jobs, all idempotent and safe to run on every tick (the
+# numbering below is the order they were added, not the order they run):
 #
 #   1. Backup     — rotated `pg_dump -Fc` of the embedded pg to a volume
 #                   SEPARATE from the data volume, so a data-volume loss
@@ -24,6 +25,48 @@
 #                   never reads again; left unbounded they accumulate
 #                   (tens of thousands carrying transcript JSON).
 #                   failed/pending/processing rows are NEVER touched.
+#
+#   8a. Vacuum    — periodic `VACUUM (ANALYZE)` of the whole database, at
+#                   most once per VACUUM_INTERVAL_MIN. Belt to autovacuum's
+#                   braces: on this deployment pg's CUMULATIVE STATS DO NOT
+#                   SURVIVE A CONTAINER RECREATE — minutes after a roll,
+#                   pg_stat_database.stats_reset is NULL and last_autovacuum
+#                   is empty for every table. Autovacuum fires off n_dead_tup
+#                   in exactly those stats, so every image roll resets its
+#                   counters toward zero and autovacuum can go unfired for
+#                   long stretches; job #2's scale-factor tuning lowers the
+#                   threshold but cannot fix a counter that keeps restarting
+#                   at 0. The payoff measured on the live host is the
+#                   VISIBILITY MAP, not disk space: before a manual vacuum,
+#                   entity_cooccurrences was 35.1% all-visible,
+#                   observation_history 25.2%, memory_links 86.3%; after a
+#                   25-SECOND `vacuumdb -j 8 --analyze` of the whole 19 GB
+#                   database, 99.0% / 100% / 99.2%. A low all-visible
+#                   fraction forces heap fetches instead of index-only
+#                   scans — one observed graph-maintenance query was doing
+#                   1.15 MILLION heap fetches. NEVER `VACUUM FULL`: it takes
+#                   an ACCESS EXCLUSIVE lock and would freeze fleet memory
+#                   for the duration.
+#   8b. Reindex   — conditional `REINDEX INDEX CONCURRENTLY`, at most once
+#                   per REINDEX_INTERVAL_MIN, and MEASURED not guessed:
+#                   pgstatindex().avg_leaf_density below
+#                   REINDEX_MIN_DENSITY (a freshly built btree is ~90).
+#                   Measured on the live host: idx_memory_links_unique 73.5%
+#                   density / 29.1% leaf fragmentation,
+#                   idx_memory_links_to_type_weight 68.7% / 35.3%,
+#                   idx_memory_links_from_type_weight 69.6% / 34.3%,
+#                   pk_entity_cooccurrences 67.4% / 44.6%. Candidates come
+#                   from the CATALOG (pg_am.amname='btree', public schema,
+#                   larger than REINDEX_MIN_MB), never a hardcoded list —
+#                   this DB also carries hnsw (pgvector) and bm25
+#                   (pg_search) indexes, where pgstatindex ERRORS outright
+#                   and a rebuild is enormously expensive and not a bloat
+#                   fix. CONCURRENTLY always (a bare REINDEX takes an
+#                   exclusive lock). Guarded by free disk (CONCURRENTLY
+#                   builds a full second copy), capped per tick, and never
+#                   run in the same tick as 8a — both take a
+#                   ShareUpdateExclusiveLock on the table and would
+#                   serialize.
 #
 # Everything is best-effort: any failure (pg not up yet, missing creds,
 # psql absent) is logged and swallowed so a bad tick can never wedge the
@@ -56,6 +99,18 @@
 #   SWITCHROOM_HINDSIGHT_API_URL / _API_TOKEN  override the loopback engine API base
 #                                             URL / bearer token for the requeue POST
 #                                             (else http://127.0.0.1:${HINDSIGHT_API_PORT:-9077})
+#   SWITCHROOM_HINDSIGHT_VACUUM               job 8a master switch. 1=on (default), 0=off
+#   SWITCHROOM_HINDSIGHT_VACUUM_INTERVAL_MIN  min minutes between vacuums. default 360 (6h)
+#   SWITCHROOM_HINDSIGHT_VACUUM_JOBS          vacuumdb -j parallelism. default 4 (the host
+#                                             is not assumed to be big)
+#   SWITCHROOM_HINDSIGHT_REINDEX              job 8b master switch. 1=on (default), 0=off
+#   SWITCHROOM_HINDSIGHT_REINDEX_INTERVAL_MIN min minutes between reindex sweeps.
+#                                             default 10080 (weekly)
+#   SWITCHROOM_HINDSIGHT_REINDEX_MIN_DENSITY  rebuild only below this avg_leaf_density
+#                                             percent. default 70 (fresh btree is ~90)
+#   SWITCHROOM_HINDSIGHT_REINDEX_MIN_MB       ignore indexes smaller than this. default 256
+#   SWITCHROOM_HINDSIGHT_REINDEX_MAX_PER_RUN  max indexes rebuilt per sweep, lowest density
+#                                             first. default 3 (the skipped count is LOGGED)
 set -u
 
 MAINT_ENABLED="${SWITCHROOM_HINDSIGHT_MAINTENANCE:-1}"
@@ -97,6 +152,15 @@ STUCK_OP_WARN_S="${SWITCHROOM_HINDSIGHT_STUCK_OP_WARN_S:-3600}"
 DEAD_LETTER_WARN_S="${SWITCHROOM_HINDSIGHT_DEAD_LETTER_WARN_S:-21600}"
 REQUEUE_DEAD_LETTERS="${SWITCHROOM_HINDSIGHT_REQUEUE_DEAD_LETTERS:-0}"
 REQUEUE_MAX="${SWITCHROOM_HINDSIGHT_REQUEUE_MAX:-100}"
+# Job 8a/8b — periodic vacuum + conditional reindex (see the header block).
+VACUUM_ENABLED="${SWITCHROOM_HINDSIGHT_VACUUM:-1}"
+VACUUM_INTERVAL_MIN="${SWITCHROOM_HINDSIGHT_VACUUM_INTERVAL_MIN:-360}"
+VACUUM_JOBS="${SWITCHROOM_HINDSIGHT_VACUUM_JOBS:-4}"
+REINDEX_ENABLED="${SWITCHROOM_HINDSIGHT_REINDEX:-1}"
+REINDEX_INTERVAL_MIN="${SWITCHROOM_HINDSIGHT_REINDEX_INTERVAL_MIN:-10080}"
+REINDEX_MIN_DENSITY="${SWITCHROOM_HINDSIGHT_REINDEX_MIN_DENSITY:-70}"
+REINDEX_MIN_MB="${SWITCHROOM_HINDSIGHT_REINDEX_MIN_MB:-256}"
+REINDEX_MAX_PER_RUN="${SWITCHROOM_HINDSIGHT_REINDEX_MAX_PER_RUN:-3}"
 
 log() { echo "switchroom-hindsight-maintenance: $*" >&2; }
 
@@ -108,6 +172,9 @@ log() { echo "switchroom-hindsight-maintenance: $*" >&2; }
 _bindir="$(ls -d /home/hindsight/.pg0/installation/*/bin 2>/dev/null | head -1)"
 PSQL="$(command -v psql 2>/dev/null || echo "${_bindir:-/nonexistent}/psql")"
 PG_DUMP="$(command -v pg_dump 2>/dev/null || echo "${_bindir:-/nonexistent}/pg_dump")"
+# vacuumdb gives job 8a table-level parallelism; absent, 8a falls back to
+# per-table `VACUUM (ANALYZE)` over the same connection psql already uses.
+VACUUMDB="$(command -v vacuumdb 2>/dev/null || echo "${_bindir:-/nonexistent}/vacuumdb")"
 [ -x "${PSQL}" ] || exit 0
 
 # Pull connection fields from the descriptor without a JSON dep in sh.
@@ -127,6 +194,14 @@ PGPASSWORD="${PGPW_}" "${PSQL}" -U "${PGUSER_}" -h /tmp -p "${PGPORT_}" -d "${PG
 _sql() {
   PGPASSWORD="${PGPW_}" "${PSQL}" -U "${PGUSER_}" -h /tmp -p "${PGPORT_}" -d "${PGDB_}" \
     -v ON_ERROR_STOP=0 -tAc "$1" 2>/dev/null
+}
+
+# Same connection, but ON_ERROR_STOP=1 so the CALLER can branch on failure.
+# `_sql` deliberately swallows errors (exit 0) — a DDL statement whose outcome
+# we report on (job 8b's REINDEX / DROP INDEX) must not silently "succeed".
+_sql_x() {
+  PGPASSWORD="${PGPW_}" "${PSQL}" -U "${PGUSER_}" -h /tmp -p "${PGPORT_}" -d "${PGDB_}" \
+    -v ON_ERROR_STOP=1 -tAc "$1" >/dev/null 2>&1
 }
 
 # --- 2. Autovacuum tuning (idempotent; ALTER is a no-op if unchanged) ---
@@ -356,6 +431,137 @@ if [ "${REQUEUE_DEAD_LETTERS}" = "1" ]; then
       else
         log "dead-letter requeue: ${_ok} requeued, ${_fail} failed (bounded at ${REQUEUE_MAX}/tick)."
       fi
+    fi
+  fi
+fi
+
+# --- 8a. Periodic VACUUM (ANALYZE) — belt to autovacuum's braces ---
+# Cumulative stats do NOT survive a container recreate on this deployment
+# (pg_stat_database.stats_reset NULL, last_autovacuum empty for every table
+# minutes after a roll), so autovacuum's n_dead_tup trigger keeps restarting
+# from zero and can go unfired for long stretches. The measured win is the
+# visibility map: 35.1% / 25.2% all-visible before, 99.0% / 100% after — a low
+# all-visible fraction forces heap fetches instead of index-only scans (one
+# graph-maintenance query observed doing 1.15M heap fetches).
+#
+# PLAIN VACUUM ONLY. `VACUUM FULL` takes an ACCESS EXCLUSIVE lock and would
+# freeze every agent's memory for the whole rewrite; it is never issued here.
+#
+# The throttle marker lives in BACKUP_DIR because that is a SEPARATE
+# PERSISTENT volume — a marker under the pg data dir or /tmp would vanish on
+# a container recreate and the vacuum would re-run on every roll.
+_vacuum_ran=0
+if [ "${VACUUM_ENABLED}" = "1" ] && mkdir -p "${BACKUP_DIR}" 2>/dev/null; then
+  _vac_marker="${BACKUP_DIR}/.vacuum-last"
+  if [ -z "$(find "${_vac_marker}" -maxdepth 0 -mmin "-${VACUUM_INTERVAL_MIN}" 2>/dev/null)" ]; then
+    # Claim the window BEFORE the work: a vacuum that dies mid-way (container
+    # stop) must not re-run on every subsequent tick.
+    touch "${_vac_marker}" 2>/dev/null
+    _vacuum_ran=1
+    _vac_t0="$(date +%s)"
+    if [ -x "${VACUUMDB}" ]; then
+      if PGPASSWORD="${PGPW_}" "${VACUUMDB}" -U "${PGUSER_}" -h /tmp -p "${PGPORT_}" \
+           -d "${PGDB_}" -j "${VACUUM_JOBS}" --analyze >/dev/null 2>&1; then
+        log "vacuum (analyze) completed in $(( $(date +%s) - _vac_t0 ))s (vacuumdb -j ${VACUUM_JOBS})"
+      else
+        log "vacuum (analyze) FAILED via vacuumdb after $(( $(date +%s) - _vac_t0 ))s (will retry in ${VACUUM_INTERVAL_MIN}m)"
+      fi
+    else
+      # No vacuumdb in the image — serial per-table fallback over psql.
+      _vac_tables="$(_sql "SELECT quote_ident(schemaname)||'.'||quote_ident(relname) FROM pg_stat_user_tables WHERE schemaname='public' ORDER BY relname")"
+      _vac_n=0
+      if [ -n "${_vac_tables}" ]; then
+        _vac_tmpf="$(mktemp 2>/dev/null || echo "/tmp/hs-vacuum.$$")"
+        printf '%s\n' "${_vac_tables}" > "${_vac_tmpf}"
+        while IFS= read -r _vt; do
+          [ -n "${_vt}" ] || continue
+          _sql "VACUUM (ANALYZE) ${_vt}" >/dev/null 2>&1
+          _vac_n=$((_vac_n + 1))
+        done < "${_vac_tmpf}"
+        rm -f "${_vac_tmpf}" 2>/dev/null
+      fi
+      log "vacuum (analyze) completed in $(( $(date +%s) - _vac_t0 ))s (${_vac_n} table(s), per-table fallback — vacuumdb absent)"
+    fi
+  fi
+fi
+
+# --- 8b. Conditional REINDEX INDEX CONCURRENTLY — measured, not guessed ---
+# Skipped entirely in a tick where 8a ran: VACUUM and REINDEX CONCURRENTLY both
+# take a ShareUpdateExclusiveLock on the table and would simply serialize.
+if [ "${REINDEX_ENABLED}" = "1" ] && [ "${_vacuum_ran}" = "0" ] && mkdir -p "${BACKUP_DIR}" 2>/dev/null; then
+  _rix_marker="${BACKUP_DIR}/.reindex-last"
+  if [ -z "$(find "${_rix_marker}" -maxdepth 0 -mmin "-${REINDEX_INTERVAL_MIN}" 2>/dev/null)" ]; then
+    touch "${_rix_marker}" 2>/dev/null
+    # pgstattuple supplies pgstatindex(); best-effort, same shape as amcheck.
+    _sql "CREATE EXTENSION IF NOT EXISTS pgstattuple" >/dev/null 2>&1
+    # Candidates from the CATALOG: btree ONLY. This DB carries hnsw (pgvector)
+    # and bm25 (pg_search) indexes — pgstatindex errors on those AMs and
+    # rebuilding them is enormously expensive and not a bloat fix.
+    _rix_cands="$(_sql "SELECT c.oid::regclass::text||'|'||pg_relation_size(c.oid) FROM pg_class c JOIN pg_am am ON am.oid=c.relam JOIN pg_index i ON i.indexrelid=c.oid JOIN pg_class t ON t.oid=i.indrelid JOIN pg_namespace n ON n.oid=t.relnamespace WHERE c.relkind='i' AND am.amname='btree' AND n.nspname='public' AND i.indisvalid AND pg_relation_size(c.oid) > ${REINDEX_MIN_MB}*1024*1024 ORDER BY pg_relation_size(c.oid) DESC")"
+    if [ -n "${_rix_cands}" ]; then
+      # Residue sweep: a CANCELLED `REINDEX ... CONCURRENTLY` leaves an INVALID
+      # index behind that still costs writes. Drop only the ones matching pg's
+      # own `_ccnew` suffix — a user index that is invalid for some other reason
+      # is NOT ours to remove.
+      _rix_dead="$(_sql "SELECT c.oid::regclass::text FROM pg_index i JOIN pg_class c ON c.oid=i.indexrelid JOIN pg_class t ON t.oid=i.indrelid JOIN pg_namespace n ON n.oid=t.relnamespace WHERE NOT i.indisvalid AND n.nspname='public' AND c.relname LIKE '%\\_ccnew%'")"
+      if [ -n "${_rix_dead}" ]; then
+        _rix_dtmp="$(mktemp 2>/dev/null || echo "/tmp/hs-ccnew.$$")"
+        printf '%s\n' "${_rix_dead}" > "${_rix_dtmp}"
+        while IFS= read -r _di; do
+          [ -n "${_di}" ] || continue
+          if _sql_x "DROP INDEX CONCURRENTLY IF EXISTS ${_di}"; then
+            log "reindex: dropped leftover INVALID index ${_di} (residue of a cancelled REINDEX CONCURRENTLY)"
+          fi
+        done < "${_rix_dtmp}"
+        rm -f "${_rix_dtmp}" 2>/dev/null
+      fi
+
+      # Measure each candidate's avg_leaf_density; a freshly built btree is ~90.
+      _rix_tmpf="$(mktemp 2>/dev/null || echo "/tmp/hs-reindex.$$")"
+      _rix_bloated="$(mktemp 2>/dev/null || echo "/tmp/hs-reindex-b.$$")"
+      printf '%s\n' "${_rix_cands}" > "${_rix_tmpf}"
+      : > "${_rix_bloated}"
+      while IFS='|' read -r _ix _ixbytes; do
+        [ -n "${_ix}" ] || continue
+        _dens="$(_sql "SELECT round(avg_leaf_density)::int FROM pgstatindex('${_ix}')")"
+        # Unreadable density (non-btree slipped through, extension missing,
+        # index vanished) => leave it alone rather than rebuild blind.
+        [ -n "${_dens}" ] || continue
+        [ "${_dens}" -lt "${REINDEX_MIN_DENSITY}" ] 2>/dev/null || continue
+        printf '%s|%s|%s\n' "${_dens}" "${_ix}" "${_ixbytes:-0}" >> "${_rix_bloated}"
+      done < "${_rix_tmpf}"
+      rm -f "${_rix_tmpf}" 2>/dev/null
+
+      _rix_total="$(grep -c . "${_rix_bloated}" 2>/dev/null || echo 0)"
+      if [ "${_rix_total:-0}" -gt 0 ] 2>/dev/null; then
+        # Worst bloat (lowest density) first, capped per tick.
+        _rix_pgdata="$(_sql "SHOW data_directory")"
+        [ -n "${_rix_pgdata}" ] && [ -d "${_rix_pgdata}" ] || _rix_pgdata="$(dirname "${PG0_INSTANCE}")"
+        sort -t'|' -k1,1n "${_rix_bloated}" | head -n "${REINDEX_MAX_PER_RUN}" > "${_rix_bloated}.pick"
+        mv -f "${_rix_bloated}.pick" "${_rix_bloated}" 2>/dev/null
+        _rix_picked="$(grep -c . "${_rix_bloated}" 2>/dev/null || echo 0)"
+        while IFS='|' read -r _dens _ix _ixbytes; do
+          [ -n "${_ix}" ] || continue
+          # Disk guard: CONCURRENTLY builds a full SECOND copy before swapping.
+          _free_kb="$(df -P "${_rix_pgdata}" 2>/dev/null | awk 'NR==2{print $4}')"
+          _need_kb=$(( (${_ixbytes:-0} / 1024) * 2 ))
+          if [ -n "${_free_kb}" ] && [ "${_free_kb}" -lt "${_need_kb}" ] 2>/dev/null; then
+            log "reindex: SKIPPED ${_ix} (density ${_dens}%) — only $((_free_kb/1024))MB free on ${_rix_pgdata}, CONCURRENTLY needs $((_need_kb/1024))MB (2x the index)."
+            continue
+          fi
+          _rix_t0="$(date +%s)"
+          if _sql_x "REINDEX INDEX CONCURRENTLY ${_ix}"; then
+            log "reindex: rebuilt ${_ix} (avg_leaf_density was ${_dens}% < ${REINDEX_MIN_DENSITY}%) in $(( $(date +%s) - _rix_t0 ))s"
+          else
+            log "WARNING: reindex: REINDEX INDEX CONCURRENTLY ${_ix} failed after $(( $(date +%s) - _rix_t0 ))s — continuing with the next candidate."
+          fi
+        done < "${_rix_bloated}"
+        _rix_skipped=$((_rix_total - _rix_picked))
+        if [ "${_rix_skipped}" -gt 0 ] 2>/dev/null; then
+          log "reindex: ${_rix_skipped} bloated index(es) left for the next sweep — capped at ${REINDEX_MAX_PER_RUN}/run (SWITCHROOM_HINDSIGHT_REINDEX_MAX_PER_RUN)."
+        fi
+      fi
+      rm -f "${_rix_bloated}" 2>/dev/null
     fi
   fi
 fi

--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -66,7 +66,12 @@
 #                   builds a full second copy), capped per tick, and never
 #                   run in the same tick as 8a — both take a
 #                   ShareUpdateExclusiveLock on the table and would
-#                   serialize.
+#                   serialize. Note the entrypoint calls this script
+#                   SYNCHRONOUSLY inside its refresh loop, so a long 8a/8b
+#                   pushes that tick's next credential refresh out by its
+#                   own duration — bounded by REINDEX_MAX_PER_RUN, and
+#                   harmless because the fetcher refreshes far ahead of
+#                   token expiry.
 #
 # Everything is best-effort: any failure (pg not up yet, missing creds,
 # psql absent) is logged and swallowed so a bad tick can never wedge the
@@ -532,17 +537,19 @@ if [ "${REINDEX_ENABLED}" = "1" ] && [ "${_vacuum_ran}" = "0" ] && mkdir -p "${B
       done < "${_rix_tmpf}"
       rm -f "${_rix_tmpf}" 2>/dev/null
 
-      _rix_total="$(grep -c . "${_rix_bloated}" 2>/dev/null || echo 0)"
+      _rix_total="$(grep -c . "${_rix_bloated}" 2>/dev/null || true)"
       if [ "${_rix_total:-0}" -gt 0 ] 2>/dev/null; then
         # Worst bloat (lowest density) first, capped per tick.
         _rix_pgdata="$(_sql "SHOW data_directory")"
         [ -n "${_rix_pgdata}" ] && [ -d "${_rix_pgdata}" ] || _rix_pgdata="$(dirname "${PG0_INSTANCE}")"
         sort -t'|' -k1,1n "${_rix_bloated}" | head -n "${REINDEX_MAX_PER_RUN}" > "${_rix_bloated}.pick"
         mv -f "${_rix_bloated}.pick" "${_rix_bloated}" 2>/dev/null
-        _rix_picked="$(grep -c . "${_rix_bloated}" 2>/dev/null || echo 0)"
+        _rix_picked="$(grep -c . "${_rix_bloated}" 2>/dev/null || true)"
         while IFS='|' read -r _dens _ix _ixbytes; do
           [ -n "${_ix}" ] || continue
           # Disk guard: CONCURRENTLY builds a full SECOND copy before swapping.
+          # An unreadable df (path gone) leaves _free_kb empty and the guard
+          # open — the same best-effort posture as the rest of the script.
           _free_kb="$(df -P "${_rix_pgdata}" 2>/dev/null | awk 'NR==2{print $4}')"
           _need_kb=$(( (${_ixbytes:-0} / 1024) * 2 ))
           if [ -n "${_free_kb}" ] && [ "${_free_kb}" -lt "${_need_kb}" ] 2>/dev/null; then
@@ -556,7 +563,7 @@ if [ "${REINDEX_ENABLED}" = "1" ] && [ "${_vacuum_ran}" = "0" ] && mkdir -p "${B
             log "WARNING: reindex: REINDEX INDEX CONCURRENTLY ${_ix} failed after $(( $(date +%s) - _rix_t0 ))s — continuing with the next candidate."
           fi
         done < "${_rix_bloated}"
-        _rix_skipped=$((_rix_total - _rix_picked))
+        _rix_skipped=$(( ${_rix_total:-0} - ${_rix_picked:-0} ))
         if [ "${_rix_skipped}" -gt 0 ] 2>/dev/null; then
           log "reindex: ${_rix_skipped} bloated index(es) left for the next sweep — capped at ${REINDEX_MAX_PER_RUN}/run (SWITCHROOM_HINDSIGHT_REINDEX_MAX_PER_RUN)."
         fi

--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -522,6 +522,9 @@ if [ "${REINDEX_ENABLED}" = "1" ] && [ "${_vacuum_ran}" = "0" ] && mkdir -p "${B
       fi
 
       # Measure each candidate's avg_leaf_density; a freshly built btree is ~90.
+      # pgstatindex reads the whole index, so this costs one sequential pass per
+      # candidate — bounded by the >REINDEX_MIN_MB floor and the weekly interval,
+      # and it is the price of not rebuilding on a guess.
       _rix_tmpf="$(mktemp 2>/dev/null || echo "/tmp/hs-reindex.$$")"
       _rix_bloated="$(mktemp 2>/dev/null || echo "/tmp/hs-reindex-b.$$")"
       printf '%s\n' "${_rix_cands}" > "${_rix_tmpf}"

--- a/tests/docker/hindsight-maintenance.test.ts
+++ b/tests/docker/hindsight-maintenance.test.ts
@@ -14,6 +14,7 @@ import {
   mkdtempSync,
   rmSync,
   accessSync,
+  utimesSync,
   constants as fsConstants,
 } from "node:fs";
 import { resolve, join } from "node:path";
@@ -74,6 +75,19 @@ case "$sql" in
   *"status='failed'"*"ORDER BY created_at"*)
     # Requeue candidate select (#3795): "bank|operation_id" lines.
     [ -n "\${FAKE_DL_CANDS:-}" ] && printf '%s\\n' "\$FAKE_DL_CANDS"; exit 0 ;;
+  *"amname='btree'"*)
+    # Job 8b candidate select: "index|size_bytes" lines.
+    [ -n "\${FAKE_IDX_CANDS:-}" ] && printf '%s\\n' "\$FAKE_IDX_CANDS"; exit 0 ;;
+  *_ccnew*)
+    # Job 8b invalid-index residue sweep: bare index names.
+    [ -n "\${FAKE_IDX_INVALID:-}" ] && printf '%s\\n' "\$FAKE_IDX_INVALID"; exit 0 ;;
+  *pgstatindex*)
+    # Density lookup. FAKE_IDX_DENSITY is "name=NN;name2=NN".
+    ix="\$(printf '%s' "\$sql" | sed "s/.*pgstatindex('\\([^']*\\)').*/\\1/")"
+    for pair in \$(printf '%s' "\${FAKE_IDX_DENSITY:-}" | tr ';' ' '); do
+      case "\$pair" in "\$ix="*) printf '%s\\n' "\${pair#*=}" ;; esac
+    done
+    exit 0 ;;
   *) exit 0 ;;
 esac
 `,
@@ -95,6 +109,22 @@ url=""
 for a in "$@"; do url="$a"; done
 [ -n "\${FAKE_CURL_LOG:-}" ] && printf '%s\\n' "$url" >> "$FAKE_CURL_LOG"
 printf '%s' "\${FAKE_CURL_CODE:-200}"
+`,
+    { mode: 0o755 },
+  );
+}
+
+/**
+ * Write a fake `vacuumdb` beside the fake `psql`. It appends its full argv to
+ * `$FAKE_VACUUMDB_LOG` so a test can assert WHAT was asked of it (e.g.
+ * `--analyze`, `-j N`, and never a full-rewrite flag).
+ */
+function installFakeVacuumdb(binDir: string): void {
+  writeFileSync(
+    join(binDir, "vacuumdb"),
+    `#!/bin/sh
+[ -n "\${FAKE_VACUUMDB_LOG:-}" ] && printf '%s\\n' "$*" >> "$FAKE_VACUUMDB_LOG"
+exit "\${FAKE_VACUUMDB_EXIT:-0}"
 `,
     { mode: 0o755 },
   );
@@ -554,5 +584,297 @@ describe("hindsight-maintenance.sh", () => {
     expect(raw).toMatch(/Authorization: Bearer \$\{_tok\}/);
     // The requeue must NOT reach into the queue table with a raw UPDATE.
     expect(raw).not.toMatch(/UPDATE async_operations SET status='pending'/);
+  });
+
+  // ── Job 8a/8b: periodic VACUUM (ANALYZE) + conditional REINDEX ──────────
+  //
+  // Driven with a fake psql/vacuumdb; every assertion is on an OUTCOME — what
+  // the script actually executed and logged — not on the presence of code.
+  describe("job #8 vacuum + conditional reindex", () => {
+    /** One maintenance tick against the fakes in `binDir`, state under `dir`. */
+    function runTick(binDir: string, dir: string, env: Record<string, string>) {
+      return spawnSync("sh", [SCRIPT], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: join(dir, "instance.json"),
+          SWITCHROOM_HINDSIGHT_BACKUP_DIR: join(dir, "backups"),
+          ...env,
+        },
+        encoding: "utf-8",
+        timeout: 20_000,
+      });
+    }
+
+    /** Fresh (dir, binDir) with a pg descriptor + fake psql/vacuumdb. */
+    function setup(): { dir: string; binDir: string } {
+      const dir = mkdtempSync(join(tmpdir(), "swr-hsi-vac-"));
+      const binDir = installFakePsql();
+      installFakeVacuumdb(binDir);
+      writePgInstance(join(dir, "instance.json"));
+      return { dir, binDir };
+    }
+
+    function teardown(dir: string, binDir: string): void {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+
+    function lines(path: string): string[] {
+      try {
+        return readFileSync(path, "utf-8").split("\n").filter(Boolean);
+      } catch {
+        return [];
+      }
+    }
+
+    it("8a vacuums once per interval: throttled inside the window, permitted after it", () => {
+      const { dir, binDir } = setup();
+      try {
+        const vlog = join(dir, "vacuumdb.log");
+        const env = {
+          FAKE_VACUUMDB_LOG: vlog,
+          SWITCHROOM_HINDSIGHT_REINDEX: "0",
+          SWITCHROOM_HINDSIGHT_VACUUM_INTERVAL_MIN: "360",
+        };
+
+        const r1 = runTick(binDir, dir, env);
+        expect(r1.status).toBe(0);
+        expect(r1.stderr).toMatch(/vacuum \(analyze\) completed in \d+s \(vacuumdb -j 4\)/);
+        expect(lines(vlog)).toHaveLength(1);
+        expect(lines(vlog)[0]).toContain("--analyze");
+        expect(lines(vlog)[0]).toMatch(/-j 4\b/);
+
+        // Second tick inside the window: the throttle must SUPPRESS it.
+        const r2 = runTick(binDir, dir, env);
+        expect(r2.status).toBe(0);
+        expect(r2.stderr).not.toMatch(/vacuum \(analyze\) completed/);
+        expect(lines(vlog)).toHaveLength(1);
+
+        // Age the marker past the window: the next tick must vacuum again.
+        const marker = join(dir, "backups", ".vacuum-last");
+        const old = new Date(Date.now() - 7 * 3600_000);
+        utimesSync(marker, old, old);
+        const r3 = runTick(binDir, dir, env);
+        expect(r3.status).toBe(0);
+        expect(r3.stderr).toMatch(/vacuum \(analyze\) completed/);
+        expect(lines(vlog)).toHaveLength(2);
+      } finally {
+        teardown(dir, binDir);
+      }
+    });
+
+    it("8a NEVER issues VACUUM FULL (it would take an ACCESS EXCLUSIVE lock)", () => {
+      const { dir, binDir } = setup();
+      try {
+        const vlog = join(dir, "vacuumdb.log");
+        const sqlLog = join(dir, "psql-sql.log");
+        const r = runTick(binDir, dir, {
+          FAKE_VACUUMDB_LOG: vlog,
+          FAKE_PSQL_LOG: sqlLog,
+          FAKE_IDX_CANDS: "idx_low|1048576",
+          FAKE_IDX_DENSITY: "idx_low=60",
+        });
+        expect(r.status).toBe(0);
+        // Nothing the script executed — via psql or vacuumdb — was a full vacuum.
+        for (const l of [...lines(vlog), ...lines(sqlLog)]) {
+          expect(l).not.toMatch(/VACUUM\s+FULL/i);
+          expect(l).not.toMatch(/(^|\s)(-f|--full)(\s|$)/);
+        }
+        // ...and the source carries no full-vacuum call site at all (the only
+        // permitted mention is the comment explaining why it is banned).
+        const code = readFileSync(SCRIPT, "utf-8")
+          .split("\n")
+          .filter((l) => !l.trimStart().startsWith("#"));
+        expect(code.join("\n")).not.toMatch(/VACUUM\s+FULL/i);
+      } finally {
+        teardown(dir, binDir);
+      }
+    });
+
+    it("8a and 8b no-op when their master switch is 0", () => {
+      const { dir, binDir } = setup();
+      try {
+        const vlog = join(dir, "vacuumdb.log");
+        const sqlLog = join(dir, "psql-sql.log");
+        const r = runTick(binDir, dir, {
+          SWITCHROOM_HINDSIGHT_VACUUM: "0",
+          SWITCHROOM_HINDSIGHT_REINDEX: "0",
+          FAKE_VACUUMDB_LOG: vlog,
+          FAKE_PSQL_LOG: sqlLog,
+          FAKE_IDX_CANDS: "idx_low|1048576",
+          FAKE_IDX_DENSITY: "idx_low=10",
+        });
+        expect(r.status).toBe(0);
+        expect(lines(vlog)).toHaveLength(0);
+        expect(r.stderr).not.toMatch(/vacuum \(analyze\)/);
+        const sql = lines(sqlLog).join("\n");
+        expect(sql).not.toMatch(/REINDEX/);
+        expect(sql).not.toMatch(/VACUUM/);
+        // Neither job claimed its throttle window.
+        expect(lines(join(dir, "backups", ".vacuum-last"))).toHaveLength(0);
+        expect(() => readFileSync(join(dir, "backups", ".reindex-last"))).toThrow();
+      } finally {
+        teardown(dir, binDir);
+      }
+    });
+
+    it("8a and 8b no-op (exit 0, no markers) when psql is absent", () => {
+      const { dir, binDir } = setup();
+      try {
+        // A PATH with the fake vacuumdb but NO psql at all: the script must
+        // bail at the client-resolution guard before touching anything.
+        const noPsqlBin = execTmpDir("swr-maint-nopsql-");
+        installFakeVacuumdb(noPsqlBin);
+        const vlog = join(dir, "vacuumdb.log");
+        const r = spawnSync("/bin/sh", [SCRIPT], {
+          env: {
+            ...process.env,
+            PATH: noPsqlBin, // no psql anywhere on PATH
+            SWITCHROOM_HINDSIGHT_PG0_INSTANCE: join(dir, "instance.json"),
+            SWITCHROOM_HINDSIGHT_BACKUP_DIR: join(dir, "backups"),
+            FAKE_VACUUMDB_LOG: vlog,
+          },
+          encoding: "utf-8",
+          timeout: 20_000,
+        });
+        expect(r.status).toBe(0);
+        // No maintenance log line at all — the script's own logs are prefixed.
+        expect(r.stderr).not.toMatch(/switchroom-hindsight-maintenance:/);
+        expect(lines(vlog)).toHaveLength(0);
+        expect(() => readFileSync(join(dir, "backups", ".vacuum-last"))).toThrow();
+        rmSync(noPsqlBin, { recursive: true, force: true });
+      } finally {
+        teardown(dir, binDir);
+      }
+    });
+
+    it("8b rebuilds ONLY the below-threshold index, always CONCURRENTLY, and clears _ccnew residue", () => {
+      const { dir, binDir } = setup();
+      try {
+        const sqlLog = join(dir, "psql-sql.log");
+        const r = runTick(binDir, dir, {
+          FAKE_PSQL_LOG: sqlLog,
+          // 8a would otherwise hold the ShareUpdateExclusiveLock window.
+          SWITCHROOM_HINDSIGHT_VACUUM: "0",
+          FAKE_IDX_CANDS: "idx_low|1048576\nidx_high|1048576",
+          FAKE_IDX_DENSITY: "idx_low=60;idx_high=85",
+          FAKE_IDX_INVALID: "idx_low_ccnew",
+        });
+        expect(r.status).toBe(0);
+        const sql = lines(sqlLog);
+        // The candidate query ACTUALLY SENT to postgres filters on the access
+        // method — an hnsw/bm25 index can never enter the candidate set.
+        const candidateSql = sql.filter((l) => /FROM pg_class c JOIN pg_am/.test(l));
+        expect(candidateSql).toHaveLength(1);
+        expect(candidateSql[0]).toContain("am.amname='btree'");
+        // The bloated one was rebuilt; the healthy one was left alone.
+        expect(r.stderr).toMatch(/reindex: rebuilt idx_low \(avg_leaf_density was 60% < 70%\)/);
+        expect(r.stderr).not.toMatch(/rebuilt idx_high/);
+        expect(sql).toContain("REINDEX INDEX CONCURRENTLY idx_low");
+        expect(sql.join("\n")).not.toMatch(/REINDEX[^\n]*idx_high/);
+        // EVERY reindex issued is CONCURRENTLY — a bare REINDEX would take an
+        // exclusive lock on a live fleet-memory table.
+        for (const l of sql.filter((s) => /REINDEX/.test(s))) {
+          expect(l).toMatch(/^REINDEX INDEX CONCURRENTLY /);
+        }
+        // Residue of a cancelled CONCURRENTLY build was dropped concurrently.
+        expect(sql).toContain("DROP INDEX CONCURRENTLY IF EXISTS idx_low_ccnew");
+        expect(r.stderr).toMatch(/dropped leftover INVALID index idx_low_ccnew/);
+      } finally {
+        teardown(dir, binDir);
+      }
+    });
+
+    it("8b caps the work per tick and LOGS how many candidates it skipped", () => {
+      const { dir, binDir } = setup();
+      try {
+        const sqlLog = join(dir, "psql-sql.log");
+        const r = runTick(binDir, dir, {
+          FAKE_PSQL_LOG: sqlLog,
+          SWITCHROOM_HINDSIGHT_VACUUM: "0",
+          FAKE_IDX_CANDS: ["a|1048576", "b|1048576", "c|1048576", "d|1048576"].join("\n"),
+          FAKE_IDX_DENSITY: "a=50;b=55;c=60;d=65",
+        });
+        expect(r.status).toBe(0);
+        const rebuilt = lines(sqlLog).filter((l) => /^REINDEX/.test(l));
+        expect(rebuilt).toHaveLength(3); // default REINDEX_MAX_PER_RUN
+        // Worst bloat first: a (50) / b (55) / c (60), never d (65).
+        expect(rebuilt.join("\n")).not.toMatch(/\bd\b/);
+        // The cap is LOUD — a silent cap reads as "did everything".
+        expect(r.stderr).toMatch(
+          /reindex: 1 bloated index\(es\) left for the next sweep — capped at 3\/run/,
+        );
+      } finally {
+        teardown(dir, binDir);
+      }
+    });
+
+    it("8b skips an index when free disk is under 2x its size (CONCURRENTLY doubles it)", () => {
+      const { dir, binDir } = setup();
+      try {
+        const sqlLog = join(dir, "psql-sql.log");
+        const r = runTick(binDir, dir, {
+          FAKE_PSQL_LOG: sqlLog,
+          SWITCHROOM_HINDSIGHT_VACUUM: "0",
+          // 1 PB index: no CI runner has 2 PB free.
+          FAKE_IDX_CANDS: "idx_huge|1000000000000000",
+          FAKE_IDX_DENSITY: "idx_huge=40",
+        });
+        expect(r.status).toBe(0);
+        expect(r.stderr).toMatch(/reindex: SKIPPED idx_huge \(density 40%\)[^\n]*free/);
+        expect(lines(sqlLog).join("\n")).not.toMatch(/REINDEX/);
+      } finally {
+        teardown(dir, binDir);
+      }
+    });
+
+    it("8b never runs in the same tick as 8a (lock contention), but runs on the next one", () => {
+      const { dir, binDir } = setup();
+      try {
+        const sqlLog = join(dir, "psql-sql.log");
+        const vlog = join(dir, "vacuumdb.log");
+        const env = {
+          FAKE_PSQL_LOG: sqlLog,
+          FAKE_VACUUMDB_LOG: vlog,
+          FAKE_IDX_CANDS: "idx_low|1048576",
+          FAKE_IDX_DENSITY: "idx_low=60",
+        };
+        // Tick 1: 8a runs (fresh marker) ⇒ 8b must stand down.
+        const r1 = runTick(binDir, dir, env);
+        expect(r1.status).toBe(0);
+        expect(lines(vlog)).toHaveLength(1);
+        expect(lines(sqlLog).join("\n")).not.toMatch(/REINDEX/);
+        // Tick 2: 8a is throttled ⇒ 8b gets the table to itself.
+        const r2 = runTick(binDir, dir, env);
+        expect(r2.status).toBe(0);
+        expect(lines(vlog)).toHaveLength(1);
+        expect(lines(sqlLog)).toContain("REINDEX INDEX CONCURRENTLY idx_low");
+        expect(r2.stderr).toMatch(/reindex: rebuilt idx_low/);
+      } finally {
+        teardown(dir, binDir);
+      }
+    });
+
+    it("8b candidate selection is btree-ONLY and catalog-driven (hnsw/bm25 can never be picked)", () => {
+      // Comment lines are stripped: the header block legitimately DISCUSSES
+      // btree/hnsw/bm25, and a guard satisfied by prose guards nothing.
+      const raw = readFileSync(SCRIPT, "utf-8")
+        .split("\n")
+        .filter((l) => !l.trimStart().startsWith("#"))
+        .join("\n");
+      // The candidate query joins pg_am and filters to btree — pgstatindex
+      // ERRORS on hnsw/bm25 and rebuilding them is not a bloat fix.
+      expect(raw).toMatch(/JOIN pg_am am ON am\.oid=c\.relam/);
+      expect(raw).toMatch(/am\.amname='btree'/);
+      // No hardcoded index list, and the size floor comes from the knob.
+      expect(raw).toMatch(/pg_relation_size\(c\.oid\) > \$\{REINDEX_MIN_MB\}\*1024\*1024/);
+      // Invalid-index residue is scoped to pg's own _ccnew suffix — a user
+      // index that is invalid for another reason is not ours to drop.
+      expect(raw).toMatch(/NOT i\.indisvalid[^\n]*relname LIKE '%\\\\_ccnew%'/);
+      // Throttle markers live on the PERSISTENT backup volume, not pg data/tmp.
+      expect(raw).toMatch(/_vac_marker="\$\{BACKUP_DIR\}\/\.vacuum-last"/);
+      expect(raw).toMatch(/_rix_marker="\$\{BACKUP_DIR\}\/\.reindex-last"/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds job **#8** to `docker/hindsight-maintenance.sh` (the best-effort loop the hindsight entrypoint ticks every `SWITCHROOM_HINDSIGHT_REFRESH_S`, default 30 min):

- **8a — periodic `VACUUM (ANALYZE)`**, at most once per `SWITCHROOM_HINDSIGHT_VACUUM_INTERVAL_MIN` (default 6h). Prefers `vacuumdb -j N --analyze` (`SWITCHROOM_HINDSIGHT_VACUUM_JOBS`, default 4), falls back to per-table `VACUUM (ANALYZE)` over psql when the binary is absent. **Plain vacuum only — `VACUUM FULL` is never issued** (ACCESS EXCLUSIVE lock would freeze fleet memory), and a test asserts that across everything the script executes.
- **8b — conditional `REINDEX INDEX CONCURRENTLY`**, at most once per `SWITCHROOM_HINDSIGHT_REINDEX_INTERVAL_MIN` (default weekly), **measured not guessed**: `pgstatindex().avg_leaf_density` below `SWITCHROOM_HINDSIGHT_REINDEX_MIN_DENSITY` (default 70; a fresh btree is ~90). Candidates come from the catalog joined to `pg_am` and filtered to `amname='btree'`, public schema, larger than `SWITCHROOM_HINDSIGHT_REINDEX_MIN_MB` (default 256). Disk-guarded at 2x index size (CONCURRENTLY builds a full second copy), capped at `SWITCHROOM_HINDSIGHT_REINDEX_MAX_PER_RUN` (default 3) worst-bloat-first **with the skipped count logged**, per-index failures logged and stepped over, and `_ccnew` residue from a cancelled rebuild dropped concurrently first.

Both are throttled by marker files in `${BACKUP_DIR}` — the only *persistent* volume separate from pg data, so a container recreate cannot reset the throttle. Both are best-effort, idempotent, `set -u`-safe POSIX sh, master-switchable (`SWITCHROOM_HINDSIGHT_VACUUM` / `_REINDEX`), and no-op cleanly when pg/psql is absent.

## Why (measured on the live host, not theory)

**8a — autovacuum cannot be trusted alone on this deployment.** `pg_stat_database.stats_reset` is NULL and `last_autovacuum` is empty for *every* table minutes after a container recreate: cumulative stats do not survive the restart here. Autovacuum decides from `n_dead_tup` in exactly those stats, so every image roll resets its counters toward zero and autovacuum can go unfired for long stretches. Job #2's scale-factor tuning is necessary but not sufficient — it lowers a threshold on a counter that keeps restarting at 0.

**The payoff is the visibility map, not disk space.** Before today's manual vacuum: `entity_cooccurrences` 35.1% all-visible, `observation_history` 25.2%, `memory_links` 86.3%. After a **25-second** `vacuumdb -j 8 --analyze` of the whole 19 GB database: **99.0% / 100% / 99.2%**. A low all-visible fraction forces heap fetches instead of index-only scans — one observed graph-maintenance query was doing **1.15 million heap fetches**.

**8b — measured btree bloat justifying the rebuild:** `idx_memory_links_unique` avg_leaf_density 73.5% / leaf_fragmentation 29.1%; `idx_memory_links_to_type_weight` 68.7% / 35.3%; `idx_memory_links_from_type_weight` 69.6% / 34.3%; `pk_entity_cooccurrences` 67.4% / 44.6%.

**Why the btree filter is critical:** this DB also carries `hnsw` (pgvector) and `bm25` (pg_search) indexes. `pgstatindex` errors outright on those AMs, and rebuilding them is enormously expensive and is not a bloat fix — so candidates are selected from `pg_am`, never a hardcoded name list.

**Why 8b stands down when 8a ran:** `VACUUM` and `REINDEX ... CONCURRENTLY` both take a `ShareUpdateExclusiveLock` on the table and would simply serialize. No `statement_timeout` is set — a long REINDEX is expected.

## Test plan

`tests/docker/hindsight-maintenance.test.ts` (+9 cases, all outcome assertions driven through a fake `psql` / `vacuumdb`):

- the throttle suppresses a second vacuum inside the window and permits it once the marker ages past it;
- `VACUUM FULL` never appears in any statement the script executes (psql *or* vacuumdb argv) nor in non-comment source;
- the candidate query **actually sent to postgres** carries `am.amname='btree'` (hnsw/bm25 can never be selected);
- every REINDEX issued is `REINDEX INDEX CONCURRENTLY`;
- an index at 85% density is **not** rebuilt while one at 60% **is**;
- the per-run cap rebuilds worst-bloat-first and logs `1 bloated index(es) left … capped at 3/run`;
- the disk guard skips an index when free space is under 2x its size;
- 8b never runs in the same tick as 8a, and does run on the next tick;
- both jobs no-op (no statements, no markers) with their master switch at 0 and when psql is absent.

Verified these fail against mutations of the code they guard (bare `REINDEX`, dropped btree filter, uncapped head, disabled throttle): 5 of the new tests go red.

Local: `vitest run tests/docker/hindsight-maintenance.test.ts` → 27/27 green; `npm run lint` clean.

Also adds `docker/hindsight-maintenance.sh` to the `relevant` path filter in `docker-e2e.yml`. The suite reads the script with `readFileSync` and spawns it — neither is an import, so vitest's `--changed` module-graph tracing cannot reach it from a script-only edit, and the e2e filter didn't list it either. Without that line these guards would be skipped for exactly the change they exist to police (same reasoning already documented for `dockerfile-hindsight-bakes.test.ts`).

## Risk

Low-to-moderate, and bounded by design. Both jobs are off-switchable, best-effort, and swallow failures so a bad tick cannot wedge the loop or the container. The vacuum is a plain concurrent-safe VACUUM; the reindex is always CONCURRENTLY, disk-guarded, capped at 3/tick, weekly, and only fires on measured density. The claimed-before-work throttle marker means a killed job costs at most one skipped window rather than a retry storm.

Job spec: `reference/jobs/fleet-stays-healthy.md` (the memory backend staying fast and self-maintaining without an operator in the loop), supporting `reference/jobs/remember-across-sessions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
