### PR TITLE
P7: loud in-turn directive-overflow notice (memory-RFC)

### DIFF
--- a/vendor/hindsight-memory/scripts/lib/directives.py
+++ b/vendor/hindsight-memory/scripts/lib/directives.py
@@ -47,8 +47,9 @@ from .state import list_state_names, read_state, remove_state, write_state
 # move the doctor thresholds with it.
 #
 # Banks with more active directives than this are pathological; we truncate
-# with an in-prompt footer, a `directives_omitted` field on the recall_log row,
-# and a stderr warning (see `format_active_directives_block`).
+# with a LOUD, operator-directed in-prompt overflow notice (memory-RFC P7 — the
+# in-turn channel), a `directives_omitted` field on the recall_log row, and a
+# stderr warning (see `format_active_directives_block`).
 MAX_DIRECTIVES = 30
 
 # Hard timeout for the list_directives call. The recall hook is on the
@@ -272,6 +273,10 @@ def format_active_directives_block(directives: list, max_directives: int = MAX_D
         1. [P10] <name>: <content>
         2. [P9] <name>: <content>
         ...
+
+        === DIRECTIVE OVERFLOW — ACTION REQUIRED ===
+        <N of TOTAL directives dropped; agent is told to surface it to the
+         operator this turn and merge/retire directives> (only when omitted > 0)
         (+N more, omitted)
         </active_directives>
     """
@@ -301,12 +306,45 @@ def format_active_directives_block(directives: list, max_directives: int = MAX_D
         lines.append(f"{i}. [P{priority}] {name}: {content}")
 
     if omitted > 0:
+        # LOUD in-prompt overflow notice (memory-RFC P7). The prior footer was a
+        # single quiet parenthetical — `(+N more, omitted)` — which the agent
+        # could read past without registering that explicit, operator-authored
+        # instructions had been silently DROPPED from this turn. The three other
+        # signals this module records are either not operator-visible (stderr —
+        # swallowed, see below) or not in-turn (the `directives_omitted`
+        # recall_log row and `switchroom doctor`, both read after the fact). The
+        # in-prompt block is the one channel that is BOTH in-turn and reaches an
+        # operator — indirectly, because the agent relays it in its reply. So we
+        # make the footer loud and explicitly action-directed: state the loss,
+        # name the count and cap, and instruct the agent to surface it to the
+        # operator THIS turn. This is the P7 "loud channel" and is deliberately
+        # NOT a MAX_DIRECTIVES change (raising the cap only moves the silent-drop
+        # point; visibility has to ship first).
+        #
+        # The literal `(+N more, omitted)` marker is retained verbatim so the
+        # existing recall_log/doctor cross-checks and the directive-dedup parser
+        # (`parse_active_directives_block`) keep working unchanged.
         lines.append("")
+        lines.append("=== DIRECTIVE OVERFLOW — ACTION REQUIRED ===")
+        lines.append(
+            f"{omitted} of {total} active directives were DROPPED from this turn's "
+            f"prompt: the bank exceeds MAX_DIRECTIVES={max_directives}, so the "
+            f"{omitted} LOWEST-priority directive(s) are NOT in effect this turn. "
+            "This is silent loss of explicit, operator-authored instructions."
+        )
+        lines.append(
+            "ACTION: tell the operator in your reply this turn that directive "
+            "overflow is dropping rules, then merge or retire duplicate/stale "
+            "directives (mental-model-curator skill) to get the bank back under "
+            "the cap. Do not let this pass unmentioned."
+        )
         lines.append(f"(+{omitted} more, omitted)")
-        # The in-prompt footer above only tells the AGENT. This stderr warn is
-        # the same channel every other operational failure in this module uses
-        # (see `_fetch_directives_with_status`), and it is a LAST-RESORT
-        # breadcrumb only — do NOT rely on it reaching an operator.
+        # The in-prompt notice above is the operator-visible in-turn channel
+        # (P7): the agent reads it every turn the overflow persists and is told
+        # to relay it. This stderr warn is the same channel every other
+        # operational failure in this module uses (see
+        # `_fetch_directives_with_status`), and it is a LAST-RESORT breadcrumb
+        # only — do NOT rely on it reaching an operator.
         #
         # Measured 2026-07-25: `docker logs --tail 20000` across all 12 running
         # agent containers returns ZERO `[Hindsight]` lines, and nothing under
@@ -315,7 +353,7 @@ def format_active_directives_block(directives: list, max_directives: int = MAX_D
         # appears to swallow hook stderr on a zero exit, so hook stderr is not
         # an operator-visible channel.
         #
-        # The channels that DO reach an operator:
+        # The other channels that reach an operator, but only AFTER the turn:
         #   * the `directives_omitted` field on the recall_log row
         #     (state/recall_log.jsonl — see `count_omitted_directives`), and
         #   * `switchroom doctor`'s WARN/FAIL on the bank's active directive

--- a/vendor/hindsight-memory/scripts/tests/test_directives.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directives.py
@@ -243,6 +243,58 @@ class FormatActiveDirectivesBlockTests(unittest.TestCase):
         # The in-prompt footer is still emitted (agent-facing signal).
         self.assertIn("(+4 more, omitted)", out)
 
+    def test_overflow_footer_is_loud_and_operator_directed(self):
+        """memory-RFC P7 — the in-prompt overflow notice must be LOUD and tell
+        the agent to surface the drop to the operator this turn.
+
+        The pre-P7 block emitted only the quiet `(+N more, omitted)`
+        parenthetical, which reaches the agent but neither states that explicit
+        instructions were dropped nor directs the agent to relay it. This
+        asserts the OUTCOME of the loud in-turn channel: the rendered block, on
+        overflow, names the dropped count, the total, the cap, states the loss
+        in unmistakable terms, and instructs the agent to tell the operator.
+        A test that only checked `(+N more, omitted)` would still pass on the
+        pre-P7 code, so it would not guard this change; these assertions fail
+        without it.
+        """
+        total = MAX_DIRECTIVES + 3
+        directives = [
+            _directive(f"d{i}", f"c{i}", priority=total - i) for i in range(total)
+        ]
+        with patch("sys.stderr", new=StringIO()):
+            out = format_active_directives_block(directives)
+        # A loud, explicitly-labelled overflow banner (not a lone parenthetical).
+        self.assertIn("DIRECTIVE OVERFLOW", out)
+        # Names the loss in unmistakable terms, with count/total/cap.
+        self.assertIn("DROPPED", out)
+        self.assertIn("3 of", out)  # omitted of total
+        self.assertIn(str(total), out)
+        self.assertIn(f"MAX_DIRECTIVES={MAX_DIRECTIVES}", out)
+        # Directs the agent to surface it to the OPERATOR this turn — the
+        # in-turn operator-visible channel P7 adds.
+        self.assertIn("operator", out.lower())
+        self.assertIn("ACTION", out)
+        # The literal marker is retained for the recall_log/doctor cross-checks
+        # and the dedup parser.
+        self.assertIn("(+3 more, omitted)", out)
+
+    def test_no_overflow_banner_when_under_cap(self):
+        """The loud banner must appear ONLY on overflow — an under-cap block is
+        unchanged and carries neither the banner nor the action directive."""
+        directives = [_directive(f"d{i}", f"c{i}", priority=5 - i) for i in range(3)]
+        with patch("sys.stderr", new=StringIO()) as fake_err:
+            out = format_active_directives_block(directives)
+        self.assertNotIn("DIRECTIVE OVERFLOW", out)
+        self.assertNotIn("ACTION", out)
+        self.assertNotIn("more, omitted", out)
+        self.assertEqual(fake_err.getvalue(), "")
+
+    def test_max_directives_is_unchanged_by_p7(self):
+        """P7 is the loud-channel PR only. Raising MAX_DIRECTIVES is a separate,
+        later change (RFC §5 P7: order is non-negotiable). Pin the constant so a
+        cap bump cannot ride in on this change unnoticed."""
+        self.assertEqual(MAX_DIRECTIVES, 30)
+
     def test_count_omitted_directives_matches_the_rendered_footer(self):
         """The recall_log's `directives_omitted` number must equal what the
         block actually dropped — it is the operator-visible record of it."""


### PR DESCRIPTION
## What this is

Item **P7** of the switchroom memory-redesign RFC (`workspace/memory-redesign/phase4-rfc.md`, §5 "P7 — Loud directive overflow, then the cap raise"), as a focused single-concern change. Repo-only, no fleet behaviour change on the normal path.

## The problem

When a bank exceeds `MAX_DIRECTIVES` (30), `format_active_directives_block` drops the lowest-priority directives from **every** turn's prompt. The three signals recording that are all inadequate as an in-turn operator channel:

- **stderr breadcrumb** — proven NOT operator-visible: Claude Code swallows hook stderr on a zero exit; `docker logs --tail 20000` across all 12 live containers returns zero `[Hindsight]` lines (`directives.py:295-301`).
- **`directives_omitted` recall_log row** — operator-visible but only **after the fact**.
- **`switchroom doctor`** — operator-visible but only **after the fact**.

The only in-turn signal was a single quiet `(+N more, omitted)` parenthetical the agent could read straight past.

## The change (LOUD CHANNEL ONLY)

Promote that footer into a loud, operator-directed overflow notice inside the `<active_directives>` block. On overflow it now:

- states in unmistakable terms that explicit, operator-authored instructions were **DROPPED**;
- names the dropped count, the total, and the cap;
- **instructs the agent to surface it to the operator in its reply this turn** and to merge/retire directives.

The agent relaying it is the in-turn operator-visible channel the RFC asks for, reusing the in-prompt-footer mechanism the RFC names (`directives.py`). The literal `(+N more, omitted)` marker is kept verbatim so the recall_log/doctor cross-checks and the directive-dedup parser (`parse_active_directives_block`) are unaffected.

### Channel added, in one line
A loud, action-directed directive-overflow banner rendered inside the in-prompt `<active_directives>` block that tells the agent to relay the drop to the operator this turn — the in-turn operator-visible channel.

### MAX_DIRECTIVES: NOT touched
`MAX_DIRECTIVES` stays at **30**. Per RFC §5 the cap raise is a separate, later change — raising it without the loud channel first only moves the silent-drop point from 30 to 60. A pin test (`test_max_directives_is_unchanged_by_p7`) guards the constant against riding in on this PR. The only files changed are `lib/directives.py` and its test; `retain.py` and `recall()` are untouched (no collision with in-flight P2/P3).

## Tests

- `test_overflow_footer_is_loud_and_operator_directed` — asserts the banner names count/total/cap, says DROPPED, and directs the agent to the operator. **Fails on the pre-P7 formatter** (verified by stashing the source change), passes with it. A test that only checked `(+N more, omitted)` would still pass on pre-P7 code and so would not guard this change.
- `test_no_overflow_banner_when_under_cap` — negative: under cap the block is unchanged, no banner, no stderr.
- `test_max_directives_is_unchanged_by_p7` — pins the cap at 30.

108 Python tests pass across `test_directives.py`, `test_recall_integration.py`, `test_subagent_retain_learnings.py`. `py_compile` clean (no ruff/flake8 in-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)