### PR TITLE
memory: reflect cardinality guard in the hindsight shim (RFC P9)

### DIFF
--- a/changelog.d/4748-reflect-cardinality-guard.feat.md
+++ b/changelog.d/4748-reflect-cardinality-guard.feat.md
@@ -1,0 +1,13 @@
+- **memory: reflect cardinality guard in the hindsight shim (#4748)** —
+  memory-redesign RFC P9. On the `reflect` `tools/call` path the
+  hindsight-mcp-shim now returns an explicit "no relevant memories" answer
+  instead of the engine's synthesized prose when the returned evidence set is
+  genuinely empty, so an empty retrieval produces a machine-legible absence
+  rather than a fluent-but-sourceless answer (the false-positive that defeats
+  the abstention signal). The gate keys off the REAL returned evidence
+  cardinality, not a heuristic: the shim forces `include_based_on:true` onto
+  the forwarded call (the caller's explicit value still wins) and abstains only
+  when `based_on` is present and totals zero across every bucket; when the
+  evidence set cannot be seen the synthesized answer passes through unchanged,
+  and on a non-empty result the injected evidence is stripped back out unless
+  the caller asked for it. Shim-only — no engine, retain, or recall change.

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -562,6 +562,124 @@ export function isReflectToolCallFailure(
   return texts.some((t) => t.includes(REFLECT_NO_TOOL_CALL_SIGNATURE));
 }
 
+// ─── Reflect cardinality guard (RFC P9) ────────────────────────────────────
+
+/**
+ * The explicit "no relevant memories" answer the shim substitutes for a
+ * `reflect` synthesis when the engine's returned evidence set is genuinely
+ * empty.
+ *
+ * WHY A SUBSTITUTION AND NOT A PASS-THROUGH: hindsight's reflect agent always
+ * emits SOME prose. On an empty retrieval that prose is a fluent-but-sourceless
+ * answer — the model narrating around nothing — which reads to the calling
+ * agent as a real recalled fact and is exactly the false-positive that defeats
+ * an abstention signal (RFC J2/J7). Replacing it with a flat, machine-legible
+ * absence is the whole point: downstream can branch on "the bank had nothing"
+ * instead of parsing confidence out of prose.
+ *
+ * `isError` is deliberately false on the substituted result — an empty bank is
+ * a valid answer, not a tool failure, and flagging it isError would make the
+ * agent retry a query that will keep returning empty.
+ */
+export const REFLECT_EMPTY_EVIDENCE_TEXT =
+  "No relevant memories: reflect retrieved ZERO evidence from your memory " +
+  "bank for this query — no memories, mental models, or directives matched. " +
+  "This is not an error and not a synthesized answer: the bank has nothing " +
+  "recorded on this topic. Treat it as an explicit absence, not a fact, and " +
+  "do not present the (suppressed) synthesized prose as if it were recalled.";
+
+/**
+ * Total cardinality of a reflect `based_on` evidence map.
+ *
+ * Tolerant of every shape the field takes: the MCP tool result buckets by
+ * fact_type (`world`/`experience`/`opinion`/`observation`, plus `mental-models`
+ * / `directives` when present); the REST model buckets as
+ * `memories`/`mental_models`/`directives`. Both are just an object whose values
+ * are arrays, so summing array lengths over ALL values counts every piece of
+ * evidence regardless of which spelling the pinned engine uses. A non-array
+ * value contributes nothing. Returns `null` when `based_on` is absent or is not
+ * an object — the caller reads that as "could not determine" and never
+ * abstains, which is the false-abstention-safe direction.
+ */
+export function reflectEvidenceCardinality(basedOn: unknown): number | null {
+  if (!basedOn || typeof basedOn !== "object" || Array.isArray(basedOn)) {
+    return null;
+  }
+  let total = 0;
+  for (const v of Object.values(basedOn as Record<string, unknown>)) {
+    if (Array.isArray(v)) total += v.length;
+  }
+  return total;
+}
+
+/**
+ * Post-process a forwarded `reflect` tool result: abstain explicitly when the
+ * engine's returned evidence set is genuinely empty, and strip the evidence set
+ * back out when the shim injected `include_based_on` the caller did not ask for.
+ *
+ * The gate keys off the REAL returned evidence cardinality (`based_on`), NEVER a
+ * heuristic over the synthesized prose. So it fires ONLY when retrieval was
+ * genuinely empty and can never false-abstain on a query the engine actually
+ * had evidence for — the one risk RFC P9 calls out. Whenever the evidence set
+ * cannot be seen (no `based_on`, content not the expected JSON, unexpected
+ * shape), the result is returned UNCHANGED: the safe direction is always "keep
+ * the synthesized answer", never "abstain on a doubt".
+ *
+ * `callerWantedBasedOn` records whether the original tool call asked for the
+ * evidence. The shim forces `include_based_on: true` on the forwarded request so
+ * this gate always has ground truth to read; when the caller did not ask for it
+ * and retrieval was non-empty, the injected `based_on` is removed so the
+ * caller-visible payload is byte-for-byte what it would have been without the
+ * guard. The ONLY observable behaviour change is the empty-retrieval abstention.
+ */
+export function applyReflectCardinalityGuard(
+  result: unknown,
+  callerWantedBasedOn: boolean,
+): unknown {
+  const abstain = {
+    content: [{ type: "text", text: REFLECT_EMPTY_EVIDENCE_TEXT }],
+    isError: false,
+  };
+  if (!result || typeof result !== "object") return result;
+  const res = result as {
+    content?: Array<{ type?: unknown; text?: unknown }>;
+    isError?: unknown;
+  };
+  if (res.isError) return result; // an error result carries no evidence set
+  const content = res.content;
+  if (!Array.isArray(content) || content.length === 0) return result;
+  const first = content[0];
+  if (!first || typeof first.text !== "string") return result;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(first.text);
+  } catch {
+    return result; // not the JSON envelope — leave it exactly as-is
+  }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return result;
+  }
+  const obj = payload as Record<string, unknown>;
+  if (!("based_on" in obj)) return result; // evidence not visible → never abstain
+  const cardinality = reflectEvidenceCardinality(obj.based_on);
+  if (cardinality === null) return result;
+  if (cardinality === 0) return abstain;
+  if (callerWantedBasedOn) return result; // caller asked for it — keep it
+  // Non-empty, but the caller never requested the evidence set; the shim only
+  // injected include_based_on to run this gate. Strip it back out so the
+  // caller-visible payload matches the pre-guard behaviour, preserving every
+  // other field and content entry. 2-space indent mirrors the engine's own
+  // rendering of this envelope.
+  delete obj.based_on;
+  return {
+    ...res,
+    content: [
+      { ...first, text: JSON.stringify(obj, null, 2) },
+      ...content.slice(1),
+    ],
+  };
+}
+
 /**
  * Mask secrets in the string leaves of a tool-call argument object.
  *
@@ -870,6 +988,18 @@ export function guardAndClampToolCall(
               env.HINDSIGHT_SHIM_REFLECT_BUDGET,
               DEFAULT_REFLECT_BUDGET,
             );
+    }
+    // RFC P9: force the reflect evidence set on so the cardinality guard in
+    // toolsCall() has GROUND TRUTH (the real returned evidence) to read rather
+    // than a heuristic over the synthesized prose. Only when the caller omits
+    // it — an explicit include_based_on (true OR false) is the caller's call
+    // and wins, exactly like budget/max_tokens above. When the caller leaves
+    // it false the guard simply cannot see the evidence and never abstains,
+    // which is the false-abstention-safe direction. The injected field is
+    // stripped back out post-response unless the caller asked for it, so this
+    // never bloats the caller-visible payload (see applyReflectCardinalityGuard).
+    if (name === "reflect" && injected.include_based_on === undefined) {
+      injected.include_based_on = true;
     }
     return { ok: true, params: { ...called, arguments: injected } };
   }
@@ -1582,6 +1712,16 @@ export class HindsightShim {
     // READ_ONLY_TOOL_NAMES — the allowlist is the reads, not the writes).
     const forwarded = redactToolCallParams(guarded.params);
     const toolName = (guarded.params as { name?: string } | undefined)?.name;
+    // Whether the ORIGINAL call asked for the evidence set — read from the
+    // caller's params, before guardAndClampToolCall forced include_based_on on
+    // (RFC P9). Drives whether the injected evidence is stripped back out of a
+    // non-empty result.
+    const callerWantedBasedOn =
+      toolName === "reflect" &&
+      Boolean(
+        (called?.arguments as { include_based_on?: unknown } | undefined)
+          ?.include_based_on,
+      );
     const timeoutMs = this.opts.toolsCallTimeoutMs ?? TOOLS_CALL_TIMEOUT_MS;
     try {
       let res = await this.upstream.request("tools/call", forwarded, timeoutMs);
@@ -1612,6 +1752,14 @@ export class HindsightShim {
           ],
           isError: true,
         };
+      }
+      // RFC P9 reflect cardinality guard: substitute an explicit "no relevant
+      // memories" answer when the engine's returned evidence set is genuinely
+      // empty, and strip the shim-injected evidence back out otherwise. A
+      // no-op for every non-reflect tool and for reflect results whose evidence
+      // set cannot be read.
+      if (toolName === "reflect") {
+        return applyReflectCardinalityGuard(res.result, callerWantedBasedOn);
       }
       return res.result;
     } catch (err) {

--- a/tests/hindsight-mcp-shim.test.ts
+++ b/tests/hindsight-mcp-shim.test.ts
@@ -34,6 +34,9 @@ import {
   isReflectToolCallFailure,
   REFLECT_TOOL_CALL_RETRIES,
   REFLECT_NO_TOOL_CALL_SIGNATURE,
+  REFLECT_EMPTY_EVIDENCE_TEXT,
+  reflectEvidenceCardinality,
+  applyReflectCardinalityGuard,
   type ShimOptions,
 } from "../src/cli/hindsight-mcp-shim.js";
 
@@ -1173,5 +1176,201 @@ describe("synthesized knowledge-page tools", () => {
       ).not.toContain("no dispatch arm");
       expect(result.content[0].text).toContain(`${name} failed:`);
     }
+  });
+});
+
+
+// ─── reflect cardinality guard (RFC P9) ───────────────────────────────────
+
+/**
+ * The engine's reflect tool result: a `content[0].text` JSON envelope of
+ * `{ text, based_on? }`, wrapped in the fastmcp meta the live backend adds.
+ * `basedOn === undefined` reproduces a reflect WITHOUT include_based_on
+ * (no evidence key at all).
+ */
+function reflectResult(
+  text: string,
+  basedOn?: Record<string, unknown[]>,
+): { result: unknown } {
+  const envelope =
+    basedOn === undefined ? { text } : { text, based_on: basedOn };
+  return {
+    result: {
+      _meta: { fastmcp: { wrap_result: true } },
+      content: [{ type: "text", text: JSON.stringify(envelope) }],
+      isError: false,
+    },
+  };
+}
+
+describe("reflectEvidenceCardinality (unit)", () => {
+  it("sums array lengths across every bucket, tolerant of shape", () => {
+    // MCP fact-type bucketing
+    expect(
+      reflectEvidenceCardinality({
+        world: [],
+        experience: [{}],
+        opinion: [],
+        observation: [{}, {}],
+      }),
+    ).toBe(3);
+    // REST memories/mental_models/directives bucketing
+    expect(
+      reflectEvidenceCardinality({
+        memories: [{}, {}],
+        mental_models: [{}],
+        directives: [],
+      }),
+    ).toBe(3);
+  });
+
+  it("is zero for an all-empty evidence map and for {}", () => {
+    expect(
+      reflectEvidenceCardinality({ world: [], observation: [] }),
+    ).toBe(0);
+    expect(reflectEvidenceCardinality({})).toBe(0);
+  });
+
+  it("returns null (undeterminable) for absent / non-object based_on", () => {
+    expect(reflectEvidenceCardinality(undefined)).toBeNull();
+    expect(reflectEvidenceCardinality(null)).toBeNull();
+    expect(reflectEvidenceCardinality([])).toBeNull();
+    expect(reflectEvidenceCardinality("x")).toBeNull();
+  });
+});
+
+describe("applyReflectCardinalityGuard (unit)", () => {
+  it("abstains ONLY when the evidence set is present and empty", () => {
+    const empty = reflectResult("fluent but sourceless", {
+      world: [],
+      observation: [],
+    }).result;
+    const out = applyReflectCardinalityGuard(empty, false) as {
+      content: { text: string }[];
+      isError: boolean;
+    };
+    expect(out.content[0].text).toBe(REFLECT_EMPTY_EVIDENCE_TEXT);
+    expect(out.isError).toBe(false);
+  });
+
+  it("passes through UNCHANGED when based_on is absent (never false-abstains)", () => {
+    const noEvidence = reflectResult("a real answer").result;
+    const out = applyReflectCardinalityGuard(noEvidence, false);
+    expect(out).toBe(noEvidence);
+  });
+
+  it("passes through UNCHANGED when content is not the JSON envelope", () => {
+    const plain = {
+      content: [{ type: "text", text: "not json" }],
+      isError: false,
+    };
+    expect(applyReflectCardinalityGuard(plain, false)).toBe(plain);
+  });
+
+  it("strips injected based_on on a non-empty result the caller did not ask for", () => {
+    const withEvidence = reflectResult("the answer is 42", {
+      observation: [{ id: "a" }, { id: "b" }],
+    }).result;
+    const out = applyReflectCardinalityGuard(withEvidence, false) as {
+      content: { text: string }[];
+    };
+    const parsed = JSON.parse(out.content[0].text) as Record<string, unknown>;
+    expect(parsed.text).toBe("the answer is 42");
+    expect(parsed.based_on).toBeUndefined();
+  });
+
+  it("keeps based_on on a non-empty result the caller DID ask for", () => {
+    const withEvidence = reflectResult("answer", {
+      observation: [{ id: "a" }],
+    }).result;
+    const out = applyReflectCardinalityGuard(withEvidence, true) as {
+      content: { text: string }[];
+    };
+    const parsed = JSON.parse(out.content[0].text) as Record<string, unknown>;
+    expect(parsed.based_on).toBeDefined();
+  });
+});
+
+describe("reflect cardinality guard through the live shim (RFC P9)", () => {
+  let backend: MockBackend;
+  afterEach(async () => {
+    await backend.close();
+  });
+
+  it("ABSTAINS on genuinely-empty retrieval, and forced include_based_on on the forwarded call", async () => {
+    backend = await startMockBackend({
+      onToolsCall: (_i, name) =>
+        name === "reflect"
+          ? reflectResult("The bank clearly says X — a made-up answer.", {
+              world: [],
+              experience: [],
+              opinion: [],
+              observation: [],
+            })
+          : undefined,
+    });
+    const shim = makeShim({ url: backend.url, cacheDir });
+    await shim.handle(rpc(1, "initialize", { protocolVersion: "2025-06-18" }) as never);
+
+    const res = await shim.handle(
+      rpc(2, "tools/call", { name: "reflect", arguments: { query: "q" } }) as never,
+    );
+    const result = res?.result as { isError: boolean; content: { text: string }[] };
+    // The synthesized prose is SUPPRESSED and replaced with the explicit
+    // absence — this assertion fails if the guard is removed (the raw
+    // "made-up answer" text would come back instead).
+    expect(result.content[0].text).toBe(REFLECT_EMPTY_EVIDENCE_TEXT);
+    expect(result.isError).toBe(false);
+    // The shim forced the evidence set on so the gate had ground truth.
+    const call = backend.requests.find((r) => r.method === "tools/call");
+    const args = call?.params?.arguments as Record<string, unknown>;
+    expect(args.include_based_on).toBe(true);
+  });
+
+  it("does NOT abstain when evidence is present — the synthesized answer is preserved", async () => {
+    backend = await startMockBackend({
+      onToolsCall: (_i, name) =>
+        name === "reflect"
+          ? reflectResult("Ken prefers 8-turn cadence.", {
+              observation: [{ id: "f1" }, { id: "f2" }],
+            })
+          : undefined,
+    });
+    const shim = makeShim({ url: backend.url, cacheDir });
+    await shim.handle(rpc(1, "initialize", { protocolVersion: "2025-06-18" }) as never);
+
+    const res = await shim.handle(
+      rpc(2, "tools/call", { name: "reflect", arguments: { query: "cadence" } }) as never,
+    );
+    const result = res?.result as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    // Real answer survives; the abstention text NEVER appears when the engine
+    // had evidence — this fails if the gate keys off prose instead of the
+    // returned cardinality.
+    expect(parsed.text).toBe("Ken prefers 8-turn cadence.");
+    expect(result.content[0].text).not.toContain(REFLECT_EMPTY_EVIDENCE_TEXT);
+    // Injected evidence stripped back out (caller did not request it).
+    expect(parsed.based_on).toBeUndefined();
+  });
+
+  it("preserves based_on when the CALLER explicitly requested include_based_on", async () => {
+    backend = await startMockBackend({
+      onToolsCall: (_i, name) =>
+        name === "reflect"
+          ? reflectResult("answer", { observation: [{ id: "f1" }] })
+          : undefined,
+    });
+    const shim = makeShim({ url: backend.url, cacheDir });
+    await shim.handle(rpc(1, "initialize", { protocolVersion: "2025-06-18" }) as never);
+
+    const res = await shim.handle(
+      rpc(2, "tools/call", {
+        name: "reflect",
+        arguments: { query: "q", include_based_on: true },
+      }) as never,
+    );
+    const result = res?.result as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    expect(parsed.based_on).toBeDefined();
   });
 });


### PR DESCRIPTION
Implements **P9** of the memory-redesign RFC (`phase4-rfc.md` §5, "Reflect cardinality guard in the shim"). Shim-only; no engine, `retain.py`, `recall.py`, or `client.py` change.

## What triggers the abstention

On the `reflect` `tools/call` path, the shim substitutes an explicit **"no relevant memories"** result (`REFLECT_EMPTY_EVIDENCE_TEXT`, `isError:false`) for the engine's synthesized prose **iff the engine's returned evidence set (`based_on`) is present and its total cardinality is exactly zero** — summed across every bucket, tolerant of both the MCP fact-type shape (`world`/`experience`/`opinion`/`observation`/…) and the REST shape (`memories`/`mental_models`/`directives`). Empty retrieval otherwise yields a fluent-but-sourceless answer that reads to the calling agent as a real recalled fact — the false-positive that defeats the J2/J7 abstention signal.

## How false abstention is avoided

The gate keys off the **real returned evidence cardinality, never a heuristic over the prose** (the risk P9 calls out):

- `guardAndClampToolCall` forces `include_based_on: true` onto the forwarded reflect call so the gate always has ground truth to read — the caller's explicit `include_based_on` still wins, exactly like the `budget`/`max_tokens` clamp beside it.
- `applyReflectCardinalityGuard` abstains **only** when `based_on` is present and totals zero. When `based_on` is absent, the content is not the expected JSON envelope, or the shape is unexpected, the result passes through **unchanged** — the safe direction is always "keep the synthesized answer", never "abstain on a doubt". So an empty-abstention can only fire when retrieval was genuinely empty, never when the engine had evidence the shim could not see.
- On a **non-empty** result the shim-injected `based_on` is stripped back out unless the caller originally asked for it, so the only observable behaviour change is the empty-retrieval abstention; non-empty reflect payloads are byte-for-byte what they were before.

## Evidence

- The MCP reflect result shape (a `content[0].text` JSON envelope of `{text, based_on}`, `based_on` present only when `include_based_on` is set) was captured live against the pinned engine before coding, not assumed.
- Files changed: `src/cli/hindsight-mcp-shim.ts`, `tests/hindsight-mcp-shim.test.ts`.

## Tests (outcome assertions)

New suites in `tests/hindsight-mcp-shim.test.ts`, driven end-to-end through the shim against a mock backend:

- **abstention fires on genuinely-empty retrieval** — all-empty `based_on` → response is exactly `REFLECT_EMPTY_EVIDENCE_TEXT`, and the forwarded call carried `include_based_on:true`.
- **abstention does NOT fire when evidence is present** — the synthesized answer survives, the abstention text never appears, and the injected evidence is stripped.
- caller-requested `include_based_on` preserves `based_on`; plus unit coverage of `reflectEvidenceCardinality` (shape tolerance, `null` when undeterminable) and `applyReflectCardinalityGuard`.

Mutation-checked: neutering the guard wiring fails the two end-to-end guards. `tests/hindsight-mcp-shim.test.ts` (62 tests) + contract-fixture + write-redaction suites green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)