### PR TITLE
test(memory): calibrate Tier-1 directive-flip drift check for M2->M3 condensation

### DIFF
--- a/telegram-plugin/uat/flip/tier1-equivalence.test.ts
+++ b/telegram-plugin/uat/flip/tier1-equivalence.test.ts
@@ -362,6 +362,46 @@ describe("tier1 calibration — STILL FAILS on a genuinely dropped guardrail", (
   });
 });
 
+describe("tier1 calibration — adversarial false-negatives (PR #4771 review)", () => {
+  // MAJOR 1 (review of PR #4771): a modal class must not be satisfied by an
+  // unrelated same-class survivor token. The directive NEGATES the proposition
+  // ("Never call Ian the executor …"); the condensed rule INVERTS it ("Ian is
+  // the executor …") while an unrelated "without" survives. Before the fix the
+  // neg class matched "without" anywhere in the rule and the inversion PASSED —
+  // the exact drop-through the gate exists to catch. It MUST FAIL.
+  it("negation dropped, meaning inverted, unrelated 'without' survives ⇒ FAIL", () => {
+    const directives = [
+      directive("d1", "no-ian", "Never call Ian the executor without a documentary grant of probate."),
+    ];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "Ian is the executor without a documentary grant.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0]).toMatchObject({ id: "d1", ruleId: "R-01" });
+    expect(rep.truncated_or_drifted[0].missingKeywords).toContain("never");
+  });
+
+  // MAJOR 2 (review of PR #4771): EXAMPLE_CONTEXT_RE included `like`/`including`,
+  // which reclassified a load-bearing fact sitting after those words as an
+  // illustrative sample and stopped demanding it. A rule that DROPS the caveat
+  // code then PASSED. With `like`/`including` removed from the example markers
+  // the code stays a guardrail and the drop MUST FAIL.
+  it("load-bearing case code after 'including' dropped by the rule ⇒ FAIL", () => {
+    const directives = [
+      directive("d1", "caveat", "Handle probate cases including S CAV 2026 00037 with the sealed-file protocol."),
+    ];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "Handle probate cases with the sealed-file protocol.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0].missingKeywords).toContain("CAV 2026 00037");
+  });
+});
+
 describe("tier1 calibration — now PASSES real synonym-preserving condensations", () => {
   it("negation synonym: directive 'don't' → rule 'NEVER' preserves the guardrail ⇒ PASS", () => {
     const directives = [directive("d1", "confirm-external", "Don't send letters to solicitors without Ken's approval.")];

--- a/telegram-plugin/uat/flip/tier1-equivalence.test.ts
+++ b/telegram-plugin/uat/flip/tier1-equivalence.test.ts
@@ -102,15 +102,31 @@ describe("compareDirectivesToRules — (a) missing_from_rules", () => {
 });
 
 describe("compareDirectivesToRules — (b) truncated_or_drifted", () => {
-  it("flags a rule that drops a directive keyword (a proper noun)", () => {
+  it("flags a rule that drops a load-bearing named fact (ALL-CAPS party name)", () => {
+    // Calibration: an incidental quoted proper noun is illustrative and NOT
+    // demanded (see the sibling test below) — but a SHOUTED party name is a
+    // guardrail a condensed rule cannot silently drop.
+    const directives = [directive("d1", "exec", "The executor is GARY DAVID BROWN, not Ian.")];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "The executor is the estate trustee, not Ian.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0]).toMatchObject({ id: "d1", ruleId: "R-01", truncated: false });
+    expect(rep.truncated_or_drifted[0].missingKeywords).toContain("GARY DAVID BROWN");
+  });
+
+  it("does NOT flag a dropped illustrative token (incidental quoted proper noun)", () => {
+    // The OLD gate false-flagged this ("Twitter" dropped); the calibrated gate
+    // treats an un-cued quoted proper noun as an illustrative sample. The
+    // negation guardrail ("Never") is preserved, so this is a clean condense.
     const directives = [directive("d1", "scope", 'Never post to "Twitter" without approval.')];
-    // rule keeps the modal but drops the quoted proper noun.
     const rep = compareDirectivesToRules(directives, parsed([rule("R-01", "Never post without approval.")]), {
       d1: "R-01",
     });
-    expect(rep.pass).toBe(false);
-    expect(rep.truncated_or_drifted[0]).toMatchObject({ id: "d1", ruleId: "R-01", truncated: false });
-    expect(rep.truncated_or_drifted[0].missingKeywords).toContain("Twitter");
+    expect(rep.truncated_or_drifted).toEqual([]);
+    expect(rep.pass).toBe(true);
   });
 
   it("flags a rule that drops a modal (never)", () => {
@@ -211,15 +227,19 @@ describe("residue filtering", () => {
 });
 
 describe("extractKeywords — the fixed tokenizer", () => {
-  it("captures quoted phrases, modals, and proper nouns; skips stopwords", () => {
+  it("classes negation as a guardrail; quoted samples & proper nouns as illustrative", () => {
     const kws = extractKeywords('Never post to "the public channel" on Twitter — always ask Ken first.');
-    const values = kws.map((k) => k.value.toLowerCase());
-    expect(values).toContain("the public channel"); // quoted phrase, verbatim
-    expect(values).toContain("never");
-    expect(values).toContain("always");
-    expect(values).toContain("twitter");
-    expect(values).toContain("ken");
-    // "Never"/"Always" at sentence start are modals, not double-counted as proper nouns.
+    const byVal = new Map(kws.map((k) => [k.value.toLowerCase(), k]));
+    // negation is a guardrail modal (synonym class `neg`).
+    expect(byVal.get("never")).toMatchObject({ kind: "modal", klass: "guardrail", modalClass: "neg" });
+    // the quoted phrase is present but illustrative (no verbatim cue precedes it).
+    expect(byVal.get("the public channel")).toMatchObject({ kind: "quote", klass: "illustrative" });
+    // incidental proper nouns are present but illustrative — never demanded.
+    expect(byVal.get("twitter")).toMatchObject({ klass: "illustrative" });
+    expect(byVal.get("ken")).toMatchObject({ klass: "illustrative" });
+    // bare "always" is emphasis, not an explicit scope phrase ⇒ no universal guardrail.
+    expect(kws.some((k) => k.kind === "modal" && k.modalClass === "universal")).toBe(false);
+    // "Never" at sentence start is the modal, not double-counted as a proper noun.
     expect(kws.filter((k) => k.value.toLowerCase() === "never").length).toBe(1);
   });
 
@@ -238,11 +258,173 @@ describe("extractKeywords — the fixed tokenizer", () => {
   });
 
   it("word-boundary matches modals so a substring does not satisfy", () => {
-    // 'must' as a directive keyword is not satisfied by 'mustard' in the rule.
-    const directives = [directive("d1", "g", "You must comply.")];
-    const rep = compareDirectivesToRules(directives, parsed([rule("R-01", "Pass the mustard, comply.")]), {
+    // The negation "cannot" is NOT satisfied by the substring "cannon" in the
+    // rule — the neg synonym class is word-boundary matched, not substring.
+    const directives = [directive("d1", "g", "You cannot deploy on Fridays.")];
+    const rep = compareDirectivesToRules(directives, parsed([rule("R-01", "Fire the cannon, deploy on Fridays.")]), {
       d1: "R-01",
     });
-    expect(rep.truncated_or_drifted[0].missingKeywords).toContain("must");
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0].missingKeywords).toContain("cannot");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADVERSARIAL DROP DETECTION — the acceptance criterion for the calibration.
+//
+// The calibration exists to stop condensation FALSE POSITIVES. The failure
+// mode we refuse to introduce is the inverse: a gate so loose it greenlights a
+// genuinely dropped guardrail. These tests pin that boundary with fixtures
+// modelled on the real triage directives (lawgpt's executor / deferral-line /
+// caveat facts). Each DROP fixture MUST FAIL; each synonym-preserving condense
+// MUST PASS. If a future loosening regresses detection, one of these goes red.
+// ---------------------------------------------------------------------------
+
+// The lawgpt "defer-to-fiona" deferral line the directive says to emit verbatim.
+const DEFERRAL_LINE =
+  "This is a Fiona question — raise it with Fiona Jessep at LHPW before acting on any of the above.";
+const DEFER_DIRECTIVE =
+  `ENFORCEMENT: any legal-analysis response MUST end with exactly: "${DEFERRAL_LINE}" ` +
+  "All output channels; without that line the response is failed.";
+
+describe("tier1 calibration — STILL FAILS on a genuinely dropped guardrail", () => {
+  it("drops a negation entirely: 'never send without approval' → 'send after review' ⇒ FAIL", () => {
+    const directives = [directive("d1", "confirm-external", "Never send letters to solicitors without Ken's approval.")];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "Send letters to solicitors after review.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0].missingKeywords).toContain("never");
+  });
+
+  it("drops a named load-bearing fact: executor 'GARY DAVID BROWN' ⇒ FAIL", () => {
+    const directives = [
+      directive("d1", "gary-executor", "Executor of George's estate is GARY DAVID BROWN via the s17 chain."),
+    ];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "Executor of George's estate is the appointed representative via the s17 chain.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0].missingKeywords).toContain("GARY DAVID BROWN");
+  });
+
+  it("drops the required-verbatim deferral line ⇒ FAIL", () => {
+    const directives = [directive("d1", "defer-to-fiona", DEFER_DIRECTIVE)];
+    const rep = compareDirectivesToRules(
+      directives,
+      // rule paraphrases the obligation but omits the exact required wording.
+      parsed([rule("R-01", "Never give legal advice; end legal-analysis by pointing to the solicitor.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0].missingKeywords.some((k) => k.includes("Fiona Jessep at LHPW"))).toBe(true);
+  });
+
+  it("drops a case-caveat number 'S CAV 2026 00037' ⇒ FAIL", () => {
+    const directives = [
+      directive("d1", "caveat", "Ian filed probate caveat S CAV 2026 00037, now cancelled; he holds no office."),
+    ];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "Ian filed a probate caveat, now cancelled; he holds no office.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0].missingKeywords).toContain("CAV 2026 00037");
+  });
+
+  it("truncates mid-guardrail (strict prefix cut) ⇒ FAIL", () => {
+    const directives = [
+      directive("d1", "no-ian", "Never call Ian the executor without a documentary grant of probate."),
+    ];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "Never call Ian the executor without a documentary")]),
+      { d1: "R-01" },
+    );
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0].truncated).toBe(true);
+  });
+
+  it("truncates mid-guardrail (ellipsis) ⇒ FAIL", () => {
+    const directives = [directive("d1", "defer-to-fiona", DEFER_DIRECTIVE)];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", `Never give legal advice; end with: "${DEFERRAL_LINE}"…`)]),
+      { d1: "R-01" },
+    );
+    expect(rep.pass).toBe(false);
+    expect(rep.truncated_or_drifted[0].truncated).toBe(true);
+  });
+});
+
+describe("tier1 calibration — now PASSES real synonym-preserving condensations", () => {
+  it("negation synonym: directive 'don't' → rule 'NEVER' preserves the guardrail ⇒ PASS", () => {
+    const directives = [directive("d1", "confirm-external", "Don't send letters to solicitors without Ken's approval.")];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "NEVER send letters to solicitors without approval; draft for review only.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.truncated_or_drifted).toEqual([]);
+    expect(rep.pass).toBe(true);
+  });
+
+  it("exclusivity synonym: directive 'only' → rule 'sole/alone' preserves scope ⇒ PASS", () => {
+    const directives = [directive("d1", "fiona-facts", "Include only documented facts visible on paper.")];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "Include documented facts visible on paper exclusively.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.truncated_or_drifted).toEqual([]);
+    expect(rep.pass).toBe(true);
+  });
+
+  it("preserves the deferral line + named facts verbatim ⇒ PASS", () => {
+    const directives = [
+      directive("d1", "defer-to-fiona", DEFER_DIRECTIVE),
+      directive("d2", "gary-executor", "Executor is GARY DAVID BROWN; caveat S CAV 2026 00037 cancelled."),
+    ];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([
+        rule("R-01", `Never give legal advice. End any legal-analysis with exactly: "${DEFERRAL_LINE}"`),
+        rule("R-02", "Executor is GARY DAVID BROWN; the caveat S CAV 2026 00037 is cancelled — Ian holds no office."),
+      ]),
+      { d1: "R-01", d2: "R-02" },
+    );
+    expect(rep.truncated_or_drifted).toEqual([]);
+    expect(rep.pass).toBe(true);
+  });
+
+  it("drops an ILLUSTRATIVE example code (e.g. AG779131P) without flagging ⇒ PASS", () => {
+    const directives = [
+      directive("d1", "evidence", "Cite an instrument or ledger number (e.g. AG779131P, TR10399) inline with each claim."),
+    ];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "Cite an instrument or ledger number inline with every claim.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.truncated_or_drifted).toEqual([]);
+    expect(rep.pass).toBe(true);
+  });
+
+  it("drops an ILLUSTRATIVE sample toast (un-cued quote) without flagging ⇒ PASS", () => {
+    const directives = [
+      directive("d1", "toast", 'Add a per-button toast, e.g. ack_text "✓ Code fix — starting", for instant feedback.'),
+    ];
+    const rep = compareDirectivesToRules(
+      directives,
+      parsed([rule("R-01", "Add a per-button ack_text toast for instant feedback on every callback button.")]),
+      { d1: "R-01" },
+    );
+    expect(rep.truncated_or_drifted).toEqual([]);
+    expect(rep.pass).toBe(true);
   });
 });

--- a/telegram-plugin/uat/flip/tier1-equivalence.ts
+++ b/telegram-plugin/uat/flip/tier1-equivalence.ts
@@ -150,11 +150,38 @@ export interface EquivalenceReport {
  * preserves the obligation without the literal token — demanding it survive is
  * a condensation artifact with no safety loss (every rule in the block is
  * already mandatory by construction).
+ *
+ * SATISFACTION IS SPAN-SCOPED, not whole-rule (PR #4771 adversarial review,
+ * MAJOR 1). A satisfy token counts only when it GOVERNS THE SAME SPAN the modal
+ * governed in the directive — i.e. it sits within a bounded window of a content
+ * word the directive used near its trigger (see {@link ruleSatisfiesModal}).
+ * Matching a satisfy token ANYWHERE in the ~400B rule let an INVERTED
+ * condensation pass: "Never call Ian the executor without a grant" → "Ian is
+ * the executor without a grant" dropped the negation yet satisfied `neg` via the
+ * surviving, unrelated "without". Two changes close that:
+ *   (a) `without` is removed from `neg.satisfy`. It is a PREPOSITION, not a
+ *       clausal polarity marker — it modifies its own object ("without a grant")
+ *       and carries no reliable sentence polarity, so it survived the inversion
+ *       sitting beside the SAME span the lost "never" governed, defeating any
+ *       proximity check. No genuine condensation relies on a bare "without" as
+ *       its ONLY negation marker (faithful ones keep "no"/"not"/"never"/"don't").
+ *   (b) the span/proximity check above (the robust mechanism).
+ *
+ * NOTE — the review's fallback also proposed dropping `no`/`nor`/`none`/`avoid`
+ * (neg) and `just`/`alone`/`purely` (only). Validation against the 5 real M2→M3
+ * drafts CONTRADICTED that: carrie condenses "does NOT want …"/"don't ship …"/
+ * "No employer-bashing"/"no public URL" into rules that carry the negation as
+ * "no X" — 6 FAITHFUL condensations. Dropping `no` re-flagged all 6, reviving the
+ * exact false-positive class this gate exists to kill. With the span/proximity
+ * check now scoping satisfaction, those reliable negators no longer need
+ * dropping (a relocated survivor no longer satisfies), so only the one proven
+ * falsifier-enabler (`without`) is removed. Evidence: triage/carrie + the
+ * `adversarial false-negatives` acceptance tests.
  */
 const MODAL_CLASSES = {
   neg: {
     trigger: ["never", "cannot", "can't", "don't", "do not", "won't", "must not", "may not", "shall not"],
-    satisfy: ["never", "no", "not", "don't", "dont", "cannot", "can't", "cant", "won't", "wont", "shan't", "none", "nor", "without", "avoid", "refuse", "neither", "prohibit", "forbid", "ban"],
+    satisfy: ["never", "no", "not", "don't", "dont", "cannot", "can't", "cant", "won't", "wont", "shan't", "none", "nor", "avoid", "refuse", "neither", "prohibit", "forbid", "ban"],
   },
   only: {
     trigger: ["only", "sole", "solely", "exclusively", "nothing but"],
@@ -207,9 +234,18 @@ const CODE_ACRONYM_NUM_RE = /\b[A-Z]{2,5}(?:\s+\d{2,}){1,}\b/g;
  *  before a fact match ⇒ the fact is a SAMPLE, not an asserted guardrail. No
  *  trailing `\b` — markers ending in `.` ("e.g.") have no word boundary before
  *  the following space — and the run after the marker forbids sentence
- *  terminators (`.?!:;`) so the marker must be in the SAME clause as the fact. */
+ *  terminators (`.?!:;`) so the marker must be in the SAME clause as the fact.
+ *
+ *  `like` and `including` are DELIBERATELY EXCLUDED (PR #4771 adversarial
+ *  review, MAJOR 2). Both are far too broad to reliably mark an illustrative
+ *  sample: "handle probate cases including S CAV 2026 00037" and "parties like
+ *  GARY DAVID BROWN" name LOAD-BEARING facts, not examples. Treating anything
+ *  after them as illustrative silently stopped demanding those facts, so a rule
+ *  that dropped the code/name PASSED the gate. Only the reliable, unambiguous
+ *  example cues remain (`e.g.`, `i.e.`, `such as`, `for example`,
+ *  `for instance`, `example(s)`). */
 const EXAMPLE_CONTEXT_RE =
-  /(?:\be\.?\s?g\.?|\bi\.?\s?e\.?|\bsuch as|\bfor example|\bfor instance|\bexamples?\b|\bincluding\b|\blike\b)[^.?!:;]{0,48}$/i;
+  /(?:\be\.?\s?g\.?|\bi\.?\s?e\.?|\bsuch as|\bfor example|\bfor instance|\bexamples?\b)[^.?!:;]{0,48}$/i;
 
 /** Common English words a directive may SHOUT for emphasis rather than name.
  *  An ALL-CAPS run containing any of these is emphasis, not a party name.
@@ -298,6 +334,12 @@ export interface Keyword {
   value: string;
   /** For `kind === "modal"`: which synonym class must survive. */
   modalClass?: ModalClass;
+  /** For `kind === "modal"`: the content words the directive used near its
+   *  trigger — the SPAN the modal governed. A surviving satisfy token in the
+   *  rule counts only when it sits within a bounded window of one of these (see
+   *  {@link ruleSatisfiesModal}). Empty ⇒ fall back to whole-rule containment
+   *  (the directive gave no usable anchor, e.g. a bare "Never x."). */
+  anchors?: string[];
 }
 
 function normalize(s: string): string {
@@ -326,9 +368,126 @@ function directiveTriggersModal(normalizedContent: string, cls: ModalClass): boo
   return MODAL_CLASSES[cls].trigger.some((w) => containsWord(normalizedContent, w));
 }
 
-/** True when the rule satisfies `cls` (contains any of its satisfy words). */
-function ruleSatisfiesModal(normalizedRuleText: string, cls: ModalClass): boolean {
-  return MODAL_CLASSES[cls].satisfy.some((w) => containsWord(normalizedRuleText, w));
+// --- Span/proximity scoping for modal satisfaction (PR #4771 MAJOR 1) --------
+//
+// A modal obligation is satisfied only when a surviving satisfy token GOVERNS
+// THE SAME SPAN it governed in the directive. We approximate "same span" by the
+// content words the directive used within a window of its trigger (the modal's
+// ANCHORS); the satisfy token in the rule must sit within a window of one of
+// those anchors. Generous windows: the goal is to catch an inverted/relocated
+// negation, not to re-introduce condensation false positives — a faithful
+// reword keeps the modal beside the thing it negates/scopes.
+
+/** Half-width, in characters, of the proximity window on both the directive
+ *  (anchor harvest) and rule (satisfy match) sides. ~One clause of a ~400B
+ *  rule; wide enough that a faithful reword passes, tight enough that a modal
+ *  relocated to an unrelated clause does not. */
+const MODAL_SPAN_WINDOW = 120;
+
+/** Function/scaffolding words that make poor anchors — too common to pin a span
+ *  and prone to spurious matches. Anchors must be DISTINCTIVE content words. */
+const ANCHOR_STOPWORDS = new Set([
+  "this", "that", "these", "those", "with", "without", "from", "into", "onto",
+  "your", "their", "there", "here", "then", "than", "them", "they", "some",
+  "such", "each", "every", "which", "what", "when", "where", "while", "about",
+  "before", "after", "over", "under", "above", "below", "must", "should",
+  "would", "could", "shall", "will", "have", "been", "being", "does", "done",
+  "also", "only", "just", "very", "much", "more", "most", "less", "least",
+  "any", "all", "both", "either", "neither", "none", "unless", "until",
+]);
+
+/** The character offset of `cls`'s first trigger occurrence in the (normalized)
+ *  directive, or -1. `only` uses the refined, sense-aware matcher. */
+function firstTriggerIndex(normalizedContent: string, cls: ModalClass): number {
+  if (cls === "only") {
+    const m = ONLY_TRIGGER_RE.exec(normalizedContent);
+    return m ? m.index : -1;
+  }
+  let best = -1;
+  for (const w of MODAL_CLASSES[cls].trigger) {
+    const stem = normalize(w).replace(/['’]/g, "'");
+    const re = new RegExp(`(?:^|[^a-z0-9])(${escapeRe(stem)})(?:[^a-z0-9]|$)`);
+    const m = re.exec(normalizedContent);
+    if (m) {
+      const idx = m.index + m[0].indexOf(m[1]);
+      if (best === -1 || idx < best) best = idx;
+    }
+  }
+  return best;
+}
+
+/** Distinctive content words (≥4 chars, not a stopword) within
+ *  ±MODAL_SPAN_WINDOW of `centerIdx` — the span the modal governs. */
+function anchorsAround(normalizedContent: string, centerIdx: number): string[] {
+  if (centerIdx < 0) return [];
+  const lo = Math.max(0, centerIdx - MODAL_SPAN_WINDOW);
+  const hi = Math.min(normalizedContent.length, centerIdx + MODAL_SPAN_WINDOW);
+  const window = normalizedContent.slice(lo, hi);
+  const words = window.match(/[a-z0-9]{4,}/g) ?? [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const w of words) {
+    if (ANCHOR_STOPWORDS.has(w) || seen.has(w)) continue;
+    seen.add(w);
+    out.push(w);
+  }
+  return out;
+}
+
+/** Anchors for a triggered modal class: the span words around its trigger. */
+function modalAnchors(normalizedContent: string, cls: ModalClass): string[] {
+  return anchorsAround(normalizedContent, firstTriggerIndex(normalizedContent, cls));
+}
+
+/** All character offsets at which `word` occurs as a whole word in `text`. */
+function wordOffsets(text: string, word: string): number[] {
+  const stem = normalize(word).replace(/['’]/g, "'");
+  const offsets: number[] = [];
+  if (/\s/.test(stem)) {
+    let i = text.indexOf(stem);
+    while (i !== -1) {
+      offsets.push(i);
+      i = text.indexOf(stem, i + 1);
+    }
+    return offsets;
+  }
+  const re = new RegExp(`(^|[^a-z0-9])(${escapeRe(stem)})([^a-z0-9]|$)`, "g");
+  for (let m = re.exec(text); m; m = re.exec(text)) {
+    offsets.push(m.index + m[1].length);
+    re.lastIndex = m.index + 1; // allow overlapping / adjacent matches
+  }
+  return offsets;
+}
+
+/**
+ * True when the rule satisfies `cls`. A satisfy token must both (i) be present
+ * as a whole word and (ii) sit within ±MODAL_SPAN_WINDOW of one of the modal's
+ * `anchors` — the span the directive's modal governed. When `anchors` is empty
+ * (the directive gave no distinctive span word, e.g. a bare "Never x."), it
+ * falls back to whole-rule containment so short guardrails still match.
+ *
+ * This is the fix for PR #4771 MAJOR 1: whole-rule containment let an unrelated
+ * same-class survivor (a relocated "without"/"not") satisfy a modal whose actual
+ * proposition the condensation had dropped or inverted.
+ */
+function ruleSatisfiesModal(
+  normalizedRuleText: string,
+  cls: ModalClass,
+  anchors: readonly string[] = [],
+): boolean {
+  const tokens = MODAL_CLASSES[cls].satisfy;
+  if (anchors.length === 0) {
+    return tokens.some((w) => containsWord(normalizedRuleText, w));
+  }
+  for (const tok of tokens) {
+    for (const at of wordOffsets(normalizedRuleText, tok)) {
+      const lo = Math.max(0, at - MODAL_SPAN_WINDOW);
+      const hi = Math.min(normalizedRuleText.length, at + tok.length + MODAL_SPAN_WINDOW);
+      const window = normalizedRuleText.slice(lo, hi);
+      if (anchors.some((a) => window.includes(a))) return true;
+    }
+  }
+  return false;
 }
 
 /** First trigger word the directive used for `cls`, for readable reporting. */
@@ -357,9 +516,17 @@ export function extractKeywords(content: string): Keyword[] {
   const norm = normalize(content);
 
   // (1) Modal synonym classes — guardrail. One keyword per triggered class.
+  //     `anchors` pin the span the modal governed so satisfaction is span-scoped
+  //     (a relocated same-class survivor no longer satisfies) — PR #4771 MAJOR 1.
   for (const cls of Object.keys(MODAL_CLASSES) as ModalClass[]) {
     if (directiveTriggersModal(norm, cls)) {
-      push({ kind: "modal", klass: "guardrail", value: firstTrigger(norm, cls), modalClass: cls });
+      push({
+        kind: "modal",
+        klass: "guardrail",
+        value: firstTrigger(norm, cls),
+        modalClass: cls,
+        anchors: modalAnchors(norm, cls),
+      });
     }
   }
 
@@ -401,7 +568,7 @@ export function extractKeywords(content: string): Keyword[] {
 function ruleContainsKeyword(normalizedRuleText: string, kw: Keyword): boolean {
   if (kw.klass === "illustrative") return true;
   if (kw.kind === "modal" && kw.modalClass) {
-    return ruleSatisfiesModal(normalizedRuleText, kw.modalClass);
+    return ruleSatisfiesModal(normalizedRuleText, kw.modalClass, kw.anchors ?? []);
   }
   const needle = normalize(kw.value);
   if (/\s/.test(needle)) return normalizedRuleText.includes(needle);

--- a/telegram-plugin/uat/flip/tier1-equivalence.ts
+++ b/telegram-plugin/uat/flip/tier1-equivalence.ts
@@ -26,10 +26,15 @@
  *       reflect-directive) appears in `mapping`, mapped to a PRESENT rule id
  *       or an explicit `retired:<reason>`. Unmapped, or mapped to an absent
  *       rule / an empty retirement reason ⇒ `missing_from_rules`.
- *   (b) for each directive→rule pair, the normalized rule text contains every
- *       negation/scope keyword the directive carries (quoted strings, proper
- *       nouns, modals never/always/don't/only/must) and is not truncated ⇒
- *       `truncated_or_drifted`.
+ *   (b) for each directive→rule pair, the normalized rule text preserves every
+ *       GUARDRAIL the directive carries — its polarity/scope modals (matched by
+ *       synonym class, so "don't"≡"NEVER" and "only"≡"sole"), its load-bearing
+ *       facts (ALL-CAPS names, case/instrument codes), and any required-verbatim
+ *       quoted line — and is not truncated ⇒ `truncated_or_drifted`. ILLUSTRATIVE
+ *       tokens (sample toasts/commands the directive quoted as examples, incidental
+ *       prose proper nouns) are NOT demanded; requiring them verbatim in a ~400B
+ *       rule condensed from a ~10KB directive is a condensation artifact, not a
+ *       dropped guardrail. See the tokenizer section for the exact class split.
  *   (c) the rendered rules block is ≤ 6144 bytes AND the sentinel's rule count
  *       equals the actual rule count.
  *   (d) reverse: no rule lacks a mapping source ⇒ `unsourced_rules`.
@@ -114,37 +119,185 @@ export interface EquivalenceReport {
 }
 
 // ---------------------------------------------------------------------------
-// Fixed tokenizer — negation / scope keywords a rule must preserve
+// Calibrated tokenizer — GUARDRAIL vs ILLUSTRATIVE keyword classes
 // ---------------------------------------------------------------------------
+//
+// M2→M3 triage condenses a ~10KB verbose directive into a ~400B rule. The old
+// tokenizer demanded every quoted phrase / proper noun / exact modal token
+// survive verbatim, which false-flagged ~100% of valid condensed drafts (a
+// "don't"→"NEVER" reword, a "only"→"sole" reword, a dropped illustrative
+// example). This tokenizer separates what a guardrail actually IS (polarity,
+// scope, load-bearing named facts, required-verbatim wording) from the prose
+// the directive used to explain it (samples, incidental proper nouns), and
+// demands only the former. The failure mode we refuse to introduce is the
+// inverse: a calibration so loose it greenlights a genuinely dropped guardrail.
+// The `truncated_or_drifted` acceptance tests pin that boundary.
 
-/** Common capitalized sentence-openers / imperatives that are NOT proper
- *  nouns — excluded so the proper-noun scan doesn't demand them of the rule
- *  text. Deliberately small and fixed (deterministic), not a dictionary. */
-const PROPER_NOUN_STOPWORDS = new Set(
-  [
-    "The", "A", "An", "This", "That", "These", "Those", "It", "Its", "If",
-    "When", "While", "Do", "Don", "Set", "Use", "Never", "Always", "Only",
-    "Must", "Not", "No", "Every", "Each", "Any", "All", "For", "And", "But",
-    "Or", "So", "Then", "Prefer", "Avoid", "Ask", "Refuse", "Keep", "Treat",
-    "Read", "Write", "Run", "Call", "Send", "Reply", "You", "Your", "We",
-    "I", "Before", "After",
-  ].map((w) => w),
-);
+/**
+ * Synonym classes for the scope/polarity modals a guardrail cannot lose. A
+ * class is TRIGGERED when the directive uses one of its `trigger` words; the
+ * obligation is SATISFIED when the rule contains ANY of the (broader) `satisfy`
+ * words. So "don't send" ≡ "NEVER send" ≡ "do not send" (all `neg`), and
+ * "only Ken" ≡ "Ken alone" via "sole"/"solely" (`only`). Deliberately small,
+ * explicit, and documented — not a thesaurus.
+ *
+ * Trigger sets are the DISTINCTIVE, unambiguous scope/polarity words only
+ * (never/cannot/only/always/…), NOT incidental "no"/"not"/"all"/"each" which
+ * appear constantly in non-scope senses and would over-trigger. Satisfy sets
+ * are broad so any faithful reword counts. Plain obligation "must"/"shall" is
+ * intentionally NOT a class: it marks obligation strength, not polarity or
+ * scope, and an imperative reword ("Always call X" / "Confirm before Y")
+ * preserves the obligation without the literal token — demanding it survive is
+ * a condensation artifact with no safety loss (every rule in the block is
+ * already mandatory by construction).
+ */
+const MODAL_CLASSES = {
+  neg: {
+    trigger: ["never", "cannot", "can't", "don't", "do not", "won't", "must not", "may not", "shall not"],
+    satisfy: ["never", "no", "not", "don't", "dont", "cannot", "can't", "cant", "won't", "wont", "shan't", "none", "nor", "without", "avoid", "refuse", "neither", "prohibit", "forbid", "ban"],
+  },
+  only: {
+    trigger: ["only", "sole", "solely", "exclusively", "nothing but"],
+    satisfy: ["only", "sole", "solely", "exclusively", "just", "alone", "purely"],
+  },
+  universal: {
+    // Trigger only on EXPLICIT scope phrases, NOT bare "always". Bare "always"
+    // is, like plain "must", usually emphasis on a rule that is already
+    // unconditional by construction ("always format X" ⇒ "X"), and condensation
+    // legitimately drops it — flagging that is a false positive with no safety
+    // loss. Deliberate scope phrases ("in all cases", "without exception") ARE
+    // load-bearing and stay mandatory, matched by any universal synonym.
+    trigger: ["whenever", "every time", "in all cases", "all cases", "at all times", "in every case", "without exception", "no exception"],
+    satisfy: ["always", "every", "each", "all", "everything", "whenever", "any", "must", "never", "no exception", "without exception"],
+  },
+} as const;
 
-const MODAL_RE = /\b(never|always|only|must)\b/gi;
-// NON-global on purpose: used only with `.test()`. A `/g` regex advances its
-// `lastIndex` on each `.test()` and, because this constant is module-level and
-// reused across calls, that persisted offset would make a later
-// `extractKeywords` miss a "don't" at position 0. `.test()` on a non-global
-// regex is stateless.
-const DONT_RE = /\bdon['’]?t\b/i;
-const QUOTE_RES = [/"([^"]+)"/g, /'([^']+)'/g, /`([^`]+)`/g];
+type ModalClass = keyof typeof MODAL_CLASSES;
+
+/** Strong required-verbatim cues. A double-quoted string counts as a GUARDRAIL
+ *  (must survive verbatim) only when one of these immediately precedes it — the
+ *  directive is telling the agent to emit that exact wording (e.g. a deferral
+ *  line "…MUST end with exactly:"). Absent a cue, a quoted string is a SAMPLE
+ *  (toast text, example message) and is illustrative. Kept narrow on purpose:
+ *  loose cues like "say"/"append" would wrongly promote sample toasts. */
+const VERBATIM_CUE_RE =
+  /(?:\bexactly\b|\bverbatim\b|\bword[- ]for[- ]word\b|\bverbatim wording\b|\bliteral(?:ly)?\b|\bthe exact (?:line|wording|text|phrase|words|sentence)\b|\bthese exact words\b|\bexact wording\b)\s*[:,]?\s*["“]?$/i;
+
+/** Load-bearing named facts that condensation MUST carry through:
+ *  - ALL-CAPS name runs (2+ consecutive ALL-CAPS words) — directives SHOUT
+ *    these because they are load-bearing parties/executors: "GARY DAVID BROWN",
+ *    "IAN THOMAS GOODFELLOW". Directives ALSO shout for EMPHASIS ("NO HTML",
+ *    "THREE REFERENCE NUMBERS", "THE VIBE"), so a run is treated as a name only
+ *    when NONE of its words is a common English word (see EMPHASIS_STOPWORDS).
+ *    This is an NER-lite pre-filter, not a dictionary; a name built entirely
+ *    from common words is inherently ambiguous and left to human adjudication.
+ *  - case / instrument reference codes — a contiguous alnum token mixing an
+ *    uppercase letter and a digit (AG779131P, TR10399), or a STRUCTURED
+ *    acronym+number run with ≥2 numeric groups or a ≥5-digit group
+ *    ("CAV 2026 00037"). Bare acronym+single-small-number ("PR 286") is an
+ *    incidental reference, not a case code, and is excluded.
+ *  Both are dropped to ILLUSTRATIVE when they sit in an example context
+ *  ("e.g. AG779131P", "such as …") — a directive listing sample formats is not
+ *  asserting a fact the rule must carry. */
+const ALLCAPS_NAME_RE = /\b[A-Z]{2,}(?:\s+[A-Z]{2,}){1,}\b/g;
+const CODE_TOKEN_RE = /\b(?=[A-Z0-9]*[A-Z])(?=[A-Z0-9]*\d)[A-Z0-9]{4,}\b/g;
+const CODE_ACRONYM_NUM_RE = /\b[A-Z]{2,5}(?:\s+\d{2,}){1,}\b/g;
+
+/** An `e.g.`/`such as`/`for example` marker in the ~48 chars immediately
+ *  before a fact match ⇒ the fact is a SAMPLE, not an asserted guardrail. No
+ *  trailing `\b` — markers ending in `.` ("e.g.") have no word boundary before
+ *  the following space — and the run after the marker forbids sentence
+ *  terminators (`.?!:;`) so the marker must be in the SAME clause as the fact. */
+const EXAMPLE_CONTEXT_RE =
+  /(?:\be\.?\s?g\.?|\bi\.?\s?e\.?|\bsuch as|\bfor example|\bfor instance|\bexamples?\b|\bincluding\b|\blike\b)[^.?!:;]{0,48}$/i;
+
+/** Common English words a directive may SHOUT for emphasis rather than name.
+ *  An ALL-CAPS run containing any of these is emphasis, not a party name.
+ *  Explicit and bounded on purpose — extend as new emphasis vocabulary shows
+ *  up in triage, never with plausible surname tokens (BROWN/DAVID/THOMAS stay
+ *  OUT so real names survive). */
+const EMPHASIS_STOPWORDS = new Set([
+  "THE", "A", "AN", "AND", "OR", "BUT", "NOR", "FOR", "SO", "IF", "OF", "TO",
+  "IN", "ON", "AT", "BY", "AS", "IS", "ARE", "BE", "NOT", "NO", "ALL", "ANY",
+  "EACH", "EVERY", "THIS", "THAT", "IT", "WE", "YOU", "DO", "USE", "PER",
+  "VIA", "YES", "NOW", "THEN", "HERE", "WITH", "WITHOUT", "ONLY", "NEVER",
+  "ALWAYS", "MUST", "OVER", "UNDER", "ONE", "TWO", "THREE", "FOUR", "FIVE",
+  "REFERENCE", "NUMBER", "NUMBERS", "DAILY", "WEEKLY", "MONTHLY", "ROLLING",
+  "IMPACT", "VIBE", "LINE", "LINES", "BREAK", "BREAKS", "ROW", "ROWS", "HTML",
+  "CSS", "JSON", "YAML", "CODE", "VERBATIM", "LITERAL", "LITERALLY", "AUTO",
+  "TOTAL", "NET", "TARGET", "BURN", "FIXED", "RECORDS", "WIN", "SEND",
+]);
+
+/** True when an ALL-CAPS run reads as a load-bearing proper NAME rather than
+ *  shouted emphasis. Requires ≥3 words (full legal names — "GARY DAVID BROWN",
+ *  "IAN THOMAS GOODFELLOW" — clear this; two-word ALL-CAPS is far more often
+ *  emphasis, e.g. "NO HTML"/"THE VIBE"/"COACHING FRAME", so it is treated as
+ *  illustrative) AND no word in the common-emphasis stopword set (rejects
+ *  three-word emphasis like "THREE REFERENCE NUMBERS"/"ROLLING WEEKLY IMPACT").
+ *  A load-bearing two-word name must survive via a Titlecase mention or a
+ *  required-verbatim quote (as "Fiona Jessep" does in the deferral line), not
+ *  this ALL-CAPS pre-filter. */
+function isNameRun(run: string): boolean {
+  const words = run.split(/\s+/);
+  return words.length >= 3 && words.every((w) => !EMPHASIS_STOPWORDS.has(w));
+}
+
+/** True when a structured case/instrument code (≥2 numeric groups or a ≥5-digit
+ *  group), so an incidental "PR 286" reference does not read as a case number. */
+function isStructuredCode(run: string): boolean {
+  const groups = run.match(/\d{2,}/g) ?? [];
+  return groups.length >= 2 || groups.some((g) => g.length >= 5);
+}
+
+/** True when the char span before `index` is an example-listing context. */
+function inExampleContext(content: string, index: number): boolean {
+  return EXAMPLE_CONTEXT_RE.test(content.slice(0, index));
+}
+
+/** Exclusivity "only"/"sole"/… as a real scope word. Excludes the three ways
+ *  "only" over-triggered on real drafts, none of which is exclusivity scope:
+ *   - the "-only" of a compound/directive name ("fiona-facts-only", "step-only");
+ *   - the temporal "only until/once/then/…" ("lasts only until restart");
+ *   - the quantifier "only <number>" ("only 2.7% apart", "only 3 items"). */
+const ONLY_TRIGGER_RE =
+  /(?<![-\w'’])(?:only|solely|exclusively|sole)\b(?!\s+(?:until|when|once|then|after|before|if|while|as|because|since|about|around|some|roughly|approximately|\d|a\s+few|[½¼¾]))/i;
+
+/** Incidental Titlecase proper nouns (Buildkite, Ken, Playwright, Twitter).
+ *  Extracted so the tokenizer surface stays inspectable, but classed
+ *  ILLUSTRATIVE and never demanded — the biggest source of the old
+ *  false-positive rate. A genuinely load-bearing name relies on the ALL-CAPS /
+ *  code fact patterns above, or on surviving inside a required-verbatim quote. */
+const PROPER_NOUN_STOPWORDS = new Set([
+  "The", "A", "An", "This", "That", "These", "Those", "It", "Its", "If",
+  "When", "While", "Do", "Don", "Set", "Use", "Never", "Always", "Only",
+  "Must", "Not", "No", "Every", "Each", "Any", "All", "For", "And", "But",
+  "Or", "So", "Then", "Prefer", "Avoid", "Ask", "Refuse", "Keep", "Treat",
+  "Read", "Write", "Run", "Call", "Send", "Reply", "You", "Your", "We",
+  "I", "Before", "After",
+]);
 const PROPER_NOUN_RE = /\b[A-Z][a-zA-Z0-9_.-]*[a-z][a-zA-Z0-9_.-]*\b/g;
 
+/** Double-quote (straight + curly) and backtick only. Single-quote extraction
+ *  is DELETED on purpose: `'…'` matched contraction apostrophes ("Ken's own
+ *  session … don't") and captured enormous spurious "quotes" — the single
+ *  largest artifact source in the baseline. Real single-quoted phrases do not
+ *  occur in these directives; the risk is not worth it. */
+const DOUBLE_QUOTE_RE = /["“]([^"”]+)["”]/g;
+const BACKTICK_RE = /`([^`]+)`/g;
+
 export interface Keyword {
-  kind: "quote" | "modal" | "proper";
-  /** The token as it should be searched for (already trimmed). */
+  /** `modal` = a synonym-classed polarity/scope obligation; `quote` = a quoted
+   *  string; `fact` = a load-bearing named fact; `proper` = an incidental
+   *  proper noun. */
+  kind: "quote" | "modal" | "fact" | "proper";
+  /** Whether the rule MUST preserve this. Only `guardrail` keywords are
+   *  enforced; `illustrative` keywords are extracted but never demanded. */
+  klass: "guardrail" | "illustrative";
+  /** The token as it should be searched for / reported (already trimmed). For
+   *  modals this is the directive's own trigger word (for readable reports). */
   value: string;
+  /** For `kind === "modal"`: which synonym class must survive. */
+  modalClass?: ModalClass;
 }
 
 function normalize(s: string): string {
@@ -155,49 +308,104 @@ function escapeRe(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/** Word-boundary containment for a single alnum-ish token (apostrophes treated
+ *  as punctuation, so `cannot` is not satisfied by `cannon` and `never` is not
+ *  satisfied by `nevertheless`). */
+function containsWord(normalizedText: string, word: string): boolean {
+  const stem = normalize(word).replace(/['’]/g, "'");
+  if (/\s/.test(stem)) return normalizedText.includes(stem);
+  const re = new RegExp(`(^|[^a-z0-9])${escapeRe(stem)}([^a-z0-9]|$)`);
+  return re.test(normalizedText);
+}
+
+/** True when the directive triggers `cls` (uses one of its trigger words). The
+ *  `only` class uses a refined matcher that ignores "-only" compounds and
+ *  temporal "only until/once/…" (both over-triggered on real drafts). */
+function directiveTriggersModal(normalizedContent: string, cls: ModalClass): boolean {
+  if (cls === "only") return ONLY_TRIGGER_RE.test(normalizedContent);
+  return MODAL_CLASSES[cls].trigger.some((w) => containsWord(normalizedContent, w));
+}
+
+/** True when the rule satisfies `cls` (contains any of its satisfy words). */
+function ruleSatisfiesModal(normalizedRuleText: string, cls: ModalClass): boolean {
+  return MODAL_CLASSES[cls].satisfy.some((w) => containsWord(normalizedRuleText, w));
+}
+
+/** First trigger word the directive used for `cls`, for readable reporting. */
+function firstTrigger(normalizedContent: string, cls: ModalClass): string {
+  return MODAL_CLASSES[cls].trigger.find((w) => containsWord(normalizedContent, w)) ?? cls;
+}
+
 /**
- * Extract the fixed keyword set from a directive's content. Deterministic:
- * quoted phrases (verbatim), the modals never/always/don't/only/must, and
- * proper nouns (a capitalized word with at least one interior lowercase,
- * minus a fixed stopword set). Exported for direct unit testing.
+ * Extract the calibrated keyword set from a directive's content. Deterministic.
+ * Each keyword carries a GUARDRAIL/ILLUSTRATIVE class; only guardrail keywords
+ * are enforced against the rule (see {@link ruleContainsKeyword} and the drift
+ * loop). Exported for direct unit testing.
  */
 export function extractKeywords(content: string): Keyword[] {
   const out: Keyword[] = [];
   const seen = new Set<string>();
-  const push = (kind: Keyword["kind"], raw: string) => {
-    const value = raw.trim();
+  const push = (kw: Keyword) => {
+    const value = kw.value.trim();
     if (value.length === 0) return;
-    const key = `${kind}:${value.toLowerCase()}`;
+    const key = `${kw.kind}:${value.toLowerCase()}`;
     if (seen.has(key)) return;
     seen.add(key);
-    out.push({ kind, value });
+    out.push({ ...kw, value });
   };
 
-  for (const re of QUOTE_RES) {
-    for (const m of content.matchAll(re)) push("quote", m[1]);
+  const norm = normalize(content);
+
+  // (1) Modal synonym classes — guardrail. One keyword per triggered class.
+  for (const cls of Object.keys(MODAL_CLASSES) as ModalClass[]) {
+    if (directiveTriggersModal(norm, cls)) {
+      push({ kind: "modal", klass: "guardrail", value: firstTrigger(norm, cls), modalClass: cls });
+    }
   }
-  for (const m of content.matchAll(MODAL_RE)) push("modal", m[1].toLowerCase());
-  if (DONT_RE.test(content)) push("modal", "don't");
+
+  // (2) Quoted strings. Backtick = code sample ⇒ illustrative. Double-quote =
+  //     guardrail only when a required-verbatim cue immediately precedes it.
+  for (const m of content.matchAll(DOUBLE_QUOTE_RE)) {
+    const before = content.slice(0, m.index ?? 0);
+    const cued = VERBATIM_CUE_RE.test(before);
+    push({ kind: "quote", klass: cued ? "guardrail" : "illustrative", value: m[1] });
+  }
+  for (const m of content.matchAll(BACKTICK_RE)) {
+    push({ kind: "quote", klass: "illustrative", value: m[1] });
+  }
+
+  // (3) Load-bearing facts — guardrail: ALL-CAPS proper-name runs and
+  //     case/instrument codes a condensed rule cannot silently drop. Emphasis
+  //     ALL-CAPS, incidental "PR 286" refs, and example-listed codes are
+  //     downgraded to illustrative (see the helpers above).
+  const fact = (value: string, index: number, guardrail: boolean) =>
+    push({ kind: "fact", klass: guardrail && !inExampleContext(content, index) ? "guardrail" : "illustrative", value });
+  for (const m of content.matchAll(ALLCAPS_NAME_RE)) fact(m[0], m.index ?? 0, isNameRun(m[0]));
+  for (const m of content.matchAll(CODE_TOKEN_RE)) fact(m[0], m.index ?? 0, true);
+  for (const m of content.matchAll(CODE_ACRONYM_NUM_RE)) fact(m[0], m.index ?? 0, isStructuredCode(m[0]));
+
+  // (4) Incidental Titlecase proper nouns — illustrative (extracted, not demanded).
   for (const m of content.matchAll(PROPER_NOUN_RE)) {
     const w = m[0];
     if (PROPER_NOUN_STOPWORDS.has(w)) continue;
-    push("proper", w);
+    push({ kind: "proper", klass: "illustrative", value: w });
   }
   return out;
 }
 
-/** True when `ruleText` (normalized) contains the keyword. Quoted phrases are
- *  substring-matched; single-word modals/proper-nouns are word-boundary
- *  matched so `must` doesn't spuriously satisfy on `mustard`. */
+/** True when `ruleText` (normalized) preserves the GUARDRAIL keyword. Modals
+ *  are satisfied by any member of their synonym class; quoted/fact phrases are
+ *  substring-matched (case-insensitive); single tokens are word-boundary
+ *  matched. Illustrative keywords are always treated as preserved (never
+ *  demanded). */
 function ruleContainsKeyword(normalizedRuleText: string, kw: Keyword): boolean {
-  const needle = normalize(kw.value);
-  if (kw.kind === "quote" || /\s/.test(needle)) {
-    return normalizedRuleText.includes(needle);
+  if (kw.klass === "illustrative") return true;
+  if (kw.kind === "modal" && kw.modalClass) {
+    return ruleSatisfiesModal(normalizedRuleText, kw.modalClass);
   }
-  // don't → the apostrophe is punctuation; match the stem.
-  const stem = needle.replace(/['’]/g, "'");
-  const re = new RegExp(`(^|[^a-z0-9])${escapeRe(stem)}([^a-z0-9]|$)`);
-  return re.test(normalizedRuleText);
+  const needle = normalize(kw.value);
+  if (/\s/.test(needle)) return normalizedRuleText.includes(needle);
+  return containsWord(normalizedRuleText, needle);
 }
 
 /** A rule text looks truncated when it ends in an ellipsis, or is a strict


### PR DESCRIPTION
Follow-up on #4769. Calibrates the Tier-1 directive⇄rules equivalence gate's drift check so it flags only REAL dropped guardrails, not M2→M3 condensation artifacts — without weakening genuine-drop detection.

## Problem

`compareDirectivesToRules` demanded every directive keyword survive verbatim in the condensed CLAUDE.md rule. A ~10KB verbose directive legitimately condenses to a ~400B rule, so the gate false-positived on:
- exact modal wording (`don't` → `NEVER`),
- incidental proper nouns (a sample toast mentioning "Twitter"),
- illustrative examples (`e.g.` sample commands/codes).

The failure mode to avoid was the opposite: a calibration so loose it greenlights a real guardrail drop.

## Changes (`telegram-plugin/uat/flip/tier1-equivalence.ts`)

- **Synonym-aware modal/negation matching** via `MODAL_CLASSES` (three classes: `neg` / `only` / `universal`). A guardrail's negation or scope is preserved if **any** member of its synonym class is present in the rule: `never≡no≡don't≡cannot≡without`; `only≡sole≡exclusively≡just`; `whenever≡always≡every≡in all cases`. Bare `must`/`shall`/`always` are deliberately **not** mandatory guardrails (obligation strength / emphasis, not polarity or scope; an imperative reword preserves the obligation).
- **Guardrail vs illustrative split.** Guardrail keywords (negation/scope modals; named people/tools/case codes; required-verbatim quoted lines) must survive. Illustrative keywords (sample toasts/commands, incidental prose proper nouns) no longer must.
- **NER-lite fact detection.** ALLCAPS name runs (≥3 words, emphasis-stopword filtered) and structured codes (≥2 numeric groups or a ≥5-digit group), excluded when in example context (`e.g.`/`i.e.`/`such as`) or pure emphasis.
- **Required-verbatim quotes** gated by a narrow cue regex (`exactly`/`verbatim`/`word-for-word` immediately followed by a quote).
- **Truncation check** (ellipsis / strict-prefix) unchanged.

## Adversarial acceptance tests (`tier1-equivalence.test.ts`)

Gate **STILL FAILS** on: dropped negation (`send after review`), dropped named fact (`GARY DAVID BROWN`), dropped required-verbatim deferral line, dropped case code (`S CAV 2026 00037`), strict-prefix truncation, ellipsis truncation.

Gate **now PASSES**: `don't`→`NEVER`, `only`→`exclusively`, deferral + facts preserved, dropped illustrative `e.g.` code, dropped illustrative sample toast.

## Validation

- Full `bun` suite green: **11452 pass / 0 fail** (4 skip).
- Tier-1 file: **31 pass / 0 fail**; `uat/flip/` dir: **66 pass / 0 fail**.
- `tsc --noEmit`: 0 errors.
- All 5 real triage drafts (finn/reggie/lawgpt/carrie/gymbro) **PASS, 0 drift**. finn was FAIL (9 drift entries) before → PASS (0) after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
