### PR TITLE
fix(hindsight): floor recall max_tokens, mark trimmed payloads loud (E-86)

### DIFF
--- a/changelog.d/4755-hindsight-recall-maxtokens-floor.fix.md
+++ b/changelog.d/4755-hindsight-recall-maxtokens-floor.fix.md
@@ -1,0 +1,6 @@
+- **hindsight: floor MCP recall's `max_tokens` and mark trimmed payloads loud (#4755)**
+  A too-small `max_tokens` could crater `recall`'s tail-trim loop to a
+  silent, structurally-valid `{"results": []}` — indistinguishable from
+  "nothing matched" (E-86). `max_tokens` is now floored at 256, and any
+  payload the trim loop actually shortens is stamped
+  `truncated: true` / `dropped_count: N`.

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -4051,7 +4051,23 @@ HELPER = '''
 # fact TEXT (correct for the auto-recall hook, which injects only text); the
 # MCP tool then serialized with indent=2 and explicit nulls, measured live at
 # 6.7x the text cost. See docker/Dockerfile.hindsight for the full rationale.
+#
+# E-86 FOOTGUN FIX. The tail-trim loop below originally had no floor on
+# max_tokens: at a small enough caller-supplied value (empirically ~50-200
+# tokens depending on result size) it popped EVERY ranked result and returned
+# a structurally valid, silently-empty {"results": []} -- indistinguishable
+# from "the bank has nothing relevant" (measured live: HTTP returned 2 hits
+# for the identical query/bank/budget, MCP recall(max_tokens=50) returned
+# zero). Mirrors the floor create_mental_model already enforces one function
+# away (_validate_mental_model_inputs: 256 <= max_tokens <= 8192):
+#   1. Clamp an under-floor max_tokens UP to _MCP_RECALL_MIN_MAX_TOKENS before
+#      budgeting, so the crater case cannot happen at all.
+#   2. Whenever the trim loop actually drops a result, stamp the envelope
+#      truncated=true / dropped_count=N (additive top-level fields) so "empty
+#      because nothing matched" can never be confused with "empty (or
+#      shortened) because the budget popped hits".
 _MCP_RECALL_BUDGET_MODE_ENV = "HINDSIGHT_MCP_RECALL_BUDGET_MODE"
+_MCP_RECALL_MIN_MAX_TOKENS = 256
 
 
 def _mcp_recall_budget_mode() -> str:
@@ -4068,15 +4084,40 @@ def _mcp_recall_budget_mode() -> str:
     return "legacy" if raw == "legacy" else "envelope"
 
 
+def _mark_recall_truncated(payload: str, dropped_count: int) -> str:
+    """Stamp an additive truncation marker onto a compact recall payload.
+
+    Additive-only (new top-level keys), so it is safe for every existing
+    caller: one that ignores unknown fields sees the identical
+    results/entities/... it always did. dropped_count is the number of
+    ranked results the tail-trim popped to fit max_tokens, so a caller can
+    tell "nothing matched" (no truncated key at all) apart from "the budget
+    popped hits" (truncated=true, dropped_count>0) -- the failure this patch
+    exists to make loud instead of silent.
+    """
+    import json as _json
+
+    obj = _json.loads(payload)
+    obj["truncated"] = True
+    obj["dropped_count"] = dropped_count
+    return _json.dumps(obj, separators=(",", ":"))
+
+
 def _recall_payload_within_budget(recall_result, max_tokens: int) -> str:
     """Serialize a RecallResult compactly and enforce max_tokens on the result.
 
     Compact + exclude_none first (pure encoding win, no information loss).
-    If the serialized envelope still exceeds the caller's budget, drop results
-    from the tail — the engine returns them ranked, so the lowest-ranked go
-    first — pruning source_facts entries owned by dropped results, until the
-    payload fits. Worst case (envelope alone exceeds the budget with zero
-    results left) returns the minimal envelope rather than failing the call.
+    max_tokens is floored at _MCP_RECALL_MIN_MAX_TOKENS before any budgeting
+    runs, so a too-small caller value can no longer crater the trim loop to
+    zero results (E-86). If the serialized envelope still exceeds the
+    (floored) budget, drop results from the tail -- the engine returns them
+    ranked, so the lowest-ranked go first -- pruning source_facts entries
+    owned by dropped results, until the MARKED payload fits (the marker's own
+    ~2 extra tokens are checked against the budget too, so stamping the
+    truncation flag can never itself push the wire payload over max_tokens --
+    that would silently reopen the over-delivery bug PR #4125 fixed). An
+    untrimmed payload is returned byte-identical to before (no marker added
+    when nothing was dropped).
     """
     if _mcp_recall_budget_mode() == "legacy":
         return recall_result.model_dump_json(indent=2)
@@ -4085,11 +4126,17 @@ def _recall_payload_within_budget(recall_result, max_tokens: int) -> str:
 
     encoding = get_token_encoding()
 
+    effective_max_tokens = max(max_tokens, _MCP_RECALL_MIN_MAX_TOKENS)
+
+    def fits(candidate: str) -> bool:
+        return len(encoding.encode(candidate)) <= effective_max_tokens
+
     payload = recall_result.model_dump_json(exclude_none=True)
-    if len(encoding.encode(payload)) <= max_tokens:
+    if fits(payload):
         return payload
 
     results = list(recall_result.results)
+    original_count = len(results)
     while results:
         results.pop()
         recall_result.results = results
@@ -4104,9 +4151,10 @@ def _recall_payload_within_budget(recall_result, max_tokens: int) -> str:
                 k: v for k, v in recall_result.source_facts.items() if k in keep
             } or None
         payload = recall_result.model_dump_json(exclude_none=True)
-        if len(encoding.encode(payload)) <= max_tokens:
-            return payload
-    return payload
+        marked = _mark_recall_truncated(payload, original_count - len(results))
+        if fits(marked):
+            return marked
+    return _mark_recall_truncated(payload, original_count)
 
 
 '''
@@ -4160,6 +4208,21 @@ assert "for fid in (r.source_fact_ids or [])" in t, (
     "source_fact_ids — keying on result ids deletes the source facts of RETAINED "
     "observations (source_facts is keyed by source fact id, a disjoint id space)"
 )
+# E-86 floor + loud-truncation-marker assertions:
+assert "_MCP_RECALL_MIN_MAX_TOKENS = 256" in t, (
+    f"{TAG}: the E-86 max_tokens floor is missing — recall(max_tokens=<tiny>) can "
+    "crater the tail-trim loop to zero results again"
+)
+assert "effective_max_tokens = max(max_tokens, _MCP_RECALL_MIN_MAX_TOKENS)" in t, (
+    f"{TAG}: max_tokens is no longer clamped to the floor before budgeting"
+)
+assert "def _mark_recall_truncated(" in t, (
+    f"{TAG}: the truncation marker helper is missing — a trimmed recall payload "
+    "is indistinguishable from an honest empty result again"
+)
+assert 'obj["truncated"] = True' in t and 'obj["dropped_count"] = dropped_count' in t, (
+    f"{TAG}: the truncation marker no longer stamps truncated/dropped_count"
+)
 # Deliberate scope guards — these must stay untouched:
 assert "reflect_result.model_dump_json(indent=2)" in t, (
     f"{TAG}: the reflect tool's serialization changed — this patch is scoped to recall only"
@@ -4174,9 +4237,12 @@ assert "text_tokens = len(encoding.encode(text))" in me, (
 print(
     "switchroom hindsight mcp-recall-token-budget patch: MCP recall now serializes "
     "compact with exclude_none and enforces max_tokens over the serialized payload "
-    "(tail-trim of ranked results); the shared engine selector and the reflect tool "
-    "are untouched; HINDSIGHT_MCP_RECALL_BUDGET_MODE=legacy restores upstream's exact "
-    "returns on both branches"
+    "(tail-trim of ranked results), floors max_tokens at 256 so a too-small budget "
+    "can no longer crater results to empty (E-86), and stamps truncated=true/"
+    "dropped_count=N on any payload the trim loop actually shortened; the shared "
+    "engine selector and the reflect tool are untouched; "
+    "HINDSIGHT_MCP_RECALL_BUDGET_MODE=legacy restores upstream's exact returns on "
+    "both branches"
 )
 PYEOF
 

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -4100,7 +4100,7 @@ def _mark_recall_truncated(payload: str, dropped_count: int) -> str:
     obj = _json.loads(payload)
     obj["truncated"] = True
     obj["dropped_count"] = dropped_count
-    return _json.dumps(obj, separators=(",", ":"))
+    return _json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
 
 
 def _recall_payload_within_budget(recall_result, max_tokens: int) -> str:
@@ -4154,7 +4154,7 @@ def _recall_payload_within_budget(recall_result, max_tokens: int) -> str:
         marked = _mark_recall_truncated(payload, original_count - len(results))
         if fits(marked):
             return marked
-    return _mark_recall_truncated(payload, original_count)
+    return payload if original_count == 0 else _mark_recall_truncated(payload, original_count)
 
 
 '''

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -1469,6 +1469,20 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(
       /switchroom hindsight mcp-recall-token-budget patch: MCP recall now serializes /,
     );
+    // E-86: the max_tokens floor and the loud truncation marker. Without a
+    // floor, the tail-trim loop above can pop every ranked result and return
+    // a structurally valid, silently-empty {"results": []} — see
+    // tests/docker/hindsight-recall-budget-reflect-grounding-patches.test.ts
+    // for the behavioural RED/GREEN proof.
+    expect(dockerfile).toMatch(/_MCP_RECALL_MIN_MAX_TOKENS = 256/);
+    expect(dockerfile).toMatch(
+      /effective_max_tokens = max\(max_tokens, _MCP_RECALL_MIN_MAX_TOKENS\)/,
+    );
+    expect(dockerfile).toMatch(/def _mark_recall_truncated\(/);
+    expect(dockerfile).toMatch(
+      /assert "_MCP_RECALL_MIN_MAX_TOKENS = 256" in t,/,
+    );
+    expect(dockerfile).toMatch(/assert "def _mark_recall_truncated\(" in t,/);
   });
 
   it("keeps the reflect-temperature fix (assert-guarded, fail-loud)", () => {

--- a/tests/docker/hindsight-recall-budget-reflect-grounding-patches.test.ts
+++ b/tests/docker/hindsight-recall-budget-reflect-grounding-patches.test.ts
@@ -18,6 +18,20 @@
  *     `temperature`, and the litellm provider omits the kwarg when None — so
  *     the provider default (~1.0) applied to factual synthesis.
  *
+ * A THIRD defect (E-86) lives inside fix 1's own trim loop and is asserted
+ * within the `hasattr(mcp_tools, "_recall_payload_within_budget")` guard
+ * below (patched-only, no upstream analogue): the tail-trim loop that fix 1
+ * introduced had no floor on the caller's `max_tokens`, so a small enough
+ * value (empirically ~50-200 tokens, live-reproduced at `max_tokens: 50`)
+ * popped EVERY ranked result and returned a structurally valid, silently
+ * empty `{"results": []}` — indistinguishable from "the bank has nothing
+ * relevant". The fix mirrors `create_mental_model`'s existing
+ * `256 <= max_tokens <= 8192` floor (`mcp_tools.py:1345-1346`): clamp
+ * `max_tokens` up to `_MCP_RECALL_MIN_MAX_TOKENS` (256) before budgeting, and
+ * stamp `truncated: true` / `dropped_count: N` on any payload the trim loop
+ * actually shortened, so a trimmed result can never be mistaken for "no
+ * memories".
+ *
  * (A third patch — a relevance gate on the reflect mental-model
  * short-circuit — was authored and then dropped from this PR: re-probing the
  * live bank showed every mental model on the reported failing query scored
@@ -337,6 +351,89 @@ async def drive():
                 "model_dump() - python objects in trace were coerced through JSON"
             )
 
+        # ---------------------------------------------------------- E-86
+        # Live reproduction (2026-08-17 root-cause pass): identical
+        # query/bank/budget via MCP recall(budget="low", max_tokens=50)
+        # returned {"results": []} while direct HTTP against the same engine
+        # state returned 2 ranked hits - a silent, structurally-valid empty
+        # indistinguishable from "the bank has nothing relevant". The MCP
+        # tail-trim loop had no floor on max_tokens, so a small enough value
+        # popped every ranked result. This must not be reproducible: either
+        # the floor keeps a non-empty ranked prefix, or (if a single result
+        # alone still can't fit) the drop is loud (truncated/dropped_count),
+        # never a bare silent {"results": []}.
+        E86_MAX_TOKENS = 50  # the exact value that crashed to zero live
+        e86 = await fn(query="what do we know", budget="low", max_tokens=E86_MAX_TOKENS)
+        e86_parsed = json.loads(e86)
+        e86_results = e86_parsed.get("results", [])
+        e86_silent_empty = len(e86_results) == 0 and "truncated" not in e86_parsed
+        print(
+            "E86_RESULTS",
+            len(e86_results),
+            "TRUNCATED",
+            e86_parsed.get("truncated"),
+            "DROPPED_COUNT",
+            e86_parsed.get("dropped_count"),
+            "SILENT_EMPTY",
+            e86_silent_empty,
+        )
+        if e86_silent_empty:
+            failures.append(
+                "E-86: recall(budget='low', max_tokens=%d) against a bank with real "
+                "hits returned a silent empty {'results': []} - no truncation marker, "
+                "indistinguishable from 'nothing matched'" % E86_MAX_TOKENS
+            )
+        # The floor itself: a query known to have hits must come back non-empty
+        # at ANY caller-supplied max_tokens, however small - the crater case
+        # this patch exists to close outright.
+        for tiny in (1, 10, 50, 200):
+            e86_floor = await fn(query="what do we know", budget="low", max_tokens=tiny)
+            n = len(json.loads(e86_floor).get("results", []))
+            print("E86_FLOOR_MAX_TOKENS", tiny, "RESULTS", n)
+            if n == 0:
+                failures.append(
+                    "E-86: recall(max_tokens=%d) against a bank with real hits still "
+                    "craters to zero results - the max_tokens floor is not effective"
+                    % tiny
+                )
+
+        # A single result too large to fit even after flooring must still be
+        # loud (truncated marker), not a silent empty - the residual case the
+        # floor alone cannot close.
+        def build_oversized_single_result():
+            huge_text = "one huge fact: " + ("detail " * 400)  # far > any floor
+            return RecallResult(
+                results=[MemoryFact(id="huge-0", text=huge_text, fact_type="world")],
+                trace={"query": "q"},
+            )
+
+        class OversizedMemory:
+            async def recall_async(self, **kwargs):
+                return build_oversized_single_result()
+
+        mcp4 = FastMCP("probe-e86-oversized")
+        cfg4 = mcp_tools.MCPToolsConfig(
+            bank_id_resolver=lambda: "probe-bank",
+            include_bank_id_param=True,
+        )
+        mcp_tools._register_recall(mcp4, OversizedMemory(), cfg4)
+        fn4 = (await mcp4.get_tool("recall")).fn
+        oversized = await fn4(query="q", max_tokens=mcp_tools._MCP_RECALL_MIN_MAX_TOKENS)
+        oversized_parsed = json.loads(oversized)
+        print(
+            "E86_OVERSIZED_RESULTS",
+            len(oversized_parsed.get("results", [])),
+            "TRUNCATED",
+            oversized_parsed.get("truncated"),
+            "DROPPED_COUNT",
+            oversized_parsed.get("dropped_count"),
+        )
+        if len(oversized_parsed.get("results", [])) == 0 and not oversized_parsed.get("truncated"):
+            failures.append(
+                "E-86: an oversized single result trimmed to zero without a "
+                "truncated/dropped_count marker - silent empty, not loud"
+            )
+
 
 asyncio.run(drive())
 # ------------------------------------------------------------------ fix 2
@@ -625,6 +722,17 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("RESOLVED 0.1 0.3 None");
       expect(stdout).toContain("REFLECT_CALL_SITES 6 WIRED 6");
       expect(stdout).toContain("PROVIDER_FORWARDS 0.1 OMITS_WHEN_NONE True");
+
+      // Fix 3 (E-86): the exact live-reproduced footgun — budget:"low" +
+      // max_tokens:50 against a bank with real hits — must never come back
+      // as a silent empty; the max_tokens floor must hold at every tiny
+      // value; and a single oversized result must still be loud, not silent.
+      expect(stdout).toContain("SILENT_EMPTY False");
+      expect(stdout).toMatch(/E86_FLOOR_MAX_TOKENS 1 RESULTS [1-9]\d*/);
+      expect(stdout).toMatch(/E86_FLOOR_MAX_TOKENS 10 RESULTS [1-9]\d*/);
+      expect(stdout).toMatch(/E86_FLOOR_MAX_TOKENS 50 RESULTS [1-9]\d*/);
+      expect(stdout).toMatch(/E86_FLOOR_MAX_TOKENS 200 RESULTS [1-9]\d*/);
+      expect(stdout).toMatch(/E86_OVERSIZED_RESULTS 0 TRUNCATED True DROPPED_COUNT 1/);
     }, 240_000);
   },
 );


### PR DESCRIPTION
## Summary

**Root cause (one-liner):** the MCP `recall` tail-trim loop
(`_recall_payload_within_budget`, `mcp-recall-token-budget` patch in
`docker/Dockerfile.hindsight`, originally PR #4125) had no floor on
`max_tokens`, so a small enough caller value popped every ranked result and
returned a structurally valid, silently-empty `{"results": []}` —
indistinguishable from "the bank has nothing relevant". Live-reproduced
2026-08-17: identical query/bank/budget returned 2 hits over direct HTTP and
zero over MCP `recall(budget:"low", max_tokens:50)`. Root-cause report:
`workspace/memory-redesign/m6-footgun-rootcause.md` (klanker agent
workspace, not in this repo).

## The fix

Both changes land inside the same anchored `mcp-recall-token-budget` `RUN
python3` patch block in `docker/Dockerfile.hindsight` — same file, same
mechanism the patch already uses, mirroring `create_mental_model`'s existing
`256 <= max_tokens <= 8192` floor (`mcp_tools.py:1345-1346`):

1. **`max_tokens` floor.** `effective_max_tokens = max(max_tokens,
   _MCP_RECALL_MIN_MAX_TOKENS)` (256) before any budgeting runs. A
   too-small caller value can no longer crater the trim loop to zero
   results.
2. **Loud truncation marker.** Whenever the trim loop actually drops a
   result, the returned payload is stamped `truncated: true`,
   `dropped_count: N` (additive top-level fields, both recall branches —
   the bank_id-param string branch and the single-bank dict branch, which
   routes through the same helper). An untrimmed payload is returned
   byte-identical to before. The marker's own tokens are checked against the
   budget too, so stamping it can never itself push the wire payload over
   `max_tokens` — that would reopen the over-delivery defect #4125 fixed.
   The `HINDSIGHT_MCP_RECALL_BUDGET_MODE=legacy` rollback branch is
   untouched (still upstream's exact pre-patch bytes, no floor, no marker).

## Test plan — RED → GREEN (TDD, real evidence)

Extended `tests/docker/hindsight-recall-budget-reflect-grounding-patches.test.ts`
(the existing behavioural probe: drives the *real* registered MCP `recall`
tool via `docker exec` against the pinned upstream Hindsight image, unpatched
= RED, patched = GREEN) with the exact E-86 reproduction, inside the
`hasattr(mcp_tools, "_recall_payload_within_budget")` guard (patched-only, no
upstream analogue):

- `recall(query=..., budget="low", max_tokens=50)` against a bank with real
  ranked hits must never come back a silent empty (no `truncated` key).
- The floor must hold at `max_tokens` = 1, 10, 50, 200 — non-empty results at
  every one.
- A single oversized result that still can't fit even after flooring must
  come back `truncated: true, dropped_count: 1` — loud, never silent.

**RED (before the Dockerfile fix, `git stash` on `docker/Dockerfile.hindsight`
only, test file kept):**
```
E86_RESULTS 0 TRUNCATED None DROPPED_COUNT None SILENT_EMPTY True
E86_FLOOR_MAX_TOKENS 1 RESULTS 0
E86_FLOOR_MAX_TOKENS 10 RESULTS 0
E86_FLOOR_MAX_TOKENS 50 RESULTS 0
E86_FLOOR_MAX_TOKENS 200 RESULTS 4
✗ upstream + the baked patch blocks is GREEN, including every safety property
  probe did not run to completion (crashed before PROBE_EXECUTED — the
  oversized-result probe hit `_MCP_RECALL_MIN_MAX_TOKENS`, which doesn't
  exist pre-fix)
```

**GREEN (fix applied):**
```
✓ unpatched upstream is RED on both defects (proves the probe bites)
✓ upstream + the baked patch blocks is GREEN, including every safety property
Test Files  1 passed (1)
     Tests  5 passed (5)
```

Also extended `tests/docker/dockerfile-hindsight-bakes.test.ts` (structural
pin, "keeps the mcp-recall-token-budget fix") with assertions for the new
floor constant and marker helper — passes.

Locally: scoped vitest run of both files (`SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`,
pulled image cached locally so this actually executes, not skips) +
`npm run lint` full run (clean; `check-changelog-entry` skips locally on a
missing devDependency per its own message, CI installs it). Full-suite CI
(`e2e-ok` / `docker-e2e.yml`) is the required authority for `tests/docker/`.

## Risk

Low / scoped. Both changes live inside the existing helper the
`mcp-recall-token-budget` patch already installs; the legacy rollback branch,
the reflect tool's serialization, and the engine's text-only selector are all
asserted untouched by the same probe. The only wire-visible change for an
*untrimmed* payload is none (byte-identical); for a *trimmed* payload it now
carries two additive keys a well-behaved caller ignores.

**Not fixed here (memory correction, flagged out of scope):** the root-cause
pass also found two stale facts retained in the `klanker` Hindsight bank
claiming "the MCP shim injects `budget:\"low\"`" — the shim
(`hindsight-mcp-shim.ts`) is a pure JSON-RPC passthrough with no
budget/max_tokens rewriting; those retained claims are stale/wrong. Not this
PR's scope; noting for the parent agent to correct via Hindsight.

Cites `reference/jobs/` per repo convention: this is a defect fix inside the
already-owned `docker/Dockerfile.hindsight` patch surface, not a new job —
no job spec change.