### PR TITLE
feat(memory): M6 worker read-only Hindsight recall + cross-bank guard

### DIFF
--- a/changelog.d/4759-memory-v2-m6-worker-memory-read.feat.md
+++ b/changelog.d/4759-memory-v2-m6-worker-memory-read.feat.md
@@ -8,13 +8,28 @@
   (`retain`, `create_directive`, …) and no `mcp__hindsight__*` wildcard are
   granted.
 
-  Because `recall` and `get_mental_model` both accept a caller-supplied
-  `bank_id` that the engine forwards verbatim with no grant validation
-  (M6/E-86 red-team §1 — low-entropy, agent-name-shaped bank ids make
-  cross-bank reads guessable), the shim now rejects any `bank_id` on those
-  two tools that does not match the caller's own pinned bank
-  (`guardBankScope` / `BANK_SCOPE_GUARDED_TOOLS` in
-  `src/cli/hindsight-mcp-shim.ts`). The guard is deliberately scoped to just
-  those two tools — `retain`'s documented cross-bank write pattern
+  Because `recall`, `get_mental_model`, and every other read-only Hindsight
+  MCP tool that accepts a caller-supplied `bank_id` (`reflect`, `get_memory`,
+  `list_memories`, `list_directives`, `get_bank`, `get_bank_stats`,
+  `get_document`, `get_operation`, `list_documents`, `list_mental_models`,
+  `list_operations`, `list_tags`) forward it to the engine verbatim with no
+  grant validation of their own (M6/E-86 red-team §1 — low-entropy,
+  agent-name-shaped bank ids make cross-bank reads guessable, and this
+  applies to any prompt-injected caller of the shim, worker or main agent),
+  **over the stdio MCP transport** (the fleet default) the shim now rejects
+  any `bank_id` on those read tools that does not match the caller's own
+  pinned bank (`guardBankScope` / `BANK_SCOPE_GUARDED_TOOLS` in
+  `src/cli/hindsight-mcp-shim.ts`). The guard is deliberately scoped to
+  READ tools only — `retain`'s documented cross-bank write pattern
   (`bank_id="switchroom-dev"`, routing durable repo knowledge to the shared
-  repo bank) is untouched.
+  repo bank) is untouched, and any other write tool's `bank_id` is likewise
+  unguarded.
+
+  **This guard does not cover a hypothetical `mcp_transport: http`
+  deployment.** Under stdio, every `tools/call` this shim's process makes
+  passes through `guardAndClampToolCall`. If an operator instead sets
+  `mcp_transport: http`, agents talk to the Hindsight engine directly over
+  HTTP with an `X-Bank-Id` header and never touch this shim process at all,
+  so the guard is bypassed entirely. Not exploitable today — the fleet's
+  default (and every current deployment) is stdio — but must be closed
+  before http transport is enabled for any agent. Tracked as a follow-up.

--- a/changelog.d/4759-memory-v2-m6-worker-memory-read.feat.md
+++ b/changelog.d/4759-memory-v2-m6-worker-memory-read.feat.md
@@ -1,0 +1,20 @@
+- **memory: M6 worker read-only Hindsight recall + cross-bank guard (#4759)**
+
+  Worker sub-agents now carry a small, read-only Hindsight tool grant
+  (`recall`, `get_mental_model`, `get_knowledge_tree`, `get_knowledge_page`,
+  `search_knowledge_pages`) on the default worker allowlist, so a delegated
+  worker can pull its own bank's prior context instead of only inheriting
+  whatever the parent pasted into the dispatch prompt. No write verb
+  (`retain`, `create_directive`, …) and no `mcp__hindsight__*` wildcard are
+  granted.
+
+  Because `recall` and `get_mental_model` both accept a caller-supplied
+  `bank_id` that the engine forwards verbatim with no grant validation
+  (M6/E-86 red-team §1 — low-entropy, agent-name-shaped bank ids make
+  cross-bank reads guessable), the shim now rejects any `bank_id` on those
+  two tools that does not match the caller's own pinned bank
+  (`guardBankScope` / `BANK_SCOPE_GUARDED_TOOLS` in
+  `src/cli/hindsight-mcp-shim.ts`). The guard is deliberately scoped to just
+  those two tools — `retain`'s documented cross-bank write pattern
+  (`bank_id="switchroom-dev"`, routing durable repo knowledge to the shared
+  repo bank) is untouched.

--- a/profiles/_shared/delegation-golden-rule.md.hbs
+++ b/profiles/_shared/delegation-golden-rule.md.hbs
@@ -7,3 +7,5 @@ Acting in-turn and delegating are the same move: for an execution-class task the
 If the user amends in-flight delegated work mid-turn, steer the running worker now (`SendMessage` by worker name or agent id) rather than holding it for handback — and say in your reply which you did ("folded your update into the running worker" / "queued as a separate task"); never classify silently, never inferred. Unsure? Queue it and say so — queue is the default. If the worker is effectively done and the steer lands too late, say so and apply the update yourself in the parent.
 
 If no sub-agents are configured, do the work yourself.
+
+A worker has no auto-recall of its own — it can only PULL its own bank read-only (`mcp__hindsight__recall` / `get_mental_model` / `get_knowledge_tree` / `get_knowledge_page` / `search_knowledge_pages`; M6/E-86). When you dispatch, put the orientation you already hold — the relevant roster, bank names, or prior findings — into the Task prompt as your deliberate context selection. Share orientation, not secrets: never paste a credential or another agent's private fact into a dispatch prompt.

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -922,9 +922,91 @@ function unknownArgMessage(
 }
 
 /**
+ * Forwarded tools whose caller-supplied `bank_id` is bank-scope-guarded to
+ * the caller's own bank (M6/E-86 red-team §1 — the "TOP FINDING").
+ *
+ * `recall` and `get_mental_model` both declare `bank_id` as an accepted
+ * OPTIONAL argument that the engine honors verbatim with no grant
+ * validation of its own — fleet bank names are effectively the agent names
+ * (`klanker`, `overlord`, `marko`, …), low-entropy and guessable, so an
+ * attacker-steered caller (a prompt injection landing in a worker sub-agent,
+ * say) could pass `bank_id: "overlord"` and read another agent's memory
+ * wholesale. Read-only does not contain that: the caller can still write
+ * what it read into its handback, a file, or an outbound request. These are
+ * exactly the two forwarded, bank_id-accepting tools M6 grants to workers
+ * (the other three read tools — `get_knowledge_tree`, `get_knowledge_page`,
+ * `search_knowledge_pages` — are shim-SYNTHESIZED and already have no
+ * `bank_id` property at all, see {@link SYNTHESIZED_TOOL_TABLE}).
+ *
+ * DELIBERATELY NOT every bank_id-accepting table tool: `retain` also
+ * accepts `bank_id`, and the fleet's own memory guidance
+ * (`MEMORY_GUIDANCE` in `src/agents/scaffold.ts`) has a real, current,
+ * documented cross-bank use of it — routing durable repo knowledge to a
+ * shared bank with
+ * `mcp__hindsight__retain(..., bank_id="switchroom-dev", ...)`. Guarding
+ * `retain` too would break that legitimate flow for every main agent that
+ * uses it; nothing in the codebase or fleet prompts shows an equivalent
+ * legitimate explicit `bank_id` on `recall`/`reflect`/`get_mental_model`
+ * (the shared bank's READ side is reached via the separate
+ * `memory.recall.additional_banks` / `additional_bank_filters` auto-recall
+ * config, not a caller-supplied MCP argument — see
+ * `src/setup/hindsight-recall-passthrough.ts`). `reflect` is left
+ * unguarded for the same reason — it is not in the worker's tool grant and
+ * carries no found legitimate explicit-bank_id use either way, but keeping
+ * the guard's blast radius exactly at the two tools this PR actually widens
+ * worker reach to is the more conservative, auditable scope.
+ */
+export const BANK_SCOPE_GUARDED_TOOLS = new Set(["recall", "get_mental_model"]);
+
+/**
+ * Reject a caller-supplied `bank_id` that does not match the shim's own
+ * pinned bank, for tools in {@link BANK_SCOPE_GUARDED_TOOLS}.
+ *
+ * Full grant-set validation against an operator-provisioned allowlist (M7 /
+ * W-2's bank selector) is not built yet. This is the MINIMAL deterministic
+ * guard that can ship today: a caller may only ever target its OWN bank.
+ * `bank_id` omitted (defaults to own bank via the `X-Bank-Id` header) or
+ * `bank_id` equal to the own bank both pass unchanged; anything else is
+ * REJECTED LOUDLY — never silently coerced to the caller's own bank, because
+ * a silent rewrite would hide the attempt from whoever reads the tool
+ * result/transcript.
+ *
+ * No-op when the shim itself has no bank pinned (`ownBankId` empty, i.e.
+ * `HINDSIGHT_BANK_ID` unset). Every real deployment sets it
+ * ({@link resolveShimOptionsFromEnv}'s fallback is the only place it can be
+ * empty), so this only affects a genuinely unconfigured shim — never
+ * production — rather than reaching for a "reject if we can't tell" rule
+ * that would make an already-permissive default behave inconsistently with
+ * every other guard in this file.
+ *
+ * Exported for direct unit coverage; wired in from
+ * {@link guardAndClampToolCall} only for names in
+ * {@link BANK_SCOPE_GUARDED_TOOLS}.
+ */
+export function guardBankScope(
+  name: string,
+  args: Record<string, unknown>,
+  ownBankId: string,
+): { ok: true } | { ok: false; text: string } {
+  if (!BANK_SCOPE_GUARDED_TOOLS.has(name)) return { ok: true };
+  if (!ownBankId) return { ok: true };
+  const requested = args.bank_id;
+  if (requested === undefined) return { ok: true };
+  if (requested === ownBankId) return { ok: true };
+  return {
+    ok: false,
+    text:
+      `${name}: bank_id ${JSON.stringify(requested)} is not your own bank ` +
+      `(${JSON.stringify(ownBankId)}). Cross-bank reads are not permitted ` +
+      "through this tool — omit bank_id (or pass your own) to read your " +
+      "own memory.",
+  };
+}
+
+/**
  * Guard + clamp a `tools/call` params object before it is forwarded upstream.
  *
- * Two jobs, both closing holes the engine leaves open (it declares
+ * Three jobs, all closing holes the engine leaves open (it declares
  * `additionalProperties:false` but does NOT enforce it — an unknown arg is
  * dropped SILENTLY with isError:false, so the agent believes a cap/filter
  * applied when it did not):
@@ -935,16 +1017,29 @@ function unknownArgMessage(
  *     unknown key returns a loud, self-correcting error instead of a silent
  *     drop. Tools not in the table are passed through unvalidated (no ground
  *     truth to validate against).
- *  2. DEFAULT BUDGET CLAMP — for `recall`/`reflect` only, inject
+ *  2. BANK-SCOPE GUARD — for the tools in {@link BANK_SCOPE_GUARDED_TOOLS}
+ *     (`recall`, `get_mental_model`), reject a caller-supplied `bank_id`
+ *     that is not the caller's own bank. See {@link guardBankScope} for why
+ *     this is deliberately narrower than "every table tool that accepts
+ *     bank_id" (`retain`'s cross-bank write is a real, legitimate case).
+ *  3. DEFAULT BUDGET CLAMP — for `recall`/`reflect` only, inject
  *     max_tokens (env-tunable) + budget (env-tunable; recall low, reflect
  *     mid) when the caller OMITS them. Explicit caller values ALWAYS win (a
  *     deliberate max_tokens:4096 passes untouched).
+ *
+ * `ownBankId` defaults to `env.HINDSIGHT_BANK_ID` so existing two-arg
+ * call sites (and every prior unit test) keep working unchanged; the shim's
+ * own call site passes `this.opts.bankId` explicitly — the same value
+ * already pinned onto the `X-Bank-Id` header for this shim instance, which
+ * is the correct source of truth even when it diverges from process.env
+ * (as it deliberately can in tests).
  *
  * Returns the (possibly rewritten) params to forward, or a loud error text.
  */
 export function guardAndClampToolCall(
   params: unknown,
   env: NodeJS.ProcessEnv,
+  ownBankId: string = env.HINDSIGHT_BANK_ID || "",
 ): { ok: true; params: unknown } | { ok: false; text: string } {
   const called = params as
     | { name?: string; arguments?: unknown }
@@ -965,6 +1060,16 @@ export function guardAndClampToolCall(
   const unknownKeys = Object.keys(args).filter((k) => !allowed.has(k));
   if (unknownKeys.length > 0) {
     return { ok: false, text: unknownArgMessage(name, unknownKeys, allowed) };
+  }
+
+  {
+    // guardBankScope itself narrows to BANK_SCOPE_GUARDED_TOOLS (recall,
+    // get_mental_model) — calling it unconditionally here (rather than
+    // re-testing `allowed.has("bank_id")`) keeps the single source of
+    // truth for "which tools are bank-scope-guarded" inside the function,
+    // not duplicated at each call site.
+    const scoped = guardBankScope(name, args, ownBankId);
+    if (!scoped.ok) return scoped;
   }
 
   if (name === "recall" || name === "reflect") {
@@ -1704,7 +1809,11 @@ export class HindsightShim {
     // budget defaults the engine otherwise leaves fat (see
     // guardAndClampToolCall). Runs before redaction so the injected budget is
     // covered by the same forward path.
-    const guarded = guardAndClampToolCall(params, process.env);
+    const guarded = guardAndClampToolCall(
+      params,
+      process.env,
+      this.opts.bankId,
+    );
     if (!guarded.ok) {
       return { content: [{ type: "text", text: guarded.text }], isError: true };
     }

--- a/src/cli/hindsight-mcp-shim.ts
+++ b/src/cli/hindsight-mcp-shim.ts
@@ -923,40 +923,64 @@ function unknownArgMessage(
 
 /**
  * Forwarded tools whose caller-supplied `bank_id` is bank-scope-guarded to
- * the caller's own bank (M6/E-86 red-team §1 — the "TOP FINDING").
+ * the caller's own bank (M6/E-86 red-team §1 — the "TOP FINDING", widened by
+ * red-team Major 2).
  *
- * `recall` and `get_mental_model` both declare `bank_id` as an accepted
- * OPTIONAL argument that the engine honors verbatim with no grant
- * validation of its own — fleet bank names are effectively the agent names
- * (`klanker`, `overlord`, `marko`, …), low-entropy and guessable, so an
- * attacker-steered caller (a prompt injection landing in a worker sub-agent,
- * say) could pass `bank_id: "overlord"` and read another agent's memory
- * wholesale. Read-only does not contain that: the caller can still write
- * what it read into its handback, a file, or an outbound request. These are
- * exactly the two forwarded, bank_id-accepting tools M6 grants to workers
- * (the other three read tools — `get_knowledge_tree`, `get_knowledge_page`,
- * `search_knowledge_pages` — are shim-SYNTHESIZED and already have no
- * `bank_id` property at all, see {@link SYNTHESIZED_TOOL_TABLE}).
+ * Every `FALLBACK_TOOL_TABLE` tool that (a) is READ-ONLY against the engine
+ * and (b) declares `bank_id` as an accepted argument that the engine honors
+ * verbatim with no grant validation of its own is listed here. Fleet bank
+ * names are effectively the agent names (`klanker`, `overlord`, `marko`,
+ * …), low-entropy and guessable, so an attacker-steered caller (a
+ * prompt-injected main agent, or a prompt injection landing in a worker
+ * sub-agent) could pass `bank_id: "overlord"` to any of these and read
+ * another agent's memory wholesale — `reflect(bank_id:"overlord")` or
+ * `list_memories(bank_id:"overlord", q:"credentials")` are just as much an
+ * exfil path as `recall`. Read-only does not contain that: the caller can
+ * still write what it read into its handback, a file, or an outbound
+ * request.
  *
- * DELIBERATELY NOT every bank_id-accepting table tool: `retain` also
- * accepts `bank_id`, and the fleet's own memory guidance
- * (`MEMORY_GUIDANCE` in `src/agents/scaffold.ts`) has a real, current,
- * documented cross-bank use of it — routing durable repo knowledge to a
- * shared bank with
+ * The guarded set, audited against the full `FALLBACK_TOOL_TABLE` surface:
+ *   `recall`, `reflect`, `get_mental_model`, `get_memory`, `list_memories`,
+ *   `list_directives`, `get_bank`, `get_bank_stats`, `get_document`,
+ *   `get_operation`, `list_documents`, `list_mental_models`,
+ *   `list_operations`, `list_tags`.
+ * (The three knowledge-base read tools — `get_knowledge_tree`,
+ * `get_knowledge_page`, `search_knowledge_pages` — are shim-SYNTHESIZED and
+ * already have no `bank_id` property at all, see
+ * {@link SYNTHESIZED_TOOL_TABLE}. `list_banks` takes no arguments at all.)
+ *
+ * DELIBERATELY NOT every bank_id-accepting table tool: WRITE/mutating tools
+ * (`retain`, `sync_retain`, `create_directive`, `create_bank`,
+ * `create_mental_model`, `delete_bank`, `delete_directive`,
+ * `delete_document`, `delete_mental_model`, `clear_memories`,
+ * `clear_mental_model`, `update_bank`, `update_memory`,
+ * `update_mental_model`, `refresh_mental_model`, `invalidate_memory`,
+ * `cancel_operation`) are excluded from this guard. `retain` in particular
+ * has a real, current, documented cross-bank use — the fleet's own memory
+ * guidance (`MEMORY_GUIDANCE` in `src/agents/scaffold.ts`) routes durable
+ * repo knowledge to a shared bank with
  * `mcp__hindsight__retain(..., bank_id="switchroom-dev", ...)`. Guarding
- * `retain` too would break that legitimate flow for every main agent that
- * uses it; nothing in the codebase or fleet prompts shows an equivalent
- * legitimate explicit `bank_id` on `recall`/`reflect`/`get_mental_model`
- * (the shared bank's READ side is reached via the separate
- * `memory.recall.additional_banks` / `additional_bank_filters` auto-recall
- * config, not a caller-supplied MCP argument — see
- * `src/setup/hindsight-recall-passthrough.ts`). `reflect` is left
- * unguarded for the same reason — it is not in the worker's tool grant and
- * carries no found legitimate explicit-bank_id use either way, but keeping
- * the guard's blast radius exactly at the two tools this PR actually widens
- * worker reach to is the more conservative, auditable scope.
+ * writes too would break that legitimate flow; closing the write-side
+ * exfil/tamper class needs a real allowlist (e.g. `{own, switchroom-dev}`)
+ * rather than this tool's own-bank-only rule, and is tracked as a separate
+ * follow-up rather than folded in here.
  */
-export const BANK_SCOPE_GUARDED_TOOLS = new Set(["recall", "get_mental_model"]);
+export const BANK_SCOPE_GUARDED_TOOLS = new Set([
+  "recall",
+  "reflect",
+  "get_mental_model",
+  "get_memory",
+  "list_memories",
+  "list_directives",
+  "get_bank",
+  "get_bank_stats",
+  "get_document",
+  "get_operation",
+  "list_documents",
+  "list_mental_models",
+  "list_operations",
+  "list_tags",
+]);
 
 /**
  * Reject a caller-supplied `bank_id` that does not match the shim's own
@@ -1018,10 +1042,14 @@ export function guardBankScope(
  *     drop. Tools not in the table are passed through unvalidated (no ground
  *     truth to validate against).
  *  2. BANK-SCOPE GUARD — for the tools in {@link BANK_SCOPE_GUARDED_TOOLS}
- *     (`recall`, `get_mental_model`), reject a caller-supplied `bank_id`
+ *     (every read-only table tool that accepts `bank_id`: `recall`,
+ *     `reflect`, `get_mental_model`, `get_memory`, `list_memories`,
+ *     `list_directives`, `get_bank`, `get_bank_stats`, `get_document`,
+ *     `get_operation`, `list_documents`, `list_mental_models`,
+ *     `list_operations`, `list_tags`), reject a caller-supplied `bank_id`
  *     that is not the caller's own bank. See {@link guardBankScope} for why
- *     this is deliberately narrower than "every table tool that accepts
- *     bank_id" (`retain`'s cross-bank write is a real, legitimate case).
+ *     this excludes WRITE tools (`retain`'s cross-bank write is a real,
+ *     legitimate case).
  *  3. DEFAULT BUDGET CLAMP — for `recall`/`reflect` only, inject
  *     max_tokens (env-tunable) + budget (env-tunable; recall low, reflect
  *     mid) when the caller OMITS them. Explicit caller values ALWAYS win (a
@@ -1063,11 +1091,11 @@ export function guardAndClampToolCall(
   }
 
   {
-    // guardBankScope itself narrows to BANK_SCOPE_GUARDED_TOOLS (recall,
-    // get_mental_model) — calling it unconditionally here (rather than
-    // re-testing `allowed.has("bank_id")`) keeps the single source of
-    // truth for "which tools are bank-scope-guarded" inside the function,
-    // not duplicated at each call site.
+    // guardBankScope itself narrows to BANK_SCOPE_GUARDED_TOOLS (the
+    // read-only bank_id-accepting tools) — calling it unconditionally here
+    // (rather than re-testing `allowed.has("bank_id")`) keeps the single
+    // source of truth for "which tools are bank-scope-guarded" inside the
+    // function, not duplicated at each call site.
     const scoped = guardBankScope(name, args, ownBankId);
     if (!scoped.ok) return scoped;
   }

--- a/tests/hindsight-mcp-shim.test.ts
+++ b/tests/hindsight-mcp-shim.test.ts
@@ -28,6 +28,7 @@ import {
   SYNTHESIZED_TOOL_TABLE,
   coerceSynthesizedArg,
   guardAndClampToolCall,
+  guardBankScope,
   DEFAULT_RECALL_MAX_TOKENS,
   DEFAULT_RECALL_BUDGET,
   DEFAULT_REFLECT_BUDGET,
@@ -771,6 +772,10 @@ describe("guardAndClampToolCall (unit)", () => {
   // fixture pin (FALLBACK_TOOL_TABLE ≡ snapshot) already guards call-time
   // validation against drift, in both directions.
   it("accepts EVERY prop the table declares for recall, and only those", () => {
+    // No own bank is pinned here (env {} / no 3rd arg), so the M6 bank-scope
+    // guard below is a deliberate no-op and bank_id:"v" is accepted like any
+    // other prop — this test is purely about the accepted-KEY union, not
+    // about bank-scope enforcement, which gets its own describe block below.
     const [required, optional] = FALLBACK_TOOL_TABLE.recall;
     for (const prop of [...required, ...optional]) {
       const res = guardAndClampToolCall(
@@ -785,6 +790,130 @@ describe("guardAndClampToolCall (unit)", () => {
       {},
     );
     expect(bogus.ok).toBe(false);
+  });
+});
+
+// ─── M6/E-86 bank-scope guard (red-team §1 TOP FINDING) ───────────────────
+//
+// recall (and get_mental_model, and every other FALLBACK_TOOL_TABLE tool
+// that accepts bank_id) forwards a caller-supplied bank_id to the engine
+// with no grant validation of its own. Fleet bank names are effectively
+// agent names (low-entropy, guessable), so an attacker-steered caller could
+// read another agent's memory bank wholesale. This is the minimal
+// deterministic fix: a caller may only ever target its own bank.
+describe("guardBankScope / bank-scope enforcement in guardAndClampToolCall", () => {
+  it("rejects a recall targeting a foreign bank_id", () => {
+    const res = guardAndClampToolCall(
+      {
+        name: "recall",
+        arguments: { query: "credentials api key vault", bank_id: "overlord" },
+      },
+      {},
+      "klanker",
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected rejection");
+    expect(res.text).toContain("overlord");
+    expect(res.text).toContain("klanker");
+    expect(res.text.toLowerCase()).toContain("own");
+  });
+
+  it("rejects get_mental_model targeting a foreign bank_id", () => {
+    const res = guardAndClampToolCall(
+      { name: "get_mental_model", arguments: { mental_model_id: "x", bank_id: "overlord" } },
+      {},
+      "klanker",
+    );
+    expect(res.ok).toBe(false);
+  });
+
+  it("allows recall with bank_id omitted (defaults to own bank)", () => {
+    const res = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x" } },
+      {},
+      "klanker",
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("allows recall with bank_id explicitly equal to the caller's own bank", () => {
+    const res = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x", bank_id: "klanker" } },
+      {},
+      "klanker",
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("unexpected rejection");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.bank_id).toBe("klanker"); // not silently coerced/dropped
+  });
+
+  it("reads ownBankId from env.HINDSIGHT_BANK_ID when the 3rd arg is omitted", () => {
+    const res = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x", bank_id: "overlord" } },
+      { HINDSIGHT_BANK_ID: "klanker" },
+    );
+    expect(res.ok).toBe(false);
+  });
+
+  it("is a no-op when the shim has no own bank pinned (empty ownBankId)", () => {
+    // Never true in production (resolveShimOptionsFromEnv always resolves
+    // HINDSIGHT_BANK_ID), but must not throw or reject with nothing to
+    // compare against.
+    const res = guardAndClampToolCall(
+      { name: "recall", arguments: { query: "x", bank_id: "overlord" } },
+      {},
+      "",
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("does not touch tools that don't accept bank_id at all", () => {
+    // list_banks has no accepted arguments at all (per FALLBACK_TOOL_TABLE);
+    // guardBankScope must never run against it, and an (unknown, since the
+    // tool takes none) bank_id arg is rejected by the ordinary unknown-key
+    // check, not the bank-scope guard.
+    expect(FALLBACK_TOOL_TABLE.list_banks[1]).not.toContain("bank_id");
+    const res = guardAndClampToolCall(
+      { name: "list_banks", arguments: {} },
+      {},
+      "klanker",
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("guardBankScope (unit): equal, omitted, foreign, unpinned", () => {
+    expect(guardBankScope("recall", { bank_id: "klanker" }, "klanker").ok).toBe(true);
+    expect(guardBankScope("recall", {}, "klanker").ok).toBe(true);
+    expect(guardBankScope("recall", { bank_id: "" }, "").ok).toBe(true);
+    const foreign = guardBankScope("recall", { bank_id: "overlord" }, "klanker");
+    expect(foreign.ok).toBe(false);
+  });
+
+  it("does NOT guard retain — the legitimate shared-repo-bank write pattern " +
+    "(mcp__hindsight__retain(..., bank_id=\"switchroom-dev\", ...), documented " +
+    "in MEMORY_GUIDANCE / src/agents/scaffold.ts) must still reach a bank " +
+    "other than the caller's own", () => {
+    // Unit level: guardBankScope is a no-op for any tool outside
+    // BANK_SCOPE_GUARDED_TOOLS, retain included.
+    expect(guardBankScope("retain", { content: "x", bank_id: "switchroom-dev" }, "klanker").ok)
+      .toBe(true);
+
+    // Through the full guardAndClampToolCall path too, with the caller's
+    // own bank ("klanker") different from the explicit target
+    // ("switchroom-dev") — this must pass unmodified, not be rejected.
+    const res = guardAndClampToolCall(
+      {
+        name: "retain",
+        arguments: { content: "durable repo fact", bank_id: "switchroom-dev" },
+      },
+      {},
+      "klanker",
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("unexpected rejection of legitimate cross-bank retain");
+    const args = (res.params as { arguments: Record<string, unknown> }).arguments;
+    expect(args.bank_id).toBe("switchroom-dev"); // untouched, not coerced to "klanker"
   });
 });
 
@@ -856,6 +985,45 @@ describe("tools/call clamp + rejection through the live shim", () => {
     expect(result.content[0].text).toContain("max_tokens");
     // The silent-drop is prevented: no tools/call was forwarded at all.
     expect(backend.requests.some((r) => r.method === "tools/call")).toBe(false);
+  });
+
+  it("recall with a foreign bank_id is rejected loudly and NEVER reaches the backend", async () => {
+    // makeShim() pins bankId: "test-bank" — this exercises the real
+    // toolsCall() wiring (this.opts.bankId), not just the pure function.
+    backend = await startMockBackend();
+    const shim = makeShim({ url: backend.url, cacheDir });
+    await shim.handle(rpc(1, "initialize", { protocolVersion: "2025-06-18" }) as never);
+
+    const res = await shim.handle(
+      rpc(2, "tools/call", {
+        name: "recall",
+        arguments: { query: "credentials", bank_id: "overlord" },
+      }) as never,
+    );
+    const result = res?.result as { isError: boolean; content: { text: string }[] };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("overlord");
+    expect(result.content[0].text).toContain("test-bank");
+    expect(backend.requests.some((r) => r.method === "tools/call")).toBe(false);
+  });
+
+  it("recall with bank_id equal to the shim's own bank reaches the backend", async () => {
+    backend = await startMockBackend();
+    const shim = makeShim({ url: backend.url, cacheDir });
+    await shim.handle(rpc(1, "initialize", { protocolVersion: "2025-06-18" }) as never);
+
+    const res = await shim.handle(
+      rpc(2, "tools/call", {
+        name: "recall",
+        arguments: { query: "x", bank_id: "test-bank" },
+      }) as never,
+    );
+    const result = res?.result as { isError?: boolean };
+    expect(result?.isError).not.toBe(true);
+    const call = backend.requests.find((r) => r.method === "tools/call");
+    expect(call).toBeDefined();
+    const args = call?.params?.arguments as Record<string, unknown>;
+    expect(args.bank_id).toBe("test-bank");
   });
 });
 

--- a/tests/hindsight-mcp-shim.test.ts
+++ b/tests/hindsight-mcp-shim.test.ts
@@ -29,6 +29,7 @@ import {
   coerceSynthesizedArg,
   guardAndClampToolCall,
   guardBankScope,
+  BANK_SCOPE_GUARDED_TOOLS,
   DEFAULT_RECALL_MAX_TOKENS,
   DEFAULT_RECALL_BUDGET,
   DEFAULT_REFLECT_BUDGET,
@@ -914,6 +915,117 @@ describe("guardBankScope / bank-scope enforcement in guardAndClampToolCall", () 
     if (!res.ok) throw new Error("unexpected rejection of legitimate cross-bank retain");
     const args = (res.params as { arguments: Record<string, unknown> }).arguments;
     expect(args.bank_id).toBe("switchroom-dev"); // untouched, not coerced to "klanker"
+  });
+});
+
+// ─── Major 2 — the guard widened to the whole read-tool surface ───────────
+//
+// recall/get_mental_model were never the only forwarded, bank_id-accepting
+// tools reachable by a prompt-injected caller. `reflect(bank_id:"overlord")`
+// or `list_memories(bank_id:"overlord", q:"credentials")` are just as much
+// an exfil path — main agents (unlike the M6 worker grant) can reach the
+// full FALLBACK_TOOL_TABLE surface. Every READ tool that accepts bank_id
+// must be guarded; only WRITE tools (retain, create_directive, …) are
+// deliberately left open, per a real cross-bank write pattern.
+describe("guardBankScope — Major 2: every read-only bank_id-accepting tool is guarded", () => {
+  // [tool name, minimal valid required-args (sans bank_id)] — mirrors each
+  // tool's required-arg tuple in FALLBACK_TOOL_TABLE so a call with a
+  // correct bank_id is otherwise well-formed and would succeed but for the
+  // guard.
+  const guardedReadTools: [string, Record<string, unknown>][] = [
+    ["recall", { query: "x" }],
+    ["reflect", { query: "x" }],
+    ["get_mental_model", { mental_model_id: "mm-1" }],
+    ["get_memory", { memory_id: "mem-1" }],
+    ["list_memories", {}],
+    ["list_directives", {}],
+    ["get_bank", {}],
+    ["get_bank_stats", {}],
+    ["get_document", { document_id: "doc-1" }],
+    ["get_operation", { operation_id: "op-1" }],
+    ["list_documents", {}],
+    ["list_mental_models", {}],
+    ["list_operations", {}],
+    ["list_tags", {}],
+  ];
+
+  it("BANK_SCOPE_GUARDED_TOOLS is exactly this set (no drift either direction)", () => {
+    const expected = new Set(guardedReadTools.map(([name]) => name));
+    expect(BANK_SCOPE_GUARDED_TOOLS).toEqual(expected);
+  });
+
+  it.each(guardedReadTools)(
+    "rejects %s targeting a foreign bank_id",
+    (name, baseArgs) => {
+      const res = guardAndClampToolCall(
+        { name, arguments: { ...baseArgs, bank_id: "overlord" } },
+        {},
+        "klanker",
+      );
+      expect(res.ok).toBe(false);
+      if (res.ok) throw new Error(`expected ${name} to reject a foreign bank_id`);
+      expect(res.text).toContain("overlord");
+      expect(res.text).toContain("klanker");
+    },
+  );
+
+  it.each(guardedReadTools)(
+    "allows %s with bank_id equal to the caller's own bank",
+    (name, baseArgs) => {
+      const res = guardAndClampToolCall(
+        { name, arguments: { ...baseArgs, bank_id: "klanker" } },
+        {},
+        "klanker",
+      );
+      expect(res.ok).toBe(true);
+      if (!res.ok) throw new Error(`unexpected rejection of ${name} own-bank call`);
+    },
+  );
+
+  it.each(guardedReadTools)(
+    "allows %s with bank_id omitted (defaults to own bank)",
+    (name, baseArgs) => {
+      const res = guardAndClampToolCall(
+        { name, arguments: { ...baseArgs } },
+        {},
+        "klanker",
+      );
+      expect(res.ok).toBe(true);
+      if (!res.ok) throw new Error(`unexpected rejection of ${name} with bank_id omitted`);
+    },
+  );
+
+  it("every FALLBACK_TOOL_TABLE READ tool accepting bank_id is in the guarded set " +
+    "(nothing new slips through unguarded)", () => {
+    // WRITE/mutating verbs are the deliberate carve-out (see
+    // BANK_SCOPE_GUARDED_TOOLS's doc comment) — they must NOT be guarded.
+    const writeTools = new Set([
+      "cancel_operation",
+      "clear_memories",
+      "clear_mental_model",
+      "create_bank",
+      "create_directive",
+      "create_mental_model",
+      "delete_bank",
+      "delete_directive",
+      "delete_document",
+      "delete_mental_model",
+      "invalidate_memory",
+      "refresh_mental_model",
+      "retain",
+      "sync_retain",
+      "update_bank",
+      "update_memory",
+      "update_mental_model",
+    ]);
+    for (const [name, [, optional]] of Object.entries(FALLBACK_TOOL_TABLE)) {
+      if (!optional.includes("bank_id")) continue;
+      if (writeTools.has(name)) {
+        expect(BANK_SCOPE_GUARDED_TOOLS.has(name)).toBe(false);
+        continue;
+      }
+      expect(BANK_SCOPE_GUARDED_TOOLS.has(name)).toBe(true);
+    }
   });
 });
 

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -5110,6 +5110,174 @@ describe("sub-agent file generation", () => {
     expect(content).toContain("You are a worker. Implement the task.");
   });
 
+  // ─── M6/E-86: worker read-only Hindsight memory pull ──────────────────
+  //
+  // The worker subagent's tools are fleet-config-driven
+  // (defaults.subagents.worker.tools in switchroom.yaml); this fixture
+  // mirrors that block so the render path (scaffold.ts's frontmatter
+  // builder, `tools: saDef.tools.join(", ")`) is under test the same way
+  // the deployed worker.md is produced. carve-M6.md §2 / §4a.
+  const M6_WORKER_TOOLS = [
+    "Read",
+    "Edit",
+    "Write",
+    "Bash",
+    "Grep",
+    "Glob",
+    "TodoWrite",
+    "WebSearch",
+    "mcp__webkite__*",
+    "mcp__switchroom-telegram__progress_update",
+    "mcp__hindsight__recall",
+    "mcp__hindsight__get_mental_model",
+    "mcp__hindsight__get_knowledge_tree",
+    "mcp__hindsight__get_knowledge_page",
+    "mcp__hindsight__search_knowledge_pages",
+  ];
+
+  const M6_READ_TOOLS = [
+    "mcp__hindsight__recall",
+    "mcp__hindsight__get_mental_model",
+    "mcp__hindsight__get_knowledge_tree",
+    "mcp__hindsight__get_knowledge_page",
+    "mcp__hindsight__search_knowledge_pages",
+  ];
+
+  // Anti-vacuity guard (redteam-M6.md §4): every hindsight write/mutation
+  // verb that must stay UNREACHABLE from a worker. If this list were empty
+  // or wrong, the "none of these appear" assertions below would pass
+  // vacuously — encoding the deny set explicitly is the point.
+  const WRITE_VERBS = [
+    "retain",
+    "sync_retain",
+    "reflect",
+    "create_bank",
+    "create_directive",
+    "create_mental_model",
+    "update_bank",
+    "update_memory",
+    "update_mental_model",
+    "delete_document",
+    "delete_bank",
+    "delete_mental_model",
+    "delete_directive",
+    "clear_memories",
+    "clear_mental_model",
+    "invalidate_memory",
+    "deactivate_directive",
+    "reactivate_directive",
+  ];
+
+  function renderM6WorkerFixture(promptExtra = ""): { content: string; tools: string[] } {
+    const agentConfig = makeAgentConfig({
+      subagents: {
+        worker: {
+          description: "Handles implementation tasks",
+          model: "sonnet",
+          background: true,
+          color: "blue",
+          tools: M6_WORKER_TOOLS,
+          prompt:
+            "You are a worker sub-agent. Implement the task described in " +
+            "your prompt precisely and completely." +
+            promptExtra,
+        },
+      },
+    });
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "m6-worker-agent": agentConfig },
+    } as SwitchroomConfig;
+
+    const result = scaffoldAgent(
+      "m6-worker-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    const mdPath = join(result.agentDir, ".claude", "agents", "worker.md");
+    const content = readFileSync(mdPath, "utf-8");
+    const toolsLine = content
+      .split("\n")
+      .find((l) => l.startsWith("tools:"));
+    if (!toolsLine) throw new Error("no tools: line in rendered frontmatter");
+    const tools = toolsLine
+      .slice("tools:".length)
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    return { content, tools };
+  }
+
+  it("worker frontmatter carries exactly the 5 M6 read-only Hindsight tools (UAT-1)", () => {
+    const { tools } = renderM6WorkerFixture();
+
+    // Anti-vacuity: the parse actually found tokens, and specifically the
+    // hindsight subset is non-empty and exactly the 5 expected — guards
+    // against a frontmatter-parse regression turning every "absent" check
+    // below into a vacuous pass (redteam-M6.md §4.1).
+    expect(tools.length).toBeGreaterThan(0);
+    const hindsightTools = tools.filter((t) => t.startsWith("mcp__hindsight"));
+    expect(hindsightTools.sort()).toEqual([...M6_READ_TOOLS].sort());
+
+    // Positive: every read tool present, by exact token (not a substring
+    // scan — redteam-M6.md §4.2).
+    for (const readTool of M6_READ_TOOLS) {
+      expect(tools).toContain(readTool);
+    }
+  });
+
+  it("worker frontmatter contains NO hindsight write/mutation verb (UAT-4, negative)", () => {
+    const { tools } = renderM6WorkerFixture();
+    for (const verb of WRITE_VERBS) {
+      expect(tools, `mcp__hindsight__${verb} must be absent`).not.toContain(
+        `mcp__hindsight__${verb}`,
+      );
+    }
+  });
+
+  it("worker frontmatter carries NO mcp__hindsight__* wildcard or bare-prefix blanket (UAT-4, anti-smuggling)", () => {
+    const { tools } = renderM6WorkerFixture();
+    expect(tools).not.toContain("mcp__hindsight__*");
+    expect(tools).not.toContain("mcp__hindsight__");
+    expect(tools).not.toContain("mcp__hindsight");
+    // Every hindsight token present must be one of the 5 named read tools —
+    // a superset (e.g. a stray write verb OR a wildcard) fails this.
+    const hindsightTools = tools.filter((t) => t.startsWith("mcp__hindsight"));
+    for (const t of hindsightTools) {
+      expect(M6_READ_TOOLS, `unexpected hindsight tool ${t}`).toContain(t);
+    }
+  });
+
+  it("worker prompt body names the read-only pull tools and the trimmed-retry guidance (UAT-3)", () => {
+    const { content } = renderM6WorkerFixture(
+      "\n\nYou have READ-ONLY memory pull: mcp__hindsight__recall (use tool " +
+        "defaults; a trimmed/empty result is inconclusive, retry with " +
+        "defaults before concluding the bank is empty), plus " +
+        "get_mental_model / get_knowledge_tree / get_knowledge_page / " +
+        "search_knowledge_pages. You have no write verbs.",
+    );
+    expect(content).toContain("mcp__hindsight__recall");
+    expect(content).toContain("get_mental_model");
+    expect(content).toContain("get_knowledge_tree");
+    expect(content).toContain("get_knowledge_page");
+    expect(content).toContain("search_knowledge_pages");
+    expect(content.toLowerCase()).toContain("inconclusive");
+    expect(content.toLowerCase()).toContain("no write verbs");
+  });
+
+  // UAT test-plan (d) — SubagentStop write→read round-trip. Per
+  // carve-M6.md §5: no SubagentStop retain hook exists in the wiring
+  // (Stop only), so a worker never self-retains today and this round-trip
+  // is not achievable as the epic originally stated. Left as test.todo
+  // pending Ken's ruling rather than shipped vacuous/always-skipped and
+  // labelled passing.
+  it.todo(
+    "a SubagentStop retain from a worker is later recallable by a worker (blocked — carve-M6.md §5, no SubagentStop retain hook exists)",
+  );
+
   it("merges defaults.subagents with agent.subagents by name", () => {
     const agentConfig = makeAgentConfig({
       subagents: {


### PR DESCRIPTION
## Summary

Implements the M6-remainder scope from `carve-M6.md` / `redteam-M6.md` (memory-redesign epic): gives worker sub-agents a read-only, bank-scoped Hindsight recall path.

**A — widened worker tool allowlist.** `defaults.subagents.worker.tools` (fleet config, `switchroom.yaml`, applied live outside this repo) now grants 5 read-only Hindsight MCP tools: `mcp__hindsight__recall`, `get_mental_model`, `get_knowledge_tree`, `get_knowledge_page`, `search_knowledge_pages`. No write verb (`retain`, `create_directive`, …), no `mcp__hindsight__*` wildcard. Confirmed the render path (`scaffoldAgent`/`reconcileAgent` in `src/agents/scaffold.ts`, `tools: saDef.tools.join(", ")`) is fully config-driven — no code change needed for Part A, just a regression-guard test.

The worker subagent block's `mcpServers:` key was a schema no-op (silently stripped by a non-strict zod object) — removed with a comment, per the carve's cleanup recommendation. `tools:` is the sole reachability gate.

**B — deterministic bank-scope guard.** `recall` and `get_mental_model` both accept a caller-supplied `bank_id` the engine forwards verbatim with **no grant validation** (M6/E-86 red-team §1, the "TOP FINDING"): fleet bank names are agent-name-shaped and guessable (`klanker`, `overlord`, …), so an attacker-steered worker (prompt injection) could pass `bank_id: "overlord"` and read another agent's memory wholesale.

Added `guardBankScope` / `BANK_SCOPE_GUARDED_TOOLS` in `src/cli/hindsight-mcp-shim.ts`:
- A `bank_id` equal to the caller's own pinned bank (`this.opts.bankId`, sourced from `HINDSIGHT_BANK_ID`) passes unchanged.
- `bank_id` omitted passes unchanged (defaults to own bank via the `X-Bank-Id` header).
- Any other `bank_id` is **rejected loudly** — never silently coerced to the caller's own bank (a silent rewrite would hide the attempt from the transcript).
- No-op when the shim has no bank pinned (never true in production).

**Scope (updated in fold-in commit `2acb1984` — widened from the original `{recall, get_mental_model}`):** the guard now covers **every read-only `bank_id`-accepting tool** in `FALLBACK_TOOL_TABLE` — 14 tools: `recall`, `reflect`, `get_mental_model`, `get_memory`, `list_memories`, `list_directives`, `get_bank`, `get_bank_stats`, `get_document`, `get_operation`, `list_documents`, `list_mental_models`, `list_operations`, `list_tags`. This closes the whole cross-bank **read**-exfil class on the main-agent surface, not just the two tools this PR grants to workers (a prompt-injected main agent could otherwise `reflect(bank_id:"overlord")` or `list_memories(bank_id:"overlord")` and read any bank). A drift-guard test walks the actual table and reds if a future read tool gains `bank_id` without being added.

**Write tools deliberately stay unguarded.** `retain` has a legitimate, documented cross-bank use — `mcp__hindsight__retain(..., bank_id="switchroom-dev", ...)` in `MEMORY_GUIDANCE` (`src/agents/scaffold.ts:339`), routing durable repo knowledge into the shared repo bank — so an own-bank-only rule would break it. The cross-bank **write** class (`retain`/`clear_memories`/`update_memory`/`delete_*`, etc.) needs an `{own, switchroom-dev}` allowlist instead and is tracked as follow-up **#4762**. The guard is **stdio-transport only** (the fleet default); a hypothetical `mcp_transport: http` deployment bypasses the shim entirely — tracked as follow-up **#4761**.

**Worker prompt guidance.** `profiles/_shared/delegation-golden-rule.md.hbs` (rendered into every dispatching agent's CLAUDE.md) now notes a worker has no auto-recall of its own, can only pull its own bank read-only, and that the parent should put its own held orientation into the dispatch prompt as a deliberate context selection (never secrets).

## Deviation from the carve

UAT test-plan item (d) — a SubagentStop-retain-then-recall round trip — is left as `it.todo(...)` in `tests/scaffold.test.ts`, citing `carve-M6.md §5`: no SubagentStop retain hook exists in the current wiring (Stop only), so a worker never self-retains today and the round trip isn't achievable as originally stated. Not shipped as a vacuous always-passing test.

## Tests

- `tests/hindsight-mcp-shim.test.ts`: `guardAndClampToolCall`/`guardBankScope` — rejects foreign `bank_id` on all 14 guarded read tools (`it.each`); allows omitted/equal-to-own for each; reads `ownBankId` from `env.HINDSIGHT_BANK_ID` when the 3rd arg is omitted; no-op when unpinned; doesn't touch a tool with no `bank_id` at all (`list_banks`); a test proving `retain` with an explicit cross-bank `bank_id` (`"switchroom-dev"` while own bank is `"klanker"`) is *not* rejected (don't-break-the-legitimate-caller); **and** a drift-guard test that walks the real `FALLBACK_TOOL_TABLE` and asserts every read tool taking `bank_id` is guarded and every write tool is not — a future table addition reds it. Plus live-shim integration tests. 118/118 passing (verified TDD: reverting the guarded set to `{recall, get_mental_model}` reds exactly 14).
- `tests/scaffold.test.ts`: 4 new tests — worker frontmatter carries exactly the 5 read tools (anti-vacuity: asserts the hindsight-prefixed subset is non-empty and exactly matches); contains zero of an explicit 18-verb write-verb deny-list; contains no `mcp__hindsight__*` wildcard/bare-prefix and no hindsight token outside the 5 named reads; prompt body names the pull tools + "trimmed/empty is inconclusive, retry" guidance. 252 passing + 1 todo (unchanged from before this PR).
- `npx tsc --noEmit`: clean.
- `node scripts/check-changelog-entry.mjs` / `check-hindsight-bank-hermeticity.mjs` / `check-hindsight-write-redaction.mjs` / `check-mutation-coverage.mjs`: all OK (ran scoped, not full `npm run lint`, per CI-is-full-suite-authority).

## Not in this PR

The live `switchroom.yaml` (`defaults.subagents.worker.tools` + prompt guidance) has already been hand-edited to match Part A and validated with `js-yaml` — that's fleet config outside this repo, not part of the diff here, and needs an agent restart (`switchroom apply` / per-agent `docker restart switchroom-<agent>`) to take effect. Left for the operator/parent to trigger, not done by this PR.

Not merging — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
