### PR TITLE
fix(hindsight-retain): incremental SessionEnd sweep (memory-RFC P1)

### DIFF
--- a/vendor/hindsight-memory/scripts/lib/watermark.py
+++ b/vendor/hindsight-memory/scripts/lib/watermark.py
@@ -92,6 +92,33 @@ def _lock_path(session_id: str) -> str:
     return os.path.join(watermark_dir(), f"{_safe_session(session_id)}.lock")
 
 
+def tail_after(messages: list, last_uuid: Optional[str]) -> list:
+    """Return the transcript entries AFTER the committed watermark anchor.
+
+    Pure and IO-free — the single shared slice used by BOTH the boot reconciler
+    (``reconcile_tail``) and the incremental SessionEnd sweep (``retain``, the
+    switchroom memory-RFC P1 change). One implementation, so the reconcile /
+    watermark failure category cannot grow a second, divergent copy.
+
+    Two safety fallbacks, both returning the WHOLE transcript — a safe
+    re-upsert, never a skip, never an empty slice:
+
+    * ``last_uuid`` falsy (no committed watermark) — e.g. a short session that
+      never fired a per-window retain, so the force sweep must flush it whole.
+    * ``last_uuid`` absent from ``messages`` (compaction removed the anchor).
+
+    Callers in the retain seam depend on the whole-transcript fallback: an empty
+    or skipped slice there DELETES a turn rather than degrading it
+    (``retain.py`` §4.3 hazard). Never change a fallback here to return ``[]``.
+    """
+    if not last_uuid:
+        return list(messages)
+    for i, m in enumerate(messages):
+        if isinstance(m, dict) and m.get("uuid") == last_uuid:
+            return messages[i + 1:]
+    return list(messages)
+
+
 def load(session_id: str) -> Optional[dict]:
     """Return the stored watermark dict for ``session_id``, or ``None``."""
     p = _path(session_id)

--- a/vendor/hindsight-memory/scripts/reconcile_tail.py
+++ b/vendor/hindsight-memory/scripts/reconcile_tail.py
@@ -109,18 +109,10 @@ def _human_turns(messages: list) -> int:
     )
 
 
-def _tail_after(messages: list, last_uuid: str | None) -> list:
-    """Return the transcript entries AFTER the watermark anchor.
-
-    No watermark, or a stale anchor compaction removed → the whole transcript is
-    the gap (a safe re-upsert, never a skip).
-    """
-    if not last_uuid:
-        return list(messages)
-    for i, m in enumerate(messages):
-        if isinstance(m, dict) and m.get("uuid") == last_uuid:
-            return messages[i + 1:]
-    return list(messages)
+# The transcript tail-slice is shared with the incremental SessionEnd sweep
+# (retain.py, memory-RFC P1); the single implementation lives in lib.watermark
+# so there is only ever one copy of this reconcile/watermark-critical slice.
+_tail_after = watermark.tail_after
 
 
 def _session_id_from_path(path: str) -> str:

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -366,6 +366,7 @@ def select_retain_window(
     overlap_turns: int,
     all_messages: list,
     force: bool = False,
+    since_uuid: str | None = None,
 ) -> tuple:
     """Decide which messages to retain and whether to send as a full window.
 
@@ -396,6 +397,17 @@ def select_retain_window(
     the whole session even if per-turn windowing had an edge. This costs a
     full sweep only ONCE per session (at end), not per turn.
 
+    ``since_uuid`` (memory-RFC P1) makes that final sweep INCREMENTAL: when
+    ``force=True`` and a committed watermark uuid is supplied, only the
+    transcript tail after it is retained, instead of re-storing the whole
+    session on top of the per-window documents that already carry it. The value
+    is resolved by the caller (``run_retain`` reads the watermark, wrapped) and
+    passed in — this function stays pure and IO-free. ``since_uuid=None``
+    reproduces the whole-session sweep exactly, which is what the vendor
+    full-session path and the ``retainEveryNTurns==1`` path pass. The slice
+    degrades to the whole transcript on a missing/compacted anchor
+    (``watermark.tail_after``), so a forced sweep never emits an empty slice.
+
     Durability invariant (jtbd-memory-survives-restart UAT): the window
     always extends to the END of the transcript (``slice_last_turns_by_user_boundary``
     returns ``messages[start:]``), so the turn that just completed — the one
@@ -412,8 +424,21 @@ def select_retain_window(
         window_turns = max(retain_every_n, 1) + overlap_turns
         messages_to_retain = slice_last_turns_by_user_boundary(all_messages, window_turns)
         return messages_to_retain, True
+    # Forced (SessionEnd) chunked sweep with a committed watermark uuid: retain
+    # only the transcript tail after it, instead of re-storing the whole session
+    # on top of the N per-window documents that already carry the same content
+    # (memory-RFC P1). ``since_uuid`` is None on the vendor full-session path and
+    # at retainEveryNTurns==1 (the caller withholds it there — see run_retain),
+    # which preserves today's whole-session behaviour byte-for-byte.
+    #
+    # tail_after is PURE and IO-free (the watermark READ happens in run_retain,
+    # wrapped) and degrades to the whole transcript on a missing/compacted
+    # anchor, so this branch can never emit an empty slice into the retain seam.
+    if force and since_uuid is not None:
+        return watermark.tail_after(all_messages, since_uuid), True
     # Full session: vendor full-session mode, OR a forced (SessionEnd) chunked
-    # sweep. Retain all messages, always as a full window.
+    # sweep with no watermark to slice against. Retain all messages, always as a
+    # full window.
     return list(all_messages), True
 
 
@@ -798,8 +823,37 @@ def run_retain(hook_input: dict, force: bool = False) -> dict:
     # select_retain_window() for the switchroom-divergence rationale
     # (Phase 6b: chunked window-slicing now works at retainEveryNTurns=1).
     overlap_turns = config.get("retainOverlapTurns", 0)
+
+    # Incremental SessionEnd sweep (memory-RFC P1): a forced chunked sweep at
+    # retainEveryNTurns>1 retains only the transcript tail after the committed
+    # watermark, not the whole session on top of the N per-window documents that
+    # already carry it. The watermark READ is filesystem IO on a JSON file that
+    # could be truncated / permission-broken / absent, so it lives HERE (not in
+    # the pure select_retain_window) inside a catch-all try/except.
+    #
+    # §4.3 HAZARD: this is the one seam where a raise DELETES a turn rather than
+    # degrading it. Every failure mode below MUST degrade to since_uuid=None,
+    # which reproduces today's whole-session sweep exactly. The except catches
+    # Exception (not a named subset) on purpose — any raise here is worse than a
+    # wrong value. The n==1 and full-session paths deliberately never compute a
+    # watermark: on those the document id is {session_id} and a tail slice would
+    # TRUNCATE the stored document (§4.2), so they keep the full-session sweep.
+    since_uuid = None
+    if force and retain_mode == "chunked" and retain_every_n > 1:
+        try:
+            _wm = watermark.load(session_id)
+            since_uuid = _wm.get("last_uuid") if _wm else None
+        except Exception as e:  # noqa: BLE001 - degrade, never raise into this seam
+            print(
+                "[Hindsight] watermark read failed for incremental sweep; "
+                f"falling back to full-session sweep: {e}",
+                file=sys.stderr,
+            )
+            since_uuid = None
+
     messages_to_retain, retain_full_window = select_retain_window(
-        retain_mode, retain_every_n, overlap_turns, all_messages, force=force
+        retain_mode, retain_every_n, overlap_turns, all_messages, force=force,
+        since_uuid=since_uuid,
     )
     if retain_mode == "chunked" and not force:
         window_turns = max(retain_every_n, 1) + overlap_turns
@@ -808,9 +862,11 @@ def run_retain(hook_input: dict, force: bool = False) -> dict:
             f"Chunked retain firing (window: {window_turns} human turns, {len(messages_to_retain)} messages)",
         )
     elif retain_mode == "chunked" and force:
+        _swept = "incremental (tail after watermark)" if since_uuid is not None else "full-session"
         debug_log(
             config,
-            f"Chunked retain, forced full-session sweep (SessionEnd): {len(all_messages)} messages",
+            f"Chunked retain, forced {_swept} sweep (SessionEnd): "
+            f"{len(messages_to_retain)}/{len(all_messages)} messages",
         )
     else:
         debug_log(config, f"Full session retain: {len(all_messages)} messages")

--- a/vendor/hindsight-memory/scripts/tests/test_incremental_sweep.py
+++ b/vendor/hindsight-memory/scripts/tests/test_incremental_sweep.py
@@ -1,0 +1,293 @@
+"""Switchroom memory-RFC P1 — incremental SessionEnd sweep, OUTCOME tests.
+
+Before P1 the SessionEnd hook called ``run_retain(force=True)`` which retained
+the WHOLE transcript, duplicating content the per-window retains already landed
+(RFC §1.2). P1 makes the forced chunked sweep slice only the transcript tail
+after the committed watermark, degrading to the whole transcript on any failure
+so the §4.3 hazard (a raise here DELETES a turn) is never triggered.
+
+Stdlib-only (`python3 -m unittest discover tests/`). Every test drives the real
+hook code against a FAKE in-process daemon (no network, no LLM) and asserts
+OUTCOMES — the bytes/turns that actually landed in the bank — not that a code
+path ran.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import retain  # noqa: E402
+from lib import watermark  # noqa: E402
+from lib.client import HindsightClient  # noqa: E402
+
+
+class FakeDaemon:
+    """Records retained documents by document_id with upsert semantics."""
+
+    def __init__(self):
+        self.docs = {}   # document_id -> content
+        self.posts = []  # [(document_id, async_processing)]
+
+    def retain(self, bank_id, content, document_id="conversation", context=None,
+               metadata=None, tags=None, timeout=15, async_processing=True,
+               observation_scopes=None):
+        self.posts.append((document_id, async_processing))
+        # Upsert: same document_id overwrites (the daemon contract §1).
+        self.docs[document_id] = content
+        return {"ok": True}
+
+    def content_blob(self):
+        return "\n".join(self.docs.values())
+
+    def bytes_for(self, session_prefix: str) -> int:
+        """Total stored content bytes across every document for a session."""
+        return sum(
+            len(c.encode("utf-8"))
+            for doc_id, c in self.docs.items()
+            if doc_id.startswith(session_prefix)
+        )
+
+    def last_post_content(self) -> str:
+        return self.docs[self.posts[-1][0]]
+
+
+def _write_transcript(path, n_turns, prefix):
+    """Flat-format JSONL: n_turns human turns, each user+assistant with a uuid."""
+    lines = []
+    for i in range(n_turns):
+        lines.append(json.dumps(
+            {"role": "user", "content": f"user turn {i}", "uuid": f"{prefix}-u{i}"}))
+        lines.append(json.dumps(
+            {"role": "assistant", "content": f"assistant turn {i}", "uuid": f"{prefix}-a{i}"}))
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+def _stdin(obj):
+    import io
+    return io.StringIO(json.dumps(obj))
+
+
+class IncrementalSweepBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="hs-rfc-p1-")
+        self.plugin_root = os.path.join(self.tmp, "plugin_root")
+        self.home = os.path.join(self.tmp, "home")
+        self.data = os.path.join(self.tmp, "data")
+        self.transcripts = os.path.join(self.tmp, "transcripts")
+        for d in (self.plugin_root, self.home, self.data, self.transcripts):
+            os.makedirs(d)
+
+        self._write_settings(8)  # default cadence for these tests; overridable
+
+        self.env = mock.patch.dict(os.environ, {
+            "CLAUDE_PLUGIN_ROOT": self.plugin_root,
+            "CLAUDE_PLUGIN_DATA": self.data,
+            "HOME": self.home,
+            "HINDSIGHT_PENDING_DIR": os.path.join(self.home, ".hindsight", "pending-retains"),
+            "HINDSIGHT_RETAINED_DIR": os.path.join(self.home, ".hindsight", "retained"),
+            "HINDSIGHT_INFLIGHT_LOCK": os.path.join(self.home, ".hindsight", "retain-inflight.lock"),
+            "HINDSIGHT_TRANSCRIPTS_DIR": self.transcripts,
+        }, clear=False)
+        self.env.start()
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_") and k not in (
+                "HINDSIGHT_PENDING_DIR", "HINDSIGHT_RETAINED_DIR",
+                "HINDSIGHT_INFLIGHT_LOCK", "HINDSIGHT_TRANSCRIPTS_DIR",
+            ):
+                os.environ.pop(k, None)
+
+        self.daemon = FakeDaemon()
+        self._patches = [
+            mock.patch.object(HindsightClient, "retain", self._fake_retain),
+            mock.patch("retain.get_api_url", return_value="http://fake"),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def _write_settings(self, every_n_turns: int):
+        settings = {
+            "autoRetain": True,
+            "retainMode": "chunked",
+            "retainEveryNTurns": every_n_turns,
+            "retainOverlapTurns": 0,
+            "bankId": "test-bank",
+        }
+        with open(os.path.join(self.plugin_root, "settings.json"), "w") as f:
+            json.dump(settings, f)
+
+    def _fake_retain(self, *a, **kw):
+        return self.daemon.retain(*a, **kw)
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self.env.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _hook(self, session):
+        return {
+            "session_id": session,
+            "transcript_path": os.path.join(self.transcripts, f"{session}.jsonl"),
+            "cwd": "/x",
+        }
+
+    def _fire_window(self, session, transcript_turns, turn_count):
+        """Drive a live per-window Stop retain (advances the watermark)."""
+        _write_transcript(self._hook(session)["transcript_path"], transcript_turns, session)
+        with mock.patch("retain.increment_turn_count", return_value=turn_count), \
+                mock.patch("sys.stdin", _stdin(self._hook(session))):
+            retain.main()
+
+
+class TestIncrementalSweep(IncrementalSweepBase):
+
+    def test_two_turn_no_watermark_sweep_retains_both_turns(self):
+        # A short session that never fired a per-window retain has no committed
+        # watermark, so the forced sweep must flush the WHOLE (2-turn) transcript
+        # (RFC §4.2 — short sessions still land on disk).
+        session = "sessShort"
+        _write_transcript(self._hook(session)["transcript_path"], 2, session)
+        self.assertIsNone(watermark.load(session))  # precondition: no watermark
+
+        result = retain.run_retain(self._hook(session), force=True)
+
+        self.assertEqual(result.get("status"), "ok")
+        blob = self.daemon.content_blob()
+        self.assertIn("user turn 0", blob)
+        self.assertIn("user turn 1", blob)
+
+    def test_thirty_turn_sweep_is_incremental_and_smaller_than_full(self):
+        # Windows fire at turns 8/16/24 (n=8, overlap 0), then SessionEnd sweeps.
+        # The sweep must contain ONLY turns after the last window's tail uuid,
+        # and the total bytes stored for the session must be strictly less than
+        # the pre-change (full-session sweep) total. This is the test that fails
+        # on the bug it guards: a non-incremental sweep re-stores all 30 turns,
+        # so the totals become equal and assertLess fires.
+        inc = "sessInc"
+        for fire_at in (8, 16, 24):
+            self._fire_window(inc, fire_at, fire_at)
+        # The last window committed its tail uuid as the watermark.
+        wm = watermark.load(inc)
+        self.assertIsNotNone(wm, "expected the per-window retains to commit a watermark")
+        self.assertEqual(wm["last_uuid"], f"{inc}-a23")
+
+        _write_transcript(self._hook(inc)["transcript_path"], 30, inc)
+        result = retain.run_retain(self._hook(inc), force=True)
+        self.assertEqual(result.get("status"), "ok")
+
+        sweep = self.daemon.last_post_content()
+        # Only turns AFTER the watermark (24..29); nothing at/ before it.
+        for i in range(24, 30):
+            self.assertIn(f"user turn {i}", sweep, f"turn {i} missing from incremental sweep")
+        for i in (0, 15, 23):
+            self.assertNotIn(f"user turn {i}", sweep,
+                             f"turn {i} leaked into the incremental sweep")
+
+        # Pre-change baseline: identical scenario, but the SessionEnd sweep runs
+        # full-session (watermark unseen), on a distinct session id in the same
+        # daemon so window docs are directly comparable.
+        full = "sessFull"
+        for fire_at in (8, 16, 24):
+            self._fire_window(full, fire_at, fire_at)
+        _write_transcript(self._hook(full)["transcript_path"], 30, full)
+        with mock.patch("retain.watermark.load", return_value=None):
+            self.assertEqual(retain.run_retain(self._hook(full), force=True).get("status"), "ok")
+
+        self.assertLess(
+            self.daemon.bytes_for(inc),
+            self.daemon.bytes_for(full),
+            "incremental sweep did not reduce total retained bytes vs full sweep",
+        )
+
+    def test_corrupt_watermark_json_sweeps_whole_transcript_no_raise(self):
+        # A watermark file corrupted to invalid JSON must degrade to a whole
+        # -transcript sweep, and no exception may escape run_retain (§4.3).
+        session = "sessCorrupt"
+        _write_transcript(self._hook(session)["transcript_path"], 4, session)
+        retained_dir = os.environ["HINDSIGHT_RETAINED_DIR"]
+        os.makedirs(retained_dir, exist_ok=True)
+        with open(os.path.join(retained_dir, f"{session}.json"), "w") as f:
+            f.write("{ this is not valid json ]]]")
+
+        try:
+            result = retain.run_retain(self._hook(session), force=True)
+        except Exception as e:  # noqa: BLE001 - the whole point is nothing escapes
+            self.fail(f"run_retain raised into the SessionEnd seam: {e!r}")
+
+        self.assertEqual(result.get("status"), "ok")
+        blob = self.daemon.content_blob()
+        for i in range(4):
+            self.assertIn(f"user turn {i}", blob)
+
+    def test_watermark_load_raising_degrades_to_full_sweep(self):
+        # Belt-and-braces for the §4.3 catch-all: even if the watermark READ
+        # itself raises an unexpected error, run_retain must NOT propagate it —
+        # it degrades to the whole-transcript sweep.
+        session = "sessBoom"
+        _write_transcript(self._hook(session)["transcript_path"], 4, session)
+
+        def _boom(_):
+            raise RuntimeError("simulated watermark read explosion")
+
+        with mock.patch("retain.watermark.load", side_effect=_boom):
+            try:
+                result = retain.run_retain(self._hook(session), force=True)
+            except Exception as e:  # noqa: BLE001
+                self.fail(f"run_retain propagated a watermark read failure: {e!r}")
+
+        self.assertEqual(result.get("status"), "ok")
+        blob = self.daemon.content_blob()
+        for i in range(4):
+            self.assertIn(f"user turn {i}", blob)
+
+    def test_compacted_watermark_uuid_sweeps_whole_transcript(self):
+        # The watermark anchor was compacted out of the transcript: tail_after
+        # cannot find it and returns the whole transcript (a safe re-upsert).
+        session = "sessCompact"
+        _write_transcript(self._hook(session)["transcript_path"], 4, session)
+        # Commit a watermark whose uuid is NOT present in the transcript.
+        watermark.commit(session, "ghost-uuid-not-in-transcript", "doc-ghost",
+                         ordered_uuids=["ghost-uuid-not-in-transcript"])
+        self.assertEqual(watermark.load(session)["last_uuid"], "ghost-uuid-not-in-transcript")
+
+        result = retain.run_retain(self._hook(session), force=True)
+        self.assertEqual(result.get("status"), "ok")
+        blob = self.daemon.content_blob()
+        for i in range(4):
+            self.assertIn(f"user turn {i}", blob)
+
+    def test_every_n_turns_1_is_byte_identical_full_session(self):
+        # At retainEveryNTurns==1 the document id is {session_id} and a tail slice
+        # would TRUNCATE it (RFC §4.2). The n==1 path must keep the full-session
+        # sweep even when a committed watermark exists — byte-identical to before.
+        self._write_settings(1)
+        session = "sessN1"
+        _write_transcript(self._hook(session)["transcript_path"], 4, session)
+        # A watermark exists (a prior every-turn fire) sitting mid-transcript.
+        watermark.commit(session, f"{session}-a1", "doc-prior",
+                         ordered_uuids=[f"{session}-u{i//2}" if i % 2 == 0 else f"{session}-a{i//2}"
+                                        for i in range(8)])
+        self.assertEqual(watermark.load(session)["last_uuid"], f"{session}-a1")
+
+        result = retain.run_retain(self._hook(session), force=True)
+        self.assertEqual(result.get("status"), "ok")
+
+        # Whole transcript, under the plain {session_id} document id — the tail
+        # slice must NOT have applied.
+        self.assertIn(session, self.daemon.docs, "n==1 sweep must post under the {session_id} id")
+        content = self.daemon.docs[session]
+        for i in range(4):
+            self.assertIn(f"user turn {i}", content, f"turn {i} missing — n==1 sweep was truncated")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

Implements **P1** of the agent-memory redesign RFC (`memory-redesign/phase4-rfc.md` §4).

Today the SessionEnd hook calls `run_retain(force=True)`, which retains the **whole transcript** — duplicating content the per-window retains already landed. At `retainEveryNTurns > 1` the sweep's content-derived `document_id` (anchored at the transcript's *first* uuid) can never converge with any window's id, so the engine stores the whole session as an *additional* document, every session, scaling with session length (RFC §1.2).

## The change

- `select_retain_window` gains an optional `since_uuid`. When `force=True` and it is not `None`, it returns the transcript tail after that uuid instead of `list(all_messages)`. The function stays **pure and IO-free** (RFC §4.3 rule 1).
- The tail slice `_tail_after` is moved to `lib.watermark.tail_after` as the **single shared implementation**; `reconcile_tail` now aliases it — no forked second copy of a reconcile/watermark-critical slice (RFC §4.1).
- `run_retain` reads the watermark inside a **catch-all `try/except Exception`** that degrades to `since_uuid=None` (today's whole-session sweep) on *any* failure. This seam is the one place a raise **DELETES** a turn rather than degrading it (RFC §4.3; `retain.py` #3244 comment). Every new failure mode degrades to `list(all_messages)`.
- The `retainEveryNTurns == 1` path is left **unchanged**: its document id is `{session_id}` and a tail slice would *truncate* the stored document (RFC §4.2). The watermark is read only when `force and chunked and every_n > 1`.

## Tests (outcome assertions — RFC §4.3)

New `tests/test_incremental_sweep.py`:
- 2-turn session, no prior watermark → sweep flushes **both** turns.
- 30-turn session at `every_n_turns=8`, windows fired → sweep contains **only** turns after the last window's tail uuid, **and** total retained bytes for the session are strictly less than the full-session baseline. *Mutation-verified*: disabling the incremental branch makes this test fail.
- Watermark corrupted to invalid JSON → whole-transcript sweep, **no exception escapes** `run_retain`.
- Watermark read raising an unexpected error → degrades to whole-transcript sweep (belt-and-braces for the catch-all).
- Watermark uuid absent from transcript (compaction) → whole transcript.
- `every_n_turns=1` → byte-identical full-session sweep under the `{session_id}` id.

`python3 -m unittest discover tests/` → **1085 passed**. Existing `test_retain_window` / `test_reconcile_durability` unchanged and green.

## Rollback

Pass `since_uuid=None` unconditionally (one line) or revert the commit. No stored data is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)