### PR TITLE
memory: harden reflect cardinality guard against non-array based_on buckets (RFC P9 follow-up)

### DIFF
--- a/changelog.d/4749-reflect-cardinality-nonarray-guard.fix.md
+++ b/changelog.d/4749-reflect-cardinality-nonarray-guard.fix.md
@@ -1,0 +1,1 @@
+- **memory: harden the reflect cardinality guard so a `based_on` object with any non-array bucket returns "undeterminable" (`null`) instead of `0`, so the empty-evidence abstention can only ever fire on a genuinely-empty, fully array-shaped evidence set — never a false abstention on an unrecognised shape (RFC P9 follow-up to #4748) (#4749)**

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -596,10 +596,13 @@ export const REFLECT_EMPTY_EVIDENCE_TEXT =
  * / `directives` when present); the REST model buckets as
  * `memories`/`mental_models`/`directives`. Both are just an object whose values
  * are arrays, so summing array lengths over ALL values counts every piece of
- * evidence regardless of which spelling the pinned engine uses. A non-array
- * value contributes nothing. Returns `null` when `based_on` is absent or is not
- * an object — the caller reads that as "could not determine" and never
- * abstains, which is the false-abstention-safe direction.
+ * evidence regardless of which spelling the pinned engine uses. If ANY bucket
+ * value is not an array the shape is unrecognised, so we return `null` rather
+ * than sum a partial count — a 0 there would be a FALSE abstention. Returns
+ * `null` when `based_on` is absent, is not an object, or has any non-array
+ * bucket — the caller reads that as "could not determine" and never abstains,
+ * which is the false-abstention-safe direction. Abstention (a 0) can only ever
+ * fire on a genuinely-empty, fully-array-shaped evidence set.
  */
 export function reflectEvidenceCardinality(basedOn: unknown): number | null {
   if (!basedOn || typeof basedOn !== "object" || Array.isArray(basedOn)) {
@@ -607,7 +610,8 @@ export function reflectEvidenceCardinality(basedOn: unknown): number | null {
   }
   let total = 0;
   for (const v of Object.values(basedOn as Record<string, unknown>)) {
-    if (Array.isArray(v)) total += v.length;
+    if (!Array.isArray(v)) return null; // any non-array bucket → shape unseen, never abstain
+    total += v.length;
   }
   return total;
 }

--- a/tests/hindsight-mcp-shim.test.ts
+++ b/tests/hindsight-mcp-shim.test.ts
@@ -1259,6 +1259,29 @@ describe("applyReflectCardinalityGuard (unit)", () => {
     expect(out).toBe(noEvidence);
   });
 
+  it("passes through UNCHANGED when a based_on bucket is not an array (never false-abstains)", () => {
+    // A malformed/unexpected engine shape: `based_on` is an object but a bucket
+    // holds a non-array value. reflectEvidenceCardinality must return null (not
+    // 0), so the guard leaves the synthesized answer intact — the false-
+    // abstention-safe direction that P9 exists to protect.
+    const envelope = { text: "a real, sourced answer", based_on: { world: 3 } };
+    const nonArrayBucket = {
+      _meta: { fastmcp: { wrap_result: true } },
+      content: [{ type: "text", text: JSON.stringify(envelope) }],
+      isError: false,
+    };
+    const out = applyReflectCardinalityGuard(nonArrayBucket, false);
+    // Reference identity: the exact same object flows through, untouched.
+    expect(out).toBe(nonArrayBucket);
+    // And the synthesized text is preserved, not replaced by the abstention.
+    expect(
+      (out as { content: { text: string }[] }).content[0].text,
+    ).toBe(nonArrayBucket.content[0].text);
+    expect(
+      (out as { content: { text: string }[] }).content[0].text,
+    ).not.toBe(REFLECT_EMPTY_EVIDENCE_TEXT);
+  });
+
   it("passes through UNCHANGED when content is not the JSON envelope", () => {
     const plain = {
       content: [{ type: "text", text: "not json" }],


### PR DESCRIPTION
Follow-up to #4748 (merged as d39641c10), closing the reviewer's **minor #1**: the one-line defensive guard did not make it into #4748 before the merge queue drained it into \`main\`, so this lands it separately against current \`main\`.

## The defect (theoretical under the pinned engine, cheap to close)

\`reflectEvidenceCardinality\` returned \`0\` when \`based_on\` was an object whose bucket values were **not** arrays. The guard reads \`0\` as a genuinely-empty evidence set and would **false-abstain** on it — the exact property P9 exists to protect against. It now returns \`null\` (pass-through, no abstention) the moment any bucket value is not an array; abstention (\`0\`) can only ever fire on a genuinely-empty, **fully array-shaped** evidence set.

Matches the \`Array.isArray\` discipline already used by \`summarizeBasedOn\` in \`src/memory/bank-health.ts\`.

## Test

Adds one outcome-asserting test in \`tests/hindsight-mcp-shim.test.ts\`: a reflect result whose \`based_on\` has a non-array bucket passes through \`applyReflectCardinalityGuard\` by **reference identity** (synthesized text preserved, not replaced by the abstention). Mutation-checked locally: the test FAILS if the guard sums non-array buckets as \`0\` instead of returning \`null\`.

Shim + test only. \`tsc --noEmit\` clean; shim + contract-fixture + write-redaction suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)