### PR TITLE
test(memory): decisive-relative-gap ranking regression set (RFC memory-redesign P11)

### DIFF
--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -98,9 +98,20 @@ jobs:
       - name: Validate recall query set
         run: python3 evals/recall/validate_queryset.py
 
+      # ── Decisive-relative-gap regression set (RFC memory-redesign P11) ──
+      # Guards the ranking rule HINDSIGHT_CE_DECISIVE_RELATIVE_GAP controls. The
+      # fixture lint cross-checks every expected top against the faithful ranker,
+      # and the self-check proves that lint can fail. Zero model cost, fork-safe.
+      - name: Decisive-gap fixture lint self-check (must fire)
+        run: python3 evals/recall/decisive_gap/validate_fixtures.py --selftest
+
+      - name: Validate decisive-gap fixture set
+        run: python3 evals/recall/decisive_gap/validate_fixtures.py
+
       - name: Recall-quality scorer unit tests
         # Includes the non-vacuity proof (#4479 AC1): an ablated run must score
-        # worse and drive the regression gate red, asserted offline.
+        # worse and drive the regression gate red, asserted offline. Discovery
+        # also picks up the decisive-gap (P11) tests under decisive_gap/.
         run: python3 -m unittest discover -s evals/recall -p 'test_*.py' -t .
 
   # ─── Trigger routing eval ────────────────────────────────────────

--- a/evals/recall/decisive_gap/README.md
+++ b/evals/recall/decisive_gap/README.md
@@ -1,0 +1,129 @@
+# Decisive-relative-gap ranking regression set (RFC memory-redesign P11)
+
+The regression set that gates RFC memory-redesign item **P11**
+(`HINDSIGHT_CE_DECISIVE_RELATIVE_GAP`). P11 was the last blocked RFC item, and
+the block was the absence of exactly this asset:
+
+> **Gate, and it is hard:** a fixed-query regression set must exist first … No
+> such set exists today. Building it is the actual work of this item; turning the
+> knob is one line.
+> — `workspace/memory-redesign/phase4-rfc.md:796-799`
+
+This set is that gate, built as an **offline, deterministic** fixture suite in
+the same shape as the recall-quality suite next door (`../metrics.py` /
+`../queryset/v1.yaml` / `../test_recall_quality.py`): a versioned+hashed YAML
+asset, a pure scorer with no I/O, a strict loader, a `--selftest` validator, and
+a unittest that asserts outcomes.
+
+## What the knob actually is (read this before adding a case)
+
+`HINDSIGHT_CE_DECISIVE_RELATIVE_GAP` is a **ranking-damping knob**, not an
+"abstain / no confident answer" gate. There is no abstention anywhere in the
+engine or the shim, and P11 introduces none — so this set has **no `abstain`
+class**, and building one would encode a policy that neither the code nor the RFC
+has.
+
+The final ranking score baked by the CE-saturation patch
+(`docker/Dockerfile.hindsight`, `_boost_authority` ~L400 and the damped
+`combined_score` ~L435) is:
+
+```
+combined_score = cross_encoder_score_normalized * (boost_product ** k)
+boost_product  = recency_boost * temporal_boost * proof_count_boost
+each boost      = 1 + alpha * (signal - 0.5),  signal in [0, 1]
+k               = min(1.0, log1p(gap) / log(hi / lo))
+```
+
+`k` confines the boost product's worst-case max/min ratio to exactly `1 + gap`.
+So the knob **bounds how far the recency / temporal / proof_count boosts may
+perturb the cross-encoder's ordering**:
+
+- **decisive** — one candidate's CE score leads by more than the worst-case boost
+  span, so the CE order holds regardless of the boosts. This is the fix: on the
+  measured saturated bank (`overlord`, every CE inside 0.9800-0.9999) the single
+  highest-CE memory had ranked 7th behind older, more-proven ones.
+- **bunched** — the CE scores are close, so the boosts decide, and recency (the
+  strongest boost, alpha 0.2) wins. That is **constraint 4, "recency bias is
+  correct"** (`phase4-rfc.md:46`), which is the constraint P11 serves
+  (`phase4-rfc.md:960`).
+- **rollback** — widening `gap` to `>= ~0.651` clamps `k` to `1.0`, i.e.
+  byte-for-byte upstream scoring with the patch inert. This is the documented
+  container-restart rollback path (`recall.py:573`), and it reproduces the
+  pre-patch defect (old high-proof outranks fresh high-CE) on purpose.
+
+## Is the threshold pinned?
+
+**Yes — the RFC and the patch pin it, so nothing here is invented policy.**
+
+- Default gap **`0.02`** (`Dockerfile.hindsight:343`) — the measured saturation
+  spread on bank `overlord`.
+- Clamp / rollback threshold **`~0.6510721`** (`= expm1(log(hi/lo))` at the
+  production alphas `(0.2, 0.2, 0.1)`; `recall.py:573`,
+  `hindsight-search-patches.test.ts:354`).
+
+Every case nonetheless carries an explicit `gap`, so the set is reproducible
+regardless of host env **and** the eventual implementer can sweep the knob per
+deployment. One subtlety the boundary cases encode: `1 + gap` is a *worst-case*
+band (all three boosts maxed in opposition); the gap at which a *specific* pair
+actually flips is tighter and depends on which signals differ. `dg-bnd-004/005`
+straddle the ~0.134 flip of the canonical fresh-CE-vs-old-proof pair, which is
+**not** the 0.651 clamp.
+
+## Layout
+
+```
+decisive_gap/
+  ranker.py             pure re-implementation of the baked scorer; no I/O, no env
+  fixtures.py           strict loader (unknown key / dup id / out-of-range = error)
+  fixtures/v1.yaml       the versioned, hashed asset
+  validate_fixtures.py  zero-cost lint + --selftest (a tampered expectation must fail)
+  test_decisive_gap.py  unittest: per-case expected-top + class invariants + drift guard
+```
+
+`ranker.py` is a client-side re-implementation for the same reason `../metrics.py`
+recomputes RRF as `rrf_client`: CI must assert offline without the 6.4 GB pinned
+image. **The authority that the *baked* code matches this is the docker probe**
+`tests/docker/hindsight-search-patches.test.ts`; `DriftGuard` in the test pins
+`ranker.py` to the exact constants that probe asserts (`k = 0.03949271225122802`,
+damped ratio `1.02`, undamped ratio `~1.651`, clamp `~0.651`), so a divergence
+between this offline set and what actually ranks the fleet's recalls fails loudly.
+
+## Run
+
+```bash
+pip install pyyaml
+python3 evals/recall/decisive_gap/validate_fixtures.py            # lint the asset
+python3 evals/recall/decisive_gap/validate_fixtures.py --selftest # prove the lint can fail
+python3 -m unittest discover -s evals/recall -p 'test_*.py' -t .   # discovers this suite too
+```
+
+## Why these cases go green, not red
+
+The task that commissioned this set anticipated pending/xfail cases, on the
+premise that the ranking rule was unimplemented. It is not: the CE-saturation
+patch **ships** at the default gap, so the ranking behaviour is live and these
+assertions **pass**. This set is therefore a *validation asset* for safely tuning
+the knob (run it at a candidate gap, see which cases move), not a spec for
+unbuilt behaviour — which is why no case is `xfail`.
+
+The one part of P11's RFC gate that is **genuinely unbuilt** is a live,
+per-bank, human-judged before/after run of real operator queries
+(`phase4-rfc.md:796-798`). That cannot be an offline fixture — this repo is
+public and the banks are private, and it needs relevance judgements the
+`../qrels/` campaign has not produced yet (see `../README.md`, "Graded metrics").
+It is deferred on the same judgement coverage the recall-quality suite waits on,
+not delivered here.
+
+## Adding a case
+
+1. Pick a class, or add one to `classes` with a one-line description. An
+   undeclared class is a hard lint error.
+2. Give it a stable id `dg-<class-prefix>-NNN`.
+3. Write the `text` yourself — authored flavour only, never a real query, bank,
+   or transcript slice. The assertion is on the scores, never the wording.
+4. Set each candidate's `ce` and its three boost signals in `[0, 1]`
+   (`recency` / `temporal` / `proof`; omitted signals default to the neutral
+   `0.5`). Set `gap` and `expect_top`.
+5. Run `python3 evals/recall/decisive_gap/validate_fixtures.py` — it recomputes
+   the ranking and rejects an `expect_top` that does not match the mechanic, so a
+   hand-computed expectation cannot silently drift.

--- a/evals/recall/decisive_gap/fixtures.py
+++ b/evals/recall/decisive_gap/fixtures.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Fixture loading for the decisive-relative-gap regression set (RFC P11).
+
+Loading is strict, the same discipline ``queryset.py`` follows: an unknown key,
+a duplicate id, an undeclared class, an out-of-range score or a candidate id
+that is not among a case's candidates is an error, not a warning. A silently
+dropped or malformed case is a silently weakened regression set.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+TOP_KEYS = {
+    "schema_version",
+    "fixtureset_version",
+    "fixtureset_id",
+    "provenance",
+    "classes",
+    "cases",
+}
+CASE_KEYS = {"id", "cls", "text", "gap", "candidates", "expect_top", "note"}
+CANDIDATE_KEYS = {"id", "ce", "recency", "temporal", "proof"}
+_SIGNAL_FIELDS = ("recency", "temporal", "proof")
+
+
+class FixtureError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class FixtureCandidate:
+    id: str
+    ce: float
+    recency: float
+    temporal: float
+    proof: float
+
+
+@dataclass(frozen=True)
+class FixtureCase:
+    id: str
+    cls: str
+    text: str
+    gap: float
+    candidates: tuple[FixtureCandidate, ...]
+    expect_top: str
+    note: str | None = None
+
+
+@dataclass
+class FixtureSet:
+    fixtureset_id: str
+    fixtureset_version: str
+    schema_version: int
+    classes: dict[str, str]
+    provenance: dict
+    cases: list[FixtureCase]
+    sha256: str
+
+
+def _require(cond: bool, msg: str) -> None:
+    if not cond:
+        raise FixtureError(msg)
+
+
+def _unit(value: object, where: str) -> float:
+    _require(
+        isinstance(value, (int, float)) and not isinstance(value, bool),
+        f"{where}: expected a number, got {value!r}",
+    )
+    v = float(value)  # type: ignore[arg-type]
+    _require(math.isfinite(v) and 0.0 <= v <= 1.0, f"{where}: {v!r} is outside [0, 1]")
+    return v
+
+
+def load_fixtures(path: str | Path) -> FixtureSet:
+    path = Path(path)
+    raw_bytes = path.read_bytes()
+    doc = yaml.safe_load(raw_bytes)
+    _require(isinstance(doc, dict), "top level must be a mapping")
+
+    unknown = set(doc) - TOP_KEYS
+    _require(not unknown, f"unknown top-level keys: {sorted(unknown)}")
+    for key in TOP_KEYS:
+        _require(key in doc, f"missing top-level key: {key}")
+
+    classes = doc["classes"]
+    _require(isinstance(classes, dict) and bool(classes), "`classes` must be a non-empty mapping")
+
+    cases_raw = doc["cases"]
+    _require(isinstance(cases_raw, list) and bool(cases_raw), "`cases` must be a non-empty list")
+
+    seen_ids: set[str] = set()
+    cases: list[FixtureCase] = []
+    for i, c in enumerate(cases_raw):
+        _require(isinstance(c, dict), f"case #{i} is not a mapping")
+        extra = set(c) - CASE_KEYS
+        _require(not extra, f"case #{i} has unknown keys: {sorted(extra)}")
+        for k in ("id", "cls", "text", "gap", "candidates", "expect_top"):
+            _require(k in c, f"case #{i} missing required key: {k}")
+
+        cid = c["id"]
+        _require(isinstance(cid, str) and bool(cid), f"case #{i} has an empty id")
+        _require(cid not in seen_ids, f"duplicate case id: {cid}")
+        seen_ids.add(cid)
+
+        cls = c["cls"]
+        _require(cls in classes, f"{cid}: class {cls!r} is not declared in `classes`")
+
+        gap = c["gap"]
+        _require(
+            isinstance(gap, (int, float)) and not isinstance(gap, bool),
+            f"{cid}: gap must be a number, got {gap!r}",
+        )
+        gap = float(gap)
+        _require(math.isfinite(gap) and gap > 0.0, f"{cid}: gap {gap!r} must be finite and > 0")
+
+        cand_raw = c["candidates"]
+        _require(
+            isinstance(cand_raw, list) and len(cand_raw) >= 2,
+            f"{cid}: needs at least two candidates",
+        )
+        cand_ids: set[str] = set()
+        candidates: list[FixtureCandidate] = []
+        for j, cd in enumerate(cand_raw):
+            _require(isinstance(cd, dict), f"{cid} candidate #{j} is not a mapping")
+            cextra = set(cd) - CANDIDATE_KEYS
+            _require(not cextra, f"{cid} candidate #{j} has unknown keys: {sorted(cextra)}")
+            _require("id" in cd and "ce" in cd, f"{cid} candidate #{j} needs id and ce")
+            did = cd["id"]
+            _require(isinstance(did, str) and bool(did), f"{cid} candidate #{j} has an empty id")
+            _require(did not in cand_ids, f"{cid}: duplicate candidate id {did!r}")
+            cand_ids.add(did)
+            candidates.append(
+                FixtureCandidate(
+                    id=did,
+                    ce=_unit(cd["ce"], f"{cid}/{did}.ce"),
+                    # Signals default to 0.5 (neutral: boost multiplier 1.0).
+                    recency=_unit(cd.get("recency", 0.5), f"{cid}/{did}.recency"),
+                    temporal=_unit(cd.get("temporal", 0.5), f"{cid}/{did}.temporal"),
+                    proof=_unit(cd.get("proof", 0.5), f"{cid}/{did}.proof"),
+                )
+            )
+
+        expect_top = c["expect_top"]
+        _require(
+            expect_top in cand_ids,
+            f"{cid}: expect_top {expect_top!r} is not one of the candidates {sorted(cand_ids)}",
+        )
+
+        cases.append(
+            FixtureCase(
+                id=cid,
+                cls=cls,
+                text=c["text"],
+                gap=gap,
+                candidates=tuple(candidates),
+                expect_top=expect_top,
+                note=c.get("note"),
+            )
+        )
+
+    # Hash the normalised content so a result can never be compared against a set
+    # it was not computed on (same guard queryset.py applies).
+    canonical = json.dumps(doc, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return FixtureSet(
+        fixtureset_id=doc["fixtureset_id"],
+        fixtureset_version=doc["fixtureset_version"],
+        schema_version=doc["schema_version"],
+        classes=classes,
+        provenance=doc.get("provenance", {}),
+        cases=cases,
+        sha256=hashlib.sha256(canonical).hexdigest(),
+    )
+
+
+DEFAULT_PATH = Path(__file__).resolve().parent / "fixtures" / "v1.yaml"

--- a/evals/recall/decisive_gap/fixtures/v1.yaml
+++ b/evals/recall/decisive_gap/fixtures/v1.yaml
@@ -1,0 +1,224 @@
+# Decisive-relative-gap ranking regression set — version 1
+#
+# RFC memory-redesign item P11 (`HINDSIGHT_CE_DECISIVE_RELATIVE_GAP`). See
+# ../README.md for the mechanic, the threshold provenance, and how to add a case.
+# Rules that bind every entry:
+#
+#   1. NO REAL USER OR BANK TEXT. This repo is public; the banks are a live
+#      operator's private memory. Every `text` below is authored flavour, present
+#      only to make a case legible. The ASSERTION is on the candidate scores and
+#      the expected top id, never on the wording.
+#   2. Each candidate is reduced to the fields the gap decision actually consumes:
+#      `ce` (cross_encoder_score_normalized, [0,1]) and the three boost SIGNALS
+#      `recency` / `temporal` / `proof` in [0,1], each feeding `1 + alpha*(s-0.5)`.
+#      Upstream decay curves that map age/proof_count onto those signals are out
+#      of scope (RFC constraint 1) and deliberately not modelled here.
+#   3. `gap` is the per-case value of HINDSIGHT_CE_DECISIVE_RELATIVE_GAP. It is
+#      explicit on every case so the set is reproducible regardless of the host
+#      env, and so the eventual implementer can sweep it. The shipped default is
+#      0.02 (docker/Dockerfile.hindsight:343).
+
+schema_version: 1
+fixtureset_version: "v1"
+fixtureset_id: p11-decisive-gap-v1
+
+provenance:
+  method: authored-derived
+  derives_from:
+    # The ranking function under regression is the switchroom CE-saturation
+    # patch baked into the pinned Hindsight image. These anchors are what the
+    # expected outcomes are computed against; ../ranker.py reproduces them and
+    # ../test_decisive_gap.py cross-checks that reproduction against the
+    # constants the docker probe pins on the *baked* code.
+    ranker_patch: docker/Dockerfile.hindsight (CE-saturation patch, ~L324-436)
+    boost_authority: docker/Dockerfile.hindsight ~L400
+    damped_combined_score: docker/Dockerfile.hindsight ~L435
+    docker_probe: tests/docker/hindsight-search-patches.test.ts (SATURATED_ORDER, GAP_*)
+    rfc_item: workspace/memory-redesign/phase4-rfc.md:789 (P11), :807 (§6.1), :46 (constraint 4)
+  production_alphas: [0.2, 0.2, 0.1]   # recency, temporal, proof_count
+  default_gap: 0.02                     # HINDSIGHT_CE_DECISIVE_RELATIVE_GAP unset
+  clamp_threshold: 0.6510721247563356   # gap >= this clamps k->1.0 = upstream
+  notes: >-
+    The knob is a ranking-damping knob, NOT an abstain/"no confident answer"
+    gate. There is no abstention anywhere in the engine or shim and P11 adds
+    none, so this set has no `abstain` class. "Decisive" means the cross-encoder
+    ordering is preserved; "bunched" means the CE scores are close enough that
+    the boosts decide, and recency wins there (constraint 4). The `1+gap` band is
+    a WORST-CASE guarantee (all three boosts maxed in opposition); the gap at
+    which a specific pair actually flips is tighter and depends on which signals
+    differ — see the bnd-* cases.
+
+classes:
+  decisive: >-
+    One candidate's CE score leads by more than the worst-case boost span, so the
+    CE order holds no matter how the boosts fall. Expect the high-CE candidate.
+  bunched: >-
+    CE scores are close enough that the present boost differential decides.
+    Recency has the most authority (alpha 0.2), so the fresher memory wins —
+    constraint 4. Expect the fresher candidate, not the higher-CE or higher-proof
+    one.
+  boundary: >-
+    Straddles a flip point. Includes the worst-case `1+gap` band edge and the
+    pair-specific gap at which the canonical fresh-CE vs old-proof pair flips as
+    the operator widens the knob.
+  rollback: >-
+    Gap widened to/above the ~0.651 clamp threshold. k clamps to 1.0, i.e.
+    byte-for-byte upstream scoring with the patch inert. The undamped boosts
+    decide again and the old, heavily-proven memory outranks the fresher one —
+    the pre-patch defect, reproduced as the documented rollback path.
+
+cases:
+  # ── decisive: CE lead survives any boost configuration ───────────
+  - id: dg-dec-001
+    cls: decisive
+    text: "which database are we using for the memory backend"
+    gap: 0.02
+    candidates:
+      - {id: A_highce,  ce: 0.95, recency: 0.1, temporal: 0.1, proof: 0.1}
+      - {id: B_boosted, ce: 0.80, recency: 0.9, temporal: 0.9, proof: 0.9}
+    expect_top: A_highce
+    note: "15pt CE lead; the boosted-but-irrelevant row must not win."
+
+  - id: dg-dec-002
+    cls: decisive
+    text: "what turn budget did we settle on for the small model"
+    gap: 0.02
+    candidates:
+      - {id: fresh_pin, ce: 0.99, recency: 0.5, temporal: 0.5, proof: 0.1}
+      - {id: old_pin,   ce: 0.95, recency: 0.5, temporal: 0.5, proof: 0.9}
+    expect_top: fresh_pin
+    note: "The current decision (high CE, single-source) beats a superseded, heavily-cited one."
+
+  - id: dg-dec-003
+    cls: decisive
+    text: "how does reciprocal rank fusion combine the arms"
+    gap: 0.02
+    candidates:
+      - {id: hi,  ce: 0.90, recency: 0.1, temporal: 0.1, proof: 0.1}
+      - {id: mid, ce: 0.70, recency: 0.9, temporal: 0.5, proof: 0.9}
+      - {id: lo,  ce: 0.50, recency: 0.9, temporal: 0.9, proof: 0.9}
+    expect_top: hi
+    note: "Well-spread CE; full CE order preserved despite inverted boosts."
+
+  - id: dg-dec-004
+    cls: decisive
+    text: "which redis version did we pin in the compose file"
+    gap: 0.02
+    candidates:
+      - {id: redis_new, ce: 0.97, recency: 0.6, temporal: 0.5, proof: 0.2}
+      - {id: redis_old, ce: 0.90, recency: 0.2, temporal: 0.5, proof: 0.9}
+    expect_top: redis_new
+    note: "Version fact: the newer pin wins on CE; the old well-corroborated pin does not resurface."
+
+  # ── bunched: CE saturated, recency breaks the tie ────────────────
+  - id: dg-bun-001
+    cls: bunched
+    text: "what did we decide about the retain cadence last week"
+    gap: 0.02
+    candidates:
+      - {id: fresh, ce: 0.9900, recency: 0.9, temporal: 0.5, proof: 0.5}
+      - {id: stale, ce: 0.9950, recency: 0.1, temporal: 0.5, proof: 0.5}
+    expect_top: fresh
+    note: "Fresher wins over a 0.5pt-higher-CE stale row within the band. Constraint 4."
+
+  - id: dg-bun-002
+    cls: bunched
+    text: "what is the current policy on running claude programmatically"
+    gap: 0.02
+    candidates:
+      - {id: fresh_dec,   ce: 0.9820, recency: 0.9, temporal: 0.5, proof: 0.1}
+      - {id: proven_old,  ce: 0.9840, recency: 0.1, temporal: 0.5, proof: 0.9}
+    expect_top: fresh_dec
+    note: "Recency (alpha 0.2) outweighs proof_count (alpha 0.1) when CE is near-tied."
+
+  - id: dg-bun-003
+    cls: bunched
+    text: "where do worker sub-agents write their scratch files"
+    gap: 0.02
+    candidates:
+      - {id: noise_stale, ce: 0.9800001, recency: 0.02, temporal: 0.5, proof: 0.02}
+      - {id: real_fresh,  ce: 0.9800000, recency: 0.99, temporal: 0.5, proof: 0.9}
+    expect_top: real_fresh
+    note: "A 1e-7 CE difference is encoder noise, not signal; recency+proof must decide, not the noise."
+
+  - id: dg-bun-004
+    cls: bunched
+    text: "what is lisa's current email address"
+    gap: 0.02
+    candidates:
+      - {id: lisa_new, ce: 0.985, recency: 0.9, temporal: 0.5, proof: 0.5}
+      - {id: lisa_old, ce: 0.990, recency: 0.1, temporal: 0.5, proof: 0.5}
+    expect_top: lisa_new
+    note: "Person fact: the recently-updated contact beats a slightly-higher-CE stale one."
+
+  # ── boundary: flip points, straddled ─────────────────────────────
+  - id: dg-bnd-001
+    cls: boundary
+    text: "saturated-band worst case: fresh high-CE vs old high-proof"
+    gap: 0.02
+    candidates:
+      - {id: fresh_hce,  ce: 0.9999, recency: 0.5, temporal: 0.5, proof: 0.1}
+      - {id: old_hproof, ce: 0.9800, recency: 0.5, temporal: 0.5, proof: 0.9}
+    expect_top: fresh_hce
+    note: "CE ratio 1.0203 just exceeds the 1+gap=1.02 worst-case band, so at the default gap the fix holds and the fresh row wins. Mirrors the docker probe's SATURATED_ORDER."
+
+  - id: dg-bnd-002
+    cls: boundary
+    text: "recency flip, just inside: fresher wins by a whisker"
+    gap: 0.02
+    candidates:
+      - {id: fresh, ce: 0.9950, recency: 0.9, temporal: 0.5, proof: 0.5}
+      - {id: old,   ce: 0.9990, recency: 0.1, temporal: 0.5, proof: 0.5}
+    expect_top: fresh
+    note: "0.4pt CE gap is under the ~0.8% recency-only flip point at gap 0.02, so recency flips it."
+
+  - id: dg-bnd-003
+    cls: boundary
+    text: "recency flip, just outside: CE lead survives"
+    gap: 0.02
+    candidates:
+      - {id: fresh, ce: 0.9900, recency: 0.9, temporal: 0.5, proof: 0.5}
+      - {id: old,   ce: 0.9990, recency: 0.1, temporal: 0.5, proof: 0.5}
+    expect_top: old
+    note: "0.9pt CE gap exceeds the recency-only flip point, so the higher-CE row holds. Straddles dg-bnd-002."
+
+  - id: dg-bnd-004
+    cls: boundary
+    text: "widening the knob, just below the pair's flip: fix still holds"
+    gap: 0.13
+    candidates:
+      - {id: fresh_hce,  ce: 0.9999, recency: 0.5, temporal: 0.5, proof: 0.1}
+      - {id: old_hproof, ce: 0.9800, recency: 0.5, temporal: 0.5, proof: 0.9}
+    expect_top: fresh_hce
+    note: "For THIS pair the fresh row wins until gap ~0.134 (a pair-specific flip, NOT the 0.651 clamp). At 0.13 it still wins."
+
+  - id: dg-bnd-005
+    cls: boundary
+    text: "widening the knob, just above the pair's flip: proof reclaims"
+    gap: 0.14
+    candidates:
+      - {id: fresh_hce,  ce: 0.9999, recency: 0.5, temporal: 0.5, proof: 0.1}
+      - {id: old_hproof, ce: 0.9800, recency: 0.5, temporal: 0.5, proof: 0.9}
+    expect_top: old_hproof
+    note: "Just past the ~0.134 flip for this pair, the undamped-enough proof boost overturns the 2% CE lead."
+
+  # ── rollback: gap >= clamp threshold, upstream behaviour ─────────
+  - id: dg-rbk-001
+    cls: rollback
+    text: "full rollback: gap 1.0, damping off"
+    gap: 1.0
+    candidates:
+      - {id: fresh_hce,  ce: 0.9999, recency: 0.5, temporal: 0.5, proof: 0.1}
+      - {id: old_hproof, ce: 0.9800, recency: 0.5, temporal: 0.5, proof: 0.9}
+    expect_top: old_hproof
+    note: "k clamps to 1.0 = byte-for-byte upstream. The old high-proof row wins again — the pre-patch defect, on purpose. Mirrors the docker probe's GAP_ROLLBACK."
+
+  - id: dg-rbk-002
+    cls: rollback
+    text: "just above the clamp threshold: still upstream"
+    gap: 0.657583
+    candidates:
+      - {id: fresh_hce,  ce: 0.9999, recency: 0.5, temporal: 0.5, proof: 0.1}
+      - {id: old_hproof, ce: 0.9800, recency: 0.5, temporal: 0.5, proof: 0.9}
+    expect_top: old_hproof
+    note: "clamp_threshold * 1.01. Anything at/above ~0.651 is exactly upstream scoring, so the old row still wins."

--- a/evals/recall/decisive_gap/ranker.py
+++ b/evals/recall/decisive_gap/ranker.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Pure re-implementation of the decisive-gap ranker for RFC memory-redesign P11.
+
+Everything here is a **pure function** over a candidate's own fields. No HTTP, no
+database, no clock, no randomness, no environment read. That is deliberate and it
+is the same discipline ``metrics.py`` follows: the scoring half of an eval is the
+half CI runs, and it has to be reproducible bit-for-bit on a machine that cannot
+reach a Hindsight instance nor pull the 6.4 GB pinned image.
+
+## What this models, and what the knob actually does
+
+``HINDSIGHT_CE_DECISIVE_RELATIVE_GAP`` is **not** an "abstain when the top hits
+are bunched" confidence gate — no such mechanism exists in the engine or the
+shim, and P11 introduces none. It is a **ranking-damping knob** baked into
+``apply_combined_scoring`` by the switchroom CE-saturation patch
+(``docker/Dockerfile.hindsight`` — the ``_boost_authority`` helper at line ~400
+and the damped ``combined_score`` at line ~435). The final score is::
+
+    combined_score = cross_encoder_score_normalized * (boost_product ** k)
+
+where ``boost_product = recency_boost * temporal_boost * proof_count_boost`` and
+each boost is ``1 + alpha * (signal - 0.5)`` for a signal in ``[0, 1]``
+(``Dockerfile.hindsight`` ``_boost_authority`` docstring). The exponent ``k`` is
+**derived, not tuned**::
+
+    k = min(1.0, log1p(gap) / log(hi / lo))
+
+with ``hi`` / ``lo`` the undamped worst-case boost product
+(``hi = prod(1 + alpha/2)``, ``lo = prod(1 - alpha/2)``). ``k`` confines the boost
+product's worst-case max/min ratio to exactly ``1 + gap``. So the knob bounds how
+far the recency / temporal / proof_count boosts may perturb the cross-encoder's
+ordering:
+
+* When one candidate's CE score is more than the gap fraction above another's,
+  the CE order is **decisive** and the boosts cannot overturn it.
+* When the CE scores are **bunched** (within the gap band — the measured
+  saturation regime, every CE inside 0.9800-0.9999), the boosts break the tie,
+  and because recency has authority there the fresher memory wins. That is
+  constraint 4 ("recency bias is correct"), which is the constraint P11 serves
+  (``phase4-rfc.md:46``, ``:960``).
+* Widening the gap to ``>= ~0.651`` clamps ``k`` to ``1.0`` — byte-for-byte
+  upstream scoring, the documented container-restart rollback path
+  (``vendor/hindsight-memory/scripts/recall.py:573``).
+
+## Faithfulness
+
+This module reproduces the two load-bearing functions from the patch verbatim in
+behaviour. It deliberately takes each candidate's three boost **signals** in
+``[0, 1]`` directly rather than deriving them from ``age_days`` / ``proof_count``
+via the engine's decay curves: those curves are upstream and orthogonal to P11,
+and pinning them here would couple this fixture to code the RFC's constraint 1
+puts out of scope. ``test_decisive_gap.py`` cross-checks this re-implementation
+against the constants the docker probe
+(``tests/docker/hindsight-search-patches.test.ts``) pins against the *baked*
+code, so drift between this file and what actually ships fails loudly.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+# Production alphas. `memory_engine.py` calls `apply_combined_scoring` with no
+# alpha argument, so these signature defaults are what runs for every agent. The
+# docker probe pins them (hindsight-search-patches.test.ts:310) and fails loudly
+# if upstream re-tunes one, because both `k` and the clamp threshold are derived
+# from them.
+PROD_ALPHAS: tuple[float, float, float] = (0.2, 0.2, 0.1)
+
+# The shipped default, read from `HINDSIGHT_CE_DECISIVE_RELATIVE_GAP` at import in
+# production and defaulting here (Dockerfile.hindsight:343). This module never
+# reads the environment — the gap is always an explicit argument so a fixture is
+# reproducible regardless of the host's env.
+DEFAULT_GAP: float = 0.02
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One reranker candidate, reduced to the fields the gap decision consumes.
+
+    ``ce`` is ``cross_encoder_score_normalized`` in ``[0, 1]`` — the absolute,
+    caller-visible score the patch deliberately never rewrites. ``recency`` /
+    ``temporal`` / ``proof`` are the three boost signals in ``[0, 1]`` that feed
+    ``1 + alpha * (signal - 0.5)``; higher means fresher / more temporally
+    relevant / more corroborated.
+    """
+
+    id: str
+    ce: float
+    recency: float = 0.5
+    temporal: float = 0.5
+    proof: float = 0.5
+
+
+def boost_authority(gap: float, alphas: Sequence[float] = PROD_ALPHAS) -> float:
+    """Damping exponent ``k`` — a pure function of the alphas and the gap.
+
+    Mirrors ``_boost_authority`` in the CE-saturation patch
+    (``Dockerfile.hindsight`` ~L400) exactly, including its two escape hatches:
+    returns ``1.0`` (no damping, exact upstream scoring) when the boosts cannot
+    span a ratio at all, or when the operator has widened the gap past what the
+    boosts can span.
+    """
+    hi = 1.0
+    lo = 1.0
+    for alpha in alphas:
+        hi *= 1.0 + alpha / 2.0
+        lo *= 1.0 - alpha / 2.0
+    if lo <= 0.0 or hi <= lo:
+        return 1.0
+    return min(1.0, math.log1p(gap) / math.log(hi / lo))
+
+
+def combined_score(
+    cand: Candidate, gap: float = DEFAULT_GAP, alphas: Sequence[float] = PROD_ALPHAS
+) -> float:
+    """``ce * (boost_product ** k)`` — the baked ``combined_score``.
+
+    Mirrors the damped body the patch installs (``Dockerfile.hindsight`` ~L435).
+    Set-independent by construction: a candidate's score depends only on its own
+    fields and the (set-independent) exponent.
+    """
+    k = boost_authority(gap, alphas)
+    boost = 1.0
+    for alpha, signal in zip(alphas, (cand.recency, cand.temporal, cand.proof)):
+        boost *= 1.0 + alpha * (signal - 0.5)
+    return cand.ce * (boost**k)
+
+
+def rank(
+    candidates: Sequence[Candidate],
+    gap: float = DEFAULT_GAP,
+    alphas: Sequence[float] = PROD_ALPHAS,
+) -> list[str]:
+    """Rank candidate ids best-first by ``combined_score``.
+
+    Ties break by input order so the output is a deterministic total order, the
+    same tie discipline ``metrics.rrf_fuse`` uses.
+    """
+    scored = [(combined_score(c, gap, alphas), i, c.id) for i, c in enumerate(candidates)]
+    scored.sort(key=lambda t: (-t[0], t[1]))
+    return [cid for _, _, cid in scored]
+
+
+def undamped_boost_ratio(alphas: Sequence[float] = PROD_ALPHAS) -> float:
+    """The worst-case max/min boost product with no damping (``k = 1``).
+
+    ~1.651 at the production alphas — the ratio that let proof_count decide a
+    saturated set before the patch, and the number the clamp threshold is the
+    ``expm1(log(...))`` of.
+    """
+    hi = 1.0
+    lo = 1.0
+    for alpha in alphas:
+        hi *= 1.0 + alpha / 2.0
+        lo *= 1.0 - alpha / 2.0
+    return hi / lo
+
+
+def clamp_threshold(alphas: Sequence[float] = PROD_ALPHAS) -> float:
+    """The gap at/above which ``k`` clamps to 1.0 — the rollback boundary.
+
+    ``expm1(log(hi / lo))`` = ``hi/lo - 1`` ≈ 0.651 at the production alphas
+    (hindsight-search-patches.test.ts:354, recall.py:573).
+    """
+    return math.expm1(math.log(undamped_boost_ratio(alphas)))

--- a/evals/recall/decisive_gap/test_decisive_gap.py
+++ b/evals/recall/decisive_gap/test_decisive_gap.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Regression tests for the decisive-relative-gap ranker (RFC memory-redesign P11).
+
+Runs in CI with no network, no database and no docker image. It asserts
+**outcomes**: for every fixture case, which candidate the gap-damped scorer ranks
+first at that case's gap. These are the spec for the knob's ranking behaviour.
+
+The ranking rule this set guards ALREADY SHIPS — the CE-saturation patch bakes it
+into the pinned image at the default gap 0.02 — so these assertions PASS against
+the faithful re-implementation in ``ranker.py``. This set is therefore a
+*validation asset* for tuning ``HINDSIGHT_CE_DECISIVE_RELATIVE_GAP``, not a
+pending spec: there is no abstain/"no confident answer" behaviour anywhere in the
+engine or shim, and P11 introduces none, so no case is marked xfail. The one part
+of P11's RFC gate that is genuinely unbuilt — a live, per-bank, human-judged
+before/after run — cannot be an offline fixture and rides on the same qrels
+judgement campaign the recall-quality suite's README documents as pending.
+
+`DriftGuard` is the load-bearing safety: it pins ``ranker.py`` to the exact
+constants the docker probe (``tests/docker/hindsight-search-patches.test.ts``)
+asserts against the *baked* code, so this offline re-implementation cannot drift
+from what actually ranks the fleet's recalls without failing loudly here.
+
+Run: `python3 -m unittest discover -s evals/recall -p 'test_*.py' -t .`
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent))
+
+from evals.recall.decisive_gap import ranker  # noqa: E402
+from evals.recall.decisive_gap.fixtures import DEFAULT_PATH, load_fixtures  # noqa: E402
+
+FIXTURES = load_fixtures(DEFAULT_PATH)
+
+
+class DriftGuard(unittest.TestCase):
+    """Pin ranker.py to the constants the docker probe asserts on the baked code.
+
+    Every literal here is one the probe (hindsight-search-patches.test.ts) checks
+    against the real ``apply_combined_scoring``. If upstream re-tunes an alpha or
+    the derivation changes, both this and the probe must be updated together — a
+    silent divergence between this offline set and the shipped ranker is exactly
+    what this class exists to prevent.
+    """
+
+    def test_production_alphas_match_the_probe(self):
+        # hindsight-search-patches.test.ts:310
+        self.assertEqual(ranker.PROD_ALPHAS, (0.2, 0.2, 0.1))
+
+    def test_default_gap_matches_the_patch(self):
+        # Dockerfile.hindsight:343
+        self.assertEqual(ranker.DEFAULT_GAP, 0.02)
+
+    def test_damping_exponent_at_default_gap(self):
+        # hindsight-search-patches.test.ts:327 pins k = 0.03949271225122802.
+        self.assertAlmostEqual(ranker.boost_authority(0.02), 0.03949271225122802, places=12)
+
+    def test_damped_worst_case_ratio_is_one_plus_gap(self):
+        # hindsight-search-patches.test.ts:329 — damped ratio lands on 1.02 exactly.
+        k = ranker.boost_authority(0.02)
+        self.assertAlmostEqual(ranker.undamped_boost_ratio() ** k, 1.02, places=9)
+
+    def test_undamped_ratio_is_about_1_65(self):
+        self.assertAlmostEqual(ranker.undamped_boost_ratio(), 1.6510721247563356, places=12)
+
+    def test_clamp_threshold_is_about_0_651(self):
+        # recall.py:573 / hindsight-search-patches.test.ts:354.
+        self.assertAlmostEqual(ranker.clamp_threshold(), 0.6510721247563356, places=12)
+
+    def test_wide_gap_clamps_exponent_to_one(self):
+        # hindsight-search-patches.test.ts:346 — gap 1.0 => k == 1.0 (upstream).
+        self.assertEqual(ranker.boost_authority(1.0), 1.0)
+        self.assertEqual(ranker.boost_authority(ranker.clamp_threshold() * 1.01), 1.0)
+
+    def test_knob_is_monotone_in_the_exponent(self):
+        # hindsight-search-patches.test.ts:364 — wider gap damps less.
+        exps = [ranker.boost_authority(g) for g in (0.005, 0.02, 0.10, 0.30)]
+        self.assertEqual(exps, sorted(exps))
+        self.assertLess(exps[0], exps[-1])
+
+
+class FixtureShape(unittest.TestCase):
+    def test_every_declared_class_is_exercised(self):
+        # Non-vacuity: a class nothing tests is a claim nothing backs.
+        used = {c.cls for c in FIXTURES.cases}
+        self.assertEqual(used, set(FIXTURES.classes), "declared classes and used classes diverge")
+
+    def test_the_set_is_not_trivially_small(self):
+        self.assertGreaterEqual(len(FIXTURES.cases), 12)
+
+
+class ExpectedTop(unittest.TestCase):
+    """The regression assertion: the gap-damped scorer ranks expect_top first."""
+
+
+def _make(case):
+    def test(self):
+        cands = [
+            ranker.Candidate(c.id, c.ce, c.recency, c.temporal, c.proof) for c in case.candidates
+        ]
+        ranked = ranker.rank(cands, case.gap)
+        self.assertEqual(
+            ranked[0],
+            case.expect_top,
+            f"{case.id} ({case.cls}, gap={case.gap}): expected {case.expect_top!r} on top, "
+            f"got {ranked!r}",
+        )
+
+    return test
+
+
+for _case in FIXTURES.cases:
+    setattr(ExpectedTop, f"test_{_case.id.replace('-', '_')}", _make(_case))
+
+
+class ClassInvariants(unittest.TestCase):
+    def test_decisive_cases_preserve_full_ce_order(self):
+        # A "decisive" case is one where CE alone should decide, so ranking by
+        # combined_score must equal ranking by ce. This is a stronger claim than
+        # just the top id and it is the defining property of the class.
+        for case in FIXTURES.cases:
+            if case.cls != "decisive":
+                continue
+            cands = [
+                ranker.Candidate(c.id, c.ce, c.recency, c.temporal, c.proof)
+                for c in case.candidates
+            ]
+            by_score = ranker.rank(cands, case.gap)
+            by_ce = [c.id for c in sorted(cands, key=lambda c: -c.ce)]
+            self.assertEqual(by_score, by_ce, f"{case.id}: boosts perturbed a decisive CE order")
+
+    def test_rollback_cases_reproduce_upstream(self):
+        # At a rollback gap the exponent must be exactly clamped (upstream scoring).
+        for case in FIXTURES.cases:
+            if case.cls != "rollback":
+                continue
+            self.assertEqual(
+                ranker.boost_authority(case.gap),
+                1.0,
+                f"{case.id}: rollback gap {case.gap} did not clamp the exponent to 1.0",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/recall/decisive_gap/validate_fixtures.py
+++ b/evals/recall/decisive_gap/validate_fixtures.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Zero-cost schema + consistency lint for the decisive-gap fixture set (RFC P11).
+
+No network, no database, no docker. Loads the fixture set strictly and checks
+that every case's declared ``expect_top`` is actually what the faithful ranker
+ranks first at that case's gap — so a hand-edited expectation that no longer
+matches the mechanic is caught here, not only in the unittest.
+
+    python3 evals/recall/decisive_gap/validate_fixtures.py
+    python3 evals/recall/decisive_gap/validate_fixtures.py --selftest
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent))
+
+from evals.recall.decisive_gap import ranker  # noqa: E402
+from evals.recall.decisive_gap.fixtures import (  # noqa: E402
+    DEFAULT_PATH,
+    FixtureError,
+    load_fixtures,
+)
+
+
+def _check_expectations(fs) -> list[str]:
+    problems: list[str] = []
+    for case in fs.cases:
+        cands = [
+            ranker.Candidate(c.id, c.ce, c.recency, c.temporal, c.proof) for c in case.candidates
+        ]
+        top = ranker.rank(cands, case.gap)[0]
+        if top != case.expect_top:
+            problems.append(
+                f"{case.id}: expect_top={case.expect_top!r} but ranker returns {top!r} "
+                f"at gap {case.gap}"
+            )
+    used = {c.cls for c in fs.cases}
+    missing = set(fs.classes) - used
+    if missing:
+        problems.append(f"declared classes never exercised: {sorted(missing)}")
+    return problems
+
+
+def validate(path: Path) -> int:
+    try:
+        fs = load_fixtures(path)
+    except FixtureError as e:
+        print(f"FAIL {path}: {e}")
+        return 1
+    problems = _check_expectations(fs)
+    if problems:
+        for p in problems:
+            print(f"FAIL {p}")
+        return 1
+    print(
+        f"OK {fs.fixtureset_id} {fs.fixtureset_version} "
+        f"({len(fs.cases)} cases, {len(fs.classes)} classes, sha256={fs.sha256[:12]})"
+    )
+    return 0
+
+
+def selftest() -> int:
+    """Prove the lint can fail: a tampered expectation must be rejected."""
+    import copy
+
+    import yaml
+
+    doc = yaml.safe_load(DEFAULT_PATH.read_bytes())
+    tampered = copy.deepcopy(doc)
+    # Flip the first case's expected winner to the other candidate.
+    first = tampered["cases"][0]
+    others = [c["id"] for c in first["candidates"] if c["id"] != first["expect_top"]]
+    first["expect_top"] = others[0]
+
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=True) as fh:
+        yaml.safe_dump(tampered, fh)
+        fh.flush()
+        rc = validate(Path(fh.name))
+    if rc == 0:
+        print("SELFTEST FAIL: a tampered expectation was accepted")
+        return 1
+    print("SELFTEST OK: tampered expectation rejected")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        raise SystemExit(selftest())
+    raise SystemExit(validate(DEFAULT_PATH))


### PR DESCRIPTION
## What

Adds an offline regression set for the `HINDSIGHT_CE_DECISIVE_RELATIVE_GAP` ranking-damping knob (RFC memory-redesign **P11**).

The knob bounds how far recency/temporal/proof_count boosts can perturb the cross-encoder ordering: `combined_score = ce * (boosts)**k`, worst-case ratio `≤ 1 + gap` (default gap `0.02`, k-clamp `~0.6510721`). It already ships baked into `docker/Dockerfile.hindsight`. This PR pins its behaviour with a fixture-driven test so future changes can't silently regress the ordering guarantee.

## Contents

- `evals/recall/decisive_gap/ranker.py` — client-side reimpl of the baked ranking patch
- `fixtures.py` + `fixtures/v1.yaml` — 15 cases (4 decisive, 4 bunched, 5 boundary, 2 rollback)
- `validate_fixtures.py` — fixture schema/consistency guard
- `test_decisive_gap.py` — 27 new eval assertions
- 2 steps wired into `.github/workflows/ci-evals.yml`

## Verification

66 eval tests pass (+27 net), all green (the rule already ships, so the fixtures encode current true behaviour). `actionlint` clean on the workflow edit.

## Scope note

This is the **offline** regression set. RFC P11 acceptance (`phase4-rfc.md:796-799`) also asks for a live per-bank human-judged before/after set, which cannot be a public offline fixture and remains deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[skip changelog]
