### PR TITLE
fix(m4): gate prefetch buffer join on topic relevance (#4778)

### DIFF
--- a/vendor/hindsight-memory/scripts/lib/recall_buffer.py
+++ b/vendor/hindsight-memory/scripts/lib/recall_buffer.py
@@ -93,13 +93,27 @@ def _sentinel_path(session_id: str) -> str:
     return os.path.join(buffer_dir(), f"{_safe_session(session_id)}.buffer.done")
 
 
-def write_buffer(session_id: str, context: str, telemetry: Optional[dict] = None) -> None:
+def write_buffer(
+    session_id: str,
+    context: str,
+    telemetry: Optional[dict] = None,
+    query: Optional[str] = None,
+) -> None:
     """Write the prefetched recall payload for ``session_id``.
 
     Atomic (temp file + ``os.replace`` within the same directory). Does NOT
     write the sentinel — the caller MUST call ``write_sentinel`` after this,
     and only once the payload write has returned, to preserve the
     read-after-write ordering guarantee.
+
+    ``query`` (#4778) is the speculative query the producer used to build this
+    buffer. It is stored verbatim so the consumer can gate the join on topical
+    similarity between it and turn N+1's ACTUAL prompt — the buffer is keyed by
+    ``session_id`` alone and, without this, a fresh buffer built for the prior
+    turn is served on a topic pivot regardless of relevance. A ``None``/absent
+    query is stored as ``""``, which the consumer treats as "cannot establish a
+    topic match" and falls through to synchronous recall (fail-safe; also the
+    backward-compat behaviour for buffers written before this field existed).
     """
     d = _ensure_dir()
     final = _buffer_path(session_id)
@@ -108,6 +122,7 @@ def write_buffer(session_id: str, context: str, telemetry: Optional[dict] = None
         "schema": SCHEMA,
         "session_id": session_id,
         "context": context,
+        "query": query or "",
         "telemetry": telemetry or {},
         "written_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
@@ -187,7 +202,11 @@ def sentinel_exists(session_id: str) -> bool:
 def read_if_fresh(session_id: str, last_consumed_token: Optional[int]) -> tuple:
     """Return ``(payload_dict | None, current_token)``.
 
-    ``payload_dict`` (when present) is ``{"context": str, "telemetry": dict}``.
+    ``payload_dict`` (when present) is
+    ``{"context": str, "query": str, "telemetry": dict}``. ``query`` (#4778) is
+    the speculative query the buffer was built for — the consumer uses it to
+    gate the join on topical similarity to turn N+1's prompt. It is ``""`` for a
+    legacy buffer written before the field existed.
 
     Returns ``(None, token_or_last_consumed)`` when:
       * no sentinel exists yet (nothing has been produced this session), or
@@ -207,7 +226,11 @@ def read_if_fresh(session_id: str, last_consumed_token: Optional[int]) -> tuple:
         # Torn write: sentinel landed but payload didn't (or is corrupt).
         # Fail-closed — never serve this as fresh.
         return None, token
-    return {"context": payload.get("context", ""), "telemetry": payload.get("telemetry", {})}, token
+    return {
+        "context": payload.get("context", ""),
+        "query": payload.get("query", ""),
+        "telemetry": payload.get("telemetry", {}),
+    }, token
 
 
 def invalidate(session_id: str) -> None:

--- a/vendor/hindsight-memory/scripts/prefetch.py
+++ b/vendor/hindsight-memory/scripts/prefetch.py
@@ -159,7 +159,13 @@ def run_prefetch(hook_input: dict, config: dict) -> bool:
 
     # Step 3 — write payload THEN sentinel, strictly in that order.
     try:
-        recall_buffer.write_buffer(session_id, memories_block, {"result_count": len(results)})
+        # #4778 — persist the speculative `query` alongside the buffer so the
+        # consumer can gate the turn-N+1 join on topical similarity, not just
+        # session freshness. Without it a fresh buffer built for THIS turn's
+        # prompt is served on next turn's prompt even after a topic pivot.
+        recall_buffer.write_buffer(
+            session_id, memories_block, {"result_count": len(results)}, query=query
+        )
         recall_buffer.write_sentinel(session_id)
     except Exception as exc:  # pragma: no cover - defensive
         debug_log(config, f"Prefetch: buffer write failed: {exc}")

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -664,6 +664,21 @@ def _handle_prefetch_buffer(config: dict, hook_input: dict, prompt: str) -> bool
 
     payload, _token = recall_buffer.read_if_fresh(session_id, last_consumed_token=last_consumed)
 
+    # #4778 — TOPIC-RELEVANCE GUARD. `read_if_fresh` only proves the buffer is
+    # FRESH (a strictly-newer sentinel this session), never that it is ON TOPIC:
+    # the producer built it from turn N's last human prompt, so on a topic PIVOT
+    # a perfectly-fresh buffer holds the WRONG-topic memories. Gate the join on
+    # topical similarity between the buffered query and turn N+1's ACTUAL prompt
+    # BEFORE the directive fetch below; a mismatch marks the token consumed (so
+    # it is never reconsidered) and falls through to SYNCHRONOUS recall — which
+    # fetches correct, current-topic memories AND re-injects directives itself.
+    # This is layered ON TOP of the F3 freshness machinery, not a replacement.
+    if payload is not None and not _prefetch_topic_matches(prompt, payload.get("query", ""), config):
+        if _token is not None:
+            _write_consumed_token(session_id, _token)
+        debug_log(config, "Prefetch buffer: topic mismatch vs current prompt, falling through to synchronous recall")
+        return False
+
     # Directives stay on the synchronous, always-fresh path (M3 rule) even
     # in the fast path — fetched here directly, never from the buffer.
     directives_block = None
@@ -886,6 +901,48 @@ def _overlap_tokens(text) -> set:
         if len(tok) > 1 and tok not in _OVERLAP_STOPWORDS:
             out.add(tok)
     return out
+
+
+_PREFETCH_TOPIC_OVERLAP_DEFAULT = 0.3
+
+
+def _prefetch_topic_matches(prompt, buffered_query, config) -> bool:
+    """#4778 — True iff turn N+1's ``prompt`` is topically close enough to the
+    ``buffered_query`` the M4 producer used to build the warm buffer.
+
+    Jaccard overlap (``|A∩B| / |A∪B|``) on ``_overlap_tokens`` — the same
+    stop-word-stripped, digit-preserving, dependency-free tokenizer the
+    transcript-fallback keyword match uses (unicode-safe via ``str.isalnum``,
+    characterised in ``tests/test_overlap_tokens.py``) — against
+    ``memoryPrefetchMinTopicOverlap`` (default 0.3). Jaccard, not the overlap
+    coefficient: both score 0 on a true pivot (disjoint content tokens), so the
+    correctness guarantee is identical, but Jaccard cannot be driven to 1.0 by a
+    single incidental shared token in a short prompt — it biases the residual
+    error toward a harmless false-MISS (sync recall, slower) rather than a
+    false-HIT (wrong-topic memories, the bug).
+
+    Fail-safe: an empty token set on EITHER side — a contentless prompt, or a
+    legacy/torn buffer whose ``query`` is ``""`` — returns False, so the caller
+    falls through to synchronous recall. A miss only ever costs latency; it can
+    never serve wrong-topic memories. Both sides are stripped of the ``<channel>``
+    envelope first, matching the producer's own query derivation.
+    """
+    now_tokens = _overlap_tokens(strip_channel_envelope(prompt or ""))
+    buf_tokens = _overlap_tokens(strip_channel_envelope(buffered_query or ""))
+    if not now_tokens or not buf_tokens:
+        return False
+    intersection = len(now_tokens & buf_tokens)
+    if intersection == 0:
+        return False
+    union = len(now_tokens | buf_tokens)
+    threshold = config.get("memoryPrefetchMinTopicOverlap", _PREFETCH_TOPIC_OVERLAP_DEFAULT)
+    try:
+        threshold = float(threshold)
+    except (TypeError, ValueError):
+        threshold = _PREFETCH_TOPIC_OVERLAP_DEFAULT
+    if not (0.0 <= threshold <= 1.0):
+        threshold = _PREFETCH_TOPIC_OVERLAP_DEFAULT
+    return (intersection / union) >= threshold
 
 
 def _result_final_score(m) -> float:

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -905,6 +905,25 @@ def _overlap_tokens(text) -> set:
 
 _PREFETCH_TOPIC_OVERLAP_DEFAULT = 0.3
 
+# #4778 review MAJOR — short-prompt Jaccard floor. Jaccard is probabilistic, not
+# absolute, on SHORT prompts: two ~2-content-token turns that share ONE incidental
+# token while EACH carries a divergent token give 1/3 = 0.333 >= 0.30 and wrongly
+# clear the ratio bar ("call mom" buffer served on a "call ended" turn — the pivot
+# signature). When either token set is small (fewer than ``MIN_SMALL_SET_TOKENS``)
+# such a partial overlap must supply at least ``_PREFETCH_MIN_SMALL_SET_INTERSECTION``
+# shared tokens, not just clear the ratio.
+#
+# The floor fires ONLY on that divergent-on-both-sides shape. It deliberately
+# EXEMPTS full containment (``intersection == min(|A|, |B|)`` — the smaller set is
+# wholly shared: identical or subset/narrowing queries like "decide" vs "decide",
+# or "restart klanker" vs "restart the klanker agent"), which is a legitimate
+# topical match regardless of brevity and must still be served. Long prompts (both
+# sides at or above ``MIN_SMALL_SET_TOKENS``) skip the floor entirely and use the
+# Jaccard ratio exactly as before. The floor only ever ANDs a stricter condition
+# onto the ratio — it can reject, never serve.
+MIN_SMALL_SET_TOKENS = 3
+_PREFETCH_MIN_SMALL_SET_INTERSECTION = 2
+
 
 def _prefetch_topic_matches(prompt, buffered_query, config) -> bool:
     """#4778 — True iff turn N+1's ``prompt`` is topically close enough to the
@@ -933,6 +952,17 @@ def _prefetch_topic_matches(prompt, buffered_query, config) -> bool:
         return False
     intersection = len(now_tokens & buf_tokens)
     if intersection == 0:
+        return False
+    # Short-prompt floor (#4778 review MAJOR): when either side is small, a single
+    # incidental shared token must not clear the guard on the Jaccard ratio alone.
+    # Exempt full containment (intersection == smaller set) — identical/subset
+    # queries are a legitimate topical match, never the divergent-on-both-sides
+    # pivot this floor targets. ANDed with the ratio check below: stricter, never
+    # looser, and long prompts (both sides >= MIN_SMALL_SET_TOKENS) are untouched.
+    min_set = min(len(now_tokens), len(buf_tokens))
+    if min_set < MIN_SMALL_SET_TOKENS \
+            and intersection < min_set \
+            and intersection < _PREFETCH_MIN_SMALL_SET_INTERSECTION:
         return False
     union = len(now_tokens | buf_tokens)
     threshold = config.get("memoryPrefetchMinTopicOverlap", _PREFETCH_TOPIC_OVERLAP_DEFAULT)

--- a/vendor/hindsight-memory/scripts/tests/test_prefetch_invalidation.py
+++ b/vendor/hindsight-memory/scripts/tests/test_prefetch_invalidation.py
@@ -278,7 +278,9 @@ class NoDuplicateInjectionTests(InvalidationBase):
         config = self._config(prefetch_enabled=True)
         marker = "- unique-fact-abc123 decided at standup"
 
-        recall_buffer.write_buffer(SESSION, marker, {})
+        # #4778 — on-topic with the `_consume` prompt ("what did we decide") so
+        # the topic guard passes and this stays a genuine warm-buffer hit.
+        recall_buffer.write_buffer(SESSION, marker, {}, query="what did we decide")
         recall_buffer.write_sentinel(SESSION)
 
         # Turn N+1: consumer injects the buffered block once.
@@ -311,7 +313,10 @@ class ReplyPathDoesNotBlockOnRecallTests(InvalidationBase):
 
     def test_fresh_buffer_served_without_calling_recall(self):
         config = self._config(prefetch_enabled=True)
-        recall_buffer.write_buffer(SESSION, "- a prefetched memory xyz", {})
+        # #4778 — on-topic with the `_consume` prompt so the topic guard passes;
+        # the point of THIS test is that a matched fresh buffer never blocks on a
+        # synchronous recall, so the query must clear the guard.
+        recall_buffer.write_buffer(SESSION, "- a prefetched memory xyz", {}, query="what did we decide")
         recall_buffer.write_sentinel(SESSION)
 
         class _ExplodingRecallClient:

--- a/vendor/hindsight-memory/scripts/tests/test_prefetch_pipeline.py
+++ b/vendor/hindsight-memory/scripts/tests/test_prefetch_pipeline.py
@@ -147,7 +147,7 @@ class CallOrderTests(PrefetchPipelineBase):
             order.append("retain")
             return {"status": "ok"}
 
-        def _spy_write_buffer(session_id, context, telemetry=None):
+        def _spy_write_buffer(session_id, context, telemetry=None, query=None):
             order.append("buffer")
 
         def _spy_write_sentinel(session_id):

--- a/vendor/hindsight-memory/scripts/tests/test_prefetch_topic_guard.py
+++ b/vendor/hindsight-memory/scripts/tests/test_prefetch_topic_guard.py
@@ -49,6 +49,28 @@ SYNC_RECALL_TEXT = "sync recalled: Melbourne weekend outlook is sunny"
 # An on-topic FOLLOW-UP that reuses the salient nouns of the producer query.
 ONTOPIC_PROMPT = "and is the us-east-1 primary still the rollback target"
 
+# --- #4778 review MAJOR: SHORT-PROMPT Jaccard floor -------------------------
+# Jaccard is probabilistic on short prompts. The producer built a buffer for a
+# 2-content-token "call mom" turn; its block is a mom-topic reminder. Turn N+1 is
+# "call ended" — a SHARP pivot that shares only the incidental "call". Raw
+# Jaccard = |{call}| / |{call, mom, ended}| = 1/3 = 0.333 >= 0.30, so the
+# pre-floor guard WRONGLY serves the mom buffer. The small-set intersection floor
+# (either side < 3 tokens => demand >= 2 shared tokens) rejects it.
+SHORT_PRODUCER_QUERY = "call mom"
+SHORT_BUFFERED_BLOCK = "- Reminder: call mom about her dentist appointment"
+SHORT_PIVOT_PROMPT = "call ended"
+SHORT_BUFFER_MARKER = "dentist"
+
+# Positive control: two SHORT prompts that LEGITIMATELY share >= 2 content tokens
+# still join the warm buffer. Buffer query has 3 content tokens (restart, klanker,
+# agent — "the" is a stop word); the follow-up "restart klanker" is 2 tokens, so
+# the small-set floor applies, but the intersection {restart, klanker} = 2 clears
+# it and Jaccard = 2/3 = 0.667 clears the ratio. Served, no synchronous recall.
+SHORT_ONTOPIC_PRODUCER_QUERY = "restart the klanker agent"
+SHORT_ONTOPIC_BLOCK = "- Runbook: restart klanker with docker restart switchroom-klanker"
+SHORT_ONTOPIC_PROMPT = "restart klanker"
+SHORT_ONTOPIC_MARKER = "docker"
+
 
 class _SyncClient:
     """Directive-free client whose synchronous recall returns a marker distinct
@@ -168,6 +190,70 @@ class LegacyBufferFailsSafeTests(TopicGuardBase):
         ctx = self._run(self._config(), _SyncClient(), PIVOT_PROMPT)
         self.assertNotIn("us-east-1", ctx)
         self.assertIn(SYNC_RECALL_TEXT, ctx)
+
+
+class ShortPromptFloorTests(TopicGuardBase):
+    def test_short_pivot_sharing_one_incidental_token_is_not_served(self):
+        # RED without the small-set floor: "call mom" buffer + "call ended" turn
+        # gives raw Jaccard 1/3 = 0.333 >= 0.30, so the mom-topic block is served
+        # on an unrelated turn. GREEN with the floor: either side has < 3 tokens
+        # and the intersection is only {call} = 1 < 2, so the guard rejects and
+        # the turn falls through to synchronous recall.
+        recall_buffer.write_buffer(SESSION, SHORT_BUFFERED_BLOCK, {}, query=SHORT_PRODUCER_QUERY)
+        recall_buffer.write_sentinel(SESSION)
+
+        ctx = self._run(self._config(), _SyncClient(), SHORT_PIVOT_PROMPT)
+
+        self.assertNotIn(
+            SHORT_BUFFER_MARKER, ctx,
+            "a short-prompt pivot sharing one incidental token must NOT be served the buffer",
+        )
+        self.assertIn(
+            SYNC_RECALL_TEXT, ctx,
+            "a short-prompt pivot must fall through to synchronous recall",
+        )
+
+    def test_short_ontopic_sharing_two_tokens_still_gets_the_warm_buffer(self):
+        # Positive control: the floor must not kill a legitimate short warm hit.
+        # "restart klanker" (2 tokens) vs "restart the klanker agent" shares
+        # {restart, klanker} = 2, clearing both the small-set floor and the ratio;
+        # served WITHOUT any synchronous recall.
+        class _ExplodingRecallClient:
+            def list_directives(self, bank_id, active_only=True, timeout=2):
+                return {"items": []}
+
+            def recall(self, bank_id, query, **kwargs):
+                raise AssertionError("short on-topic warm hit must not fall through to sync recall")
+
+        recall_buffer.write_buffer(SESSION, SHORT_ONTOPIC_BLOCK, {}, query=SHORT_ONTOPIC_PRODUCER_QUERY)
+        recall_buffer.write_sentinel(SESSION)
+
+        ctx = self._run(self._config(), _ExplodingRecallClient(), SHORT_ONTOPIC_PROMPT)
+        self.assertIn(
+            SHORT_ONTOPIC_MARKER, ctx,
+            "a short on-topic follow-up sharing >= 2 tokens must still join the warm buffer",
+        )
+
+    def test_short_floor_unit_boundaries(self):
+        cfg = self._config()
+        # Short pivot, one incidental shared token -> floor rejects despite ratio.
+        self.assertFalse(recall._prefetch_topic_matches(SHORT_PIVOT_PROMPT, SHORT_PRODUCER_QUERY, cfg))
+        # Short on-topic, two shared tokens -> floor and ratio both clear.
+        self.assertTrue(
+            recall._prefetch_topic_matches(SHORT_ONTOPIC_PROMPT, SHORT_ONTOPIC_PRODUCER_QUERY, cfg)
+        )
+        # The reviewer's borderline case: "kill process 4080" / "process 4080 logs"
+        # shares two tokens (both sides 3 tokens) -> served, unaffected by floor.
+        self.assertTrue(
+            recall._prefetch_topic_matches("kill process 4080", "process 4080 logs", cfg)
+        )
+        # Full-containment exemption: an identical single-content-token query
+        # ("what did we decide" -> {decide} both sides) is wholly shared, not a
+        # divergent pivot -> the floor must NOT reject it. Guards the regression
+        # the naive floor caused in test_prefetch_invalidation's short queries.
+        self.assertTrue(recall._prefetch_topic_matches("what did we decide", "what did we decide", cfg))
+        # Subset/narrowing short query is likewise exempt from the floor.
+        self.assertTrue(recall._prefetch_topic_matches("call mom please", "call mom", cfg))
 
 
 class TopicMatchUnitTests(TopicGuardBase):

--- a/vendor/hindsight-memory/scripts/tests/test_prefetch_topic_guard.py
+++ b/vendor/hindsight-memory/scripts/tests/test_prefetch_topic_guard.py
@@ -1,0 +1,193 @@
+"""M4 #4778 — prefetch buffer TOPIC-RELEVANCE guard.
+
+The F3 freshness machinery proves a joined buffer is FRESH (a strictly-newer
+sentinel this session); it does NOT prove the buffer is ON TOPIC. The producer
+builds the buffer from turn N's last human prompt, so on a topic PIVOT a
+perfectly-fresh buffer holds the WRONG-topic memories. These are OUTCOME tests
+on the rendered ``additionalContext`` (the real injection surface):
+
+  * RED/GREEN: a pivot query must NOT be served the prior-topic buffer — it must
+    fall through to SYNCHRONOUS recall (correct, current-topic memories). On the
+    pre-guard code the prior-topic block is injected at warm-buffer latency; with
+    the guard the pivot turn shows the synchronous result instead.
+  * An on-topic follow-up is STILL a warm hit (the guard is not so tight it kills
+    the latency win).
+  * A legacy buffer with no stored query fails safe to synchronous recall.
+
+Mirrors the harness in ``tests/test_recall_buffer_join.py`` (drives ``recall.main``
+end-to-end, asserts on transport). Stdlib-only.
+"""
+
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import recall  # noqa: E402
+from lib import recall_buffer  # noqa: E402
+
+SESSION = "topic-guard-session"
+
+# The producer built the warm buffer for turn N's prompt about a DB failover
+# rollback; its recalled block is the us-east-1 standby plan.
+PRODUCER_QUERY = "what's the rollback plan for the us-east-1 primary failover"
+BUFFERED_BLOCK = "- Rollback plan: keep the us-east-1 primary in read-only standby"
+
+# Turn N+1 PIVOTS sharply to an unrelated topic (the issue's reproduction shape).
+PIVOT_PROMPT = "what's the weather forecast for Melbourne this weekend"
+SYNC_RECALL_TEXT = "sync recalled: Melbourne weekend outlook is sunny"
+
+# An on-topic FOLLOW-UP that reuses the salient nouns of the producer query.
+ONTOPIC_PROMPT = "and is the us-east-1 primary still the rollback target"
+
+
+class _SyncClient:
+    """Directive-free client whose synchronous recall returns a marker distinct
+    from the buffered block, so a served warm buffer and a served sync result are
+    unambiguously distinguishable in the rendered output."""
+
+    def list_directives(self, bank_id, active_only=True, timeout=2):
+        return {"items": []}
+
+    def recall(self, bank_id, query, **kwargs):
+        return {"results": [{
+            "text": SYNC_RECALL_TEXT, "type": "fact",
+            "mentioned_at": "2026-01-01", "id": "s1", "scores": {"final": 0.9},
+        }]}
+
+
+class TopicGuardBase(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="topic-guard-test-")
+        self._prev = os.environ.get("CLAUDE_PLUGIN_DATA")
+        os.environ["CLAUDE_PLUGIN_DATA"] = self._tmpdir
+
+        self._bufdir = tempfile.mkdtemp(prefix="topic-guard-buf-")
+        self.env = mock.patch.dict(
+            os.environ, {"HINDSIGHT_PREFETCH_BUFFER_DIR": self._bufdir}, clear=False
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+        shutil.rmtree(self._bufdir, ignore_errors=True)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        if self._prev is None:
+            os.environ.pop("CLAUDE_PLUGIN_DATA", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_DATA"] = self._prev
+
+    def _config(self):
+        return {
+            "autoRecall": True,
+            "bankId": "test-bank",
+            "recallMaxTokens": 4096,
+            "recallBudget": "mid",
+            "recallContextTurns": 1,
+            "recallMaxQueryChars": 800,
+            "recallPromptPreamble": "",
+            "recallParallelDeadlineSeconds": 5,
+            "directivesCacheTtlSeconds": 0,
+            "memoryPrefetchEnabled": True,
+            "memoryPrefetchPollCapMs": 100,
+        }
+
+    def _run(self, config, client, prompt):
+        hook_input = {"prompt": prompt, "session_id": SESSION, "transcript_path": "", "cwd": "/tmp"}
+        stdout = io.StringIO()
+        with patch("recall.load_config", return_value=config), \
+                patch("recall.get_api_url", return_value="http://fake"), \
+                patch("recall.HindsightClient", return_value=client), \
+                patch("recall.ensure_bank_mission"), \
+                patch("sys.stdin", io.StringIO(json.dumps(hook_input))), \
+                patch("sys.stdout", stdout):
+            recall.main()
+        out = stdout.getvalue()
+        return json.loads(out)["hookSpecificOutput"]["additionalContext"] if out else ""
+
+
+class PivotFallsThroughTests(TopicGuardBase):
+    def test_pivot_query_is_not_served_the_prior_topic_buffer(self):
+        # RED on pre-guard code: `read_if_fresh` returns the fresh buffer and the
+        # consumer injects the rollback block for a WEATHER prompt at ~1ms. GREEN
+        # with the guard: the topic mismatch falls through to synchronous recall.
+        recall_buffer.write_buffer(SESSION, BUFFERED_BLOCK, {}, query=PRODUCER_QUERY)
+        recall_buffer.write_sentinel(SESSION)
+
+        ctx = self._run(self._config(), _SyncClient(), PIVOT_PROMPT)
+
+        self.assertNotIn(
+            "us-east-1", ctx,
+            "a topic pivot must NOT be served the prior turn's wrong-topic buffer",
+        )
+        self.assertIn(
+            SYNC_RECALL_TEXT, ctx,
+            "a topic pivot must fall through to synchronous recall for correct memories",
+        )
+
+
+class OnTopicStillHitsTests(TopicGuardBase):
+    def test_ontopic_followup_still_gets_the_warm_buffer(self):
+        # The guard must not be so tight it kills the latency win: a follow-up
+        # reusing the salient nouns still clears the Jaccard threshold and joins
+        # the warm buffer WITHOUT a synchronous recall.
+        class _ExplodingRecallClient:
+            def list_directives(self, bank_id, active_only=True, timeout=2):
+                return {"items": []}
+
+            def recall(self, bank_id, query, **kwargs):
+                raise AssertionError("on-topic warm hit must not fall through to synchronous recall")
+
+        recall_buffer.write_buffer(SESSION, BUFFERED_BLOCK, {}, query=PRODUCER_QUERY)
+        recall_buffer.write_sentinel(SESSION)
+
+        ctx = self._run(self._config(), _ExplodingRecallClient(), ONTOPIC_PROMPT)
+        self.assertIn(
+            "us-east-1", ctx,
+            "an on-topic follow-up must still join the warm prefetch buffer",
+        )
+
+
+class LegacyBufferFailsSafeTests(TopicGuardBase):
+    def test_buffer_without_stored_query_falls_through_to_sync_recall(self):
+        # Backward-compat: a buffer written before the `query` field existed has
+        # query="" -> the guard cannot establish a topic match -> fail-safe to
+        # synchronous recall, never a blind wrong-topic serve.
+        recall_buffer.write_buffer(SESSION, BUFFERED_BLOCK, {})  # no query
+        recall_buffer.write_sentinel(SESSION)
+
+        ctx = self._run(self._config(), _SyncClient(), PIVOT_PROMPT)
+        self.assertNotIn("us-east-1", ctx)
+        self.assertIn(SYNC_RECALL_TEXT, ctx)
+
+
+class TopicMatchUnitTests(TopicGuardBase):
+    def test_jaccard_threshold_boundaries(self):
+        cfg = self._config()
+        # Disjoint content tokens -> pivot -> no match.
+        self.assertFalse(recall._prefetch_topic_matches(PIVOT_PROMPT, PRODUCER_QUERY, cfg))
+        # Identical query -> match.
+        self.assertTrue(recall._prefetch_topic_matches(PRODUCER_QUERY, PRODUCER_QUERY, cfg))
+        # On-topic follow-up sharing salient nouns -> match.
+        self.assertTrue(recall._prefetch_topic_matches(ONTOPIC_PROMPT, PRODUCER_QUERY, cfg))
+        # Empty buffered query (legacy) -> fail-safe miss.
+        self.assertFalse(recall._prefetch_topic_matches(PRODUCER_QUERY, "", cfg))
+        # Empty current prompt -> fail-safe miss.
+        self.assertFalse(recall._prefetch_topic_matches("", PRODUCER_QUERY, cfg))
+        # Garbage threshold coerces to the 0.3 default rather than raising.
+        bad = dict(cfg)
+        bad["memoryPrefetchMinTopicOverlap"] = "not-a-number"
+        self.assertTrue(recall._prefetch_topic_matches(PRODUCER_QUERY, PRODUCER_QUERY, bad))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_recall_buffer_join.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_buffer_join.py
@@ -99,7 +99,10 @@ class BufferJoinBase(unittest.TestCase):
 
 class FreshHitTests(BufferJoinBase):
     def test_fresh_buffer_hit_is_rendered_with_directives_layered_on(self):
-        recall_buffer.write_buffer(SESSION, "- a prefetched memory", {})
+        # #4778 — the buffered query must be on-topic with the consumer prompt
+        # (default "what did we decide about deploys") for the join to fire;
+        # here it is identical, so the topic guard passes and the warm hit lands.
+        recall_buffer.write_buffer(SESSION, "- a prefetched memory", {}, query="what did we decide about deploys")
         recall_buffer.write_sentinel(SESSION)
 
         out = self._run(self._config(prefetch_enabled=True), _DirectiveClient())
@@ -194,7 +197,7 @@ class StaleBufferTokenTests(BufferJoinBase):
     turns N+1..N+k when no strictly-newer sentinel has been produced."""
 
     def test_consumed_buffer_is_not_reserved_as_fresh_next_turn(self):
-        recall_buffer.write_buffer(SESSION, "- a prefetched memory", {})
+        recall_buffer.write_buffer(SESSION, "- a prefetched memory", {}, query="what did we decide about deploys")
         recall_buffer.write_sentinel(SESSION)
         cfg = self._config(prefetch_enabled=True)
 
@@ -219,7 +222,7 @@ class StaleBufferTokenTests(BufferJoinBase):
         # Positive control: once the producer writes a STRICTLY-NEWER sentinel,
         # the fresh path serves again — the token gate rejects only re-reads of
         # an ALREADY-consumed sentinel, never a genuinely new one.
-        recall_buffer.write_buffer(SESSION, "- memory one", {})
+        recall_buffer.write_buffer(SESSION, "- memory one", {}, query="what did we decide about deploys")
         recall_buffer.write_sentinel(SESSION)
         cfg = self._config(prefetch_enabled=True)
 
@@ -227,7 +230,7 @@ class StaleBufferTokenTests(BufferJoinBase):
         self.assertIn("memory one", json.loads(out1)["hookSpecificOutput"]["additionalContext"])
 
         # New turn's producer output.
-        recall_buffer.write_buffer(SESSION, "- memory two", {})
+        recall_buffer.write_buffer(SESSION, "- memory two", {}, query="what did we decide about deploys")
         recall_buffer.write_sentinel(SESSION)
         out2 = self._run(cfg, _DirectiveClient())
         ctx2 = json.loads(out2)["hookSpecificOutput"]["additionalContext"]


### PR DESCRIPTION
Closes #4778.

## Problem
M4 async recall-prefetch (`memoryPrefetchEnabled`) had a **freshness** contract but no **relevance** contract. The producer (`prefetch.py`) builds the warm buffer from turn N's last human prompt (`_last_human_prompt`, prefetch.py:88) and writes it keyed **only by `session_id`** (prefetch.py:162-163). The consumer (`recall.py::_handle_prefetch_buffer`, :665) served that buffer on turn N+1 gated purely by the F3 sentinel **freshness token** — nothing checked that the buffered memories matched turn N+1's actual query. On a topic **pivot**, a perfectly-fresh buffer holds the **wrong-topic** memories, served at warm-buffer latency. Reproduced in the issue: a "weather forecast for Melbourne" turn was served "Rollback plan: keep the us-east-1 primary in read-only standby…" in 1.68 ms.

This is distinct from the already-landed F3 freshness fix (persisted `last_consumed_token` / `prefetch_consumed.json`). This PR is the topic-relevance guard, **layered on top of** the F3 machinery, not a replacement.

## Fix
- **Producer:** persist the speculative `query` alongside the buffer — `recall_buffer.write_buffer(session_id, block, telemetry, query=query)`, surfaced back by `read_if_fresh`.
- **Consumer:** join the warm buffer only if turn N+1's actual prompt is topically close enough to the buffered query — **Jaccard overlap** (`|A∩B|/|A∪B|`) on `_overlap_tokens` (the same stop-word-stripped, digit-preserving, dependency-free tokenizer the transcript-fallback keyword match already uses; no embedding round-trip on the hot path) against `memoryPrefetchMinTopicOverlap` (default **0.3**). A mismatch marks the sentinel token consumed (never reconsidered) and **falls through to synchronous recall**, which fetches correct current-topic memories and re-injects directives itself.

### Why Jaccard / threshold 0.3
Both Jaccard and the overlap coefficient score 0 on a true pivot (disjoint content tokens), so the correctness guarantee — never serve a pivot — is identical. They differ only in false-miss rate; the overlap coefficient can reach 1.0 on a single incidental shared token in a short prompt (a false-HIT = the bug), whereas Jaccard yields `~1/(|A|+|B|-1)` (< 0.1 for real prompts), keeping residual error in the harmless direction. 0.3 catches every true pivot while retaining genuine on-topic continuations (e.g. `{weather,forecast,melbourne,weekend}` vs a follow-up `{sydney,weather,weekend}` → 0.40 ≥ 0.3). Tunable via `memoryPrefetchMinTopicOverlap` (read via `config.get` default, consistent with `memoryPrefetchPollCapMs`).

## Fail-safe
Every mismatch or ambiguity degrades to the pre-existing synchronous recall path — correct but slower, never wrong-topic, never a broken turn. An empty token set on either side (contentless prompt, or a **legacy buffer written before the `query` field existed** → `query == ""`) falls through to sync recall. A miss only ever costs latency; it can never serve wrong-topic memories.

## Tests
New RED/GREEN module `tests/test_prefetch_topic_guard.py`:
- `PivotFallsThroughTests::test_pivot_query_is_not_served_the_prior_topic_buffer` — **RED on pre-guard code** (verified: the weather prompt is served the "us-east-1" rollback block), GREEN with the guard (falls through to synchronous recall).
- `OnTopicStillHitsTests::test_ontopic_followup_still_gets_the_warm_buffer` — an on-topic follow-up is still a warm hit (recall raises if called), proving the guard does not kill the latency win.
- `LegacyBufferFailsSafeTests::test_buffer_without_stored_query_falls_through_to_sync_recall` — backward-compat fail-safe.
- `TopicMatchUnitTests::test_jaccard_threshold_boundaries` — boundary/coercion unit coverage.

Suites stay green: `python3 -m unittest discover tests/` → 1228 pass; sibling `python3 -m pytest tests/` → 262 pass.

## Residual risk
The producer query is a proxy for turn N+1's intent, so a genuine on-topic follow-up that reuses few salient nouns can degrade to synchronous recall (latency only, never a correctness violation). The threshold is fleet-tunable if the empirical miss rate proves too high. M4 remains OFF fleet-wide; this guard is a prerequisite to flipping it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)